### PR TITLE
use rust types for VDFInfo, VDFProof and ClassgroupElement

### DIFF
--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 import logging
 import time
 from typing import Optional, Tuple
@@ -194,9 +193,9 @@ def validate_unfinished_header_block(
                         icc_iters_proof,
                         sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf.output,
                     )
-                    if sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf != dataclasses.replace(
-                        target_vdf_info,
-                        number_of_iterations=icc_iters_committed,
+                    if (
+                        sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf
+                        != target_vdf_info.replace(number_of_iterations=icc_iters_committed)
                     ):
                         return None, ValidationError(Err.INVALID_ICC_EOS_VDF)
                     if not skip_vdf_is_valid:
@@ -338,9 +337,8 @@ def validate_unfinished_header_block(
                 else:
                     cc_eos_vdf_info_iters = expected_sub_slot_iters
             # Check that the modified data is correct
-            if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf != dataclasses.replace(
-                partial_cc_vdf_info,
-                number_of_iterations=cc_eos_vdf_info_iters,
+            if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf != partial_cc_vdf_info.replace(
+                number_of_iterations=cc_eos_vdf_info_iters
             ):
                 return None, ValidationError(Err.INVALID_CC_EOS_VDF, "wrong challenge chain end of slot vdf")
 
@@ -659,9 +657,8 @@ def validate_unfinished_header_block(
             header_block.reward_chain_block.challenge_chain_sp_vdf.output,
         )
 
-        if header_block.reward_chain_block.challenge_chain_sp_vdf != dataclasses.replace(
-            target_vdf_info,
-            number_of_iterations=sp_iters,
+        if header_block.reward_chain_block.challenge_chain_sp_vdf != target_vdf_info.replace(
+            number_of_iterations=sp_iters
         ):
             return None, ValidationError(Err.INVALID_CC_SP_VDF)
         if not skip_vdf_is_valid:
@@ -944,14 +941,10 @@ def validate_finished_header_block(
         ip_vdf_iters,
         header_block.reward_chain_block.challenge_chain_ip_vdf.output,
     )
-    if header_block.reward_chain_block.challenge_chain_ip_vdf != dataclasses.replace(
-        cc_target_vdf_info,
-        number_of_iterations=ip_iters,
+    if header_block.reward_chain_block.challenge_chain_ip_vdf != cc_target_vdf_info.replace(
+        number_of_iterations=ip_iters
     ):
-        expected = dataclasses.replace(
-            cc_target_vdf_info,
-            number_of_iterations=ip_iters,
-        )
+        expected = cc_target_vdf_info.replace(number_of_iterations=ip_iters)
         log.error(f"{header_block.reward_chain_block.challenge_chain_ip_vdf }. expected {expected}")
         log.error(f"Block: {header_block}")
         return None, ValidationError(Err.INVALID_CC_IP_VDF)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1387,8 +1387,8 @@ class FullNode:
         self.log.info(
             f"⏲️  Finished signage point {request.index_from_challenge}/"
             f"{self.constants.NUM_SPS_SUB_SLOT}: "
-            f"CC: {request.challenge_chain_vdf.output.get_hash()} "
-            f"RC: {request.reward_chain_vdf.output.get_hash()} "
+            f"CC: {request.challenge_chain_vdf.output.get_hash().hex()} "
+            f"RC: {request.reward_chain_vdf.output.get_hash().hex()} "
         )
         self.signage_point_times[request.index_from_challenge] = time.time()
         sub_slot_tuple = self.full_node_store.get_sub_slot(request.challenge_chain_vdf.challenge)
@@ -1456,7 +1456,7 @@ class FullNode:
         self.log.info(
             f"🌱 Updated peak to height {record.height}, weight {record.weight}, "
             f"hh {record.header_hash}, "
-            f"forked at {state_change_summary.fork_height}, rh: {record.reward_infusion_new_challenge}, "
+            f"forked at {state_change_summary.fork_height}, rh: {record.reward_infusion_new_challenge.hex()}, "
             f"total iters: {record.total_iters}, "
             f"overflow: {record.overflow}, "
             f"deficit: {record.deficit}, "
@@ -2093,7 +2093,9 @@ class FullNode:
             # If not found, cache keyed on prev block
             if prev_b is None:
                 self.full_node_store.add_to_future_ip(request)
-                self.log.warning(f"Previous block is None, infusion point {request.reward_chain_ip_vdf.challenge}")
+                self.log.warning(
+                    f"Previous block is None, infusion point {request.reward_chain_ip_vdf.challenge.hex()}"
+                )
                 return None
 
         finished_sub_slots: Optional[List[EndOfSubSlotBundle]] = self.full_node_store.get_finished_sub_slots(
@@ -2242,7 +2244,7 @@ class FullNode:
             else:
                 self.log.info(
                     f"End of slot not added CC challenge "
-                    f"{end_of_slot_bundle.challenge_chain.challenge_chain_end_of_slot_vdf.challenge}"
+                    f"{end_of_slot_bundle.challenge_chain.challenge_chain_end_of_slot_vdf.challenge.hex()}"
                 )
         return None, False
 

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -576,7 +576,7 @@ class FullNodeAPI:
         else:
             if self.full_node.full_node_store.get_sub_slot(request.challenge_hash) is None:
                 if request.challenge_hash != self.full_node.constants.GENESIS_CHALLENGE:
-                    self.log.info(f"Don't have challenge hash {request.challenge_hash}")
+                    self.log.info(f"Don't have challenge hash {request.challenge_hash.hex()}")
 
             sp: Optional[SignagePoint] = self.full_node.full_node_store.get_signage_point_by_index(
                 request.challenge_hash,
@@ -651,7 +651,8 @@ class FullNodeAPI:
             else:
                 self.log.debug(
                     f"Signage point {request.index_from_challenge} not added, CC challenge: "
-                    f"{request.challenge_chain_vdf.challenge}, RC challenge: {request.reward_chain_vdf.challenge}"
+                    f"{request.challenge_chain_vdf.challenge.hex()}, "
+                    f"RC challenge: {request.reward_chain_vdf.challenge.hex()}"
                 )
 
             return None
@@ -706,7 +707,7 @@ class FullNodeAPI:
                 if sp_vdfs.rc_vdf.output.get_hash() != request.reward_chain_sp:
                     self.log.debug(
                         f"Received proof of space for a potentially old signage point {request.challenge_chain_sp}. "
-                        f"Current sp: {sp_vdfs.rc_vdf.output.get_hash()}"
+                        f"Current sp: {sp_vdfs.rc_vdf.output.get_hash().hex()}"
                     )
                     return None
 
@@ -1093,7 +1094,7 @@ class FullNodeAPI:
         if not added:
             self.log.error(
                 f"Was not able to add end of sub-slot: "
-                f"{request.end_of_sub_slot_bundle.challenge_chain.challenge_chain_end_of_slot_vdf.challenge}. "
+                f"{request.end_of_sub_slot_bundle.challenge_chain.challenge_chain_end_of_slot_vdf.challenge.hex()}. "
                 f"Re-sending new-peak to timelord"
             )
             await self.full_node.send_peak_to_timelords(peer=peer)

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1559,7 +1559,7 @@ def get_sp_total_iters(
     assert sub_slot_data.total_iters is not None
     assert sub_slot_data.signage_point_index is not None
     sp_iters: uint64 = calculate_sp_iters(constants, ssi, sub_slot_data.signage_point_index)
-    ip_iters: uint64 = sub_slot_data.cc_ip_vdf_info.number_of_iterations
+    ip_iters: uint64 = uint64(sub_slot_data.cc_ip_vdf_info.number_of_iterations)
     sp_sub_slot_total_iters = uint128(sub_slot_data.total_iters - ip_iters)
     if is_overflow:
         sp_sub_slot_total_iters = uint128(sp_sub_slot_total_iters - ssi)

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -1350,7 +1350,7 @@ class BlockTools:
                             cc_challenge,
                             ip_iters,
                         )
-                        cc_ip_vdf = replace(cc_ip_vdf, number_of_iterations=ip_iters)
+                        cc_ip_vdf = cc_ip_vdf.replace(number_of_iterations=ip_iters)
                         rc_ip_vdf, rc_ip_proof = get_vdf_info_and_proof(
                             constants,
                             ClassgroupElement.get_default_element(),
@@ -1552,7 +1552,7 @@ def get_signage_point(
         rc_vdf_challenge,
         rc_vdf_iters,
     )
-    cc_sp_vdf = replace(cc_sp_vdf, number_of_iterations=sp_iters)
+    cc_sp_vdf = cc_sp_vdf.replace(number_of_iterations=sp_iters)
     if normalized_to_identity_cc_sp:
         _, cc_sp_proof = get_vdf_info_and_proof(
             constants,
@@ -1597,7 +1597,7 @@ def finish_block(
         cc_vdf_challenge,
         new_ip_iters,
     )
-    cc_ip_vdf = replace(cc_ip_vdf, number_of_iterations=ip_iters)
+    cc_ip_vdf = cc_ip_vdf.replace(number_of_iterations=ip_iters)
     if normalized_to_identity_cc_ip:
         _, cc_ip_proof = get_vdf_info_and_proof(
             constants,

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -485,13 +485,13 @@ class Timelord:
                 rc_challenge = self.last_state.get_challenge(Chain.REWARD_CHAIN)
                 if rc_info.challenge != rc_challenge:
                     assert rc_challenge is not None
-                    log.warning(f"SP: Do not have correct challenge {rc_challenge.hex()} has {rc_info.challenge}")
+                    log.warning(f"SP: Do not have correct challenge {rc_challenge.hex()} has {rc_info.challenge.hex()}")
                     # This proof is on an outdated challenge, so don't use it
                     continue
                 iters_from_sub_slot_start = uint64(cc_info.number_of_iterations + self.last_state.get_last_ip())
                 response = timelord_protocol.NewSignagePointVDF(
                     signage_point_index,
-                    dataclasses.replace(cc_info, number_of_iterations=iters_from_sub_slot_start),
+                    cc_info.replace(number_of_iterations=iters_from_sub_slot_start),
                     cc_proof,
                     rc_info,
                     rc_proof,
@@ -584,7 +584,7 @@ class Timelord:
                         assert rc_challenge is not None
                         log.warning(
                             f"Do not have correct challenge {rc_challenge.hex()} "
-                            f"has {rc_info.challenge}, partial hash {block.reward_chain_block.get_hash()}"
+                            f"has {rc_info.challenge.hex()}, partial hash {block.reward_chain_block.get_hash()}"
                         )
                         # This proof is on an outdated challenge, so don't use it
                         continue
@@ -599,7 +599,7 @@ class Timelord:
                         log.warning("Too many blocks, or overflow in new epoch, cannot infuse, discarding")
                         return
 
-                    cc_info = dataclasses.replace(cc_info, number_of_iterations=ip_iters)
+                    cc_info = cc_info.replace(number_of_iterations=ip_iters)
                     response = timelord_protocol.NewInfusionPointVDF(
                         challenge,
                         cc_info,
@@ -755,14 +755,14 @@ class Timelord:
             rc_challenge = self.last_state.get_challenge(Chain.REWARD_CHAIN)
             if rc_vdf.challenge != rc_challenge:
                 assert rc_challenge is not None
-                log.warning(f"Do not have correct challenge {rc_challenge.hex()} has {rc_vdf.challenge}")
+                log.warning(f"Do not have correct challenge {rc_challenge.hex()} has {rc_vdf.challenge.hex()}")
                 # This proof is on an outdated challenge, so don't use it
                 return
             log.debug("Collected end of subslot vdfs.")
             self.iters_finished.add(iter_to_look_for)
             self.last_active_time = time.time()
             iters_from_sub_slot_start = uint64(cc_vdf.number_of_iterations + self.last_state.get_last_ip())
-            cc_vdf = dataclasses.replace(cc_vdf, number_of_iterations=iters_from_sub_slot_start)
+            cc_vdf = cc_vdf.replace(number_of_iterations=iters_from_sub_slot_start)
             if icc_ip_vdf is not None:
                 if self.last_state.peak is not None:
                     total_iters = (
@@ -778,7 +778,7 @@ class Timelord:
                     log.error(f"{self.last_state.subslot_end}")
                     assert False
                 assert iters_from_cb <= self.last_state.sub_slot_iters
-                icc_ip_vdf = dataclasses.replace(icc_ip_vdf, number_of_iterations=iters_from_cb)
+                icc_ip_vdf = icc_ip_vdf.replace(number_of_iterations=iters_from_cb)
 
             icc_sub_slot: Optional[InfusedChallengeChainSubSlot] = (
                 None if icc_ip_vdf is None else InfusedChallengeChainSubSlot(icc_ip_vdf)
@@ -1118,7 +1118,7 @@ class Timelord:
                                     ip,
                                     reader,
                                     writer,
-                                    info[1].new_proof_of_time.number_of_iterations,
+                                    uint64(info[1].new_proof_of_time.number_of_iterations),
                                     info[1].header_hash,
                                     info[1].height,
                                     info[1].field_vdf,
@@ -1170,7 +1170,7 @@ class Timelord:
                     bluebox_process_data = BlueboxProcessData(
                         picked_info.new_proof_of_time.challenge,
                         uint16(self.constants.DISCRIMINANT_SIZE_BITS),
-                        picked_info.new_proof_of_time.number_of_iterations,
+                        uint64(picked_info.new_proof_of_time.number_of_iterations),
                     )
                     proof = await asyncio.get_running_loop().run_in_executor(
                         pool,

--- a/chia/types/blockchain_format/classgroup.py
+++ b/chia/types/blockchain_format/classgroup.py
@@ -1,34 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from chia_rs import ClassgroupElement
 
-from chia.types.blockchain_format.sized_bytes import bytes100
-from chia.util.streamable import Streamable, streamable
-
-
-@streamable
-@dataclass(frozen=True)
-class ClassgroupElement(Streamable):
-    """
-    Represents a classgroup element (a,b,c) where a, b, and c are 512 bit signed integers. However this is using
-    a compressed representation. VDF outputs are a single classgroup element. VDF proofs can also be one classgroup
-    element (or multiple).
-    """
-
-    data: bytes100
-
-    @staticmethod
-    def create(data: bytes) -> ClassgroupElement:
-        if len(data) < 100:
-            data += b"\x00" * (100 - len(data))
-        return ClassgroupElement(bytes100(data))
-
-    @staticmethod
-    def get_default_element() -> ClassgroupElement:
-        # Bit 3 in the first byte of serialized compressed form indicates if
-        # it's the default generator element.
-        return ClassgroupElement.create(b"\x08")
-
-    @staticmethod
-    def get_size() -> int:
-        return 100
+__all__ = ["ClassgroupElement"]

--- a/chia/types/blockchain_format/vdf.py
+++ b/chia/types/blockchain_format/vdf.py
@@ -2,20 +2,21 @@ from __future__ import annotations
 
 import logging
 import traceback
-from dataclasses import dataclass
 from enum import IntEnum
 from functools import lru_cache
 from typing import Optional
 
+from chia_rs import VDFInfo, VDFProof
 from chiavdf import create_discriminant, verify_n_wesolowski
 
 from chia.consensus.constants import ConsensusConstants
 from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.sized_bytes import bytes32, bytes100
 from chia.util.ints import uint8, uint64
-from chia.util.streamable import Streamable, streamable
 
 log = logging.getLogger(__name__)
+
+__all__ = ["VDFInfo", "VDFProof"]
 
 
 @lru_cache(maxsize=200)
@@ -44,22 +45,6 @@ def verify_vdf(
         discriminant_size,
         witness_type,
     )
-
-
-@streamable
-@dataclass(frozen=True)
-class VDFInfo(Streamable):
-    challenge: bytes32  # Used to generate the discriminant (VDF group)
-    number_of_iterations: uint64
-    output: ClassgroupElement
-
-
-@streamable
-@dataclass(frozen=True)
-class VDFProof(Streamable):
-    witness_type: uint8
-    witness: bytes
-    normalized_to_identity: bool
 
 
 def validate_vdf(

--- a/chia/util/recursive_replace.py
+++ b/chia/util/recursive_replace.py
@@ -7,11 +7,15 @@ from typing import Any
 def recursive_replace(root_obj: Any, replace_str: str, replace_with: Any) -> Any:
     split_str = replace_str.split(".")
     if len(split_str) == 1:
+        # This check is here to support native types (implemented in Rust
+        # in chia_rs) that aren't dataclasses. They instead implement a
+        # replace() method in their python bindings.
         if hasattr(root_obj, "replace"):
             return root_obj.replace(**{split_str[0]: replace_with})
         else:
             return replace(root_obj, **{split_str[0]: replace_with})
     sub_obj = recursive_replace(getattr(root_obj, split_str[0]), ".".join(split_str[1:]), replace_with)
+    # See comment above
     if hasattr(root_obj, "replace"):
         return root_obj.replace(**{split_str[0]: sub_obj})
     else:

--- a/chia/util/recursive_replace.py
+++ b/chia/util/recursive_replace.py
@@ -7,6 +7,12 @@ from typing import Any
 def recursive_replace(root_obj: Any, replace_str: str, replace_with: Any) -> Any:
     split_str = replace_str.split(".")
     if len(split_str) == 1:
-        return replace(root_obj, **{split_str[0]: replace_with})
+        if hasattr(root_obj, "replace"):
+            return root_obj.replace(**{split_str[0]: replace_with})
+        else:
+            return replace(root_obj, **{split_str[0]: replace_with})
     sub_obj = recursive_replace(getattr(root_obj, split_str[0]), ".".join(split_str[1:]), replace_with)
-    return replace(root_obj, **{split_str[0]: sub_obj})
+    if hasattr(root_obj, "replace"):
+        return root_obj.replace(**{split_str[0]: sub_obj})
+    else:
+        return replace(root_obj, **{split_str[0]: sub_obj})

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -576,10 +576,9 @@ class TestBlockHeaderValidation:
                         block.finished_sub_slots[-1],
                         "infused_challenge_chain",
                         InfusedChallengeChainSubSlot(
-                            replace(
-                                block.finished_sub_slots[
-                                    -1
-                                ].infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf,
+                            block.finished_sub_slots[
+                                -1
+                            ].infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf.replace(
                                 number_of_iterations=uint64(10000000),
                             )
                         ),
@@ -594,10 +593,9 @@ class TestBlockHeaderValidation:
                         block.finished_sub_slots[-1],
                         "infused_challenge_chain",
                         InfusedChallengeChainSubSlot(
-                            replace(
-                                block.finished_sub_slots[
-                                    -1
-                                ].infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf,
+                            block.finished_sub_slots[
+                                -1
+                            ].infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf.replace(
                                 output=ClassgroupElement.get_default_element(),
                             )
                         ),
@@ -613,11 +611,10 @@ class TestBlockHeaderValidation:
                         block.finished_sub_slots[-1],
                         "infused_challenge_chain",
                         InfusedChallengeChainSubSlot(
-                            replace(
-                                block.finished_sub_slots[
-                                    -1
-                                ].infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf,
-                                challenge=bytes32([0] * 32),
+                            block.finished_sub_slots[
+                                -1
+                            ].infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf.replace(
+                                challenge=bytes32([0] * 32)
                             )
                         ),
                     )

--- a/tests/util/test_recursive_replace.py
+++ b/tests/util/test_recursive_replace.py
@@ -17,6 +17,8 @@ class TestC:
         self.a = a
         self.b = b
 
+    # WARNING: this is just a simple stand in for rust classes and is not a good
+    # reference for how such a method should be implemented in python
     def replace(self, **kwargs: Union[int, str, Optional[TestA]]) -> TestC:
         ret = TestC(copy.deepcopy(self.a), copy.deepcopy(self.b))
         for key, value in kwargs.items():
@@ -47,6 +49,8 @@ class TestB:
         self.b = b
         self.c = c
 
+    # WARNING: this is just a simple stand in for rust classes and is not a good
+    # reference for how such a method should be implemented in python
     def replace(self, **kwargs: Union[int, str, Optional[TestA]]) -> TestB:
         ret = TestB(copy.deepcopy(self.a), copy.deepcopy(self.b), copy.deepcopy(self.c))
         for key, value in kwargs.items():

--- a/tests/util/test_recursive_replace.py
+++ b/tests/util/test_recursive_replace.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+import pytest
+
+from chia.util.recursive_replace import recursive_replace
+
+
+class TestC:
+    a: int
+    b: str
+
+    def __init__(self, a: int, b: str):
+        self.a = a
+        self.b = b
+
+    def replace(self, **kwargs: Union[int, str, Optional[TestA]]) -> TestC:
+        ret = TestC(copy.deepcopy(self.a), copy.deepcopy(self.b))
+        for key, value in kwargs.items():
+            if key == "a":
+                ret.a = value  # type: ignore[assignment]
+            elif key == "b":  # pragma: no cover
+                ret.b = value  # type: ignore[assignment]
+            else:  # pragma: no cover
+                raise TypeError(f"unknown field {key}")
+        return ret
+
+
+@dataclass
+class TestA:
+    a: int
+    b: str
+    c: List[int]
+    d: Optional[TestC]
+
+
+class TestB:
+    a: int
+    b: str
+    c: Optional[TestA]
+
+    def __init__(self, a: int, b: str, c: Optional[TestA]):
+        self.a = a
+        self.b = b
+        self.c = c
+
+    def replace(self, **kwargs: Union[int, str, Optional[TestA]]) -> TestB:
+        ret = TestB(copy.deepcopy(self.a), copy.deepcopy(self.b), copy.deepcopy(self.c))
+        for key, value in kwargs.items():
+            if key == "a":  # pragma: no cover
+                ret.a = value  # type: ignore[assignment]
+            elif key == "b":
+                ret.b = value  # type: ignore[assignment]
+            elif key == "c":
+                ret.c = value  # type: ignore[assignment]
+            else:
+                raise TypeError(f"unknown field {key}")
+        return ret
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, TestB):
+            return self.a == other.a and self.b == other.b and self.c == self.c
+        else:
+            return False  # pragma: no cover
+
+
+def test_recursive_replace_dataclass() -> None:
+    a = TestA(42, "foobar", [1337, 42], None)
+    a2 = recursive_replace(a, "b", "barfoo")
+
+    assert a.a == a2.a
+    assert a.b == "foobar"
+    assert a2.b == "barfoo"
+    assert a.c == a2.c
+
+
+def test_recursive_replace_other() -> None:
+    b = TestB(42, "foobar", None)
+    b2 = recursive_replace(b, "b", "barfoo")
+
+    assert b.a == b2.a
+    assert b.b == "foobar"
+    assert b2.b == "barfoo"
+    assert b.c == b2.c
+
+
+def test_recursive_replace() -> None:
+    b1 = TestB(42, "foobar", TestA(1337, "barfoo", [1, 2, 3], None))
+    b2 = recursive_replace(b1, "c.a", 110)
+
+    assert b1 == TestB(42, "foobar", TestA(1337, "barfoo", [1, 2, 3], None))
+    assert b2 == TestB(42, "foobar", TestA(110, "barfoo", [1, 2, 3], None))
+
+
+def test_recursive_replace2() -> None:
+    b1 = TestB(42, "foobar", TestA(1337, "barfoo", [1, 2, 3], TestC(123, "345")))
+    b2 = recursive_replace(b1, "c.d.a", 110)
+
+    assert b1 == TestB(42, "foobar", TestA(1337, "barfoo", [1, 2, 3], TestC(123, "345")))
+    assert b2 == TestB(42, "foobar", TestA(1337, "barfoo", [1, 2, 3], TestC(110, "345")))
+
+
+def test_recursive_replace_unknown() -> None:
+    b = TestB(42, "foobar", TestA(1337, "barfoo", [1, 2, 3], None))
+    with pytest.raises(TypeError):
+        recursive_replace(b, "c.foobar", 110)
+
+    with pytest.raises(TypeError):
+        recursive_replace(b, "foobar", 110)


### PR DESCRIPTION
### Purpose:

This is a step towards making `FullBlock` a rust type, to move enough of the block validation into rust to be able to use threads instead of processes.

The rust counterparts are defined here:
https://github.com/Chia-Network/chia_rs/blob/main/chia-protocol/src/vdf.rs
https://github.com/Chia-Network/chia_rs/blob/main/chia-protocol/src/classgroup.rs

Since these types aren't dataclasses, the `dataclass.replace()` is changed to method `replace()`.

### Current Behavior:

`VDFInfo`, `VDFProof` and `ClasgroupElement` are python types.

### New Behavior:

`VDFInfo`, `VDFProof` and `ClasgroupElement` are native (rust)  types.