### PR TITLE
Update "Could not find parent coin" error log to print hex and not bytes

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -747,7 +747,7 @@ class WalletStateManager:
             [coin_state.coin.parent_coin_info], peer=peer, fork_height=fork_height
         )
         if len(response) == 0:
-            self.log.warning(f"Could not find a parent coin with ID: {coin_state.coin.parent_coin_info}")
+            self.log.warning(f"Could not find a parent coin with ID: {coin_state.coin.parent_coin_info.hex()}")
             return None, None
         parent_coin_state = response[0]
         assert parent_coin_state.spent_height == coin_state.created_height


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Improve the usability of wallet logs by using human readable output instead of a byte array.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
```2024-01-05T14:18:36.525 wallet chia.wallet.wallet_state_manager: WARNING  Could not find a parent coin with ID: b'y;\x89\xd5bk8/\xc02_\xa2\\\x14\xbb.\x03H[\x06\xf6\xb7t\x1d\x17\n\x8b\xd0\xed\x0b\xfd\x82'```


### New Behavior:
```2024-01-05T14:18:36.525 wallet chia.wallet.wallet_state_manager: WARNING  Could not find a parent coin with ID: 793b89d5626b382fc0325fa25c14bb2e03485b06f6b7741d170a8bd0ed0bfd82```


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
