### PR TITLE
Log string header_hash on long validation warnings

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1808,7 +1808,7 @@ class FullNode:
             f"pre_validation time: {pre_validation_time:0.2f} seconds, "
             f"post-process time: {post_process_time:0.2f} seconds, "
             f"cost: {block.transactions_info.cost if block.transactions_info is not None else 'None'}"
-            f"{percent_full_str} header_hash: {block.header_hash} height: {block.height}",
+            f"{percent_full_str} header_hash: {header_hash.hex()} height: {block.height}",
         )
 
         # this is not covered by any unit tests as it's essentially test code

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1808,7 +1808,7 @@ class FullNode:
             f"pre_validation time: {pre_validation_time:0.2f} seconds, "
             f"post-process time: {post_process_time:0.2f} seconds, "
             f"cost: {block.transactions_info.cost if block.transactions_info is not None else 'None'}"
-            f"{percent_full_str} block.header_hash: {block.header_hash} height: {block.height}",
+            f"{percent_full_str} header_hash: {block.header_hash} height: {block.height}",
         )
 
         # this is not covered by any unit tests as it's essentially test code

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1808,7 +1808,7 @@ class FullNode:
             f"pre_validation time: {pre_validation_time:0.2f} seconds, "
             f"post-process time: {post_process_time:0.2f} seconds, "
             f"cost: {block.transactions_info.cost if block.transactions_info is not None else 'None'}"
-            f"{percent_full_str} header_hash: {header_hash} height: {block.height}",
+            f"{percent_full_str} header_hash: {block.header_hash} height: {block.height}",
         )
 
         # this is not covered by any unit tests as it's essentially test code

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1808,7 +1808,7 @@ class FullNode:
             f"pre_validation time: {pre_validation_time:0.2f} seconds, "
             f"post-process time: {post_process_time:0.2f} seconds, "
             f"cost: {block.transactions_info.cost if block.transactions_info is not None else 'None'}"
-            f"{percent_full_str} header_hash: {block.header_hash} height: {block.height}",
+            f"{percent_full_str} block.header_hash: {block.header_hash} height: {block.height}",
         )
 
         # this is not covered by any unit tests as it's essentially test code


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
We are logging the binary form of the header hash in the "WARNING Block validation time" is slow log entry. Instead log the human readable header hash.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Slow look up warning log looks like this:
```
2024-01-11T14:44:13.647 full_node chia.full_node.full_node: WARNING  Block validation time: 11.09 seconds, pre_validation time: 1.68 seconds, post-process time: 6.97 seconds, cost: 5462045750, percent full: 49.655% header_hash: b'\xd5\x96\xc8\x10\xb4\x93Y\x82\xf8\x99H:G\x99\xe7E\x86\x02\xaa\x97q\x868\x1fO\x97Pe\xfd27\x95' height: 4787397
```


### New Behavior:
Now these will be human readable and searchable:
```
2024-01-11T14:44:13.647 full_node chia.full_node.full_node: WARNING  Block validation time: 11.09 seconds, pre_validation time: 1.68 seconds, post-process time: 6.97 seconds, cost: 5462045750, percent full: 49.655% header_hash: d596c810b4935982f899483a4799e7458602aa977186381f4f975065fd323795 height: 4787397
```


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
