### PR TITLE
remove old work-around for a bug in version 1.1.4 and earlier

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1975,10 +1975,6 @@ class FullNode:
             validation_start = time.monotonic()
             validate_result = await self.blockchain.validate_unfinished_block(block, npc_result)
             if validate_result.error is not None:
-                if validate_result.error == Err.COIN_AMOUNT_NEGATIVE.value:
-                    # TODO: remove in the future, hotfix for 1.1.5 peers to not disconnect older peers
-                    self.log.info(f"Consensus error {validate_result.error}, not disconnecting")
-                    return
                 raise ConsensusError(Err(validate_result.error))
             validation_time = time.monotonic() - validation_start
 


### PR DESCRIPTION
### Purpose:

there was a bug in early version of the full node where an invalid block would sometimes be forwarded to peers (only to be classified invalid later). This was a work-around to not disconnect clients sending you an invalid block (given it was the right kind of invalid).

This was fixed a long time ago now, and we (probably) don't need this work-around anymore.

### Current Behavior:

If a peer sends an unfinished block that fails with `COIN_AMOUNT_NEGATIVE`, we discard the block but forgive the peer, and stay connected to it.

### New Behavior:

If a peer sends an unfinished block that's invalid, we always disconnect the peer.