### PR TITLE
Check dependencies to avoid a useless sudo on Archlinux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -210,7 +210,9 @@ elif [ "$(uname)" = "Linux" ]; then
     echo "Installing on Arch Linux."
     case $(uname -m) in
       x86_64|aarch64)
-        sudo pacman ${PACMAN_AUTOMATED} -S --needed git openssl
+        if ! pacman -Qs "^git$" > /dev/null || ! pacman -Qs "^openssl$" > /dev/null ; then
+          sudo pacman ${PACMAN_AUTOMATED} -S --needed git openssl
+        fi
         ;;
       *)
         echo "Incompatible CPU architecture. Must be x86_64 or aarch64."


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Prevent a useless call to `sudo` during this installation of Chia on Archlinux, by checking if the dependencies are not already installed. 
The point is to make the installation easier: 
* `sudo` forces the user to type its password (event if there is nothing to do).
* Some people prefer to use `su` and don't setup `sudo`. In this case, the installation of chia is impossible without modifying the `instal.sh`. (it's what I do for years)

<!-- Does this PR introduce a breaking change? -->
### Old Behavior:

Calling `sudo` every time to install the dependencies. 

### New Behavior:

Verify if `git` and `openssl` are installed, then call `sudo pacman -S git openssl` only if needed.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

I wanted to keep the existing code, so I simply added a if statement. But in fact, we can simplify the code for Archlinux: 
no dependencies needs to be installed (at least line 213), because: 
* openssl is a base package of archlinux  (base => coreutils => openssl)
* git is already called line 71 (so no point to install it line 213, it's too late).

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
