### PR TITLE
Subscribe to DIDs that come into wallet

### DIFF
--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -424,6 +424,7 @@ class DIDWallet:
         )
 
         await self.add_parent(coin.name(), future_parent)
+        await self.wallet_state_manager.add_interested_coin_ids([coin.name()])
 
     def create_backup(self) -> str:
         """
@@ -1516,7 +1517,7 @@ class DIDWallet:
         )
         if len(spendable_coins) == 0:
             raise RuntimeError("DID is not currently spendable")
-        return list(spendable_coins)[0].coin
+        return sorted(list(spendable_coins), key=lambda c: c.confirmed_block_height, reverse=True)[0].coin
 
     async def match_hinted_coin(self, coin: Coin, hint: bytes32) -> bool:
         if self.did_info.origin_coin is None:

--- a/tests/wallet/did_wallet/test_did.py
+++ b/tests/wallet/did_wallet/test_did.py
@@ -23,6 +23,8 @@ from chia.wallet.singleton import create_singleton_puzzle
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.tx_config import DEFAULT_COIN_SELECTION_CONFIG, DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.wallet_state_manager import WalletStateManager
+from tests.environments.wallet import WalletStateTransition, WalletTestFramework
 from tests.util.setup_nodes import OldSimulatorsAndWallets
 from tests.util.time_out_assert import time_out_assert, time_out_assert_not_none
 
@@ -1338,3 +1340,68 @@ class TestDIDWallet:
         await time_out_assert(30, get_wallet_num, 2, wallet_node_2.wallet_state_manager)
         did_wallet_2 = wallet_node_2.wallet_state_manager.get_wallet(uint32(2), DIDWallet)
         assert did_info == did_wallet_2.did_info
+
+
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [
+        {
+            "num_environments": 1,
+            "blocks_needed": [1],
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.anyio
+async def test_did_coin_records(wallet_environments: WalletTestFramework, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Setup
+    wallet_node = wallet_environments.environments[0].node
+    wallet = wallet_environments.environments[0].xch_wallet
+    client = wallet_environments.environments[0].rpc_client
+
+    # Generate DID wallet
+    did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(wallet_node.wallet_state_manager, wallet, uint64(1))
+
+    await wallet_environments.process_pending_states(
+        [
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    1: {"set_remainder": True},
+                    2: {"init": True, "set_remainder": True},
+                },
+                post_block_balance_updates={
+                    1: {"set_remainder": True},
+                    2: {"set_remainder": True},
+                },
+            ),
+            WalletStateTransition(),
+        ]
+    )
+
+    # When transfer_did doesn't push the transactions automatically, this monkeypatching is no longer necessary
+    with monkeypatch.context() as m:
+
+        async def nothing(*args) -> None:
+            pass
+
+        m.setattr(WalletStateManager, "add_pending_transaction", nothing)
+        for _ in range(0, 2):
+            tx = await did_wallet.transfer_did(
+                await wallet.get_puzzle_hash(new=False), uint64(0), True, wallet_environments.tx_config
+            )
+            assert tx.spend_bundle is not None
+            await client.push_tx(tx.spend_bundle)
+            await wallet_environments.process_pending_states(
+                [
+                    WalletStateTransition(
+                        pre_block_balance_updates={},
+                        post_block_balance_updates={
+                            1: {"set_remainder": True},
+                            2: {"set_remainder": True},
+                        },
+                    ),
+                    WalletStateTransition(),
+                ]
+            )
+
+    assert len(await wallet.wallet_state_manager.get_spendable_coins_for_wallet(did_wallet.id())) == 1


### PR DESCRIPTION
This addresses https://github.com/Chia-Network/chia-blockchain/issues/17242.

There's sort of two fixes in this PR.  The first subscribes to any DIDs that we sync so that when they are spent we still get their update.  This is normally covered by the transactions we submit but in edge cases where transactions are not actually pushed to the wallet, we can forget to mark previous DIDs as spent.

The second fix is to make the `DIDWallet.get_coin()` method more robust to make sure that if we somehow get into a state where multiple DIDs are unspent, we take the unspent one with the highest confirmed height to drastically increase our chances of selecting the proper one.  Should be an unnecessary change but if future bugs arise, this will mute the symptoms a bit.