### PR TITLE
DL Compress get_keys_values output by hash.

### DIFF
--- a/chia/data_layer/data_layer_util.py
+++ b/chia/data_layer/data_layer_util.py
@@ -43,6 +43,10 @@ def leaf_hash(key: bytes, value: bytes) -> bytes32:
     return Program.to((key, value)).get_tree_hash()  # type: ignore[no-any-return]
 
 
+def key_hash(key: bytes) -> bytes32:
+    return Program.to(key).get_tree_hash()  # type: ignore[no-any-return]
+
+
 async def _debug_dump(db: DBWrapper2, description: str = "") -> None:
     async with db.reader() as reader:
         cursor = await reader.execute("SELECT name FROM sqlite_master WHERE type='table';")

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -673,7 +673,9 @@ class DataStore:
 
         return internal_nodes
 
-    async def get_keys_values_cursor(self, reader, root_hash: bytes32) -> aiosqlite.Cursor:
+    async def get_keys_values_cursor(
+        self, reader: aiosqlite.Connection, root_hash: Optional[bytes32]
+    ) -> aiosqlite.Cursor:
         return await reader.execute(
             """
             WITH RECURSIVE

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -1055,14 +1055,16 @@ class DataStore:
     ) -> Optional[Root]:
         root_hash = None if root is None else root.node_hash
         async with self.db_wrapper.writer():
+            node: Union[TerminalNode, InternalNode]
+
             if hint_keys_values is None:
                 node = await self.get_node_by_key(key=key, tree_id=tree_id)
+                assert isinstance(node, TerminalNode)
             else:
                 if key_hash(key) not in hint_keys_values:
                     log.debug(f"Request to delete an unknown key ignored: {key.hex()}")
                     return root
                 node_hash = hint_keys_values[key_hash(key)]
-                node: Union[TerminalNode, InternalNode]
                 node = await self.get_node(node_hash)
                 assert isinstance(node, TerminalNode)
                 del hint_keys_values[key_hash(key)]

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -28,6 +28,7 @@ from chia.data_layer.data_layer_util import (
     Subscription,
     TerminalNode,
     internal_hash,
+    key_hash,
     leaf_hash,
     row_to_node,
 )
@@ -672,35 +673,38 @@ class DataStore:
 
         return internal_nodes
 
+    async def get_keys_values_cursor(self, reader, root_hash: bytes32) -> aiosqlite.Cursor:
+        return await reader.execute(
+            """
+            WITH RECURSIVE
+                tree_from_root_hash(hash, node_type, left, right, key, value, depth, rights) AS (
+                    SELECT node.*, 0 AS depth, 0 AS rights FROM node WHERE node.hash == :root_hash
+                    UNION ALL
+                    SELECT
+                        node.*,
+                        tree_from_root_hash.depth + 1 AS depth,
+                        CASE
+                            WHEN node.hash == tree_from_root_hash.right
+                            THEN tree_from_root_hash.rights + (1 << (62 - tree_from_root_hash.depth))
+                            ELSE tree_from_root_hash.rights
+                            END AS rights
+                        FROM node, tree_from_root_hash
+                    WHERE node.hash == tree_from_root_hash.left OR node.hash == tree_from_root_hash.right
+                )
+            SELECT * FROM tree_from_root_hash
+            WHERE node_type == :node_type
+            ORDER BY depth ASC, rights ASC
+            """,
+            {"root_hash": root_hash, "node_type": NodeType.TERMINAL},
+        )
+
     async def get_keys_values(self, tree_id: bytes32, root_hash: Optional[bytes32] = None) -> List[TerminalNode]:
         async with self.db_wrapper.reader() as reader:
             if root_hash is None:
                 root = await self.get_tree_root(tree_id=tree_id)
                 root_hash = root.node_hash
-            cursor = await reader.execute(
-                """
-                WITH RECURSIVE
-                    tree_from_root_hash(hash, node_type, left, right, key, value, depth, rights) AS (
-                        SELECT node.*, 0 AS depth, 0 AS rights FROM node WHERE node.hash == :root_hash
-                        UNION ALL
-                        SELECT
-                            node.*,
-                            tree_from_root_hash.depth + 1 AS depth,
-                            CASE
-                                WHEN node.hash == tree_from_root_hash.right
-                                THEN tree_from_root_hash.rights + (1 << (62 - tree_from_root_hash.depth))
-                                ELSE tree_from_root_hash.rights
-                                END AS rights
-                            FROM node, tree_from_root_hash
-                        WHERE node.hash == tree_from_root_hash.left OR node.hash == tree_from_root_hash.right
-                    )
-                SELECT * FROM tree_from_root_hash
-                WHERE node_type == :node_type
-                ORDER BY depth ASC, rights ASC
-                """,
-                {"root_hash": None if root_hash is None else root_hash, "node_type": NodeType.TERMINAL},
-            )
 
+            cursor = await self.get_keys_values_cursor(reader, root_hash)
             terminal_nodes: List[TerminalNode] = []
             async for row in cursor:
                 if row["depth"] > 62:
@@ -721,6 +725,26 @@ class DataStore:
                 terminal_nodes.append(node)
 
         return terminal_nodes
+
+    async def get_keys_values_compressed(
+        self, tree_id: bytes32, root_hash: Optional[bytes32] = None
+    ) -> Dict[bytes32, bytes32]:
+        async with self.db_wrapper.reader() as reader:
+            if root_hash is None:
+                root = await self.get_tree_root(tree_id=tree_id)
+                root_hash = root.node_hash
+
+            cursor = await self.get_keys_values_cursor(reader, root_hash)
+            kv_compressed: Dict[bytes32, bytes32] = {}
+            async for row in cursor:
+                if row["depth"] > 62:
+                    raise Exception("Tree depth exceeded 62, unable to guarantee left-to-right node order.")
+                node = row_to_node(row=row)
+                if not isinstance(node, TerminalNode):
+                    raise Exception(f"Unexpected internal node found: {node.hash.hex()}")
+                kv_compressed[key_hash(node.key)] = leaf_hash(node.key, node.value)
+
+            return kv_compressed
 
     async def get_node_type(self, node_hash: bytes32) -> NodeType:
         async with self.db_wrapper.reader() as reader:
@@ -795,7 +819,7 @@ class DataStore:
         key: bytes,
         value: bytes,
         tree_id: bytes32,
-        hint_keys_values: Optional[Dict[bytes, bytes]] = None,
+        hint_keys_values: Optional[Dict[bytes32, bytes32]] = None,
         use_optimized: bool = True,
         status: Status = Status.PENDING,
         root: Optional[Root] = None,
@@ -941,7 +965,7 @@ class DataStore:
         tree_id: bytes32,
         reference_node_hash: Optional[bytes32],
         side: Optional[Side],
-        hint_keys_values: Optional[Dict[bytes, bytes]] = None,
+        hint_keys_values: Optional[Dict[bytes32, bytes32]] = None,
         use_optimized: bool = True,
         status: Status = Status.PENDING,
         root: Optional[Root] = None,
@@ -959,7 +983,7 @@ class DataStore:
                     if any(key == node.key for node in pairs):
                         raise Exception(f"Key already present: {key.hex()}")
                 else:
-                    if key in hint_keys_values:
+                    if key_hash(key) in hint_keys_values:
                         raise Exception(f"Key already present: {key.hex()}")
 
             if reference_node_hash is None:
@@ -1015,14 +1039,14 @@ class DataStore:
                 )
 
             if hint_keys_values is not None:
-                hint_keys_values[key] = value
+                hint_keys_values[key_hash(key)] = leaf_hash(key, value)
             return InsertResult(node_hash=new_terminal_node_hash, root=new_root)
 
     async def delete(
         self,
         key: bytes,
         tree_id: bytes32,
-        hint_keys_values: Optional[Dict[bytes, bytes]] = None,
+        hint_keys_values: Optional[Dict[bytes32, bytes32]] = None,
         use_optimized: bool = True,
         status: Status = Status.PENDING,
         root: Optional[Root] = None,
@@ -1032,13 +1056,13 @@ class DataStore:
             if hint_keys_values is None:
                 node = await self.get_node_by_key(key=key, tree_id=tree_id)
             else:
-                if key not in hint_keys_values:
+                if key_hash(key) not in hint_keys_values:
                     log.debug(f"Request to delete an unknown key ignored: {key.hex()}")
                     return root
-                value = hint_keys_values[key]
-                node_hash = leaf_hash(key=key, value=value)
-                node = TerminalNode(node_hash, key, value)
-                del hint_keys_values[key]
+                node_hash = hint_keys_values[key_hash(key)]
+                node = await self.get_node(node_hash)
+                assert isinstance(node, TerminalNode)
+                del hint_keys_values[key_hash(key)]
 
             ancestors: List[InternalNode] = await self.get_ancestors_common(
                 node_hash=node.hash,
@@ -1106,7 +1130,7 @@ class DataStore:
         key: bytes,
         new_value: bytes,
         tree_id: bytes32,
-        hint_keys_values: Optional[Dict[bytes, bytes]] = None,
+        hint_keys_values: Optional[Dict[bytes32, bytes32]] = None,
         use_optimized: bool = True,
         status: Status = Status.PENDING,
         root: Optional[Root] = None,
@@ -1134,7 +1158,7 @@ class DataStore:
                     return InsertResult(leaf_hash(key, new_value), root)
                 old_node_hash = old_node.hash
             else:
-                if key not in hint_keys_values:
+                if key_hash(key) not in hint_keys_values:
                     log.debug(f"Key not found: {key.hex()}. Doing an autoinsert instead")
                     return await self.autoinsert(
                         key=key,
@@ -1145,12 +1169,15 @@ class DataStore:
                         status=status,
                         root=root,
                     )
-                value = hint_keys_values[key]
+                node_hash = hint_keys_values[key_hash(key)]
+                node = await self.get_node(node_hash)
+                assert isinstance(node, TerminalNode)
+                value = node.value
                 if value == new_value:
                     log.debug(f"New value matches old value in upsert operation: {key.hex()}")
                     return InsertResult(leaf_hash(key, new_value), root)
                 old_node_hash = leaf_hash(key=key, value=value)
-                del hint_keys_values[key]
+                del hint_keys_values[key_hash(key)]
 
             # create new terminal node
             new_terminal_node_hash = await self._insert_terminal_node(key=key, value=new_value)
@@ -1192,7 +1219,7 @@ class DataStore:
                 )
 
             if hint_keys_values is not None:
-                hint_keys_values[key] = new_value
+                hint_keys_values[key_hash(key)] = leaf_hash(key, new_value)
             return InsertResult(node_hash=new_terminal_node_hash, root=new_root)
 
     async def clean_node_table(self, writer: aiosqlite.Connection) -> None:
@@ -1229,7 +1256,7 @@ class DataStore:
             if old_root.node_hash is None:
                 hint_keys_values = {}
             else:
-                hint_keys_values = await self.get_keys_values_dict(tree_id, root_hash=root_hash)
+                hint_keys_values = await self.get_keys_values_compressed(tree_id, root_hash=root_hash)
 
             intermediate_root: Optional[Root] = old_root
             for change in changelist:

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -1062,6 +1062,7 @@ class DataStore:
                     log.debug(f"Request to delete an unknown key ignored: {key.hex()}")
                     return root
                 node_hash = hint_keys_values[key_hash(key)]
+                node: Union[TerminalNode, InternalNode]
                 node = await self.get_node(node_hash)
                 assert isinstance(node, TerminalNode)
                 del hint_keys_values[key_hash(key)]

--- a/chia/data_layer/util/benchmark.py
+++ b/chia/data_layer/util/benchmark.py
@@ -23,7 +23,7 @@ async def generate_datastore(num_nodes: int, slow_mode: bool) -> None:
             os.remove(db_path)
 
         async with DataStore.managed(database=db_path) as data_store:
-            hint_keys_values: Dict[bytes, bytes] = {}
+            hint_keys_values: Dict[bytes32, bytes32] = {}
 
             tree_id = bytes32(b"0" * 32)
             await data_store.create_tree(tree_id)

--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -383,7 +383,7 @@ async def test_batch_update(data_store: DataStore, tree_id: bytes32, use_optimiz
 
         batch: List[Dict[str, Any]] = []
         keys_values: Dict[bytes, bytes] = {}
-        hint_keys_values: Optional[Dict[bytes, bytes]] = {} if use_optimized else None
+        hint_keys_values: Optional[Dict[bytes32, bytes32]] = {} if use_optimized else None
         for operation in range(num_batches * num_ops_per_batch):
             [op_type] = random.choices(
                 ["insert", "upsert-insert", "upsert-update", "delete"],
@@ -490,7 +490,7 @@ async def test_upsert_ignores_existing_arguments(
 ) -> None:
     key = b"key"
     value = b"value1"
-    hint_keys_values: Optional[Dict[bytes, bytes]] = {} if use_optimized else None
+    hint_keys_values: Optional[Dict[bytes32, bytes32]] = {} if use_optimized else None
 
     await data_store.autoinsert(
         key=key,
@@ -691,7 +691,7 @@ async def test_inserting_invalid_length_ancestor_hash_raises_original_exception(
 async def test_autoinsert_balances_from_scratch(data_store: DataStore, tree_id: bytes32) -> None:
     random = Random()
     random.seed(100, version=2)
-    hint_keys_values: Dict[bytes, bytes] = {}
+    hint_keys_values: Dict[bytes32, bytes32] = {}
     hashes = []
 
     for i in range(2000):
@@ -710,7 +710,7 @@ async def test_autoinsert_balances_from_scratch(data_store: DataStore, tree_id: 
 async def test_autoinsert_balances_gaps(data_store: DataStore, tree_id: bytes32) -> None:
     random = Random()
     random.seed(101, version=2)
-    hint_keys_values: Dict[bytes, bytes] = {}
+    hint_keys_values: Dict[bytes32, bytes32] = {}
     hashes = []
 
     for i in range(2000):

--- a/tests/core/data_layer/test_data_store.py
+++ b/tests/core/data_layer/test_data_store.py
@@ -308,7 +308,7 @@ async def test_get_ancestors_optimized(data_store: DataStore, tree_id: bytes32) 
         if i > 25 and i <= 200 and random.randint(0, 4):
             is_insert = True
         if i > 200:
-            hint_keys_values = await data_store.get_keys_values_dict(tree_id)
+            hint_keys_values = await data_store.get_keys_values_compressed(tree_id)
             if not deleted_all:
                 while node_count > 0:
                     node_count -= 1
@@ -643,7 +643,7 @@ async def test_inserting_duplicate_key_fails(
             side=Side.RIGHT,
         )
 
-    hint_keys_values = await data_store.get_keys_values_dict(tree_id=tree_id)
+    hint_keys_values = await data_store.get_keys_values_compressed(tree_id=tree_id)
     # TODO: more specific exception
     with pytest.raises(Exception):
         await data_store.insert(
@@ -749,7 +749,7 @@ async def test_delete_from_left_both_terminal(data_store: DataStore, tree_id: by
 
     hint_keys_values = None
     if use_hint:
-        hint_keys_values = await data_store.get_keys_values_dict(tree_id=tree_id)
+        hint_keys_values = await data_store.get_keys_values_compressed(tree_id=tree_id)
 
     expected = Program.to(
         (
@@ -789,7 +789,7 @@ async def test_delete_from_left_other_not_terminal(data_store: DataStore, tree_i
 
     hint_keys_values = None
     if use_hint:
-        hint_keys_values = await data_store.get_keys_values_dict(tree_id=tree_id)
+        hint_keys_values = await data_store.get_keys_values_compressed(tree_id=tree_id)
 
     expected = Program.to(
         (
@@ -827,7 +827,7 @@ async def test_delete_from_right_both_terminal(data_store: DataStore, tree_id: b
 
     hint_keys_values = None
     if use_hint:
-        hint_keys_values = await data_store.get_keys_values_dict(tree_id=tree_id)
+        hint_keys_values = await data_store.get_keys_values_compressed(tree_id=tree_id)
 
     expected = Program.to(
         (
@@ -867,7 +867,7 @@ async def test_delete_from_right_other_not_terminal(data_store: DataStore, tree_
 
     hint_keys_values = None
     if use_hint:
-        hint_keys_values = await data_store.get_keys_values_dict(tree_id=tree_id)
+        hint_keys_values = await data_store.get_keys_values_compressed(tree_id=tree_id)
 
     expected = Program.to(
         (


### PR DESCRIPTION
Introduces `get_keys_values_compressed` which maps from `hash(key)` to `hash(leaf)`. `hint_keys_values` is modified to store this instead of all (key, values) data to optimize the memory usage.