### PR TITLE
CHIA-69 remove task for long sync

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -148,7 +148,7 @@ class FullNode:
     subscriptions: PeerSubscriptions = dataclasses.field(default_factory=PeerSubscriptions)
     _transaction_queue_task: Optional[asyncio.Task[None]] = None
     simulator_transaction_callback: Optional[Callable[[bytes32], Awaitable[None]]] = None
-    _sync_task: Optional[asyncio.Task[None]] = None
+    _sync_bool: bool = False
     _transaction_queue: Optional[TransactionQueue] = None
     _compact_vdf_sem: Optional[LimitedSemaphore] = None
     _new_peak_sem: Optional[LimitedSemaphore] = None
@@ -365,15 +365,11 @@ class FullNode:
                 if self._transaction_queue_task is not None:
                     self._transaction_queue_task.cancel()
                 cancel_task_safe(task=self.wallet_sync_task, log=self.log)
-                cancel_task_safe(task=self._sync_task, log=self.log)
 
                 for task_id, task in list(self.full_node_store.tx_fetch_tasks.items()):
                     cancel_task_safe(task, self.log)
                 if self._init_weight_proof is not None:
                     await asyncio.wait([self._init_weight_proof])
-                if self._sync_task is not None:
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await self._sync_task
 
     @property
     def block_store(self) -> BlockStore:
@@ -765,9 +761,16 @@ class FullNode:
                 if await self.short_sync_batch(peer, uint32(max(curr_peak_height - 6, 0)), request.height):
                     return None
 
+            if self._sync_bool:
+                return None
+
             # This is the either the case where we were not able to sync successfully (for example, due to the fork
             # point being in the past), or we are very far behind. Performs a long sync.
-            self._sync_task = asyncio.create_task(self._sync())
+            self._sync_bool=True
+            try:
+                await self._sync()
+            finally:
+                self._sync_bool=False 
 
     async def send_peak_to_timelords(
         self, peak_block: Optional[FullBlock] = None, peer: Optional[WSChiaConnection] = None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -766,11 +766,11 @@ class FullNode:
 
             # This is the either the case where we were not able to sync successfully (for example, due to the fork
             # point being in the past), or we are very far behind. Performs a long sync.
-            self._sync_bool=True
+            self._sync_bool = True
             try:
                 await self._sync()
             finally:
-                self._sync_bool=False 
+                self._sync_bool = False
 
     async def send_peak_to_timelords(
         self, peak_block: Optional[FullBlock] = None, peer: Optional[WSChiaConnection] = None


### PR DESCRIPTION
### Purpose:

remove task for long sync

### Current Behavior:

creates new task for long sync which could be double entered, killed, etc causing issues for sync primitives

### New Behavior:

just wait on the async function. new_peak already runs in its own task and allows 2 simultaneously.

### Testing Notes:

None