### PR TITLE
extend measured sizes for plot check with value for k39

### DIFF
--- a/chia/plotting/cache.py
+++ b/chia/plotting/cache.py
@@ -138,7 +138,16 @@ class Cache:
                 cache_data: CacheDataV1 = CacheDataV1.from_bytes(stored_cache.blob)
                 self._data = {}
                 estimated_c2_sizes: Dict[int, int] = {}
-                measured_sizes: Dict[int, int] = {32: 738, 33: 1083, 34: 1771, 35: 3147, 36: 5899, 37: 11395, 38: 22395}
+                measured_sizes: Dict[int, int] = {
+                    32: 738,
+                    33: 1083,
+                    34: 1771,
+                    35: 3147,
+                    36: 5899,
+                    37: 11395,
+                    38: 22395,
+                    39: 44367,
+                }
                 for path, cache_entry in cache_data.entries:
                     new_entry = CacheEntry(
                         DiskProver.from_bytes(cache_entry.prover_data),


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Extends PR #16830 with measured size values for k39 plots.
The reformatting was done automatically using the command
``` 
black . && isort benchmarks build_scripts chia tests tools *.py && mypy && flake8 benchmarks build_scripts chia tests tools *.py && pylint benchmarks build_scripts chia tests tools *.py
py.test tests -v --durations 0
```


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
only plots with a k size <= 38 are cached


### New Behavior:
all plots with a k size <= 39 are cached


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Added this log line in `chia/plotting/cache.py`:
```python
log.info(f"prover_size: {prover_size}, estimated_sum: {(estimated_c2_sizes[k] + memo_size + 2000)}, estimated_c2: {estimated_c2_sizes[k]}, memo_size: {memo_size}")
```

Then restarted the harvester process and got this log line:
```python
2024-01-08T11:10:00.357 harvester chia.plotting.cache     : INFO     prover_size: 44367, estimated_sum: 29602, estimated_c2: 27490, memo_size: 112
```


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
