### PR TITLE
Try to fit more mempool items in a block when an item exceeds the block limit

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -413,7 +413,7 @@ class Mempool:
                     bundle_coin_spends=item.bundle_coin_spends, max_cost=cost
                 )
                 item_cost = cost - cost_saving
-                log.info("Cumulative cost: %d, item cost: %d fee per cost: %0.4f, percent: %0.4f", cost_sum, item_cost, fee / item_cost, (item_cost / self.mempool_info.max_block_clvm_cost) * 100)
+                log.info("Cumulative cost: %d, item cost: %d, fee per cost: %0.4f, percent: %0.2f", cost_sum, item_cost, fee / item_cost, (item_cost / self.mempool_info.max_block_clvm_cost) * 100)
                 if fee + fee_sum > DEFAULT_CONSTANTS.MAX_COIN_AMOUNT:
                     log.info("Fee sum exceeds MAX_COIN_AMOUNT")
                     break


### PR DESCRIPTION
## Purpose:
The purpose is to optimize the way we fill blocks from the mempool items without going into the complexity of the knapsack problem.

**Pros**
- Increase the number of fees gained by the farmers.
- Increase the number of tx/second of the network.
- Help to decongests the mempool.

**Cons**
- Slight increase of processing time.

## Current Behavior:
Today we fill the blocks from a list of mempool items sorted by `fee_per_cost`. We iterate each item one by one and see if it fit into the block. If the item's `cost` exceeds the `max_block_clvm_cost`, we break out and use all the previous items to fill the block:

https://github.com/Chia-Network/chia-blockchain/blob/4711c52fcd266c92bd9a28816b6b94adfdbde85c/chia/full_node/mempool.py#L411-L415

This can be problematic if 1 transaction is too large to fit but there is still some place in the block for smaller transactions. This can lead to situations where blocks created cannot exceed a certain percentage.

See [Discord discussion](https://discord.com/channels/1034523881404370984/1034523882268401676/1197957022105219273)


## New Behavior:
With the new behavior, if an item fails to be included in the block, we still give a try for the next `x` items. If 1 out of the `x` item fits into the block we restart the counter and try the next ones until `x` items cannot fit into the block, then we break out and use all the previous items to fill the block.


## Considerations:
`x` in this PR is arbitrarily set to `10` and could be reduced or increased. This could also be a constant.

I believe 10 more iterations is not much when we can see hundreds of items fitting in 1 block. This should not be detrimental to lower farming equipments.

## Potential improvement:
- Do not retry if we are already >`x`% full. However the results show that the blocks were between 99.8% - 99.99% full.
I don't think the gain will be significant.

## Testing Notes:
I have created a small python script that compare the 2 behavior with real mempool content based on a sample of 14 mempool from 16.01.24 / 17.01.24 / 22.01.24

2 tests were done: 
- with 10 retry
- with 5 retry

**Results**

| Label                                         | Min       | Max                 | Average | Stdev   |
|-----------------------------------------------|-----------|---------------------|---------|---------|
| Block size gain (`x` times bigger)                               | 1*        | 5.6 | 2.29    | 1.64    |
| Number of transaction gain                    | 0         | 479                 | 87      | 130     |
| Increase in time (relative) (`x` times slower)                  | 1*        | 5.68 | 1.89    | 1.35    |
| Increase in time (absolute) (`x` seconds slower)                   | 0.0000486 | 0.0009 | 0.1937 | 0.000261 |
| Number of successful retry                    | 0         | 8                   | 1.5     | 2.06    |
| Number of retry before to find a new tx       | 0         | 6                   | 1.14    | 1.61    |

* 1 means no differences.

_Notice that those times are from the simulation code run on a Mac M1 Max and not from real farmed blocks._

Only 1 sample benefited from the 10 retry.

[gist: Script + Results](https://gist.github.com/Ganbin/beb3734549529a5cce9e35438fc60042)

### Test procedure
- Create a folder named `mempool_items`.
- Add mempool json files from the chia rpc command `chia rpc full_node get_all_mempool_items > all_mempool_items_$(date +%y_%m_%d_%H_%M).json`
- Run the `simulate_create_bundle_from_mempool_items.py` script

## With Simulator
This was tested with the simulator and here are some logs :

### Current Situation
```log
2024-01-21T18:47:51.319 full_node chia.full_node.full_node_api: INFO     Farming new block!
2024-01-21T18:47:51.320 full_node chia.full_node.mempool  : INFO     Starting to make block, max cost: 5500000000
2024-01-21T18:47:51.320 full_node chia.full_node.mempool  : INFO     Cumulative cost: 0, fee per cost: 83.9653
2024-01-21T18:47:51.321 full_node chia.full_node.mempool  : INFO     Cumulative cost: 1190968752, fee per cost: 83.9653
2024-01-21T18:47:51.321 full_node chia.full_node.mempool  : INFO     Cumulative cost: 2381937504, fee per cost: 83.9653
2024-01-21T18:47:51.321 full_node chia.full_node.mempool  : INFO     Cumulative cost: 3572906256, fee per cost: 83.9653
2024-01-21T18:47:51.321 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4763875008, fee per cost: 83.9636
2024-01-21T18:47:51.321 full_node chia.full_node.mempool  : INFO     Cumulative cost of block (real cost should be less) 4763875008. Proportion full: 0.8661590923636364
```

### Tests with retry
<details>
<summary><b>Test 1</b></summary>

```log
2024-01-21T18:31:14.687 full_node chia.full_node.mempool : INFO Starting to make block, max cost: 5500000000
2024-01-21T18:31:14.687 full_node chia.full_node.mempool : INFO Cumulative cost: 0, fee per cost: 83.9653
2024-01-21T18:31:14.687 full_node chia.full_node.mempool : INFO Cumulative cost: 1190968752, fee per cost: 83.9653
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 2381937504, fee per cost: 83.9653
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 3572906256, fee per cost: 83.9653
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 4763875008, fee per cost: 83.9636
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Retrying last 1 items
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 4763875008, fee per cost: 0.0579
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 4781131481, fee per cost: 0.0579
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 4798387954, fee per cost: 0.0579
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 4815644427, fee per cost: 0.0579
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 4832900900, fee per cost: 0.0579
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 4850157373, fee per cost: 0.0579
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 4867413846, fee per cost: 0.0579
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 4884670319, fee per cost: 0.0579
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 4901926792, fee per cost: 0.0579
2024-01-21T18:31:14.688 full_node chia.full_node.mempool : INFO Cumulative cost: 4919183265, fee per cost: 0.0579
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 4936439738, fee per cost: 0.0579
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 4953696211, fee per cost: 0.0579
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 4970952684, fee per cost: 0.0579
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 4988209157, fee per cost: 0.0579
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 5005465630, fee per cost: 0.0579
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 5022722103, fee per cost: 0.0579
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 5039978576, fee per cost: 0.0579
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 5057235049, fee per cost: 0.0579
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 5074491522, fee per cost: 0.0579
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 5091747995, fee per cost: 0.0579
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 5109004468, fee per cost: 0.0578
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 5126308945, fee per cost: 0.0578
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 5143613422, fee per cost: 0.0578
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 5160917899, fee per cost: 0.0578
2024-01-21T18:31:14.689 full_node chia.full_node.mempool : INFO Cumulative cost: 5178222376, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5195526853, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5212831330, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5230135807, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5247440284, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5264744761, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5282049238, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5299353715, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5316658192, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5333962669, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5351267146, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5368571623, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5385876100, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5403180577, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5420485054, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5437789531, fee per cost: 0.0578
2024-01-21T18:31:14.690 full_node chia.full_node.mempool : INFO Cumulative cost: 5455094008, fee per cost: 0.0578
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Cumulative cost: 5472398485, fee per cost: 0.0578
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Cumulative cost: 5489702962, fee per cost: 0.0425
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Retrying last 1 items
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Cumulative cost: 5489702962, fee per cost: 0.0425
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Retrying last 2 items
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Cumulative cost: 5489702962, fee per cost: 0.0337
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Retrying last 3 items
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Cumulative cost: 5489702962, fee per cost: 0.0337
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Retrying last 4 items
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Cumulative cost: 5489702962, fee per cost: 0.0337
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Retrying last 5 items
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Cumulative cost: 5489702962, fee per cost: 0.0337
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Retrying last 6 items
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Cumulative cost: 5489702962, fee per cost: 0.0337
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Retrying last 7 items
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Cumulative cost: 5489702962, fee per cost: 0.0337
2024-01-21T18:31:14.691 full_node chia.full_node.mempool : INFO Retrying last 8 items
2024-01-21T18:31:14.692 full_node chia.full_node.mempool : INFO Cumulative cost: 5489702962, fee per cost: 0.0337
2024-01-21T18:31:14.692 full_node chia.full_node.mempool : INFO Retrying last 9 items
2024-01-21T18:31:14.692 full_node chia.full_node.mempool : INFO Cumulative cost: 5489702962, fee per cost: 0.0337
2024-01-21T18:31:14.692 full_node chia.full_node.mempool : INFO Retrying last 10 items
2024-01-21T18:31:14.692 full_node chia.full_node.mempool : INFO Cumulative cost: 5489702962, fee per cost: 0.0337
2024-01-21T18:31:14.692 full_node chia.full_node.mempool : INFO Cumulative cost of block (real cost should be less) 5489702962. Proportion full: 0.9981278112727273
```
</details>

<details>
<summary><b>Test 2</b></summary>

```log
2024-01-21T22:23:58.929 full_node chia.full_node.mempool  : INFO     Starting to make block, max cost: 5500000000
2024-01-21T22:23:58.930 full_node chia.full_node.mempool  : INFO     Cumulative cost: 0, item cost: 1190968752 fee per cost: 83.9653, percent: 21.6540
2024-01-21T22:23:58.930 full_node chia.full_node.mempool  : INFO     Cumulative cost: 1190968752, item cost: 1190968752 fee per cost: 8.3965, percent: 21.6540
2024-01-21T22:23:58.930 full_node chia.full_node.mempool  : INFO     Cumulative cost: 2381937504, item cost: 1190956750 fee per cost: 0.8397, percent: 21.6538
2024-01-21T22:23:58.930 full_node chia.full_node.mempool  : INFO     Cumulative cost: 3572894254, item cost: 1190956750 fee per cost: 0.8397, percent: 21.6538
2024-01-21T22:23:58.930 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4763851004, item cost: 1190980752 fee per cost: 0.8396, percent: 21.6542
2024-01-21T22:23:58.930 full_node chia.full_node.mempool  : INFO     Cost sum exceeds max block cost: 5954831756
2024-01-21T22:23:58.931 full_node chia.full_node.mempool  : INFO     Retry to add more items: 1/10
2024-01-21T22:23:58.931 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4763851004, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.931 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4781107477, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.931 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4798363950, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.931 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4815620423, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.931 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4832876896, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.931 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4850133369, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.931 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4867389842, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.931 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4884646315, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.931 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4901902788, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.931 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4919159261, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.932 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4936415734, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.932 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4953672207, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.932 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4970928680, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.932 full_node chia.full_node.mempool  : INFO     Cumulative cost: 4988185153, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.932 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5005441626, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.932 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5022698099, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.932 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5039954572, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.932 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5057211045, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.932 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5074467518, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.932 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5091723991, item cost: 17256473 fee per cost: 0.3477, percent: 0.3138
2024-01-21T22:23:58.932 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5108980464, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.932 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5126236937, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5143493410, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5160749883, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5178006356, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5195262829, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5212519302, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5229775775, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5247032248, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5264288721, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5281545194, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5298801667, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5316058140, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5333314613, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5350571086, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5367827559, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.933 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5385084032, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5402340505, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5419596978, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5436853451, item cost: 17256473 fee per cost: 0.2318, percent: 0.3138
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5454109924, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5471366397, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5488622870, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Cost sum exceeds max block cost: 5505879343
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Retry to add more items: 1/10
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5488622870, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Cost sum exceeds max block cost: 5505879343
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Retry to add more items: 2/10
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5488622870, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Cost sum exceeds max block cost: 5505879343
2024-01-21T22:23:58.934 full_node chia.full_node.mempool  : INFO     Retry to add more items: 3/10
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5488622870, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Cost sum exceeds max block cost: 5505879343
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Retry to add more items: 4/10
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5488622870, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Cost sum exceeds max block cost: 5505879343
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Retry to add more items: 5/10
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5488622870, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Cost sum exceeds max block cost: 5505879343
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Retry to add more items: 6/10
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5488622870, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Cost sum exceeds max block cost: 5505879343
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Retry to add more items: 7/10
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5488622870, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.935 full_node chia.full_node.mempool  : INFO     Cost sum exceeds max block cost: 5505879343
2024-01-21T22:23:58.936 full_node chia.full_node.mempool  : INFO     Retry to add more items: 8/10
2024-01-21T22:23:58.936 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5488622870, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.936 full_node chia.full_node.mempool  : INFO     Cost sum exceeds max block cost: 5505879343
2024-01-21T22:23:58.936 full_node chia.full_node.mempool  : INFO     Retry to add more items: 9/10
2024-01-21T22:23:58.936 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5488622870, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.936 full_node chia.full_node.mempool  : INFO     Cost sum exceeds max block cost: 5505879343
2024-01-21T22:23:58.936 full_node chia.full_node.mempool  : INFO     Retry to add more items: 10/10
2024-01-21T22:23:58.936 full_node chia.full_node.mempool  : INFO     Cumulative cost: 5488622870, item cost: 17256473 fee per cost: 0.0579, percent: 0.3138
2024-01-21T22:23:58.936 full_node chia.full_node.mempool  : INFO     Cost sum exceeds max block cost: 5505879343
2024-01-21T22:23:58.936 full_node chia.full_node.mempool  : INFO     Cumulative cost of block (real cost should be less) 5488622870. Proportion full: 0.9979314309090909
```
</details>

### Test procedure
- Start simulator with `autofarm off`
- Split the prefarm coins into at least 5 big coins (for example 5 coins of `1'000'000` XCH
- Create 5 split coins transactions with 5 of the big coins: 
```shell
chia wallet coins split -t <coin_id> -n 500 -a 1 -m 0.1 -f <fingerprint>
chia wallet coins split -t <coin_id> -n 500 -a 1 -m 0.01 -f <fingerprint>
chia wallet coins split -t <coin_id> -n 500 -a 1 -m 0.001 -f <fingerprint>
chia wallet coins split -t <coin_id> -n 500 -a 1 -m 0.001 -f <fingerprint>
chia wallet coins split -t <coin_id> -n 500 -a 1 -m 0.001 -f <fingerprint>
```
- Create many small transactions with some fees:
```shell
for i in {1..20}; do chia wallet send -t <target_address> -a 0.5 -m 0.000001 -f <fingerprint>; done
for i in {1..20}; do chia wallet send -t <target_address> -a 0.5 -m 0.000004 -f <fingerprint>; done
for i in {1..20}; do chia wallet send -t <target_address> -a 0.5 -m 0.000006 -f <fingerprint>; done
```
- Run `chia dev sim farm` to farm the next transaction block


## Other Notes:
Logs have been added/improved in order to give a better view of the item added.
Separate the condition about fees exceeding `MAX_COIN_AMOUNT`