### PR TITLE
improve mempool reorg logic when the peak is a non-transaction block

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -194,6 +194,26 @@ class Blockchain(BlockchainInterface):
             return None
         return self.height_to_block_record(self._peak_height)
 
+    def get_tx_peak(self) -> Optional[BlockRecord]:
+        """
+        Return the most recent transaction block. i.e. closest to the peak of the blockchain
+        Requires the blockchain to be initialized and there to be a peak set
+        """
+
+        if self._peak_height is None:
+            return None
+        tx_height = self._peak_height
+        tx_peak = self.height_to_block_record(tx_height)
+        while not tx_peak.is_transaction_block:
+            # it seems BlockTools only produce chains where the first block is a
+            # transaction block, which makes it hard to test this case
+            if tx_height == 0:  # pragma: no cover
+                return None
+            tx_height = uint32(tx_height - 1)
+            tx_peak = self.height_to_block_record(tx_height)
+
+        return tx_peak
+
     async def get_full_peak(self) -> Optional[FullBlock]:
         if self._peak_height is None:
             return None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -316,7 +316,7 @@ class FullNode:
                     f"time taken: {int(time_taken)}s"
                 )
                 async with self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
-                    pending_tx = await self.mempool_manager.new_peak(peak, None)
+                    pending_tx = await self.mempool_manager.new_peak(self.blockchain.get_tx_peak(), None)
                 assert len(pending_tx) == 0  # no pending transactions when starting up
 
                 full_peak: Optional[FullBlock] = await self.blockchain.get_full_peak()
@@ -1544,9 +1544,8 @@ class FullNode:
 
         # Update the mempool (returns successful pending transactions added to the mempool)
         spent_coins: List[bytes32] = [coin_id for coin_id, _ in state_change_summary.removals]
-        mempool_new_peak_result: List[Tuple[SpendBundle, NPCResult, bytes32]] = await self.mempool_manager.new_peak(
-            self.blockchain.get_peak(), spent_coins
-        )
+        mempool_new_peak_result: List[Tuple[SpendBundle, NPCResult, bytes32]]
+        mempool_new_peak_result = await self.mempool_manager.new_peak(self.blockchain.get_tx_peak(), spent_coins)
 
         # Check if we detected a spent transaction, to load up our generator cache
         if block.transactions_generator is not None and self.full_node_store.previous_generator is None:

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -620,6 +620,11 @@ class MempoolManager:
     ) -> List[Tuple[SpendBundle, NPCResult, bytes32]]:
         """
         Called when a new peak is available, we try to recreate a mempool for the new tip.
+        new_peak should always be the most recent *transaction* block of the chain. Since
+        the mempool cannot traverse the chain to find the most recent transaction block,
+        we wouldn't be able to detect, and correctly update the mempool, if we saw a
+        non-transaction block on a fork. self.peak must always be set to a transaction
+        block.
         """
         if new_peak is None:
             return []


### PR DESCRIPTION
## Purpose:

This PR addresses the issue raised by https://github.com/Chia-Network/chia-blockchain/issues/17186.

## Background

In order for the mempool to evict transactions as they become invalid (either because they made it into a block or the coins they spend became spent by some other transaction), it needs to know about new blocks added to the chain.

The "ground truth" about whether a transaction is valid or not is the `CoinStore`, which the mempool has access to via the `get_coin_record` function, passed into it. This function reflects the peak of the chain, the current coin set.

### transaction blocks

The mempool needs to keep a reference to the most recent *transaction* block, because those are what matters for timelock conditions. e.g. height-based timelock conditions compare the argument against the *previous* transaction block's height, and the time-based timelock conditions compare the argument against the *previous* transaction block's timestamp. Only transaction blocks have timestamps. (see [mempool_check_time_locks()](https://github.com/Chia-Network/chia-blockchain/blob/main/chia/full_node/mempool_check_conditions.py#L189))

Since the mempool validates transactions before including them, it needs to know about the most recent transaction block, not necessarily the actual peak.

### Reorgs

When a re-org happens, the fork we switch over to is not replayed one block at a time to the mempool, it will just learn about the most recent peak. If this peak is not a transaction block, there's not much the mempool can do about it (currently). It can't update its set of transactions, because it doesn't know what the most recent transcaction block is.

As pointed out in https://github.com/Chia-Network/chia-blockchain/issues/17186, this delays updating the mempool until we receive a transaction block on the new chain. This in turn risks us failing to create a valid block if we happen to find a valid proof-of-space for that next transaction block.

## Solution

Since the mempool itself can't traverse the blockchain, even if it would detect the reorg, it can't step back to find the most recent transaction block on the new chain. A simpler solution (I believe) is to ensure that the full node only ever passes the most recent transaction block to the mempool.

This patch adds a sibling function to `Blockchain.get_peak()` called `Blockchain.get_tx_peak()`, which returns the most recent transaction block (which may be the peak, if that is a transaction block).

### Current Behavior:

the mempool may be delayed one block in updating after a reorg

### New Behavior:

The mempool updates immediately with a reorg

### Testing Notes:

There are two new tests for the `Blockchain` class, one where blocks are just added linearly and the `get_tx_block()` is tested to always return the most recent tx block. The other test exrcises a reorg where the switch-over happens on a non-transaction block, and ensures it still returns the most recent one.