### PR TITLE
slight simplification to get_min_fee_rate()

### DIFF
--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -310,8 +310,7 @@ class TestMempool:
         mempool = Mempool(mempool_info, fee_estimator)
         assert mempool.get_min_fee_rate(104000) == 0
 
-        with pytest.raises(ValueError):
-            mempool.get_min_fee_rate(max_mempool_cost + 1)
+        assert mempool.get_min_fee_rate(max_mempool_cost + 1) is None
 
         coin = await next_block(full_node_1, wallet_a, bt)
         spend_bundle = generate_test_spend_bundle(wallet_a, coin)


### PR DESCRIPTION
### Purpose:

instead of throwing an exception from `get_min_fee_rate()`, return None.

### Current Behavior:

`get_min_fee_rate()` may throw an exception if the mempool limit is set small.

### New Behavior:

`get_min_fee_rate()`  does not throw an exception because the mempool limit is set small.