### PR TITLE
Fix bug trading NFT0+XCH for CAT

### DIFF
--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -485,7 +485,7 @@ class TradeManager:
                     amount_to_select = abs(amount)
                     if wallet.type() == WalletType.STANDARD_WALLET:
                         amount_to_select += fee
-                    coins_to_offer[id] = await wallet.get_coins_to_offer(
+                    coins_to_offer[wallet.id()] = await wallet.get_coins_to_offer(
                         asset_id, uint64(amount_to_select), tx_config.coin_selection_config
                     )
                     # Note: if we use check_for_special_offer_making, this is not used.

--- a/tests/wallet/nft_wallet/test_nft_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_offers.py
@@ -1014,7 +1014,11 @@ async def test_nft_offer_nft0_and_xch_for_cat(
     maker_xch_offered = 1000
     taker_cat_offered = 2500
     wallet_maker_id = wallet_maker.id()
-    offer_nft_for_cat = {wallet_maker_id: -maker_xch_offered, nft_asset_id: -1, wallet_maker_for_taker_cat.id(): taker_cat_offered}
+    offer_nft_for_cat = {
+        wallet_maker_id: -maker_xch_offered,
+        nft_asset_id: -1,
+        wallet_maker_for_taker_cat.id(): taker_cat_offered,
+    }
     maker_unused_index = (
         await wallet_maker.wallet_state_manager.puzzle_store.get_current_derivation_record_for_wallet(uint32(1))
     ).index

--- a/tests/wallet/nft_wallet/test_nft_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_offers.py
@@ -878,6 +878,7 @@ async def test_nft_offer_nft_for_nft(
     assert await nft_wallet_maker.get_nft_count() == 1
     assert await nft_wallet_taker.get_nft_count() == 1
 
+
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
 @pytest.mark.parametrize("trusted", [False])
 @pytest.mark.parametrize("reuse_puzhash", [False])

--- a/tests/wallet/nft_wallet/test_nft_offers.py
+++ b/tests/wallet/nft_wallet/test_nft_offers.py
@@ -877,3 +877,265 @@ async def test_nft_offer_nft_for_nft(
 
     assert await nft_wallet_maker.get_nft_count() == 1
     assert await nft_wallet_taker.get_nft_count() == 1
+
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
+@pytest.mark.parametrize("trusted", [False])
+@pytest.mark.parametrize("reuse_puzhash", [False])
+@pytest.mark.anyio
+async def test_nft_offer_nft0_and_xch_for_cat(
+    self_hostname: str,
+    two_wallet_nodes: Any,
+    trusted: Any,
+    reuse_puzhash: bool,
+    seeded_random: random.Random,
+) -> None:
+    full_nodes, wallets, _ = two_wallet_nodes
+    full_node_api: FullNodeSimulator = full_nodes[0]
+    full_node_server = full_node_api.server
+    wallet_node_0, server_0 = wallets[0]
+    wallet_node_1, server_1 = wallets[1]
+    wallet_maker = wallet_node_0.wallet_state_manager.main_wallet
+    wallet_taker = wallet_node_1.wallet_state_manager.main_wallet
+
+    maker_ph = await wallet_maker.get_new_puzzlehash()
+    taker_ph = await wallet_taker.get_new_puzzlehash()
+    token_ph = bytes32.random(seeded_random)
+
+    if trusted:
+        wallet_node_0.config["trusted_peers"] = {
+            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+        }
+        wallet_node_1.config["trusted_peers"] = {
+            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
+        }
+    else:
+        wallet_node_0.config["trusted_peers"] = {}
+        wallet_node_1.config["trusted_peers"] = {}
+
+    await server_0.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
+    await server_1.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
+
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(maker_ph))
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(taker_ph))
+    await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node_0, wallet_node_1], timeout=20)
+
+    funds = sum([calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, 2)])
+
+    await time_out_assert(20, wallet_maker.get_unconfirmed_balance, funds)
+    await time_out_assert(20, wallet_maker.get_confirmed_balance, funds)
+
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(token_ph))
+    await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node_0, wallet_node_1], timeout=20)
+
+    tx_config = DEFAULT_TX_CONFIG.override(reuse_puzhash=reuse_puzhash)
+
+    # Create NFT wallets and nfts for maker and taker
+    nft_wallet_maker = await NFTWallet.create_new_nft_wallet(
+        wallet_node_0.wallet_state_manager, wallet_maker, name="NFT WALLET 1"
+    )
+
+    nft_wallet_taker = await NFTWallet.create_new_nft_wallet(
+        wallet_node_1.wallet_state_manager, wallet_taker, name="NFT WALLET 2"
+    )
+
+    trade_manager_maker = wallet_maker.wallet_state_manager.trade_manager
+    trade_manager_taker = wallet_taker.wallet_state_manager.trade_manager
+
+    metadata = Program.to(
+        [
+            ("u", ["https://www.chia.net/img/branding/chia-logo.svg"]),
+            ("h", "0xD4584AD463139FA8C0D9F68F4B59F185"),
+        ]
+    )
+
+    sb = await nft_wallet_maker.generate_new_nft(metadata, tx_config)
+    assert sb
+    await time_out_assert_not_none(20, full_node_api.full_node.mempool_manager.get_spendbundle, sb.name())
+
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(token_ph))
+    await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node_0, wallet_node_1], timeout=20)
+
+    coins_maker = await nft_wallet_maker.get_current_nfts()
+    assert len(coins_maker) == 1
+    assert await nft_wallet_taker.get_nft_count() == 0
+    # Create two new CATs and wallets for maker and taker
+    cats_to_mint = 10000
+    async with wallet_node_0.wallet_state_manager.lock:
+        cat_wallet_maker: CATWallet = await CATWallet.create_new_cat_wallet(
+            wallet_node_0.wallet_state_manager,
+            wallet_maker,
+            {"identifier": "genesis_by_id"},
+            uint64(cats_to_mint),
+            tx_config,
+        )
+        await time_out_assert(20, mempool_not_empty, True, full_node_api)
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(token_ph))
+    await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node_0, wallet_node_1], timeout=20)
+
+    async with wallet_node_1.wallet_state_manager.lock:
+        cat_wallet_taker: CATWallet = await CATWallet.create_new_cat_wallet(
+            wallet_node_1.wallet_state_manager,
+            wallet_taker,
+            {"identifier": "genesis_by_id"},
+            uint64(cats_to_mint),
+            tx_config,
+        )
+        await time_out_assert(20, mempool_not_empty, True, full_node_api)
+
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(token_ph))
+    await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node_0, wallet_node_1], timeout=20)
+
+    await time_out_assert(20, cat_wallet_maker.get_confirmed_balance, cats_to_mint)
+    await time_out_assert(20, cat_wallet_maker.get_unconfirmed_balance, cats_to_mint)
+    await time_out_assert(20, cat_wallet_taker.get_confirmed_balance, cats_to_mint)
+    await time_out_assert(20, cat_wallet_taker.get_unconfirmed_balance, cats_to_mint)
+
+    wallet_maker_for_taker_cat: CATWallet = await CATWallet.get_or_create_wallet_for_cat(
+        wallet_node_0.wallet_state_manager, wallet_maker, cat_wallet_taker.get_asset_id()
+    )
+
+    wallet_taker_for_maker_cat: CATWallet = await CATWallet.get_or_create_wallet_for_cat(
+        wallet_node_1.wallet_state_manager, wallet_taker, cat_wallet_maker.get_asset_id()
+    )
+
+    assert wallet_taker_for_maker_cat
+    # MAKE FIRST TRADE: 1 NFT for 10 taker cats
+    maker_balance_pre = await wallet_maker.get_confirmed_balance()
+    taker_balance_pre = await wallet_taker.get_confirmed_balance()
+    taker_cat_maker_balance_pre = await wallet_maker_for_taker_cat.get_confirmed_balance()
+    taker_cat_taker_balance_pre = await cat_wallet_taker.get_confirmed_balance()
+
+    nft_to_offer = coins_maker[0]
+    nft_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_offer.full_puzzle))
+    nft_asset_id: bytes32 = create_asset_id(nft_info)  # type: ignore
+    driver_dict: Dict[bytes32, Optional[PuzzleInfo]] = {nft_asset_id: nft_info}
+
+    maker_fee = uint64(10)
+    maker_xch_offered = 1000
+    taker_cat_offered = 2500
+    wallet_maker_id = wallet_maker.id()
+    offer_nft_for_cat = {wallet_maker_id: -maker_xch_offered, nft_asset_id: -1, wallet_maker_for_taker_cat.id(): taker_cat_offered}
+    maker_unused_index = (
+        await wallet_maker.wallet_state_manager.puzzle_store.get_current_derivation_record_for_wallet(uint32(1))
+    ).index
+    taker_unused_index = (
+        await wallet_taker.wallet_state_manager.puzzle_store.get_current_derivation_record_for_wallet(uint32(1))
+    ).index
+
+    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+        offer_nft_for_cat, tx_config, driver_dict, fee=maker_fee
+    )
+    assert success is True
+    assert error is None
+    assert trade_make is not None
+
+    taker_fee = uint64(1)
+
+    peer = wallet_node_1.get_full_node_peer()
+    trade_take, tx_records = await trade_manager_taker.respond_to_offer(
+        Offer.from_bytes(trade_make.offer),
+        peer,
+        tx_config,
+        fee=taker_fee,
+    )
+
+    assert trade_take is not None
+    assert tx_records is not None
+
+    await full_node_api.process_transaction_records(records=tx_records)
+    await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node_0, wallet_node_1], timeout=20)
+
+    await time_out_assert(20, get_trade_and_status, TradeStatus.CONFIRMED, trade_manager_maker, trade_make)
+    await time_out_assert(20, get_trade_and_status, TradeStatus.CONFIRMED, trade_manager_taker, trade_take)
+
+    taker_cat_maker_balance_post = await wallet_maker_for_taker_cat.get_confirmed_balance()
+    taker_cat_taker_balance_post = await cat_wallet_taker.get_confirmed_balance()
+    assert taker_cat_maker_balance_post == taker_cat_maker_balance_pre + taker_cat_offered
+    assert taker_cat_taker_balance_post == taker_cat_taker_balance_pre - taker_cat_offered
+    maker_balance_post = await wallet_maker.get_confirmed_balance()
+    taker_balance_post = await wallet_taker.get_confirmed_balance()
+    assert maker_balance_post == maker_balance_pre - maker_fee - maker_xch_offered
+    assert taker_balance_post == taker_balance_pre - taker_fee + maker_xch_offered
+    coins_taker = await nft_wallet_taker.get_current_nfts()
+    assert len(coins_taker) == 1
+
+    assert await nft_wallet_maker.get_nft_count() == 0
+    if reuse_puzhash:
+        # Check if unused index changed
+        assert (
+            maker_unused_index
+            == (
+                await wallet_maker.wallet_state_manager.puzzle_store.get_current_derivation_record_for_wallet(uint32(1))
+            ).index
+        )
+        assert (
+            taker_unused_index
+            == (
+                await wallet_taker.wallet_state_manager.puzzle_store.get_current_derivation_record_for_wallet(uint32(1))
+            ).index
+        )
+    else:
+        assert (
+            maker_unused_index
+            < (
+                await wallet_maker.wallet_state_manager.puzzle_store.get_current_derivation_record_for_wallet(uint32(1))
+            ).index
+        )
+        assert (
+            taker_unused_index
+            < (
+                await wallet_taker.wallet_state_manager.puzzle_store.get_current_derivation_record_for_wallet(uint32(1))
+            ).index
+        )
+    # Make an offer for taker NFT for multiple cats
+    maker_cat_amount = 400
+    taker_cat_amount = 500
+
+    nft_to_buy = coins_taker[0]
+    nft_to_buy_info: Optional[PuzzleInfo] = match_puzzle(uncurry_puzzle(nft_to_buy.full_puzzle))
+    nft_to_buy_asset_id: bytes32 = create_asset_id(nft_to_buy_info)  # type: ignore
+
+    driver_dict_to_buy: Dict[bytes32, Optional[PuzzleInfo]] = {
+        nft_to_buy_asset_id: nft_to_buy_info,
+    }
+
+    maker_fee = uint64(10)
+    offer_multi_cats_for_nft = {
+        nft_to_buy_asset_id: 1,
+        wallet_maker_for_taker_cat.id(): -taker_cat_amount,
+        cat_wallet_maker.id(): -maker_cat_amount,
+    }
+
+    success, trade_make, error = await trade_manager_maker.create_offer_for_ids(
+        offer_multi_cats_for_nft, tx_config, driver_dict_to_buy, fee=maker_fee
+    )
+    assert success is True
+    assert error is None
+    assert trade_make is not None
+
+    taker_fee = uint64(1)
+
+    trade_take, tx_records = await trade_manager_taker.respond_to_offer(
+        Offer.from_bytes(trade_make.offer), peer, tx_config, fee=taker_fee
+    )
+
+    assert trade_take is not None
+    assert tx_records is not None
+
+    await full_node_api.process_transaction_records(records=tx_records)
+    # check balances: taker wallet down an NFT, up cats
+    await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node_0, wallet_node_1], timeout=20)
+
+    await time_out_assert(20, get_trade_and_status, TradeStatus.CONFIRMED, trade_manager_maker, trade_make)
+    await time_out_assert(20, get_trade_and_status, TradeStatus.CONFIRMED, trade_manager_taker, trade_take)
+
+    taker_cat_maker_balance_post_2 = await wallet_maker_for_taker_cat.get_confirmed_balance()
+    taker_cat_taker_balance_post_2 = await cat_wallet_taker.get_confirmed_balance()
+    assert taker_cat_maker_balance_post_2 == taker_cat_maker_balance_post - taker_cat_amount
+    assert taker_cat_taker_balance_post_2 == taker_cat_taker_balance_post + taker_cat_amount
+    maker_balance_post_2 = await wallet_maker.get_confirmed_balance()
+    taker_balance_post_2 = await wallet_taker.get_confirmed_balance()
+    assert maker_balance_post_2 == maker_balance_post - maker_fee
+    assert taker_balance_post_2 == taker_balance_post - taker_fee
+    assert await nft_wallet_maker.get_nft_count() == 1
+    assert await nft_wallet_taker.get_nft_count() == 0


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

This fixes a bug when trading NFT0+XCH for a CAT. The root cause is a sorting function that attempts to sort a list that contains ints (wallet ids) and bytes32 (asset ids). This does not affect NFT1 because NFT1 offers are handled in a separate code path.

```
in _create_offer_for_ids
    for id in sorted(coins_to_offer.keys()):
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'bytes32' and 'int'
```

The fix is to always use wallet ids.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Exception when trying to accept an offer for NFT0+XCH.


### New Behavior:

No exception, works as expected.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Added a new test trading NFT0+XCH for CAT.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
