### PR TITLE
Port get_notifications RPC to RPC marshaller

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -1390,7 +1390,7 @@ async def get_notifications(
         )
         for notification in response.notifications:
             print("")
-            print(f"ID: {notification.coin_id.hex()}")
+            print(f"ID: {notification.id.hex()}")
             print(f"message: {notification.message.decode('utf-8')}")
             print(f"amount: {notification.amount}")
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -19,6 +19,7 @@ from chia.cmds.cmds_util import (
 )
 from chia.cmds.peer_funcs import print_connections
 from chia.cmds.units import units
+from chia.rpc.wallet_request_types import GetNotifications
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.bech32m import bech32_decode, decode_puzzle_hash, encode_puzzle_hash
@@ -1382,8 +1383,12 @@ async def get_notifications(
         if ids is not None and len(ids) == 0:
             ids = None
 
-        notifications = await wallet_client.get_notifications(ids=ids, pagination=(start, end))
-        for notification in notifications:
+        response = await wallet_client.get_notifications(
+            GetNotifications(
+                ids=ids, start=None if start is None else uint32(start), end=None if end is None else uint32(end)
+            )
+        )
+        for notification in response.notifications:
             print("")
             print(f"ID: {notification.coin_id.hex()}")
             print(f"message: {notification.message.decode('utf-8')}")

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -1384,9 +1384,7 @@ async def get_notifications(
             ids = None
 
         response = await wallet_client.get_notifications(
-            GetNotifications(
-                ids=ids, start=None if start is None else uint32(start), end=None if end is None else uint32(end)
-            )
+            GetNotifications(ids=ids, start=uint32.construct_optional(start), end=uint32.construct_optional(end))
         )
         for notification in response.notifications:
             print("")

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.ints import uint32
+from chia.util.streamable import Streamable, streamable
+from chia.wallet.notification_store import Notification
+
+
+@streamable
+@dataclass(frozen=True)
+class GetNotifications(Streamable):
+    ids: Optional[List[bytes32]] = None
+    start: Optional[uint32] = None
+    end: Optional[uint32] = None
+
+
+@streamable
+@dataclass(frozen=True)
+class GetNotificationsResponse(Streamable):
+    notifications: List[Notification]

--- a/chia/wallet/notification_store.py
+++ b/chia/wallet/notification_store.py
@@ -8,10 +8,12 @@ from typing import List, Optional, Tuple
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32, uint64
+from chia.util.streamable import Streamable, streamable
 
 
+@streamable
 @dataclasses.dataclass(frozen=True)
-class Notification:
+class Notification(Streamable):
     coin_id: bytes32
     message: bytes
     amount: uint64

--- a/chia/wallet/notification_store.py
+++ b/chia/wallet/notification_store.py
@@ -14,7 +14,7 @@ from chia.util.streamable import Streamable, streamable
 @streamable
 @dataclasses.dataclass(frozen=True)
 class Notification(Streamable):
-    coin_id: bytes32
+    id: bytes32
     message: bytes
     amount: uint64
     height: uint32
@@ -72,7 +72,7 @@ class NotificationStore:
             cursor = await conn.execute(
                 "INSERT OR REPLACE INTO notifications (coin_id, msg, amount, height) VALUES(?, ?, ?, ?)",
                 (
-                    notification.coin_id,
+                    notification.id,
                     notification.message,
                     notification.amount.stream_to_bytes(),
                     notification.height,
@@ -80,7 +80,7 @@ class NotificationStore:
             )
             cursor = await conn.execute(
                 "INSERT OR REPLACE INTO all_notification_ids (coin_id) VALUES(?)",
-                (notification.coin_id,),
+                (notification.id,),
             )
             await cursor.close()
 

--- a/tests/cmds/wallet/test_notifications.py
+++ b/tests/cmds/wallet/test_notifications.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional, Tuple, cast
 
+from chia.rpc.wallet_request_types import GetNotifications, GetNotificationsResponse
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.ints import uint32, uint64
@@ -62,11 +63,11 @@ def test_notifications_get(capsys: object, get_test_cli_clients: Tuple[TestRpcCl
 
     # set RPC Client
     class NotificationsGetRpcClient(TestWalletRpcClient):
-        async def get_notifications(
-            self, ids: Optional[List[bytes32]] = None, pagination: Optional[Tuple[Optional[int], Optional[int]]] = None
-        ) -> List[Notification]:
-            self.add_to_log("get_notifications", (ids, pagination))
-            return [Notification(get_bytes32(1), bytes("hello", "utf8"), uint64(1000000000), uint32(50))]
+        async def get_notifications(self, request: GetNotifications) -> GetNotificationsResponse:
+            self.add_to_log("get_notifications", (request,))
+            return GetNotificationsResponse(
+                [Notification(get_bytes32(1), bytes("hello", "utf8"), uint64(1000000000), uint32(50))]
+            )
 
     inst_rpc_client = NotificationsGetRpcClient()  # pylint: disable=no-value-for-parameter
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
@@ -87,7 +88,7 @@ def test_notifications_get(capsys: object, get_test_cli_clients: Tuple[TestRpcCl
         "amount: 1000000000",
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
-    expected_calls: logType = {"get_notifications": [([get_bytes32(1)], (10, 10))]}
+    expected_calls: logType = {"get_notifications": [(GetNotifications([get_bytes32(1)], uint32(10), uint32(10)),)]}
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
 
 

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -2066,13 +2066,13 @@ async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironmen
     await time_out_assert(20, env.wallet_2.wallet.get_confirmed_balance, uint64(100000000000))
 
     notification = (await client_2.get_notifications(GetNotifications())).notifications[0]
-    assert [notification] == (await client_2.get_notifications(GetNotifications([notification.coin_id]))).notifications
+    assert [notification] == (await client_2.get_notifications(GetNotifications([notification.id]))).notifications
     assert [] == (await client_2.get_notifications(GetNotifications(None, uint32(0), uint32(0)))).notifications
     assert [notification] == (await client_2.get_notifications(GetNotifications(None, None, uint32(1)))).notifications
     assert [] == (await client_2.get_notifications(GetNotifications(None, uint32(1), None))).notifications
     assert [notification] == (await client_2.get_notifications(GetNotifications(None, None, None))).notifications
     assert await client_2.delete_notifications()
-    assert [] == (await client_2.get_notifications(GetNotifications([notification.coin_id]))).notifications
+    assert [] == (await client_2.get_notifications(GetNotifications([notification.id]))).notifications
 
     tx = await client.send_notification(
         await wallet_2.get_new_puzzlehash(),
@@ -2092,8 +2092,8 @@ async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironmen
     await time_out_assert(20, env.wallet_2.wallet.get_confirmed_balance, uint64(200000000000))
 
     notification = (await client_2.get_notifications(GetNotifications())).notifications[0]
-    assert await client_2.delete_notifications([notification.coin_id])
-    assert [] == (await client_2.get_notifications(GetNotifications([notification.coin_id]))).notifications
+    assert await client_2.delete_notifications([notification.id])
+    assert [] == (await client_2.get_notifications(GetNotifications([notification.id]))).notifications
 
 
 # The signatures below were made from an ephemeral key pair that isn't included in the test code.

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -16,6 +16,7 @@ from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate
 from chia.consensus.coinbase import create_puzzlehash_for_pk
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
 from chia.rpc.rpc_server import RpcServer
+from chia.rpc.wallet_request_types import GetNotifications
 from chia.rpc.wallet_rpc_api import WalletRpcApi
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.server.server import ChiaServer
@@ -2064,14 +2065,14 @@ async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironmen
     await farm_transaction(full_node_api, wallet_node, tx.spend_bundle)
     await time_out_assert(20, env.wallet_2.wallet.get_confirmed_balance, uint64(100000000000))
 
-    notification = (await client_2.get_notifications())[0]
-    assert [notification] == (await client_2.get_notifications([notification.coin_id]))
-    assert [] == (await client_2.get_notifications(pagination=(0, 0)))
-    assert [notification] == (await client_2.get_notifications(pagination=(None, 1)))
-    assert [] == (await client_2.get_notifications(pagination=(1, None)))
-    assert [notification] == (await client_2.get_notifications(pagination=(None, None)))
+    notification = (await client_2.get_notifications(GetNotifications())).notifications[0]
+    assert [notification] == (await client_2.get_notifications(GetNotifications([notification.coin_id]))).notifications
+    assert [] == (await client_2.get_notifications(GetNotifications(None, uint32(0), uint32(0)))).notifications
+    assert [notification] == (await client_2.get_notifications(GetNotifications(None, None, uint32(1)))).notifications
+    assert [] == (await client_2.get_notifications(GetNotifications(None, uint32(1), None))).notifications
+    assert [notification] == (await client_2.get_notifications(GetNotifications(None, None, None))).notifications
     assert await client_2.delete_notifications()
-    assert [] == (await client_2.get_notifications([notification.coin_id]))
+    assert [] == (await client_2.get_notifications(GetNotifications([notification.coin_id]))).notifications
 
     tx = await client.send_notification(
         await wallet_2.get_new_puzzlehash(),
@@ -2090,9 +2091,9 @@ async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironmen
     await farm_transaction(full_node_api, wallet_node, tx.spend_bundle)
     await time_out_assert(20, env.wallet_2.wallet.get_confirmed_balance, uint64(200000000000))
 
-    notification = (await client_2.get_notifications())[0]
+    notification = (await client_2.get_notifications(GetNotifications())).notifications[0]
     assert await client_2.delete_notifications([notification.coin_id])
-    assert [] == (await client_2.get_notifications([notification.coin_id]))
+    assert [] == (await client_2.get_notifications(GetNotifications([notification.coin_id]))).notifications
 
 
 # The signatures below were made from an ephemeral key pair that isn't included in the test code.

--- a/tests/wallet/test_notifications.py
+++ b/tests/wallet/test_notifications.py
@@ -166,7 +166,7 @@ async def test_notifications(
     assert len(notifications) == 1
     assert notifications[0].message == b"allow_larger"
     assert (
-        await notification_manager_2.notification_store.get_notifications([n.coin_id for n in notifications])
+        await notification_manager_2.notification_store.get_notifications([n.id for n in notifications])
         == notifications
     )
 
@@ -176,7 +176,7 @@ async def test_notifications(
     await notification_manager_2.notification_store.delete_all_notifications()
     assert len(await notification_manager_2.notification_store.get_all_notifications()) == 0
     await notification_manager_2.notification_store.add_notification(notifications[0])
-    await notification_manager_2.notification_store.delete_notifications([n.coin_id for n in notifications])
+    await notification_manager_2.notification_store.delete_notifications([n.id for n in notifications])
     assert len(await notification_manager_2.notification_store.get_all_notifications()) == 0
 
     assert not await func(*notification_manager_2.most_recent_args)


### PR DESCRIPTION
This moves a single RPC to the new RPC `@marshal` decorator.