### PR TITLE
Mempool logging

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -149,7 +149,7 @@ class Blockchain(BlockchainInterface):
                 max_workers=num_workers,
                 mp_context=multiprocessing_context,
                 initializer=setproctitle,
-                initargs=(f"{getproctitle()}_worker",),
+                initargs=(f"{getproctitle()}_block_validation_worker",),
             )
             log.info(f"Started {num_workers} processes for block validation")
 

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -260,7 +260,7 @@ class FullNode:
             self._hint_store = await HintStore.create(self.db_wrapper)
             self._coin_store = await CoinStore.create(self.db_wrapper)
             self.log.info("Initializing blockchain from disk")
-            start_time = time.time()
+            start_time = time.monotonic()
             reserved_cores = self.config.get("reserved_cores", 0)
             single_threaded = self.config.get("single_threaded", False)
             multiprocessing_start_method = process_config_start_method(config=self.config, log=self.log)
@@ -295,7 +295,7 @@ class FullNode:
             if self.config.get("enable_memory_profiler", False):
                 asyncio.create_task(mem_profile_task(self.root_path, "node", self.log))
 
-            time_taken = time.time() - start_time
+            time_taken = time.monotonic() - start_time
             peak: Optional[BlockRecord] = self.blockchain.get_peak()
             if peak is None:
                 self.log.info(f"Initialized with empty blockchain time taken: {int(time_taken)}s")
@@ -1336,7 +1336,7 @@ class FullNode:
         if agg_state_change_summary is not None:
             self._state_changed("new_peak")
             self.log.debug(
-                f"Total time for {len(blocks_to_validate)} blocks: {time.time() - pre_validate_start}, "
+                f"Total time for {len(blocks_to_validate)} blocks: {time.monotonic() - pre_validate_start}, "
                 f"advanced: True"
             )
         return True, agg_state_change_summary, None
@@ -1716,7 +1716,7 @@ class FullNode:
             # After acquiring the lock, check again, because another asyncio thread might have added it
             if self.blockchain.contains_block(header_hash):
                 return None
-            validation_start = time.time()
+            validation_start = time.monotonic()
             # Tries to add the block to the blockchain, if we already validated transactions, don't do it again
             npc_results = {}
             if pre_validation_result is not None and pre_validation_result.npc_result is not None:
@@ -1728,7 +1728,7 @@ class FullNode:
                 [block], npc_results, validate_signatures=False
             )
             added: Optional[AddBlockResult] = None
-            pre_validation_time = time.time() - validation_start
+            pre_validation_time = time.monotonic() - validation_start
             try:
                 if len(pre_validation_results) < 1:
                     raise ValueError(f"Failed to validate block {header_hash} height {block.height}")
@@ -1765,12 +1765,15 @@ class FullNode:
                 elif added == AddBlockResult.NEW_PEAK:
                     # Only propagate blocks which extend the blockchain (becomes one of the heads)
                     assert state_change_summary is not None
+                    post_process_time = time.monotonic()
                     ppp_result = await self.peak_post_processing(block, state_change_summary, peer)
+                    post_process_time = time.monotonic() - post_process_time
 
                 elif added == AddBlockResult.ADDED_AS_ORPHAN:
                     self.log.info(
                         f"Received orphan block of height {block.height} rh {block.reward_chain_block.get_hash()}"
                     )
+                    post_process_time = 0
                 else:
                     # Should never reach here, all the cases are covered
                     raise RuntimeError(f"Invalid result from add_block {added}")
@@ -1782,7 +1785,7 @@ class FullNode:
                     await self.peak_post_processing(block, state_change_summary, peer)
                 raise
 
-            validation_time = time.time() - validation_start
+            validation_time = time.monotonic() - validation_start
 
         if ppp_result is not None:
             assert state_change_summary is not None
@@ -1801,6 +1804,7 @@ class FullNode:
             logging.WARNING if validation_time > 2 else logging.DEBUG,
             f"Block validation time: {validation_time:0.2f} seconds, "
             f"pre_validation time: {pre_validation_time:0.2f} seconds, "
+            f"post-process time: {post_process_time:0.2f} seconds, "
             f"cost: {block.transactions_info.cost if block.transactions_info is not None else 'None'}"
             f"{percent_full_str} header_hash: {header_hash} height: {block.height}",
         )
@@ -1913,21 +1917,21 @@ class FullNode:
         pre_validation_time = None
 
         async with self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
-            start_header_time = time.time()
+            start_header_time = time.monotonic()
             _, header_error = await self.blockchain.validate_unfinished_block_header(block)
             if header_error is not None:
                 if header_error == Err.TIMESTAMP_TOO_FAR_IN_FUTURE:
                     raise TimestampError()
                 else:
                     raise ConsensusError(header_error)
-            validate_time = time.time() - start_header_time
+            validate_time = time.monotonic() - start_header_time
             self.log.log(
                 logging.WARNING if validate_time > 2 else logging.DEBUG,
                 f"Time for header validate: {validate_time:0.3f}s",
             )
 
         if block.transactions_generator is not None:
-            pre_validation_start = time.time()
+            pre_validation_start = time.monotonic()
             assert block.transactions_info is not None
             try:
                 block_generator: Optional[BlockGenerator] = await self.blockchain.get_block_generator(block)
@@ -1940,7 +1944,7 @@ class FullNode:
 
             height = uint32(0) if prev_b is None else uint32(prev_b.height + 1)
             npc_result = await self.blockchain.run_generator(block_bytes, block_generator, height)
-            pre_validation_time = time.time() - pre_validation_start
+            pre_validation_time = time.monotonic() - pre_validation_start
 
             # blockchain.run_generator throws on errors, so npc_result is
             # guaranteed to represent a successful run
@@ -1953,7 +1957,7 @@ class FullNode:
 
         async with self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
             # TODO: pre-validate VDFs outside of lock
-            validation_start = time.time()
+            validation_start = time.monotonic()
             validate_result = await self.blockchain.validate_unfinished_block(block, npc_result)
             if validate_result.error is not None:
                 if validate_result.error == Err.COIN_AMOUNT_NEGATIVE.value:
@@ -1961,7 +1965,7 @@ class FullNode:
                     self.log.info(f"Consensus error {validate_result.error}, not disconnecting")
                     return
                 raise ConsensusError(Err(validate_result.error))
-            validation_time = time.time() - validation_start
+            validation_time = time.monotonic() - validation_start
 
         # respond_block will later use the cache (validated_signature=True)
         validate_result = dataclasses.replace(validate_result, validated_signature=True)

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -198,7 +198,7 @@ class MempoolManager:
                 max_workers=2,
                 mp_context=multiprocessing_context,
                 initializer=setproctitle,
-                initargs=(f"{getproctitle()}_worker",),
+                initargs=(f"{getproctitle()}_mempool_worker",),
             )
 
         # The mempool will correspond to a certain peak

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -609,7 +609,7 @@ class WeightProofHandler:
             max_workers=self._num_processes,
             mp_context=self.multiprocessing_context,
             initializer=setproctitle,
-            initargs=(f"{getproctitle()}_worker",),
+            initargs=(f"{getproctitle()}_weight_proof_worker",),
         ) as executor:
             # The shutdown file manager must be inside of the executor manager so that
             # we request the workers close prior to waiting for them to close.


### PR DESCRIPTION
### Purpose:

Improve transparency of what full nodes are doing and where they spend their time.

1. Specify the post-processing time in the block validation timing warning. This is where the mempool is updated and can dominate the cost of adding a new block.
2. Specify queue depth in timing warning when validating a new transaction, slated for the mempool. This is to help identify which transaction took time, and which transactions just got stuck in the queue, behind it.
3. name worker processes to include which service they are part of (e.g. weight_proof, mempool, block_validation)
4. use monotonic clock when measuring time durations, rather than civic time

### Current Behavior:

In the logs, it's hard to tell the difference between a block that's expensive to validate vs. a block that causes the mempool to be expensive to update.

### New Behavior:

The logs clearly distinguishes between an expensive block validation vs. an expensive mempool update.

### Testing Notes:

example logs:

adding blocks:
```
2023-12-24T22:15:01.299 full_node chia.full_node.full_node: WARNING  Block validation time: 15.97 seconds, pre_validation time: 0.38 seconds, post-process time: 15.14 seconds, cost: 3969110680, percent full: 36.083% header_hash: a2603c310a4f3a57ca7540563e9fa8e54812e5d9061eb35da6b55bec17a2a614 height: 4703882
2023-12-24T23:04:55.825 full_node chia.full_node.full_node: WARNING  Block validation time: 2.67 seconds, pre_validation time: 0.77 seconds, post-process time: 0.79 seconds, cost: 5197174300, percent full: 47.247% header_hash: 552bc4c9846806c6ed0b230bdd843df5e6cbe51fa3d7709fe07bf147dd641b17 height: 4704033
```

adding transactions:
```
2023-12-24T21:41:13.317 full_node chia.full_node.mempool_manager: WARNING  pre_validate_spendbundle took 2.0004 seconds for ba6876756847aba3fdb5f8b93110e645234388c788526f359924ccc06d73d55b (queue-size: 51)
2023-12-24T21:41:13.317 full_node chia.full_node.mempool_manager: WARNING  pre_validate_spendbundle took 2.0008 seconds for 303ebdd9ce432a8e39646a5b9b8b179c4ce732a32db6145a8f72fa70362a64e7 (queue-size: 50)
2023-12-24T21:41:13.317 full_node chia.full_node.mempool_manager: WARNING  pre_validate_spendbundle took 2.0010 seconds for e80f758e8f01a2214ed2f21f5213a02f12a990fbe60a2e087283a0f086e331de (queue-size: 49)
```

processes:
```
$ ps ax | grep chia_full_node
 432814 pts/35   Rl   638:14 chia_full_node
 432940 pts/35   S      1:55 chia_full_node_block_validation_worker
 432941 pts/35   S      1:54 chia_full_node_block_validation_worker
...
 432975 pts/35   S     57:59 chia_full_node_mempool_worker
 432976 pts/35   S     57:48 chia_full_node_mempool_worker
```

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
