### PR TITLE
use rust implementation of CoinSpend

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -1223,10 +1223,7 @@ class DataLayerWallet:
             )
 
             new_solution: Program = dl_solution.replace(rrffrf=new_graftroot, rrffrrf=Program.to([None] * 5))
-            new_spend: CoinSpend = dataclasses.replace(
-                dl_spend,
-                solution=SerializedProgram.from_program(new_solution),
-            )
+            new_spend: CoinSpend = dl_spend.replace(solution=SerializedProgram.from_program(new_solution))
             signed_bundle = await dl_wallet.sign(new_spend)
             new_bundle: SpendBundle = dataclasses.replace(
                 txs[0].spend_bundle,
@@ -1307,10 +1304,7 @@ class DataLayerWallet:
                             ]
                         )
                     )
-                    new_spend: CoinSpend = dataclasses.replace(
-                        spend,
-                        solution=SerializedProgram.from_program(new_solution),
-                    )
+                    new_spend: CoinSpend = spend.replace(solution=SerializedProgram.from_program(new_solution))
                     spend = new_spend
             new_spends.append(spend)
 

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple, Union
 
+import chia_rs
+
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
@@ -13,19 +15,7 @@ from chia.types.condition_with_args import ConditionWithArgs
 from chia.util.errors import Err, ValidationError
 from chia.util.streamable import Streamable, streamable
 
-
-@streamable
-@dataclass(frozen=True)
-class CoinSpend(Streamable):
-    """
-    This is a rather disparate data structure that validates coin transfers. It's generally populated
-    with data from different sources, since burned coins are identified by name, so it is built up
-    more often that it is streamed.
-    """
-
-    coin: Coin
-    puzzle_reveal: SerializedProgram
-    solution: SerializedProgram
+CoinSpend = chia_rs.CoinSpend
 
 
 def make_spend(

--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -544,8 +544,7 @@ class VCWallet:
                 if crcat_spend.crcat.coin.name() in spends_to_fix:
                     spend_to_fix: CoinSpend = spends_to_fix[crcat_spend.crcat.coin.name()]
                     other_spends.append(
-                        dataclasses.replace(
-                            spend_to_fix,
+                        spend_to_fix.replace(
                             solution=SerializedProgram.from_program(
                                 spend_to_fix.solution.to_program().replace(
                                     ff=coin_args[coin_name][0],

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -237,7 +237,7 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
 
         block_spends_with_conditions = sorted(block_spends_with_conditions, key=lambda x: str(x.coin_spend))
 
-        coin_spend_with_conditions = block_spends_with_conditions[0]
+        coin_spend_with_conditions = block_spends_with_conditions[1]
 
         assert coin_spend_with_conditions.coin_spend.coin == Coin(
             bytes.fromhex("e3b0c44298fc1c149afbf4c8996fb9240000000000000000000000000000000a"),
@@ -275,7 +275,7 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
             ),
         ]
 
-        coin_spend_with_conditions = block_spends_with_conditions[1]
+        coin_spend_with_conditions = block_spends_with_conditions[2]
 
         assert coin_spend_with_conditions.coin_spend.coin == Coin(
             bytes.fromhex("e3b0c44298fc1c149afbf4c8996fb9240000000000000000000000000000000b"),
@@ -313,7 +313,7 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
             ),
         ]
 
-        coin_spend_with_conditions = block_spends_with_conditions[2]
+        coin_spend_with_conditions = block_spends_with_conditions[0]
 
         assert coin_spend_with_conditions.coin_spend.coin == Coin(
             bytes.fromhex("27ae41e4649b934ca495991b7852b8550000000000000000000000000000000b"),

--- a/tests/wallet/cat_wallet/test_offer_lifecycle.py
+++ b/tests/wallet/cat_wallet/test_offer_lifecycle.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import replace
 from typing import Any, Dict, List, Optional, cast
 
 import pytest
@@ -265,8 +264,7 @@ async def test_complex_offer(cost_logger: CostLogger) -> None:
         tail_offer = Offer.from_spend_bundle(SpendBundle(new_spends_list, G2Element()))
         valid_spend = tail_offer.to_valid_spend(random_hash)
         real_blue_spend = [spend for spend in valid_spend.coin_spends if b"hey there" in bytes(spend)][0]
-        real_blue_spend_replaced = replace(
-            real_blue_spend,
+        real_blue_spend_replaced = real_blue_spend.replace(
             solution=SerializedProgram.from_program(
                 real_blue_spend.solution.to_program().replace(
                     ffrfrf=Program.to(-113), ffrfrr=Program.to([str_to_tail("blue"), []])


### PR DESCRIPTION
### Purpose:

transition the `CoinSpend` class to use the rust counterpart.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
