### PR TITLE
bump chia_rs to 0.3.3

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -6,13 +6,9 @@ from typing import Dict, List, Optional
 from chia_rs import (
     AGG_SIG_ARGS,
     ALLOW_BACKREFS,
-    ENABLE_BLS_OPS,
     ENABLE_BLS_OPS_OUTSIDE_GUARD,
     ENABLE_FIXED_DIV,
-    ENABLE_SECP_OPS,
     ENABLE_SOFTFORK_CONDITION,
-    LIMIT_ANNOUNCES,
-    LIMIT_OBJECTS,
     MEMPOOL_MODE,
     NO_RELATIVE_CONDITIONS_ON_EPHEMERAL,
 )
@@ -47,14 +43,6 @@ def get_flags_for_height_and_constants(height: int, constants: ConsensusConstant
 
     if height >= constants.SOFT_FORK2_HEIGHT:
         flags = flags | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
-
-    # the soft-fork initiated with 2.0 and activated in November 2023
-    # * the number of announces created and asserted are limited per spend
-    # * the total number of CLVM objects (atoms or pairs) are limited
-    # * BLS operators enabled, behind the softfork op. This set of operators
-    #   also includes coinid, % and modpow
-    # * secp operators enabled
-    flags = flags | LIMIT_ANNOUNCES | LIMIT_OBJECTS | ENABLE_BLS_OPS | ENABLE_SECP_OPS
 
     if height >= constants.HARD_FORK_HEIGHT:
         # the hard-fork initiated with 2.0. To activate June 2024

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dependencies = [
     "chiapos==2.0.3",  # proof of space
     "clvm==0.9.8",
     "clvm_tools==0.4.7",  # Currying, Program.to, other conveniences
-    "chia_rs==0.2.13",
+    "chia_rs==0.3.3",
     "clvm-tools-rs==0.1.40",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.9.1",  # HTTP server for full node rpc
     "aiosqlite==0.19.0",  # asyncio wrapper for sqlite, to store blocks


### PR DESCRIPTION
### Purpose:

The latest version of `chia_rs` includes:

* pre-softfork 3 logic was removed, allowing some simplifications
* updated `fast_forward_singleton()` to allow changing coin amount
* fix to `SerializedProgram.to()` to match the python implementation
* full node class types
* "unchecked" versions of `from_bytes()` and `parse()` in the streamable protocol (for improved performance of trusted input)
* fix `__repr__` for types exported to python

### Current Behavior:

### New Behavior:

### Testing Notes:
