### PR TITLE
fix type annotation for solve_did_tp

### DIFF
--- a/chia/wallet/vc_wallet/vc_drivers.py
+++ b/chia/wallet/vc_wallet/vc_drivers.py
@@ -143,7 +143,7 @@ def create_tp_covenant_adapter(covenant_layer: Program) -> Program:
     return EML_TP_COVENANT_ADAPTER.curry(covenant_layer)
 
 
-def match_tp_covenant_adapter(uncurried_puzzle: UncurriedPuzzle) -> Optional[Tuple[Program]]:  # pragma: no cover
+def match_tp_covenant_adapter(uncurried_puzzle: UncurriedPuzzle) -> Optional[Program]:  # pragma: no cover
     if uncurried_puzzle.mod == EML_TP_COVENANT_ADAPTER:
         return uncurried_puzzle.args.at("f")
     else:
@@ -174,7 +174,7 @@ def match_did_tp(uncurried_puzzle: UncurriedPuzzle) -> Optional[Tuple[()]]:
 
 
 def solve_did_tp(
-    provider_innerpuzhash: bytes32, my_coin_id: bytes32, new_metadata: Program, new_transfer_program: Program
+    provider_innerpuzhash: bytes32, my_coin_id: bytes32, new_metadata: Program, new_transfer_program: bytes32
 ) -> Program:
     solution: Program = Program.to(
         [
@@ -547,7 +547,7 @@ class VerifiedCredential(Streamable):
         layer_below_eml: UncurriedPuzzle = uncurry_puzzle(layer_below_singleton.args.at("rrrrf"))
         if layer_below_eml.mod != VIRAL_BACKDOOR:
             return False, "VC did not have a provider backdoor"  # pragma: no cover
-        hidden_puzzle_hash: bytes32 = layer_below_eml.args.at("rf")
+        hidden_puzzle_hash = bytes32(layer_below_eml.args.at("rf").as_atom())
         if hidden_puzzle_hash != STANDARD_BRICK_PUZZLE_HASH:
             return (
                 False,


### PR DESCRIPTION
### Purpose:

The type passed in as 4th argument to `solve_did_tp()` is `bytes32` at all call sites. This updates the type annotation to match.

`match_tp_covenant_adapter()` is not used anywhere, but its declared return type does not match what's actually returned. That's addressed.

a value of type `Program` is assigned to a variable of type `bytes32`. This as addressed by calling `bytes32(x.as_atom())`.

This is part of an effort to improve type checking in `chia-blockchain` for `Program`.

It fixes these issues:
```
chia/wallet/vc_wallet/vc_drivers.py:148: error: Incompatible return value type (got "Program", expected "tuple[Program] | None")  [return-value]
chia/wallet/vc_wallet/vc_drivers.py:550: error: Incompatible types in assignment (expression has type "Program", variable has type "bytes32")  [assignment]
tests/wallet/vc_wallet/test_vc_lifecycle.py:228: error: Argument 4 to "solve_did_tp" has incompatible type "bytes32"; expected "Program"  [arg-type]
tests/wallet/vc_wallet/test_vc_lifecycle.py:263: error: Argument 4 to "solve_did_tp" has incompatible type "bytes32"; expected "Program"  [arg-type]
tests/wallet/vc_wallet/test_vc_lifecycle.py:289: error: Argument 4 to "solve_did_tp" has incompatible type "bytes32"; expected "Program"  [arg-type]
```

### Current Behavior:

`solve_did_tp()` has incorrect type hint for the 4th parameter.

### New Behavior:

`solve_did_tp()` has correct type hint for the 4th parameter.