### PR TITLE
initiate phasing out of the `coin_solutions` name in JSON structs

### DIFF
--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -64,10 +64,10 @@ class SpendBundle(Streamable):
     # Some API still expects this name. For now, we accept both names.
     #
     # TODO: continue this deprecation. Eventually, all code below here should be removed.
-    #  1. set `exclude_modern_keys` to `False` (and manually set to `True` where necessary)
-    #  2. set `include_legacy_keys` to `False` (and manually set to `False` where necessary)
-    #  3. remove all references to `include_legacy_keys=True`
-    #  4. remove all code below this point
+    #  1. [x] set `exclude_modern_keys` to `False` (and manually set to `True` where necessary)
+    #  2. [ ] set `include_legacy_keys` to `False` (and manually set to `False` where necessary)
+    #  3. [ ] remove all references to `include_legacy_keys=True`
+    #  4. [ ] remove all code below this point
 
     @classmethod
     def from_json_dict(cls, json_dict: Dict[str, Any]) -> SpendBundle:
@@ -78,10 +78,10 @@ class SpendBundle(Streamable):
                 )
                 warnings.warn("`coin_solutions` is now `coin_spends` in `SpendBundle.from_json_dict`")
             else:
-                raise ValueError("JSON contains both `coin_solutions` and `coin_spends`, just use `coin_spends`")
+                warnings.warn("JSON contains both `coin_solutions` and `coin_spends`, just use `coin_spends`")
         return streamable_from_dict(cls, json_dict)
 
-    def to_json_dict(self, include_legacy_keys: bool = True, exclude_modern_keys: bool = True) -> Dict[str, Any]:
+    def to_json_dict(self, include_legacy_keys: bool = True, exclude_modern_keys: bool = False) -> Dict[str, Any]:
         if include_legacy_keys is False and exclude_modern_keys is True:
             raise ValueError("`coin_spends` not included in legacy or modern outputs")
         d = recurse_jsonify(self)

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,6 +15,7 @@ markers =
 testpaths = tests
 filterwarnings =
     error
+    ignore:JSON contains both `coin_solutions` and `coin_spends`, just use `coin_spends`
     ignore:ssl_context is deprecated:DeprecationWarning
     ignore:Implicitly cleaning up:ResourceWarning
     ignore:unclosed <socket\.socket:ResourceWarning

--- a/tests/core/custom_types/test_spend_bundle.py
+++ b/tests/core/custom_types/test_spend_bundle.py
@@ -59,7 +59,7 @@ class TestStructStream(unittest.TestCase):
 
     def test_dont_use_both_legacy_and_modern(self):
         json_1 = BLANK_SPEND_BUNDLE.to_json_dict(include_legacy_keys=True, exclude_modern_keys=False)
-        with self.assertRaises(ValueError):
+        with pytest.warns(UserWarning):
             SpendBundle.from_json_dict(json_1)
 
 


### PR DESCRIPTION
in favor of `coin_spends`.

### Purpose:

The end goal is to remove the special case JSON logic in `SpendBundle`.

### Current Behavior:

The JSON field is just called `coin_solutions`.

### New Behavior:

There are two fields in the JSON struct, both `coin_solutions` *and* `coin_spends`.