### PR TITLE
20240112 unheld tasks in full node

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -65,9 +65,9 @@ jobs:
             apt: '3.8'
             install_sh: '3.8'
             matrix: '3.8'
-            exclude_from:
-              limited: True
-              main: True
+            # exclude_from:
+              # limited: True
+              # main: True
           - name: '3.9'
             file_name: '3.9'
             action: '3.9'

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -142,7 +142,7 @@ class FullNode:
     pow_creation: Dict[bytes32, asyncio.Event] = dataclasses.field(default_factory=dict)
     state_changed_callback: Optional[StateChangedProtocol] = None
     full_node_peers: Optional[FullNodePeers] = None
-    full_node_peers_tasks: Dict[str, asyncio.Task[None]] = dataclasses.field(default_factory=dict)
+    full_node_peers_tasks: Dict[int, asyncio.Task[None]] = dataclasses.field(default_factory=dict)
     sync_store: SyncStore = dataclasses.field(default_factory=SyncStore)
     uncompact_task: Optional[asyncio.Task[None]] = None
     compact_vdf_requests: Set[bytes32] = dataclasses.field(default_factory=set)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -205,6 +205,7 @@ class FullNode:
         )
 
     def local_peers_task(self, task: asyncio.Task[T]) -> None:
+        # Carried into the sub task via reference.
         tasks_to_delete: List[asyncio.Task[None]] = []
 
         async def enwrap() -> None:
@@ -213,6 +214,7 @@ class FullNode:
                 del self.full_node_peers_tasks[str(id(t))]
 
         wrapper_task = asyncio.create_task(enwrap())
+        tasks_to_delete.append(str(id(wrapper_task)))
         self.full_node_peers_tasks[str(id(wrapper_task))] = wrapper_task
 
     @contextlib.asynccontextmanager
@@ -375,7 +377,7 @@ class FullNode:
                     self.mempool_manager.shut_down()
 
                 if self.full_node_peers is not None:
-                    for t in self.full_node_peers_tasks.items():
+                    for t in self.full_node_peers_tasks.values():
                         t.cancel()
                     self.local_peers_task(asyncio.create_task(self.full_node_peers.close()))
                 if self.uncompact_task is not None:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -24,6 +24,7 @@ from typing import (
     Set,
     TextIO,
     Tuple,
+    TypeVar,
     Union,
     cast,
     final,
@@ -96,6 +97,9 @@ from chia.util.log_exceptions import log_exceptions
 from chia.util.path import path_from_root
 from chia.util.profiler import enable_profiler, mem_profile_task, profile_task
 from chia.util.safe_cancel_task import cancel_task_safe
+
+# Add a type variable for use below.
+T = TypeVar("T")
 
 
 # This is the result of calling peak_post_processing, which is then fed into peak_post_processing_2

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -206,7 +206,7 @@ class FullNode:
 
     def local_peers_task(self, task: asyncio.Task[T]) -> None:
         # Carried into the sub task via reference.
-        tasks_to_delete: List[asyncio.Task[None]] = []
+        tasks_to_delete: List[str] = []
 
         async def enwrap() -> None:
             await task

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -152,7 +152,6 @@ class FullNode:
     _ui_tasks: Set[asyncio.Task[None]] = dataclasses.field(default_factory=set)
     subscriptions: PeerSubscriptions = dataclasses.field(default_factory=PeerSubscriptions)
     _transaction_queue_task: Optional[asyncio.Task[None]] = None
-    _handle_transaction_tasks: List[asyncio.Task[None]] = None
     simulator_transaction_callback: Optional[Callable[[bytes32], Awaitable[None]]] = None
     _sync_task: Optional[asyncio.Task[None]] = None
     _transaction_queue: Optional[TransactionQueue] = None
@@ -205,8 +204,8 @@ class FullNode:
             wallet_sync_queue=asyncio.Queue(),
         )
 
-    async def local_peers_task(self, task: asyncio.Task[T]) -> None:
-        tasks_to_delete = []
+    def local_peers_task(self, task: asyncio.Task[T]) -> None:
+        tasks_to_delete: List[asyncio.Task[None]] = []
 
         async def enwrap() -> None:
             await task

--- a/tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -233,6 +233,8 @@ async def test_nft_mint_from_did_rpc(
     hex_did_id = did_wallet_maker.get_my_DID()
     hmr_did_id = encode_puzzle_hash(bytes32.from_hexstr(hex_did_id), AddressType.DID.hrp(config))
 
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_maker, timeout=20)
+
     nft_wallet_maker = await api_maker.create_new_wallet(
         dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=hmr_did_id)
     )

--- a/tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -668,6 +668,8 @@ async def test_nft_mint_from_xch(
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
     funds = calculate_pool_reward(uint32(1)) + calculate_base_farmer_reward(uint32(1))
 
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_0, timeout=20)
+
     await time_out_assert(30, wallet_0.get_unconfirmed_balance, funds)
     await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
 

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 import time
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 

--- a/tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/tests/wallet/nft_wallet/test_nft_wallet.py
@@ -177,7 +177,6 @@ async def test_nft_wallet_creation_automatically(
     assert await nft_wallet_1.get_nft_count() == 1
 
 
-@pytest.mark.skipif(sys.platform == "win32" and sys.version_info < (3, 9), reason="Flaky on Windows+3.8")
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.parametrize("trusted", [True, False])
 @pytest.mark.anyio


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Use a local list in full_node to contain formerly abandoned (and possibly gc'd tasks).  Also unmark test_nft_creation_and_transfer.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

test_nft_creation_and_transfer is flaky.

### New Behavior:

Hopefully resolve this and make things better overall.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Expected to have the same behavior.  May add specific test rig support to show tasks are being held and cancelled.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
