### PR TITLE
just use `os.cpu_count()`

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -4,7 +4,7 @@ import asyncio
 import dataclasses
 import enum
 import logging
-import multiprocessing
+import os
 import time
 import traceback
 from concurrent.futures import Executor
@@ -141,7 +141,8 @@ class Blockchain(BlockchainInterface):
         if single_threaded:
             self.pool = InlineExecutor()
         else:
-            cpu_count = multiprocessing.cpu_count()
+            cpu_count = os.cpu_count()
+            assert cpu_count is not None
             if cpu_count > 61:
                 cpu_count = 61  # Windows Server 2016 has an issue https://bugs.python.org/issue26903
             num_workers = max(cpu_count - reserved_cores, 1)

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -5,7 +5,7 @@ import concurrent
 import contextlib
 import dataclasses
 import logging
-import multiprocessing
+import os
 from concurrent.futures.thread import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncIterator, ClassVar, Dict, List, Optional, Tuple, cast
@@ -101,8 +101,10 @@ class Harvester:
 
         context_count = config.get("parallel_decompressor_count", DEFAULT_PARALLEL_DECOMPRESSOR_COUNT)
         thread_count = config.get("decompressor_thread_count", DEFAULT_DECOMPRESSOR_THREAD_COUNT)
+        cpu_count = os.cpu_count()
+        assert cpu_count is not None
         if thread_count == 0:
-            thread_count = multiprocessing.cpu_count() // 2
+            thread_count = cpu_count // 2
         disable_cpu_affinity = config.get("disable_cpu_affinity", DEFAULT_DISABLE_CPU_AFFINITY)
         max_compression_level_allowed = config.get(
             "max_compression_level_allowed", DEFAULT_MAX_COMPRESSION_LEVEL_ALLOWED

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
-import multiprocessing
+import os
 from collections import Counter
 from pathlib import Path
 from threading import Lock
@@ -57,8 +57,10 @@ def check_plots(
 
     context_count = config["harvester"].get("parallel_decompressor_count", 5)
     thread_count = config["harvester"].get("decompressor_thread_count", 0)
+    cpu_count = os.cpu_count()
+    assert cpu_count is not None
     if thread_count == 0:
-        thread_count = multiprocessing.cpu_count() // 2
+        thread_count = cpu_count // 2
     disable_cpu_affinity = config["harvester"].get("disable_cpu_affinity", False)
     max_compression_level_allowed = config["harvester"].get("max_compression_level_allowed", 7)
     use_gpu_harvesting = config["harvester"].get("use_gpu_harvesting", False)

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-import multiprocessing
+import os
 import random
 import time
 from contextlib import asynccontextmanager
@@ -1739,7 +1739,7 @@ class TestPreValidation:
     async def test_pre_validation(self, empty_blockchain, default_1000_blocks, bt):
         blocks = default_1000_blocks[:100]
         start = time.time()
-        n_at_a_time = min(multiprocessing.cpu_count(), 32)
+        n_at_a_time = min(os.cpu_count(), 32)
         times_pv = []
         times_rb = []
         for i in range(0, len(blocks), n_at_a_time):


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

extracting from https://github.com/Chia-Network/chia-blockchain/pull/17209 where it was found that `multiprocessing.cpu_count()` seems to create a multiprocessing context which can be problematic in some cases.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
