### PR TITLE
Add way to get coin states in batches

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -483,6 +483,15 @@ class CoinStore:
                 elif len(coin_states) > max_items:
                     next_coin_state = coin_states.pop()
                     start_height = uint32(max(next_coin_state.created_height or 0, next_coin_state.spent_height or 0))
+
+                    while len(coin_states) > 0:
+                        last_coin_state = coin_states[-1]
+                        height = uint32(max(last_coin_state.created_height or 0, last_coin_state.spent_height or 0))
+                        if height == start_height:
+                            coin_states.pop()
+                        else:
+                            break
+
                     break
                 else:
                     start_height = min_height

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -414,8 +414,9 @@ class CoinStore:
     async def batch_coin_states_by_puzzle_hashes(
         self,
         puzzle_hashes: List[bytes32],
-        min_height: uint32 = uint32(0),
         *,
+        start_height: uint32,
+        min_height: uint32 = uint32(0),
         include_spent: bool = True,
         include_unspent: bool = True,
         include_hinted: bool = True,
@@ -435,7 +436,6 @@ class CoinStore:
         else:
             group_size = SQLITE_MAX_VARIABLE_NUMBER - other_variable_count
 
-        start_height = min_height
         synced_puzzle_hashes = 0
 
         coin_states: List[CoinState] = []
@@ -468,7 +468,7 @@ class CoinStore:
                         f"AND (confirmed_index>=? OR spent_index>=?) "
                         f"{'' if include_spent else 'AND spent_index=0'} "
                         f"{'' if include_unspent else 'AND spent_index>0'} "
-                        f"ORDER BY MAX(confirmed_index, spent_index) ASC"
+                        f"ORDER BY MAX(confirmed_index, spent_index) ASC "
                         f"LIMIT ?",
                         select_batch_db + (start_height, start_height, max_items - len(coin_states) + 1),
                     )

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -466,10 +466,10 @@ class CoinStore:
 
             is_finished: bool
 
-            if len(coin_states) == max_items:
+            if len(coin_states) <= max_items:
                 next_height = min_height
                 is_finished = True
-            elif len(coin_states) > max_items:
+            else:
                 next_coin_state = coin_states.pop()
                 next_height = uint32(max(next_coin_state.created_height or 0, next_coin_state.spent_height or 0))
 
@@ -482,9 +482,6 @@ class CoinStore:
                         break
 
                 is_finished = False
-            else:
-                next_height = min_height
-                is_finished = True
 
         return coin_states, next_height, is_finished
 

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -426,6 +426,8 @@ class CoinStore:
         Note that the maximum number of puzzle hashes is currently set to 15000.
         """
 
+        # This number is chosen such that it's below half of the Python 3.8+ SQLite variable limit.
+        # It can be changed later without breaking the protocol, but this is a practical limit for now.
         assert len(puzzle_hashes) <= 15000
 
         coin_states: List[CoinState] = []

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -486,7 +486,7 @@ class CoinStore:
                 next_height = min_height
                 is_finished = True
 
-        return (coin_states, next_height, is_finished)
+        return coin_states, next_height, is_finished
 
     async def rollback_to_block(self, block_index: int) -> List[CoinRecord]:
         """

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -621,7 +621,7 @@ async def test_batch_many_coin_states(db_version: int) -> None:
         count = 50000
 
         for i in range(count):
-            created_height = uint32(i % 2 + 100)
+            created_height = uint32(i % 2 + 10)
             coin = Coin(
                 std_hash(b"Parent Coin Id " + i.to_bytes(4, byteorder="big")),
                 ph,
@@ -647,12 +647,13 @@ async def test_batch_many_coin_states(db_version: int) -> None:
         (all_coin_states, next_height) = await coin_store.batch_coin_states_by_puzzle_hashes([ph])
         all_coin_states.sort(key=lambda cs: cs.coin.amount)
 
-        assert next_height == 0
+        assert next_height is None
         assert len(all_coin_states) == len(coin_records)
 
         for i in range(min(len(coin_records), len(all_coin_states))):
             assert coin_records[i].coin.name().hex() == all_coin_states[i].coin.name().hex(), i
 
+        # Make sure that all but the last are found, since it's at a higher height.
         await coin_store._add_coin_records(
             [
                 CoinRecord(
@@ -667,7 +668,7 @@ async def test_batch_many_coin_states(db_version: int) -> None:
 
         (all_coin_states, next_height) = await coin_store.batch_coin_states_by_puzzle_hashes([ph])
 
-        assert next_height == 101
+        assert next_height == 50
         assert len(all_coin_states) == 50000
 
 

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -555,9 +555,9 @@ async def test_coin_state_batches(
         for cr in batch_coin_records:
             if cr.spent_block_index == 0 and not include_unspent:
                 continue
-            elif cr.spent_block_index > 0 and not include_spent:
+            if cr.spent_block_index > 0 and not include_spent:
                 continue
-            elif cr.coin.puzzle_hash not in ph_set and not include_hinted:
+            if cr.coin.puzzle_hash not in ph_set and not include_hinted:
                 continue
             expected_crs.append(cr)
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

When added to the wallet protocol, this will allow wallets to sync their coin state efficiently in batches rather than downloading all of the state in a single response (which can fail if it's too large).

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

There is a unit test for ensuring that it successfully fetches the correct number of coins with a high volume of puzzle hashes (including with filters enabled and disabled), and another for high coin record count.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
