### PR TITLE
Remove coin_solutions from SpendBundle entirely

### DIFF
--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List
 
 from chia_rs import AugSchemeMPL, G2Element
 
@@ -10,7 +9,7 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.errors import Err, ValidationError
-from chia.util.streamable import Streamable, recurse_jsonify, streamable, streamable_from_dict
+from chia.util.streamable import Streamable, streamable, streamable_from_dict
 from chia.wallet.util.debug_spend_bundle import debug_spend_bundle
 
 from .coin_spend import CoinSpend, compute_additions_with_cost
@@ -59,37 +58,13 @@ class SpendBundle(Streamable):
     def debug(self, agg_sig_additional_data: bytes = DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA) -> None:
         debug_spend_bundle(self, agg_sig_additional_data)
 
-    # Note that `coin_spends` used to have the bad name `coin_solutions`, prior
-    # to Jul 12, 2021
-    # Some API still expects this name. For now, we accept both names.
-    #
-    # TODO: continue this deprecation. Eventually, all code below here should be removed.
-    #  1. [x] set `exclude_modern_keys` to `False` (and manually set to `True` where necessary)
-    #  2. [ ] set `include_legacy_keys` to `False` (and manually set to `False` where necessary)
-    #  3. [ ] remove all references to `include_legacy_keys=True`
-    #  4. [ ] remove all code below this point
-
     @classmethod
     def from_json_dict(cls, json_dict: Dict[str, Any]) -> SpendBundle:
-        if "coin_solutions" in json_dict:
-            if "coin_spends" not in json_dict:
-                json_dict = dict(
-                    aggregated_signature=json_dict["aggregated_signature"], coin_spends=json_dict["coin_solutions"]
-                )
-                warnings.warn("`coin_solutions` is now `coin_spends` in `SpendBundle.from_json_dict`")
-            else:
-                warnings.warn("JSON contains both `coin_solutions` and `coin_spends`, just use `coin_spends`")
+        if "coin_solutions" in json_dict and "coin_spends" not in json_dict:
+            json_dict = dict(
+                aggregated_signature=json_dict["aggregated_signature"], coin_spends=json_dict["coin_solutions"]
+            )
         return streamable_from_dict(cls, json_dict)
-
-    def to_json_dict(self, include_legacy_keys: bool = True, exclude_modern_keys: bool = False) -> Dict[str, Any]:
-        if include_legacy_keys is False and exclude_modern_keys is True:
-            raise ValueError("`coin_spends` not included in legacy or modern outputs")
-        d = recurse_jsonify(self)
-        if include_legacy_keys:
-            d["coin_solutions"] = d["coin_spends"]
-        if exclude_modern_keys:
-            del d["coin_spends"]
-        return cast(Dict[str, Any], recurse_jsonify(d))
 
 
 # This function executes all the puzzles to compute the difference between

--- a/tests/core/custom_types/test_spend_bundle.py
+++ b/tests/core/custom_types/test_spend_bundle.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import random
 import unittest
 from typing import List, Tuple
@@ -21,69 +20,25 @@ NULL_SIGNATURE = "0xc" + "0" * 191
 
 
 class TestStructStream(unittest.TestCase):
-    def test_from_json_legacy(self):
-        JSON = (
-            """
-        {
-          "coin_solutions": [],
-          "aggregated_signature": "%s"
-        }
-        """
-            % NULL_SIGNATURE
-        )
-        spend_bundle = SpendBundle.from_json_dict(json.loads(JSON))
-        json_1 = json.loads(JSON)
-        json_2 = spend_bundle.to_json_dict(include_legacy_keys=True, exclude_modern_keys=True)
-        assert json_1 == json_2
-
-    def test_from_json_new(self):
-        JSON = (
-            """
-        {
-          "coin_spends": [],
-          "aggregated_signature": "%s"
-        }
-        """
-            % NULL_SIGNATURE
-        )
-        spend_bundle = SpendBundle.from_json_dict(json.loads(JSON))
-        json_1 = json.loads(JSON)
-        json_2 = spend_bundle.to_json_dict(include_legacy_keys=False, exclude_modern_keys=False)
-        assert json_1 == json_2
-
     def test_round_trip(self):
         spend_bundle = BLANK_SPEND_BUNDLE
-        round_trip(spend_bundle, include_legacy_keys=True, exclude_modern_keys=True)
-        round_trip(spend_bundle, include_legacy_keys=True, exclude_modern_keys=False)
-        round_trip(spend_bundle, include_legacy_keys=False, exclude_modern_keys=False)
+        json_dict = spend_bundle.to_json_dict()
 
-    def test_dont_use_both_legacy_and_modern(self):
-        json_1 = BLANK_SPEND_BUNDLE.to_json_dict(include_legacy_keys=True, exclude_modern_keys=False)
-        with pytest.warns(UserWarning):
-            SpendBundle.from_json_dict(json_1)
+        sb = SpendBundle.from_json_dict(json_dict)
 
+        assert sb == spend_bundle
 
-def round_trip(spend_bundle: SpendBundle, **kwargs):
-    json_dict = spend_bundle.to_json_dict(**kwargs)
+    def test_round_trip_with_legacy_key_parsing(self):
+        spend_bundle = BLANK_SPEND_BUNDLE
+        json_dict = spend_bundle.to_json_dict()
+        json_dict["coin_solutions"] = None
+        SpendBundle.from_json_dict(json_dict)  # testing no error because parser just looks at "coin_spends"
+        json_dict["coin_solutions"] = json_dict["coin_spends"]
+        del json_dict["coin_spends"]
 
-    if kwargs.get("include_legacy_keys", True):
-        assert "coin_solutions" in json_dict
-    else:
-        assert "coin_solutions" not in json_dict
+        sb = SpendBundle.from_json_dict(json_dict)
 
-    if kwargs.get("exclude_modern_keys", True):
-        assert "coin_spends" not in json_dict
-    else:
-        assert "coin_spends" in json_dict
-
-    if "coin_spends" in json_dict and "coin_solutions" in json_dict:
-        del json_dict["coin_solutions"]
-
-    sb = SpendBundle.from_json_dict(json_dict)
-    json_dict_2 = sb.to_json_dict()
-    sb = SpendBundle.from_json_dict(json_dict_2)
-    json_dict_3 = sb.to_json_dict()
-    assert json_dict_2 == json_dict_3
+        assert sb == spend_bundle
 
 
 def rand_hash(rng: random.Random) -> bytes32:

--- a/tests/fee_estimation/test_fee_estimation_rpc.py
+++ b/tests/fee_estimation/test_fee_estimation_rpc.py
@@ -16,6 +16,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint64
+from chia.util.streamable import InvalidTypeError
 
 
 @pytest.fixture(scope="function")
@@ -155,7 +156,7 @@ async def test_cost_invalid_type(setup_node_and_rpc: Tuple[FullNodeRpcClient, Fu
 @pytest.mark.anyio
 async def test_tx_invalid_type(setup_node_and_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_and_rpc
-    with pytest.raises(TypeError):
+    with pytest.raises(InvalidTypeError):
         await full_node_rpc_api.get_fee_estimate({"target_times": [], "spend_bundle": 1})
 
 

--- a/tests/fee_estimation/test_fee_estimation_rpc.py
+++ b/tests/fee_estimation/test_fee_estimation_rpc.py
@@ -157,7 +157,7 @@ async def test_cost_invalid_type(setup_node_and_rpc: Tuple[FullNodeRpcClient, Fu
 async def test_tx_invalid_type(setup_node_and_rpc: Tuple[FullNodeRpcClient, FullNodeRpcApi]) -> None:
     client, full_node_rpc_api = setup_node_and_rpc
     with pytest.raises(InvalidTypeError):
-        await full_node_rpc_api.get_fee_estimate({"target_times": [], "spend_bundle": 1})
+        await full_node_rpc_api.get_fee_estimate({"target_times": [], "spend_bundle": {"coin_spends": 1}})
 
 
 #####################


### PR DESCRIPTION
The legacy name of `coin_solutions` has been optional since release `1.2.3` for clients making requests to our RPCs.

In making responses however, we have still be returning that legacy key in constructs that use the `Spendbundle` streamable capabilities.  This was done to preserve the continuity of our RPC APIs.  At the time, a plan was outlined to gradually phase out the legacy name, however, that plan was unfortunately imperfect as step 2 was not compatible with itself being used from both a client/backend.  Since this plan is now ineffective, we have to reformulate a new one in which we break the continuity of the RPC API for clients still using pre-1.2.3 code.

Parsing the old name will still be valid to preserve the functionality of clients using code before this change.