### PR TITLE
switch transaction queue completion to a new `ValuedEvent`

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -473,7 +473,7 @@ class FullNode:
         peer = entry.peer
         try:
             inc_status, err = await self.add_transaction(entry.transaction, entry.spend_name, peer, entry.test)
-            entry.done.set_result((inc_status, err))
+            entry.done.set((inc_status, err))
         except asyncio.CancelledError:
             error_stack = traceback.format_exc()
             self.log.debug(f"Cancelling _handle_one_transaction, closing: {error_stack}")

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1272,7 +1272,7 @@ class FullNodeAPI:
         await self.full_node.transaction_queue.put(queue_entry, peer_id=None, high_priority=True)
         try:
             with anyio.fail_after(delay=45):
-                status, error = await queue_entry.done
+                status, error = await queue_entry.done.wait()
         except TimeoutError:
             response = wallet_protocol.TransactionAck(spend_name, uint8(MempoolInclusionStatus.PENDING), None)
         else:

--- a/chia/types/transaction_queue_entry.py
+++ b/chia/types/transaction_queue_entry.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass, field
 from typing import Optional, Tuple
 
@@ -9,6 +8,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.spend_bundle import SpendBundle
 from chia.util.errors import Err
+from chia.util.misc import ValuedEvent
 
 
 @dataclass(frozen=True)
@@ -22,7 +22,7 @@ class TransactionQueueEntry:
     spend_name: bytes32
     peer: Optional[WSChiaConnection] = field(compare=False)
     test: bool = field(compare=False)
-    done: asyncio.Future[Tuple[MempoolInclusionStatus, Optional[Err]]] = field(
-        default_factory=asyncio.Future,
+    done: ValuedEvent[Tuple[MempoolInclusionStatus, Optional[Err]]] = field(
+        default_factory=ValuedEvent,
         compare=False,
     )

--- a/chia/util/misc.py
+++ b/chia/util/misc.py
@@ -13,6 +13,7 @@ from typing import (
     Any,
     AsyncContextManager,
     AsyncIterator,
+    ClassVar,
     Collection,
     ContextManager,
     Dict,
@@ -374,3 +375,27 @@ async def split_async_manager(manager: AsyncContextManager[object], object: T) -
         yield split
     finally:
         await split.exit(if_needed=True)
+
+
+class ValuedEventSentinel:
+    pass
+
+
+@dataclasses.dataclass
+class ValuedEvent(Generic[T]):
+    _value_sentinel: ClassVar[ValuedEventSentinel] = ValuedEventSentinel()
+
+    _event: asyncio.Event = dataclasses.field(default_factory=asyncio.Event)
+    _value: Union[ValuedEventSentinel, T] = _value_sentinel
+
+    def set(self, value: T) -> None:
+        if not isinstance(self._value, ValuedEventSentinel):
+            raise Exception("Value already set")
+        self._value = value
+        self._event.set()
+
+    async def wait(self) -> T:
+        await self._event.wait()
+        if isinstance(self._value, ValuedEventSentinel):
+            raise Exception("Value not set despite event being set")
+        return self._value


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

https://github.com/Chia-Network/chia-blockchain/pull/17171 was the introducing pr. 
 it seems this error would have been triggered when the api handler timed out waiting for the transaction to be processed and the transaction processing later completed.  i didn't feel great about using the future there and ended up getting bit by it.  when awaiting a future gets cancelled it marks the future itself as cancelled.  when something later attempts to set a result on it the invalid state error is raised.  in this case, i believe the only effect of this bug is the logging of the error.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
