### PR TITLE
Update pool url on redirect

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -343,7 +343,7 @@ class Farmer:
                         response: Dict[str, Any] = json.loads(await resp.text())
                         self.log.info(f"GET /pool_info response: {response}")
                         new_pool_url: Optional[str] = None
-                        if resp.url != url:
+                        if resp.url != url and all(r.status in {301, 308} for r in resp.history):
                             new_pool_url = f"{resp.url}".replace("/pool_info", "")
 
                         return GetPoolInfoResult(pool_info=response, new_pool_url=new_pool_url)

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -6,6 +6,7 @@ import json
 import logging
 import time
 import traceback
+from dataclasses import dataclass
 from math import floor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncIterator, ClassVar, Dict, List, Optional, Set, Tuple, Union, cast
@@ -17,7 +18,7 @@ from chia.consensus.constants import ConsensusConstants
 from chia.daemon.keychain_proxy import KeychainProxy, connect_to_keychain_and_validate, wrap_local_keychain
 from chia.plot_sync.delta import Delta
 from chia.plot_sync.receiver import Receiver
-from chia.pools.pool_config import PoolWalletConfig, add_auth_key, load_pool_config
+from chia.pools.pool_config import PoolWalletConfig, add_auth_key, load_pool_config, update_pool_url
 from chia.protocols import farmer_protocol, harvester_protocol
 from chia.protocols.pool_protocol import (
     AuthenticationPayload,
@@ -62,6 +63,12 @@ log = logging.getLogger(__name__)
 UPDATE_POOL_INFO_INTERVAL: int = 3600
 UPDATE_POOL_INFO_FAILURE_RETRY_INTERVAL: int = 120
 UPDATE_POOL_FARMER_INFO_INTERVAL: int = 300
+
+
+@dataclass(frozen=True)
+class GetPoolInfoResult:
+    pool_info: Dict[str, Any]
+    new_pool_url: Optional[str]
 
 
 def strip_old_entries(pairs: List[Tuple[float, Any]], before: float) -> List[Tuple[float, Any]]:
@@ -327,16 +334,19 @@ class Farmer:
         if receiver.initial_sync() or harvester_updated:
             self.state_changed("harvester_update", receiver.to_dict(True))
 
-    async def _pool_get_pool_info(self, pool_config: PoolWalletConfig) -> Optional[Dict[str, Any]]:
+    async def _pool_get_pool_info(self, pool_config: PoolWalletConfig) -> Optional[GetPoolInfoResult]:
         try:
             async with aiohttp.ClientSession(trust_env=True) as session:
-                async with session.get(
-                    f"{pool_config.pool_url}/pool_info", ssl=ssl_context_for_root(get_mozilla_ca_crt(), log=self.log)
-                ) as resp:
+                url = f"{pool_config.pool_url}/pool_info"
+                async with session.get(url, ssl=ssl_context_for_root(get_mozilla_ca_crt(), log=self.log)) as resp:
                     if resp.ok:
                         response: Dict[str, Any] = json.loads(await resp.text())
                         self.log.info(f"GET /pool_info response: {response}")
-                        return response
+                        new_pool_url: Optional[str] = None
+                        if resp.url != url:
+                            new_pool_url = f"{resp.url}".replace("/pool_info", "")
+
+                        return GetPoolInfoResult(pool_info=response, new_pool_url=new_pool_url)
                     else:
                         self.handle_failed_pool_response(
                             pool_config.p2_singleton_puzzle_hash,
@@ -560,14 +570,18 @@ class Farmer:
                 if time.time() >= pool_state["next_pool_info_update"]:
                     pool_state["next_pool_info_update"] = time.time() + UPDATE_POOL_INFO_INTERVAL
                     # Makes a GET request to the pool to get the updated information
-                    pool_info = await self._pool_get_pool_info(pool_config)
-                    if pool_info is not None and "error_code" not in pool_info:
+                    pool_info_result = await self._pool_get_pool_info(pool_config)
+                    if pool_info_result is not None and "error_code" not in pool_info_result.pool_info:
+                        pool_info = pool_info_result.pool_info
                         pool_state["authentication_token_timeout"] = pool_info["authentication_token_timeout"]
                         # Only update the first time from GET /pool_info, gets updated from GET /farmer later
                         if pool_state["current_difficulty"] is None:
                             pool_state["current_difficulty"] = pool_info["minimum_difficulty"]
                     else:
                         pool_state["next_pool_info_update"] = time.time() + UPDATE_POOL_INFO_FAILURE_RETRY_INTERVAL
+
+                    if pool_info_result is not None and pool_info_result.new_pool_url is not None:
+                        update_pool_url(self._root_path, pool_config, pool_info_result.new_pool_url)
 
                 if time.time() >= pool_state["next_farmer_update"]:
                     pool_state["next_farmer_update"] = time.time() + UPDATE_POOL_FARMER_INFO_INTERVAL

--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import Any, Callable, Dict, List
 
 from chia_rs import G1Element
 
@@ -62,22 +62,62 @@ def load_pool_config(root_path: Path) -> List[PoolWalletConfig]:
 
 # TODO: remove this a few versions after 1.3, since authentication_public_key is deprecated. This is here to support
 # downgrading to versions older than 1.3.
-def add_auth_key(root_path: Path, config_entry: PoolWalletConfig, auth_key: G1Element) -> None:
+def add_auth_key(root_path: Path, pool_wallet_config: PoolWalletConfig, auth_key: G1Element) -> None:
+    def update_auth_pub_key_for_entry(config_entry: Dict[str, Any]) -> bool:
+        auth_key_hex = bytes(auth_key).hex()
+        if config_entry.get("authentication_public_key", "") != auth_key_hex:
+            config_entry["authentication_public_key"] = auth_key_hex
+
+            return True
+
+        return False
+
+    update_pool_config_entry(
+        root_path=root_path,
+        pool_wallet_config=pool_wallet_config,
+        update_closure=update_auth_pub_key_for_entry,
+        update_log_message=f"Updating pool config for auth key: {auth_key}",
+    )
+
+
+def update_pool_url(root_path: Path, pool_wallet_config: PoolWalletConfig, pool_url: str) -> None:
+    def update_pool_url_for_entry(config_entry: Dict[str, Any]) -> bool:
+        if config_entry.get("pool_url", "") != pool_url:
+            config_entry["pool_url"] = pool_url
+
+            return True
+
+        return False
+
+    update_pool_config_entry(
+        root_path=root_path,
+        pool_wallet_config=pool_wallet_config,
+        update_closure=update_pool_url_for_entry,
+        update_log_message=f"Updating pool config for pool_url change: {pool_wallet_config.pool_url} -> {pool_url}",
+    )
+
+
+def update_pool_config_entry(
+    root_path: Path,
+    pool_wallet_config: PoolWalletConfig,
+    update_closure: Callable[[Dict[str, Any]], bool],
+    update_log_message: str,
+) -> None:
     with lock_and_load_config(root_path, "config.yaml") as config:
         pool_list = config["pool"].get("pool_list", [])
         updated = False
         if pool_list is not None:
             for pool_config_dict in pool_list:
                 try:
-                    if hexstr_to_bytes(pool_config_dict["owner_public_key"]) == bytes(config_entry.owner_public_key):
-                        auth_key_hex = bytes(auth_key).hex()
-                        if pool_config_dict.get("authentication_public_key", "") != auth_key_hex:
-                            pool_config_dict["authentication_public_key"] = auth_key_hex
+                    if hexstr_to_bytes(pool_config_dict["owner_public_key"]) == bytes(
+                        pool_wallet_config.owner_public_key
+                    ):
+                        if update_closure(pool_config_dict):
                             updated = True
                 except Exception as e:
                     log.error(f"Exception updating config: {pool_config_dict} {e}")
         if updated:
-            log.info(f"Updating pool config for auth key: {auth_key}")
+            log.info(update_log_message)
             config["pool"]["pool_list"] = pool_list
             save_config(root_path, "config.yaml", config)
 

--- a/tests/farmer_harvester/test_farmer.py
+++ b/tests/farmer_harvester/test_farmer.py
@@ -927,8 +927,8 @@ def make_pool_list_entry(overrides: Dict[str, Any]) -> Dict[str, Any]:
     return pool_list_entry
 
 
-def make_pool_info(overrides: Dict[str, Any]) -> Dict[str, Any]:
-    pool_info = {
+def make_pool_info() -> Dict[str, Any]:
+    return {
         "name": "Pool Name",
         "description": "Pool Description",
         "logo_url": "https://subdomain.pool-domain.tld/path/to/logo.svg",
@@ -939,9 +939,6 @@ def make_pool_info(overrides: Dict[str, Any]) -> Dict[str, Any]:
         "minimum_difficulty": 1,
         "authentication_token_timeout": 5,
     }
-    for key, value in overrides.items():
-        pool_info[key] = value
-    return pool_info
 
 
 def make_pool_state(p2_singleton_puzzle_hash: bytes32, overrides: Dict[str, Any]) -> Dict[str, Any]:
@@ -1026,7 +1023,7 @@ class PoolInfoCase(DataCase):
             ok=True,
             status=200,
             url=URL("https://endpoint-1.pool-domain.tld/some-path"),
-            pool_info=make_pool_info({}),
+            pool_info=make_pool_info(),
         ),
         expected_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
     ),
@@ -1037,7 +1034,7 @@ class PoolInfoCase(DataCase):
             ok=True,
             status=200,
             url=URL("https://endpoint-1337.pool-domain.tld/some-other-path"),
-            pool_info=make_pool_info({}),
+            pool_info=make_pool_info(),
             history=tuple([DummyClientResponse(status=301)]),
         ),
         expected_pool_url_in_config="https://endpoint-1337.pool-domain.tld/some-other-path",
@@ -1049,7 +1046,7 @@ class PoolInfoCase(DataCase):
             ok=True,
             status=200,
             url=URL("https://endpoint-1337.pool-domain.tld/some-other-path"),
-            pool_info=make_pool_info({}),
+            pool_info=make_pool_info(),
             history=tuple([DummyClientResponse(status=302)]),
         ),
         expected_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
@@ -1061,7 +1058,7 @@ class PoolInfoCase(DataCase):
             ok=True,
             status=200,
             url=URL("https://endpoint-1337.pool-domain.tld/some-other-path"),
-            pool_info=make_pool_info({}),
+            pool_info=make_pool_info(),
             history=tuple([DummyClientResponse(status=307)]),
         ),
         expected_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
@@ -1073,7 +1070,7 @@ class PoolInfoCase(DataCase):
             ok=True,
             status=200,
             url=URL("https://endpoint-1337.pool-domain.tld/some-other-path"),
-            pool_info=make_pool_info({}),
+            pool_info=make_pool_info(),
             history=tuple([DummyClientResponse(status=308)]),
         ),
         expected_pool_url_in_config="https://endpoint-1337.pool-domain.tld/some-other-path",
@@ -1085,7 +1082,7 @@ class PoolInfoCase(DataCase):
             ok=True,
             status=200,
             url=URL("https://endpoint-1337.pool-domain.tld/some-other-path"),
-            pool_info=make_pool_info({}),
+            pool_info=make_pool_info(),
             history=tuple([DummyClientResponse(status=308), DummyClientResponse(status=308)]),
         ),
         expected_pool_url_in_config="https://endpoint-1337.pool-domain.tld/some-other-path",
@@ -1097,7 +1094,7 @@ class PoolInfoCase(DataCase):
             ok=True,
             status=200,
             url=URL("https://endpoint-1337.pool-domain.tld/some-other-path"),
-            pool_info=make_pool_info({}),
+            pool_info=make_pool_info(),
             history=tuple([DummyClientResponse(status=307), DummyClientResponse(status=308)]),
         ),
         expected_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",

--- a/tests/farmer_harvester/test_farmer.py
+++ b/tests/farmer_harvester/test_farmer.py
@@ -4,15 +4,17 @@ import dataclasses
 import json
 import logging
 from dataclasses import dataclass
+from time import time
 from types import TracebackType
 from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
 
 import pytest
 from chia_rs import AugSchemeMPL, G1Element, G2Element, PrivateKey
 from pytest_mock import MockerFixture
+from yarl import URL
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
-from chia.farmer.farmer import Farmer, increment_pool_stats, strip_old_entries
+from chia.farmer.farmer import UPDATE_POOL_FARMER_INFO_INTERVAL, Farmer, increment_pool_stats, strip_old_entries
 from chia.pools.pool_config import PoolWalletConfig
 from chia.protocols import farmer_protocol, harvester_protocol
 from chia.protocols.harvester_protocol import NewProofOfSpace, RespondSignatures
@@ -26,10 +28,11 @@ from chia.types.blockchain_format.proof_of_space import (
     verify_and_get_quality_string,
 )
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.config import load_config, save_config
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
 from tests.conftest import HarvesterFarmerEnvironment
-from tests.util.misc import Marks, datacases
+from tests.util.misc import DataCase, Marks, datacases
 
 log = logging.getLogger(__name__)
 
@@ -908,3 +911,186 @@ async def test_farmer_pool_response(
     assert_stats_24h("stale_partials_24h")
     assert_stats_since_start("missing_partials_since_start")
     assert_stats_24h("missing_partials_24h")
+
+
+def make_pool_list_entry(overrides: Dict[str, Any]) -> Dict[str, Any]:
+    pool_list_entry = {
+        "owner_public_key": "84c3fcf9d5581c1ddc702cb0f3b4a06043303b334dd993ab42b2c320ebfa98e5ce558448615b3f69638ba92cf7f43da5",  # noqa: E501
+        "p2_singleton_puzzle_hash": "302e05a1e6af431c22043ae2a9a8f71148c955c372697cb8ab348160976283df",
+        "payout_instructions": "c2b08e41d766da4116e388357ed957d04ad754623a915f3fd65188a8746cf3e8",
+        "pool_url": "localhost",
+        "launcher_id": "ae4ef3b9bfe68949691281a015a9c16630fc8f66d48c19ca548fb80768791afa",
+        "target_puzzle_hash": "344587cf06a39db471d2cc027504e8688a0a67cce961253500c956c73603fd58",
+    }
+    for key, value in overrides.items():
+        pool_list_entry[key] = value
+    return pool_list_entry
+
+
+def make_pool_info(overrides: Dict[str, Any]) -> Dict[str, Any]:
+    pool_info = {
+        "name": "Pool Name",
+        "description": "Pool Description",
+        "logo_url": "https://subdomain.pool-domain.tld/path/to/logo.svg",
+        "target_puzzle_hash": "344587cf06a39db471d2cc027504e8688a0a67cce961253500c956c73603fd58",
+        "fee": "0.01",
+        "protocol_version": 1,
+        "relative_lock_height": 100,
+        "minimum_difficulty": 1,
+        "authentication_token_timeout": 5,
+    }
+    for key, value in overrides.items():
+        pool_info[key] = value
+    return pool_info
+
+
+def make_pool_state(p2_singleton_puzzle_hash: bytes32, overrides: Dict[str, Any]) -> Dict[str, Any]:
+    pool_info = {
+        "p2_singleton_puzzle_hash": p2_singleton_puzzle_hash.hex(),
+        "points_found_since_start": 0,
+        "points_found_24h": [],
+        "points_acknowledged_since_start": 0,
+        "points_acknowledged_24h": [],
+        "next_farmer_update": 0,
+        "next_pool_info_update": 0,
+        "current_points": 0,
+        "current_difficulty": None,
+        "pool_errors_24h": [],
+        "valid_partials_since_start": 0,
+        "valid_partials_24h": [],
+        "invalid_partials_since_start": 0,
+        "invalid_partials_24h": [],
+        "insufficient_partials_since_start": 0,
+        "insufficient_partials_24h": [],
+        "stale_partials_since_start": 0,
+        "stale_partials_24h": [],
+        "missing_partials_since_start": 0,
+        "missing_partials_24h": [],
+        "authentication_token_timeout": None,
+        "plot_count": 0,
+    }
+    for key, value in overrides.items():
+        pool_info[key] = value
+    return pool_info
+
+
+@dataclass
+class DummyPoolInfoResponse:
+    ok: bool
+    status: int
+    url: URL
+    pool_info: Optional[Dict[str, Any]] = None
+
+    async def text(self) -> str:
+        if self.pool_info is None:
+            return ""
+
+        return json.dumps(self.pool_info)
+
+    async def __aenter__(self) -> DummyPoolInfoResponse:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        pass
+
+
+@dataclass
+class PoolInfoCase(DataCase):
+    _id: str
+    initial_pool_url_in_config: str
+    pool_response: DummyPoolInfoResponse
+    expected_pool_url_in_config: str
+    marks: Marks = ()
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+
+@datacases(
+    PoolInfoCase(
+        "valid_response_without_redirect",
+        initial_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
+        pool_response=DummyPoolInfoResponse(
+            ok=True,
+            status=200,
+            url=URL("https://endpoint-1.pool-domain.tld/some-path"),
+            pool_info=make_pool_info({}),
+        ),
+        expected_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
+    ),
+    PoolInfoCase(
+        "valid_response_with_redirect",
+        initial_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
+        pool_response=DummyPoolInfoResponse(
+            ok=True,
+            status=200,
+            url=URL("https://endpoint-1337.pool-domain.tld/some-other-path"),
+            pool_info=make_pool_info({}),
+        ),
+        expected_pool_url_in_config="https://endpoint-1337.pool-domain.tld/some-other-path",
+    ),
+    PoolInfoCase(
+        "failed_request_without_redirect",
+        initial_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
+        pool_response=DummyPoolInfoResponse(
+            ok=False,
+            status=500,
+            url=URL("https://endpoint-1.pool-domain.tld/some-path"),
+        ),
+        expected_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
+    ),
+    PoolInfoCase(
+        "failed_request_with_redirect",
+        initial_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
+        pool_response=DummyPoolInfoResponse(
+            ok=False,
+            status=500,
+            url=URL("https://endpoint-1337.pool-domain.tld/some-other-path"),
+        ),
+        expected_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
+    ),
+)
+@pytest.mark.anyio
+async def test_farmer_pool_info_config_update(
+    mocker: MockerFixture,
+    farmer_one_harvester: Tuple[List[HarvesterService], FarmerService, BlockTools],
+    case: PoolInfoCase,
+) -> None:
+    _, farmer_service, _ = farmer_one_harvester
+    p2_singleton_puzzle_hash = bytes32.fromhex("302e05a1e6af431c22043ae2a9a8f71148c955c372697cb8ab348160976283df")
+    farmer_service._node.authentication_keys = {
+        p2_singleton_puzzle_hash: PrivateKey.from_bytes(
+            bytes.fromhex("11ed596eb95b31364a9185e948f6b66be30415f816819449d5d40751dc70e786")
+        ),
+    }
+    farmer_service._node.pool_state[p2_singleton_puzzle_hash] = make_pool_state(
+        p2_singleton_puzzle_hash,
+        overrides={
+            "next_farmer_update": time() + UPDATE_POOL_FARMER_INFO_INTERVAL,
+        },
+    )
+    config = load_config(farmer_service.root_path, "config.yaml")
+    config["pool"]["pool_list"] = [
+        make_pool_list_entry(
+            overrides={
+                "p2_singleton_puzzle_hash": p2_singleton_puzzle_hash.hex(),
+                "pool_url": case.initial_pool_url_in_config,
+            }
+        )
+    ]
+    save_config(farmer_service.root_path, "config.yaml", config)
+    mock_http_get = mocker.patch("aiohttp.ClientSession.get", return_value=case.pool_response)
+
+    await farmer_service._node.update_pool_state()
+
+    mock_http_get.assert_called_once()
+    config = load_config(farmer_service.root_path, "config.yaml")
+    assert len(config["pool"]["pool_list"]) == 1
+    assert config["pool"]["pool_list"][0]["p2_singleton_puzzle_hash"] == p2_singleton_puzzle_hash.hex()
+    assert config["pool"]["pool_list"][0]["pool_url"] == case.expected_pool_url_in_config


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Support the migration of pool farmer api urls: when a pool changes its farmer api url, the client persists the new url to be able to continue to communicate with the pool should the old url stop working in the future.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Pools can already setup redirects to a new farmer api url and they will get used correctly, however the new url is not persisted by the client.

### New Behavior:
When a url change is detected the new url is persisted.
