### PR TITLE
Don't verify right after signing, and as a result don't re-verify the aggregated version, in sign_coin_spends

### DIFF
--- a/chia/wallet/sign_coin_spends.py
+++ b/chia/wallet/sign_coin_spends.py
@@ -64,10 +64,8 @@ async def sign_coin_spends(
                 else:
                     raise ValueError(f"no secret key for {pk}")
             signature = AugSchemeMPL.sign(secret_key, msg)
-            assert AugSchemeMPL.verify(pk, msg, signature)
             signatures.append(signature)
 
     # Aggregate signatures
     aggsig = AugSchemeMPL.aggregate(signatures)
-    assert AugSchemeMPL.aggregate_verify(pk_list, msg_list, aggsig)
     return SpendBundle(coin_spends, aggsig)


### PR DESCRIPTION
This (and the branch name) is dedicated to @emlowe 