### PR TITLE
fix type hints in data layer

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -1251,9 +1251,9 @@ class DataLayerWallet:
         for spend in offer.coin_spends():
             matched, curried_args = match_dl_singleton(spend.puzzle_reveal.to_program())
             if matched and spend.coin.name() not in all_parent_ids:
-                innerpuz, root, launcher_id = curried_args
+                innerpuz, root_prg, launcher_id = curried_args
                 singleton_struct = launcher_to_struct(bytes32(launcher_id.as_python())).get_tree_hash()
-                singleton_to_root[singleton_struct] = bytes32(root.as_python())
+                singleton_to_root[singleton_struct] = bytes32(root_prg.as_python())
                 singleton_to_innerpuzhash[singleton_struct] = innerpuz.get_tree_hash()
 
         # Create all of the new solutions
@@ -1266,9 +1266,9 @@ class DataLayerWallet:
                 except EvalError:
                     new_spends.append(spend)
                     continue
-                mod, curried_args = graftroot.uncurry()
+                mod, curried_args_prg = graftroot.uncurry()
                 if mod == GRAFTROOT_DL_OFFERS:
-                    _, singleton_structs, _, values_to_prove = curried_args.as_iter()
+                    _, singleton_structs, _, values_to_prove = curried_args_prg.as_iter()
                     all_proofs = []
                     roots = []
                     for singleton, values in zip(singleton_structs.as_iter(), values_to_prove.as_python()):
@@ -1276,7 +1276,7 @@ class DataLayerWallet:
                         proofs_of_inclusion = []
                         for value in values:
                             for proof_of_inclusion in solver["proofs_of_inclusion"]:
-                                root = proof_of_inclusion[0]
+                                root: str = proof_of_inclusion[0]
                                 proof: Tuple[int, List[bytes32]] = (proof_of_inclusion[1], proof_of_inclusion[2])
                                 calculated_root: bytes32 = _simplify_merkle_proof(value, proof)
                                 if (

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -978,7 +978,7 @@ class DataStore:
                         await self._insert_ancestor_table(left_hash, right_hash, tree_id, new_generation)
 
         if hint_keys_values is not None:
-            hint_keys_values[bytes(key)] = value
+            hint_keys_values[key] = value
         return InsertResult(node_hash=new_terminal_node_hash, root=new_root)
 
     async def delete(
@@ -995,13 +995,13 @@ class DataStore:
             if hint_keys_values is None:
                 node = await self.get_node_by_key(key=key, tree_id=tree_id)
             else:
-                if bytes(key) not in hint_keys_values:
+                if key not in hint_keys_values:
                     log.debug(f"Request to delete an unknown key ignored: {key.hex()}")
                     return root
-                value = hint_keys_values[bytes(key)]
+                value = hint_keys_values[key]
                 node_hash = leaf_hash(key=key, value=value)
                 node = TerminalNode(node_hash, key, value)
-                del hint_keys_values[bytes(key)]
+                del hint_keys_values[key]
             if use_optimized:
                 ancestors: List[InternalNode] = await self.get_ancestors_optimized(
                     node_hash=node.hash, tree_id=tree_id, root_hash=root_hash

--- a/tests/core/data_layer/conftest.py
+++ b/tests/core/data_layer/conftest.py
@@ -86,10 +86,15 @@ async def valid_node_values_fixture(
     node_type: NodeType,
 ) -> Dict[str, Any]:
     await add_01234567_example(data_store=data_store, tree_id=tree_id)
-    node_a = await data_store.get_node_by_key(key=b"\x02", tree_id=tree_id)
-    node_b = await data_store.get_node_by_key(key=b"\x04", tree_id=tree_id)
 
-    return create_valid_node_values(node_type=node_type, left_hash=node_a.hash, right_hash=node_b.hash)
+    if node_type == NodeType.INTERNAL:
+        node_a = await data_store.get_node_by_key(key=b"\x02", tree_id=tree_id)
+        node_b = await data_store.get_node_by_key(key=b"\x04", tree_id=tree_id)
+        return create_valid_node_values(node_type=node_type, left_hash=node_a.hash, right_hash=node_b.hash)
+    elif node_type == NodeType.TERMINAL:
+        return create_valid_node_values(node_type=node_type)
+    else:
+        raise Exception(f"invalid node type: {node_type!r}")
 
 
 @pytest.fixture(name="bad_node_type", params=range(2 * len(NodeType)))

--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -680,9 +680,7 @@ async def test_delete_from_left_both_terminal(data_store: DataStore, tree_id: by
         ),
     )
 
-    await data_store.delete(
-        key=Program.to(b"\x04"), tree_id=tree_id, hint_keys_values=hint_keys_values, status=Status.COMMITTED
-    )
+    await data_store.delete(key=b"\x04", tree_id=tree_id, hint_keys_values=hint_keys_values, status=Status.COMMITTED)
     result = await data_store.get_tree_as_program(tree_id=tree_id)
 
     assert result == expected
@@ -719,12 +717,8 @@ async def test_delete_from_left_other_not_terminal(data_store: DataStore, tree_i
         ),
     )
 
-    await data_store.delete(
-        key=Program.to(b"\x04"), tree_id=tree_id, hint_keys_values=hint_keys_values, status=Status.COMMITTED
-    )
-    await data_store.delete(
-        key=Program.to(b"\x05"), tree_id=tree_id, hint_keys_values=hint_keys_values, status=Status.COMMITTED
-    )
+    await data_store.delete(key=b"\x04", tree_id=tree_id, hint_keys_values=hint_keys_values, status=Status.COMMITTED)
+    await data_store.delete(key=b"\x05", tree_id=tree_id, hint_keys_values=hint_keys_values, status=Status.COMMITTED)
     result = await data_store.get_tree_as_program(tree_id=tree_id)
 
     assert result == expected
@@ -764,9 +758,7 @@ async def test_delete_from_right_both_terminal(data_store: DataStore, tree_id: b
         ),
     )
 
-    await data_store.delete(
-        key=Program.to(b"\x03"), tree_id=tree_id, hint_keys_values=hint_keys_values, status=Status.COMMITTED
-    )
+    await data_store.delete(key=b"\x03", tree_id=tree_id, hint_keys_values=hint_keys_values, status=Status.COMMITTED)
     result = await data_store.get_tree_as_program(tree_id=tree_id)
 
     assert result == expected
@@ -803,12 +795,8 @@ async def test_delete_from_right_other_not_terminal(data_store: DataStore, tree_
         ),
     )
 
-    await data_store.delete(
-        key=Program.to(b"\x03"), tree_id=tree_id, hint_keys_values=hint_keys_values, status=Status.COMMITTED
-    )
-    await data_store.delete(
-        key=Program.to(b"\x02"), tree_id=tree_id, hint_keys_values=hint_keys_values, status=Status.COMMITTED
-    )
+    await data_store.delete(key=b"\x03", tree_id=tree_id, hint_keys_values=hint_keys_values, status=Status.COMMITTED)
+    await data_store.delete(key=b"\x02", tree_id=tree_id, hint_keys_values=hint_keys_values, status=Status.COMMITTED)
     result = await data_store.get_tree_as_program(tree_id=tree_id)
 
     assert result == expected

--- a/tests/core/data_layer/util.py
+++ b/tests/core/data_layer/util.py
@@ -189,6 +189,8 @@ def create_valid_node_values(
     right_hash: Optional[bytes32] = None,
 ) -> Dict[str, Any]:
     if node_type == NodeType.INTERNAL:
+        assert left_hash is not None
+        assert right_hash is not None
         return {
             "hash": Program.to((left_hash, right_hash)).get_tree_hash_precalc(left_hash, right_hash),
             "node_type": node_type,

--- a/tests/core/data_layer/util.py
+++ b/tests/core/data_layer/util.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import subprocess
 from dataclasses import dataclass
-from typing import IO, TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
+from typing import IO, TYPE_CHECKING, Any, Dict, Iterator, List, Literal, Optional, Union, overload
 
 from chia.data_layer.data_layer_util import NodeType, Side, Status
 from chia.data_layer.data_store import DataStore
@@ -183,6 +183,22 @@ class ChiaRoot:
             self.print_log()
 
 
+@overload
+def create_valid_node_values(
+    node_type: Literal[NodeType.INTERNAL],
+    left_hash: bytes32,
+    right_hash: bytes32,
+) -> Dict[str, Any]:
+    ...
+
+
+@overload
+def create_valid_node_values(
+    node_type: Literal[NodeType.TERMINAL],
+) -> Dict[str, Any]:
+    ...
+
+
 def create_valid_node_values(
     node_type: NodeType,
     left_hash: Optional[bytes32] = None,
@@ -200,6 +216,7 @@ def create_valid_node_values(
             "value": None,
         }
     elif node_type == NodeType.TERMINAL:
+        assert left_hash is None and right_hash is None
         key = b""
         value = b""
         return {


### PR DESCRIPTION
### Purpose:

This is a step towards enabling type hints for `Program` and its member functions, as well as full mypy coverage of chia-blockchain.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

there are some invalid type hints and mypy violations in the data store code

### New Behavior:

there are fewer incorrect type hints and mypy violations in the data store code

### Testing Notes:

These are the mypy issues addressed by this PR:

```
chia/data_layer/data_layer_util.py:154: error: Incompatible return value type (got "tuple[Program, Program]", expected "tuple[bytes32, bytes32]")  [return-value]
tests/core/data_layer/util.py:193: error: Argument 1 to "get_tree_hash_precalc" of "Program" has incompatible type "bytes32 | None"; expected "bytes32"  [arg-type]
tests/core/data_layer/util.py:193: error: Argument 2 to "get_tree_hash_precalc" of "Program" has incompatible type "bytes32 | None"; expected "bytes32"  [arg-type]
tests/core/data_layer/test_data_store.py:684: error: Argument "key" to "delete" of "DataStore" has incompatible type "Program"; expected "bytes"  [arg-type]
tests/core/data_layer/test_data_store.py:723: error: Argument "key" to "delete" of "DataStore" has incompatible type "Program"; expected "bytes"  [arg-type]
tests/core/data_layer/test_data_store.py:726: error: Argument "key" to "delete" of "DataStore" has incompatible type "Program"; expected "bytes"  [arg-type]
tests/core/data_layer/test_data_store.py:768: error: Argument "key" to "delete" of "DataStore" has incompatible type "Program"; expected "bytes"  [arg-type]
tests/core/data_layer/test_data_store.py:807: error: Argument "key" to "delete" of "DataStore" has incompatible type "Program"; expected "bytes"  [arg-type]
tests/core/data_layer/test_data_store.py:810: error: Argument "key" to "delete" of "DataStore" has incompatible type "Program"; expected "bytes"  [arg-type]
chia/data_layer/data_layer_wallet.py:1269: error: Incompatible types in assignment (expression has type "Program", variable has type "Iterator[Program]")  [assignment]
chia/data_layer/data_layer_wallet.py:1271: error: "Iterator[Program]" has no attribute "as_iter"  [attr-defined]
chia/data_layer/data_layer_wallet.py:1283: error: Argument 1 to "from_hexstr" of "SizedBytes" has incompatible type "Program"; expected "str"  [arg-type]
chia/data_layer/data_layer_wallet.py:1288: error: Incompatible types in assignment (expression has type "Program", variable has type "str | None")  [assignment]
```