### PR TITLE
bump chia_rs dependency to 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dependencies = [
     "chiapos==2.0.3",  # proof of space
     "clvm==0.9.8",
     "clvm_tools==0.4.7",  # Currying, Program.to, other conveniences
-    "chia_rs==0.3.3",
+    "chia_rs==0.4.0",
     "clvm-tools-rs==0.1.40",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.9.1",  # HTTP server for full node rpc
     "aiosqlite==0.19.0",  # asyncio wrapper for sqlite, to store blocks


### PR DESCRIPTION
### Purpose:

Changes in `chia_rs` since last release: https://github.com/Chia-Network/chia_rs/releases/tag/0.4.0

The most relevant changes are some tweaks to `Program` (the rust counterpart to `SerializedProgram`) and `HeaderBlock`.