### PR TITLE
Wait for wallet_node_maker to sync before creating nft_wallet_maker in test_nft_mint_from_did_rpc_no_royalties

### DIFF
--- a/tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -427,6 +427,8 @@ async def test_nft_mint_from_did_rpc_no_royalties(
     hex_did_id = did_wallet_maker.get_my_DID()
     hmr_did_id = encode_puzzle_hash(bytes32.from_hexstr(hex_did_id), AddressType.DID.hrp(config))
 
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_maker, timeout=20)
+
     nft_wallet_maker = await api_maker.create_new_wallet(
         dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=hmr_did_id)
     )


### PR DESCRIPTION
Inspired by Art's work on [unheld tasks in full node](https://github.com/Chia-Network/chia-blockchain/pull/17323). This reduces/addresses `test_nft_mint_from_did_rpc_no_royalties` flakiness.