### PR TITLE
Optional atom fixes

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -158,7 +158,7 @@ def get_spends_for_block(generator: BlockGenerator, height: int, constants: Cons
         parent, puzzle, amount, solution = spend.as_iter()
         puzzle_hash = puzzle.get_tree_hash()
         coin = Coin(parent.as_atom(), puzzle_hash, amount.as_int())
-        spends.append(CoinSpend(coin, SerializedProgram.from_program(puzzle), SerializedProgram.from_program(solution)))
+        spends.append(CoinSpend(coin, puzzle, solution))
 
     return spends
 
@@ -184,9 +184,7 @@ def get_spends_for_block_with_conditions(
     spends: List[CoinSpendWithConditions] = []
 
     for spend in Program.to(ret).first().as_iter():
-        parent, puzzle_prg, amount, solution_prg = spend.as_iter()
-        puzzle = SerializedProgram.from_program(puzzle_prg)
-        solution = SerializedProgram.from_program(solution_prg)
+        parent, puzzle, amount, solution = spend.as_iter()
         puzzle_hash = puzzle.get_tree_hash()
         coin = Coin(parent.as_atom(), puzzle_hash, amount.as_int())
         coin_spend = CoinSpend(coin, puzzle, solution)

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -28,7 +28,6 @@ from chia_rs import (
     solution_generator,
 )
 from chiabip158 import PyBIP158
-from clvm.casts import int_from_bytes
 
 from chia.consensus.block_creation import unfinished_block_to_full_block
 from chia.consensus.block_record import BlockRecord
@@ -183,8 +182,8 @@ def compute_additions_unchecked(sb: SpendBundle) -> List[Coin]:
             op = next(atoms).atom
             if op != ConditionOpcode.CREATE_COIN.value:
                 continue
-            puzzle_hash = next(atoms).atom
-            amount = int_from_bytes(next(atoms).atom)
+            puzzle_hash = next(atoms).as_atom()
+            amount = next(atoms).as_int()
             ret.append(Coin(parent_id, puzzle_hash, amount))
     return ret
 

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple
 
-from clvm.casts import int_from_bytes
-
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
@@ -66,8 +64,8 @@ def compute_additions_with_cost(
         if op != ConditionOpcode.CREATE_COIN.value:
             continue
         cost += ConditionCost.CREATE_COIN.value
-        puzzle_hash = next(atoms).atom
-        amount = int_from_bytes(next(atoms).atom)
+        puzzle_hash = next(atoms).as_atom()
+        amount = next(atoms).as_int()
         ret.append(Coin(parent_id, puzzle_hash, amount))
 
     return ret, cost

--- a/chia/wallet/vc_wallet/cr_cat_drivers.py
+++ b/chia/wallet/vc_wallet/cr_cat_drivers.py
@@ -132,7 +132,7 @@ def match_cr_layer(
     extra_uncurried_puzzle = uncurry_puzzle(uncurried_puzzle.mod)
     if extra_uncurried_puzzle.mod == CREDENTIAL_RESTRICTION:
         return (
-            [bytes32(provider.atom) for provider in extra_uncurried_puzzle.args.at("rf").as_iter()],
+            [bytes32(provider.as_atom()) for provider in extra_uncurried_puzzle.args.at("rf").as_iter()],
             extra_uncurried_puzzle.args.at("rrf"),
             uncurried_puzzle.args.at("rf"),
         )
@@ -318,9 +318,9 @@ class CRCAT:
         second_uncurried_cr_layer: UncurriedPuzzle = uncurry_puzzle(first_uncurried_cr_layer.mod)
         return CRCAT(
             spend.coin,
-            bytes32(uncurried_puzzle.args.at("rf").atom),
+            bytes32(uncurried_puzzle.args.at("rf").as_atom()),
             spend.solution.to_program().at("rf"),
-            [bytes32(ap.atom) for ap in second_uncurried_cr_layer.args.at("rf").as_iter()],
+            [bytes32(ap.as_atom()) for ap in second_uncurried_cr_layer.args.at("rf").as_iter()],
             second_uncurried_cr_layer.args.at("rrf"),
             first_uncurried_cr_layer.args.at("rf").get_tree_hash(),
         )
@@ -353,7 +353,7 @@ class CRCAT:
                 conditions = potential_cr_layer.run(inner_solution)
             for condition in conditions.as_iter():
                 if condition.at("f") == Program.to(1):
-                    new_inner_puzzle_hash = bytes32(condition.at("rf").atom)
+                    new_inner_puzzle_hash = bytes32(condition.at("rf").as_atom())
                     authorized_providers_as_prog: Program = condition.at("rrf")
                     proofs_checker: Program = condition.at("rrrf")
                     break
@@ -378,7 +378,7 @@ class CRCAT:
             ).get_tree_hash_precalc(inner_puzzle_hash)
 
         # Convert all of the old stuff into python
-        authorized_providers: List[bytes32] = [bytes32(p.atom) for p in authorized_providers_as_prog.as_iter()]
+        authorized_providers: List[bytes32] = [bytes32(p.as_atom()) for p in authorized_providers_as_prog.as_iter()]
         new_lineage_proof: LineageProof = LineageProof(
             parent_spend.coin.parent_coin_info,
             lineage_inner_puzhash,
@@ -393,11 +393,11 @@ class CRCAT:
         partially_completed_crcats: List[CRCAT] = [
             CRCAT(
                 Coin(coin_name, bytes(32), uint64(condition.at("rrf").as_int())),
-                bytes32(tail_hash_as_prog.atom),
+                bytes32(tail_hash_as_prog.as_atom()),
                 new_lineage_proof,
                 authorized_providers,
                 proofs_checker,
-                bytes32(condition.at("rf").atom) if new_inner_puzzle_hash is None else new_inner_puzzle_hash,
+                bytes32(condition.at("rf").as_atom()) if new_inner_puzzle_hash is None else new_inner_puzzle_hash,
             )
             for condition in all_conditions
             if condition.at("f").as_int() == 51 and condition.at("rrf") != Program.to(-113)
@@ -453,7 +453,7 @@ class CRCAT:
         assert conditions is not None
         for condition in conditions:
             if condition.at("f").as_int() == 51 and condition.at("rrf").as_int() != -113:
-                new_inner_puzzle_hash: bytes32 = bytes32(condition.at("rf").atom)
+                new_inner_puzzle_hash: bytes32 = bytes32(condition.at("rf").as_atom())
                 new_amount: uint64 = uint64(condition.at("rrf").as_int())
                 announcements.append(
                     Announcement(self.coin.name(), b"\xcd" + std_hash(new_inner_puzzle_hash + int_to_bytes(new_amount)))
@@ -643,7 +643,7 @@ class ProofsChecker(Streamable):
         if uncurried_puzzle.mod != PROOF_FLAGS_CHECKER:
             raise ValueError("Puzzle was not a proof checker")  # pragma: no cover
 
-        return cls([flag.at("f").atom.decode("utf8") for flag in uncurried_puzzle.args.at("f").as_iter()])
+        return cls([flag.at("f").as_atom().decode("utf8") for flag in uncurried_puzzle.args.at("f").as_iter()])
 
 
 class CRCATVersion(IntEnum):

--- a/chia/wallet/vc_wallet/vc_drivers.py
+++ b/chia/wallet/vc_wallet/vc_drivers.py
@@ -106,7 +106,7 @@ def create_covenant_layer(initial_puzzle_hash: bytes32, parent_morpher: Program,
 def match_covenant_layer(uncurried_puzzle: UncurriedPuzzle) -> Optional[Tuple[bytes32, Program, Program]]:
     if uncurried_puzzle.mod == COVENANT_LAYER:
         return (
-            bytes32(uncurried_puzzle.args.at("f").atom),
+            bytes32(uncurried_puzzle.args.at("f").as_atom()),
             uncurried_puzzle.args.at("rf"),
             uncurried_puzzle.args.at("rrf"),
         )
@@ -200,7 +200,7 @@ def create_viral_backdoor(hidden_puzzle_hash: bytes32, inner_puzzle_hash: bytes3
 
 def match_viral_backdoor(uncurried_puzzle: UncurriedPuzzle) -> Optional[Tuple[bytes32, bytes32]]:
     if uncurried_puzzle.mod == VIRAL_BACKDOOR:
-        return bytes32(uncurried_puzzle.args.at("rf").atom), bytes32(uncurried_puzzle.args.at("rrf").atom)
+        return bytes32(uncurried_puzzle.args.at("rf").as_atom()), bytes32(uncurried_puzzle.args.at("rrf").as_atom())
     else:
         return None  # pragma: no cover
 
@@ -572,7 +572,7 @@ class VerifiedCredential(Streamable):
         solution: Program = parent_spend.solution.to_program()
 
         singleton: UncurriedPuzzle = uncurry_puzzle(puzzle)
-        launcher_id: bytes32 = bytes32(singleton.args.at("frf").atom)
+        launcher_id: bytes32 = bytes32(singleton.args.at("frf").as_atom())
         layer_below_singleton: Program = singleton.args.at("rf")
         singleton_lineage_proof: LineageProof = LineageProof(
             parent_name=parent_coin.parent_coin_info,
@@ -590,9 +590,9 @@ class VerifiedCredential(Streamable):
 
             conditions: List[Program] = list(dpuz.run(dsol).as_iter())
             remark_condition: Program = next(c for c in conditions if c.at("f").as_int() == 1)
-            inner_puzzle_hash = bytes32(remark_condition.at("rf").atom)
+            inner_puzzle_hash = bytes32(remark_condition.at("rf").as_atom())
             magic_condition: Program = next(c for c in conditions if c.at("f").as_int() == -10)
-            proof_provider = bytes32(magic_condition.at("rf").atom)
+            proof_provider = bytes32(magic_condition.at("rf").as_atom())
         else:
             metadata_layer: UncurriedPuzzle = uncurry_puzzle(layer_below_singleton)
 
@@ -603,7 +603,7 @@ class VerifiedCredential(Streamable):
             new_singleton_condition: Program = next(
                 c for c in conditions if c.at("f").as_int() == 51 and c.at("rrf").as_int() % 2 != 0
             )
-            inner_puzzle_hash = bytes32(new_singleton_condition.at("rf").atom)
+            inner_puzzle_hash = bytes32(new_singleton_condition.at("rf").as_atom())
             magic_condition = next(c for c in conditions if c.at("f").as_int() == -10)
             if magic_condition.at("rrrf") == Program.to(None):
                 proof_hash_as_prog: Program = metadata_layer.args.at("rfr")
@@ -612,16 +612,16 @@ class VerifiedCredential(Streamable):
             else:
                 proof_hash_as_prog = magic_condition.at("rrrfrrf")
 
-            proof_hash = None if proof_hash_as_prog == Program.to(None) else bytes32(proof_hash_as_prog.atom)
+            proof_hash = None if proof_hash_as_prog == Program.to(None) else bytes32(proof_hash_as_prog.as_atom())
 
-            proof_provider = bytes32(metadata_layer.args.at("rff").atom)
+            proof_provider = bytes32(metadata_layer.args.at("rff").as_atom())
 
             parent_proof_hash: bytes32 = metadata_layer.args.at("rf").get_tree_hash()
             eml_lineage_proof = VCLineageProof(
                 parent_name=parent_coin.parent_coin_info,
                 inner_puzzle_hash=create_viral_backdoor(
                     STANDARD_BRICK_PUZZLE_HASH,
-                    bytes32(uncurry_puzzle(metadata_layer.args.at("rrrrf")).args.at("rrf").atom),
+                    bytes32(uncurry_puzzle(metadata_layer.args.at("rrrrf")).args.at("rrf").as_atom()),
                 ).get_tree_hash(),
                 amount=uint64(parent_coin.amount),
                 parent_proof_hash=None if parent_proof_hash == Program.to(None) else parent_proof_hash,
@@ -743,7 +743,7 @@ class VerifiedCredential(Streamable):
         new_singleton_condition: Program = next(
             c for c in inner_puzzle.run(inner_solution).as_iter() if c.at("f") == 51 and c.at("rrf").as_int() % 2 != 0
         )
-        new_inner_puzzle_hash: bytes32 = bytes32(new_singleton_condition.at("rf").atom)
+        new_inner_puzzle_hash: bytes32 = bytes32(new_singleton_condition.at("rf").as_atom())
 
         return (
             expected_announcement,

--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -495,21 +495,23 @@ class VCWallet:
             for cc in [c for c in crcat_spend.inner_conditions if c.at("f").as_int() == 51]:
                 if not (
                     (  # it's coming to us
-                        await self.wallet_state_manager.get_wallet_identifier_for_puzzle_hash(bytes32(cc.at("rf").atom))
+                        await self.wallet_state_manager.get_wallet_identifier_for_puzzle_hash(
+                            bytes32(cc.at("rf").as_atom())
+                        )
                         is not None
                     )
                     or (  # it's going back where it came from
-                        bytes32(cc.at("rf").atom) == crcat_spend.crcat.inner_puzzle_hash
+                        bytes32(cc.at("rf").as_atom()) == crcat_spend.crcat.inner_puzzle_hash
                     )
                     or (  # it's going to the pending state
                         cc.at("rrr") != Program.to(None)
                         and cc.at("rrrf").atom is None
-                        and bytes32(cc.at("rf").atom)
+                        and bytes32(cc.at("rf").as_atom())
                         == construct_pending_approval_state(
-                            bytes32(cc.at("rrrff").atom), uint64(cc.at("rrf").as_int())
+                            bytes32(cc.at("rrrff").as_atom()), uint64(cc.at("rrf").as_int())
                         ).get_tree_hash()
                     )
-                    or bytes32(cc.at("rf").atom) == Offer.ph()  # it's going to the offer mod
+                    or bytes32(cc.at("rf").as_atom()) == Offer.ph()  # it's going to the offer mod
                 ):
                     outputs_ok = False  # pragma: no cover
             if our_crcat or outputs_ok:

--- a/chia/wallet/wallet_singleton_store.py
+++ b/chia/wallet/wallet_singleton_store.py
@@ -113,9 +113,11 @@ class WalletSingletonStore:
 
         lineage_bytes = [x.as_atom() for x in coin_state.solution.to_program().first().as_iter()]
         if len(lineage_bytes) == 2:
-            lineage_proof = LineageProof(lineage_bytes[0], None, int_from_bytes(lineage_bytes[1]))
+            lineage_proof = LineageProof(bytes32(lineage_bytes[0]), None, int_from_bytes(lineage_bytes[1]))
         else:
-            lineage_proof = LineageProof(lineage_bytes[0], lineage_bytes[1], int_from_bytes(lineage_bytes[2]))
+            lineage_proof = LineageProof(
+                bytes32(lineage_bytes[0]), bytes32(lineage_bytes[1]), int_from_bytes(lineage_bytes[2])
+            )
         # Create and save the new singleton record
         new_record = SingletonRecord(
             coin, singleton_id, wallet_id, coin_state, inner_puz.get_tree_hash(), pending, 0, lineage_proof, None

--- a/tests/wallet/nft_wallet/test_nft_puzzles.py
+++ b/tests/wallet/nft_wallet/test_nft_puzzles.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import random
 from typing import Tuple
 
-from clvm.casts import int_from_bytes
-
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.wallet.nft_wallet import uncurry_nft
@@ -102,7 +100,7 @@ def test_nft_transfer_puzzle_hashes(seeded_random: random.Random):
     # get the new NFT puzhash
     for cond in conds.as_iter():
         if cond.first().as_int() == 51:
-            expected_ph = bytes32(cond.at("rf").atom)
+            expected_ph = bytes32(cond.at("rf").as_atom())
 
     # recreate the puzzle for new_puzhash
     new_ownership_puz = NFT_OWNERSHIP_LAYER.curry(NFT_OWNERSHIP_LAYER.get_tree_hash(), None, transfer_puz, taker_p2_puz)
@@ -170,11 +168,11 @@ def make_a_new_nft_puzzle(curried_ownership_layer: Program, metadata: Program) -
 def get_updated_nft_puzzle(puzzle: Program, solution: Program) -> bytes32:
     result = puzzle.run(solution)
     for condition in result.as_iter():
-        code = int_from_bytes(condition.first().atom)
+        code = condition.first().as_int()
         if code == 51:
-            if int_from_bytes(condition.rest().rest().first().atom) == 1:
+            if condition.at("rrf").as_int() == 1:
                 # this is our new puzzle hash
-                return bytes32(condition.rest().first().atom)
+                return bytes32(condition.at("rf").as_atom())
     raise ValueError("No create coin condition found")
 
 

--- a/tools/run_block.py
+++ b/tools/run_block.py
@@ -43,7 +43,6 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 import click
-from clvm.casts import int_from_bytes
 
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
@@ -156,7 +155,7 @@ def run_generator(block_generator: BlockGenerator, constants: ConsensusConstants
             break
 
         puzzle_hash = puzzle.get_tree_hash()
-        coin = Coin(parent.atom, puzzle_hash, int_from_bytes(amount.atom))
+        coin = Coin(bytes32(parent.as_atom()), puzzle_hash, amount.as_int())
         cat_list.append(
             CAT(
                 asset_id=bytes(asset_id).hex()[2:],


### PR DESCRIPTION
### Purpose:

This PR addresses more cases where `Optional[bytes]` is used as `bytes` directly. These type errors are not caught by mypy because `Program` and all `SExp` members are untyped.

This is a continuation of https://github.com/Chia-Network/chia-blockchain/pull/17030, where `as_atom()` was made to throw in case the `SExp` node isn't an atom, and otherwise return `bytes`. This is by far the most common use case of `.atom`.

Also note that `as_int()` also throws in case the node is not an atom.

### Current Behavior:

When enabling type checking, all these calls to `.atom` are flagged because they are used as if they are `bytes`, rather than `Optional[bytes]`.

### New Behavior:

When enabling type checking, these cases are not flagged.