### PR TITLE
Add support for defining a list of full node peers to connect to

### DIFF
--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -16,7 +16,7 @@ from chia.server.outbound_message import NodeType
 from chia.server.start_service import RpcInfo, Service, async_run
 from chia.types.aliases import FullNodeService
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import load_config, load_config_cli
+from chia.util.config import get_unresolved_peer_infos, load_config, load_config_cli
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.ints import uint16
 from chia.util.misc import SignalHandlers
@@ -61,6 +61,7 @@ async def create_full_node_service(
         advertised_port=service_config["port"],
         service_name=SERVICE_NAME,
         upnp_ports=upnp_list,
+        connect_peers=get_unresolved_peer_infos(service_config, NodeType.FULL_NODE),
         on_connect_callback=full_node.on_connect,
         network_id=network_id,
         rpc_info=rpc_info,

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -353,6 +353,8 @@ timelord:
 full_node:
   # The full node server (if run) will run on this port
   port: 8444
+  # The full node will attempt to connect to these full nodes
+  full_node_peers: []
 
   # controls the sync-to-disk behavior of the database connection. Can be one of:
   # "on"    enables syncing to disk, minimizes risk of corrupting the DB in


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Allow the full node to connect to a list of full nodes configured via `config.yaml` and automatically reconnect should the connection be interrupted/disconnected.



<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Currently this is not supported, a workaround is to add peers manually via cli, but once not connected anymore they will not automatically reconnect.


### New Behavior:
A list of full nodes can be configured via `full_node_peers` in the `config.yaml`, the same way other peers are already configured.



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
