### PR TITLE
replace hardcoded value for `db_readers`

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -232,7 +232,7 @@ class FullNode:
         async with DBWrapper2.managed(
             self.db_path,
             db_version=db_version,
-            reader_count=4,
+            reader_count=self.config.get("db_readers", 4),
             log_path=sql_log_path,
             synchronous=db_sync,
         ) as self._db_wrapper:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Allow a configurable amount of db reader threads by replacing the hardcoded value of 4 and use the already available parameter `db_readers` from the `config.yaml` instead.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

The variable `db_readers` from the `full_node` dictionary in `config.yaml` is not used when starting db reader threads, instead we always start 4 db readers.

### New Behavior:

The variable value of `db_readers` from the `config.yaml` will be used when starting db reader threads.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

n/a

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
