### PR TITLE
DL: Use unsubscribe queue to relax subscriptions lock.

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -107,6 +107,7 @@ class DataLayer:
     uploaders: List[PluginRemote]
     maximum_full_file_count: int
     server_files_location: Path
+    unsubscribe_data_queue: List[UnsubscribeData]
     _server: Optional[ChiaServer] = None
     none_bytes: bytes32 = bytes32([0] * 32)
     initialized: bool = False
@@ -116,7 +117,6 @@ class DataLayer:
     periodically_manage_data_task: Optional[asyncio.Task[None]] = None
     _wallet_rpc: Optional[WalletRpcClient] = None
     subscription_lock: asyncio.Lock = dataclasses.field(default_factory=asyncio.Lock)
-    unsubscribe_data_queue: List[UnsubscribeData] = []
 
     @property
     def server(self) -> ChiaServer:
@@ -176,6 +176,7 @@ class DataLayer:
             downloaders=downloaders,
             uploaders=uploaders,
             maximum_full_file_count=config.get("maximum_full_file_count", 1),
+            unsubscribe_data_queue=[],
         )
 
         self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -48,6 +48,7 @@ from chia.data_layer.data_layer_util import (
     Subscription,
     SyncStatus,
     TerminalNode,
+    UnsubscribeData,
     leaf_hash,
 )
 from chia.data_layer.data_layer_wallet import DataLayerWallet, Mirror, SingletonRecord, verify_offer

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -654,7 +654,8 @@ class DataLayer:
             self.unsubscribe_data_queue.append(UnsubscribeData(tree_id, retain_data))
 
     async def process_unsubscribe(self, tree_id: bytes32, retain_data: bool) -> None:
-        subscriptions = await self.get_subscriptions()
+        # This function already acquired `subscriptions_lock`.
+        subscriptions = await self.data_store.get_subscriptions()
         if tree_id not in (subscription.tree_id for subscription in subscriptions):
             raise RuntimeError("No subscription found for the given tree_id.")
         filenames: List[str] = []
@@ -667,10 +668,9 @@ class DataLayer:
                 filenames.append(get_delta_filename(tree_id, root_hash, root.generation))
         # stop tracking first, then unsubscribe from the data store
         await self.wallet_rpc.dl_stop_tracking(tree_id)
-        async with self.subscription_lock:
-            await self.data_store.unsubscribe(tree_id)
-            if not retain_data:
-                await self.data_store.delete_store_data(tree_id)
+        await self.data_store.unsubscribe(tree_id)
+        if not retain_data:
+            await self.data_store.delete_store_data(tree_id)
 
         self.log.info(f"Unsubscribed to {tree_id}")
         for filename in filenames:

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -116,7 +116,7 @@ class DataLayer:
     periodically_manage_data_task: Optional[asyncio.Task[None]] = None
     _wallet_rpc: Optional[WalletRpcClient] = None
     subscription_lock: asyncio.Lock = dataclasses.field(default_factory=asyncio.Lock)
-    unsubscribe_data_queue: List[UnsubscribeData]
+    unsubscribe_data_queue: List[UnsubscribeData] = []
 
     @property
     def server(self) -> ChiaServer:
@@ -176,7 +176,6 @@ class DataLayer:
             downloaders=downloaders,
             uploaders=uploaders,
             maximum_full_file_count=config.get("maximum_full_file_count", 1),
-            unsubscribe_data_queue=[],
         )
 
         self.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/chia/data_layer/data_layer_util.py
+++ b/chia/data_layer/data_layer_util.py
@@ -725,3 +725,9 @@ class PluginStatus:
 class InsertResult:
     node_hash: bytes32
     root: Root
+
+
+@dataclasses.dataclass(frozen=True)
+class UnsubscribeData:
+    tree_id: bytes32
+    retain_data: bool

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -717,8 +717,8 @@ async def test_subscriptions(
         response = await data_rpc_api.unsubscribe(request={"id": store_id.hex()})
         assert response is not None
 
-        # wait for unsubscribe to be process
-        await asyncio.sleep(5 * interval)
+        # wait for unsubscribe to be processed
+        await asyncio.sleep(interval * 3)
 
         response = await data_rpc_api.subscriptions(request={})
         assert store_id.hex() not in response.get("store_ids", [])
@@ -2191,6 +2191,10 @@ async def test_unsubscribe_removes_files(
             assert get_full_tree_filename(store_id, hash, generation + 1) in filenames
 
         res = await data_rpc_api.unsubscribe(request={"id": store_id.hex(), "retain": retain})
+
+        # wait for unsubscribe to be processed
+        await asyncio.sleep(manage_data_interval * 3)
+
         filenames = {path.name for path in data_layer.server_files_location.iterdir()}
         assert len(filenames) == (2 * update_count if retain else 0)
 

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -718,7 +718,7 @@ async def test_subscriptions(
         assert response is not None
 
         # wait for unsubscribe to be processed
-        await asyncio.sleep(interval * 3)
+        await asyncio.sleep(interval * 5)
 
         response = await data_rpc_api.subscriptions(request={})
         assert store_id.hex() not in response.get("store_ids", [])

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -690,6 +690,12 @@ async def test_subscriptions(
     wallet_rpc_api, full_node_api, wallet_rpc_port, ph, bt = await init_wallet_and_node(
         self_hostname, one_wallet_and_one_simulator_services
     )
+
+    interval = 1
+    config = bt.config
+    config["data_layer"]["manage_data_interval"] = interval
+    bt.change_config(new_config=config)
+
     async with init_data_layer(wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path) as data_layer:
         data_rpc_api = DataLayerRpcApi(data_layer)
 
@@ -710,6 +716,9 @@ async def test_subscriptions(
         # test unsubscribe
         response = await data_rpc_api.unsubscribe(request={"id": store_id.hex()})
         assert response is not None
+
+        # wait for unsubscribe to be process
+        await asyncio.sleep(5 * interval)
 
         response = await data_rpc_api.subscriptions(request={})
         assert store_id.hex() not in response.get("store_ids", [])


### PR DESCRIPTION
Remove the subscriptions lock when doing all the heavy operations by queueing unsubscribes and doing them at the very end.