### PR TITLE
measured new_signage_point_harvester size with 100 pools for limit

### DIFF
--- a/chia/server/rate_limit_numbers.py
+++ b/chia/server/rate_limit_numbers.py
@@ -74,7 +74,7 @@ rate_limits = {
         "rate_limits_other": {
             ProtocolMessageTypes.handshake: RLSettings(5, 10 * 1024, 5 * 10 * 1024),
             ProtocolMessageTypes.harvester_handshake: RLSettings(5, 1024 * 1024),
-            ProtocolMessageTypes.new_signage_point_harvester: RLSettings(100, 1024),
+            ProtocolMessageTypes.new_signage_point_harvester: RLSettings(100, 4886),  # Size with 100 pool list
             ProtocolMessageTypes.new_proof_of_space: RLSettings(100, 2048),
             ProtocolMessageTypes.request_signatures: RLSettings(100, 2048),
             ProtocolMessageTypes.respond_signatures: RLSettings(100, 2048),


### PR DESCRIPTION
### Purpose:

Fix signage point message for remote harvesters with large numbers of pools

### Current Behavior:

Rate limits exceeded

### New Behavior:

Rate limits OK

### Testing Notes:

N/A