### PR TITLE
add feature to profile just the block validation

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -94,7 +94,7 @@ from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.limited_semaphore import LimitedSemaphore
 from chia.util.log_exceptions import log_exceptions
 from chia.util.path import path_from_root
-from chia.util.profiler import mem_profile_task, profile_task
+from chia.util.profiler import enable_profiler, mem_profile_task, profile_task
 from chia.util.safe_cancel_task import cancel_task_safe
 
 
@@ -287,6 +287,13 @@ class FullNode:
 
             if self.config.get("enable_profiler", False):
                 asyncio.create_task(profile_task(self.root_path, "node", self.log))
+
+            self.profile_block_validation = self.config.get("profile_block_validation", False)
+            if self.profile_block_validation:  # pragma: no cover
+                # this is not covered by any unit tests as it's essentially test code
+                # itself. It's exercised manually when investigating performance issues
+                profile_dir = path_from_root(self.root_path, "block-validation-profile")
+                profile_dir.mkdir(parents=True, exist_ok=True)
 
             if self.config.get("enable_memory_profiler", False):
                 asyncio.create_task(mem_profile_task(self.root_path, "node", self.log))
@@ -1706,7 +1713,9 @@ class FullNode:
                 return await self.add_block(new_block, peer)
         state_change_summary: Optional[StateChangeSummary] = None
         ppp_result: Optional[PeakPostProcessingResult] = None
-        async with self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
+        async with self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high), enable_profiler(
+            self.profile_block_validation
+        ) as pr:
             # After acquiring the lock, check again, because another asyncio thread might have added it
             if self.blockchain.contains_block(header_hash):
                 return None
@@ -1798,6 +1807,13 @@ class FullNode:
             f"cost: {block.transactions_info.cost if block.transactions_info is not None else 'None'}"
             f"{percent_full_str} header_hash: {header_hash} height: {block.height}",
         )
+
+        # this is not covered by any unit tests as it's essentially test code
+        # itself. It's exercised manually when investigating performance issues
+        if validation_time > 2 and pr is not None:  # pragma: no cover
+            pr.create_stats()
+            profile_dir = path_from_root(self.root_path, "block-validation-profile")
+            pr.dump_stats(profile_dir / f"{block.height}-{validation_time:0.1f}.profile")
 
         # This code path is reached if added == ADDED_AS_ORPHAN or NEW_TIP
         peak = self.blockchain.get_peak()

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -440,6 +440,11 @@ full_node:
   # analyze with chia/utils/profiler.py
   enable_profiler: False
 
+  # when enabled, each time a block is validated, the python profiler is
+  # engaged. If the validation takes more than 2 seconds, the profile is saved
+  # to disk, in the chia root/block-validation-profile
+  profile_block_validation: False
+
   enable_memory_profiler: False
 
   # this is a debug and profiling facility that logs all SQLite commands to a

--- a/chia/util/profiler.py
+++ b/chia/util/profiler.py
@@ -5,7 +5,9 @@ import cProfile
 import logging
 import pathlib
 import tracemalloc
+from contextlib import asynccontextmanager
 from datetime import datetime
+from typing import AsyncIterator, Optional
 
 from chia.util.path import path_from_root
 
@@ -176,3 +178,17 @@ async def mem_profile_task(root_path: pathlib.Path, service: str, log: logging.L
             counter += 1
     finally:
         tracemalloc.stop()
+
+
+@asynccontextmanager
+async def enable_profiler(profile: bool) -> AsyncIterator[Optional[cProfile.Profile]]:
+    if not profile:
+        yield None
+        return
+
+    # this is not covered by any unit tests as it's essentially test code
+    # itself. It's exercised manually when investigating performance issues
+    with cProfile.Profile() as pr:  # pragma: no cover
+        pr.enable()
+        yield pr
+        pr.disable()


### PR DESCRIPTION
This exposes what is actually going on while we validate blocks. Sometimes the block validation times are affected by other tasks that hog the CPU, blocking the main co-routine from being scheduled.

### Purpose:

When understanding what's causing spikes in block validation times, having a profile focused only on the time of validating the block can be quite helpful, especially when pre_validation nor post_processing takes very long.

It can help identify co-routines that run for too long (i.e. perform expensive work in the main thread), hogging the scheduler and delaying other tasks.

### Current Behavior:

The only available profiler is for the whole full node task.

### New Behavior:

There's now also a profiler for just block validation. If the validation takes longer than 2 seconds, the profile is saved for later analysis.

### Testing Notes:

Example profiles from `main`.

(parsing the `SubEpochChallengeSegments` is slow)

![4712903](https://github.com/Chia-Network/chia-blockchain/assets/661450/a8573892-ac54-4d23-83b9-cc2c3a1b0135)

(serializing the weight proof is slow)
![4712099](https://github.com/Chia-Network/chia-blockchain/assets/661450/1d8ffe8c-f4b0-4dab-bf76-58360553f9d3)

(parsing `BlockRecord` is slow)
![4711558](https://github.com/Chia-Network/chia-blockchain/assets/661450/86f9b68e-aa4b-49ac-b1cb-aebc1c371247)

(`sleep(0.01)` in a loop is slow)
![4710525](https://github.com/Chia-Network/chia-blockchain/assets/661450/07077f71-d67c-49e6-afa4-57affaa0d2e3)

(merkle root validation and BLS signatures can still be expensive)
![4710347](https://github.com/Chia-Network/chia-blockchain/assets/661450/b43a733b-c9a1-4f4f-9b38-7c6fb635ccae)

(saving peers is slow. This caused an 11.9 seconds block validation)
![4712916](https://github.com/Chia-Network/chia-blockchain/assets/661450/49a0d67d-05cf-4d95-9f64-acbf6ddeb0c8)

(request_additions is slow)
![4713077](https://github.com/Chia-Network/chia-blockchain/assets/661450/0fb62c3d-1d47-406f-b89e-9f85af6c86ec)
