### PR TITLE
simplify get_unfinished_blocks()

### DIFF
--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -171,8 +171,9 @@ class FullNodeStore:
             return None
         return result[2]
 
-    def get_unfinished_blocks(self) -> Dict[bytes32, Tuple[uint32, UnfinishedBlock, PreValidationResult]]:
-        return self.unfinished_blocks
+    # returns all unfinished blocks for the specified height
+    def get_unfinished_blocks(self, height: uint32) -> List[UnfinishedBlock]:
+        return [block for ub_height, block, _ in self.unfinished_blocks.values() if ub_height == height]
 
     def clear_unfinished_blocks_below(self, height: uint32) -> None:
         del_keys: List[bytes32] = []

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -556,18 +556,17 @@ class FullNodeRpcApi:
             return {"headers": []}
 
         response_headers: List[UnfinishedHeaderBlock] = []
-        for ub_height, block, _ in (self.service.full_node_store.get_unfinished_blocks()).values():
-            if ub_height == peak.height:
-                unfinished_header_block = UnfinishedHeaderBlock(
-                    block.finished_sub_slots,
-                    block.reward_chain_block,
-                    block.challenge_chain_sp_proof,
-                    block.reward_chain_sp_proof,
-                    block.foliage,
-                    block.foliage_transaction_block,
-                    b"",
-                )
-                response_headers.append(unfinished_header_block)
+        for block in self.service.full_node_store.get_unfinished_blocks(peak.height):
+            unfinished_header_block = UnfinishedHeaderBlock(
+                block.finished_sub_slots,
+                block.reward_chain_block,
+                block.challenge_chain_sp_proof,
+                block.reward_chain_sp_proof,
+                block.foliage,
+                block.foliage_transaction_block,
+                b"",
+            )
+            response_headers.append(unfinished_header_block)
         return {"headers": response_headers}
 
     async def get_network_space(self, request: Dict[str, Any]) -> EndpointResult:


### PR DESCRIPTION
### Purpose:

This is some ground-work for the larger patch that makes `FullNodeStore` support multiple `UnfinishedBlocks` with the same reward hash.

This function currently exposes the internal data structure of `FullNodeStore`, without really needing to. I'm working on a patch that will change the internal data structure, so this is in preparation for that