### PR TITLE
Spin slower `send_transaction()`

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1276,7 +1276,7 @@ class FullNodeAPI:
         )
         # Waits for the transaction to go into the mempool, times out after 45 seconds.
         status, error = None, None
-        sleep_time = 0.01
+        sleep_time = 0.5
         for i in range(int(45 / sleep_time)):
             await asyncio.sleep(sleep_time)
             for potential_name, potential_status, potential_error in self.full_node.transaction_responses:


### PR DESCRIPTION
### Purpose:

we currenly spin-wait for hearing back whether a transaction made it into the mempool or not (in FullNodeAPI.send_transaction()). We currently spin in a very tight loop, only sleeping 10ms, which appears to hog a significant amount of CPU. This patch increases the sleep to spin slower.

### Current Behavior:

Sleep 10ms in the spin-wait loop.

### New Behavior:

Sleep 500ms in the spin-wait loop.

### Testing Notes:

The main evidence suggesting that this is a problem is the following profile, collected while validating a block:
![4710523](https://github.com/Chia-Network/chia-blockchain/assets/661450/14a9974b-c80b-4a17-9916-bf40e183c272)

