### PR TITLE
add test for detecting clashing message IDs

### DIFF
--- a/tests/util/test_network_protocol_test.py
+++ b/tests/util/test_network_protocol_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import ast
 import inspect
-from typing import Any, Set, cast
+from typing import Any, Dict, Set, cast
 
 from chia.protocols import (
     farmer_protocol,
@@ -11,6 +11,7 @@ from chia.protocols import (
     harvester_protocol,
     introducer_protocol,
     pool_protocol,
+    protocol_message_types,
     shared_protocol,
     timelord_protocol,
     wallet_protocol,
@@ -45,6 +46,30 @@ def test_missing_messages_state_machine() -> None:
     assert (
         len(NO_REPLY_EXPECTED) == 7
     ), "A message was added to the protocol state machine. Make sure to update the protocol message regression test to include the new message"
+
+
+def test_message_ids() -> None:
+    parsed = ast.parse(inspect.getsource(protocol_message_types))
+    message_ids: Dict[int, str] = {}
+    for line in parsed.body:
+        if not isinstance(line, ast.ClassDef) or line.name != "ProtocolMessageTypes":
+            continue
+        for entry in line.body:
+            if not isinstance(entry, ast.Assign):  # pragma: no cover
+                continue
+            assert isinstance(entry.value, ast.Constant)
+            assert isinstance(entry.targets[0], ast.Name)
+            message_id = entry.value.value
+            message_name = entry.targets[0].id
+            if message_id in message_ids:  # pragma: no cover
+                raise AssertionError(
+                    f'protocol message ID clash between "{message_name}" and "{message_ids[message_id]}". Value {message_id}'
+                )
+            message_ids[message_id] = message_name
+            if message_id < 0 or message_id > 255:  # pragma: no cover
+                raise AssertionError(f'message ID must fit in a uint8. "{message_name}" has value {message_id}')
+        break
+    assert len(message_ids) > 0
 
 
 def test_missing_messages() -> None:


### PR DESCRIPTION
### Purpose:

It took me a long time to discover that I had introduced a message ID clashing with `none_response`. This test checks for clashing message IDs and gives a clear error message.

### Current Behavior:

The failure is non obvious.

### New Behavior:

The failure is obvious.