### PR TITLE
Parallelize tests up to 4 instead of 6 for Windows

### DIFF
--- a/tests/build-job-matrix.py
+++ b/tests/build-job-matrix.py
@@ -130,7 +130,7 @@ for path in test_paths:
     process_count = {
         "macos": {False: 0, True: 4}.get(conf["parallel"], conf["parallel"]),
         "ubuntu": {False: 0, True: 6}.get(conf["parallel"], conf["parallel"]),
-        "windows": {False: 0, True: 6}.get(conf["parallel"], conf["parallel"]),
+        "windows": {False: 0, True: 4}.get(conf["parallel"], conf["parallel"]),
     }
     pytest_parallel_args = {os: f" -n {count}" for os, count in process_count.items()}
 


### PR DESCRIPTION
6 was too much when our PR activity picks up, causing many reruns for failed tests.