### PR TITLE
use `psutil.cpu_affinity()` instead of `os.cpu_count()`

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -4,7 +4,6 @@ import asyncio
 import dataclasses
 import enum
 import logging
-import os
 import time
 import traceback
 from concurrent.futures import Executor
@@ -51,6 +50,7 @@ from chia.util.generator_tools import get_block_header
 from chia.util.hash import std_hash
 from chia.util.inline_executor import InlineExecutor
 from chia.util.ints import uint16, uint32, uint64, uint128
+from chia.util.misc import available_logical_cores
 from chia.util.priority_mutex import PriorityMutex
 from chia.util.setproctitle import getproctitle, setproctitle
 
@@ -141,10 +141,7 @@ class Blockchain(BlockchainInterface):
         if single_threaded:
             self.pool = InlineExecutor()
         else:
-            cpu_count = os.cpu_count()
-            assert cpu_count is not None
-            if cpu_count > 61:
-                cpu_count = 61  # Windows Server 2016 has an issue https://bugs.python.org/issue26903
+            cpu_count = available_logical_cores()
             num_workers = max(cpu_count - reserved_cores, 1)
             self.pool = ProcessPoolExecutor(
                 max_workers=num_workers,

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -5,7 +5,6 @@ import concurrent
 import contextlib
 import dataclasses
 import logging
-import os
 from concurrent.futures.thread import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncIterator, ClassVar, Dict, List, Optional, Tuple, cast
@@ -40,6 +39,7 @@ from chia.server.outbound_message import NodeType
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
 from chia.util.ints import uint32
+from chia.util.misc import available_logical_cores
 
 log = logging.getLogger(__name__)
 
@@ -101,8 +101,7 @@ class Harvester:
 
         context_count = config.get("parallel_decompressor_count", DEFAULT_PARALLEL_DECOMPRESSOR_COUNT)
         thread_count = config.get("decompressor_thread_count", DEFAULT_DECOMPRESSOR_THREAD_COUNT)
-        cpu_count = os.cpu_count()
-        assert cpu_count is not None
+        cpu_count = available_logical_cores()
         if thread_count == 0:
             thread_count = cpu_count // 2
         disable_cpu_affinity = config.get("disable_cpu_affinity", DEFAULT_DISABLE_CPU_AFFINITY)

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
-import os
 from collections import Counter
 from pathlib import Path
 from threading import Lock
@@ -27,6 +26,7 @@ from chia.util.config import load_config
 from chia.util.hash import std_hash
 from chia.util.ints import uint32
 from chia.util.keychain import Keychain
+from chia.util.misc import available_logical_cores
 from chia.wallet.derive_keys import master_sk_to_farmer_sk, master_sk_to_local_sk
 
 log = logging.getLogger(__name__)
@@ -57,8 +57,7 @@ def check_plots(
 
     context_count = config["harvester"].get("parallel_decompressor_count", 5)
     thread_count = config["harvester"].get("decompressor_thread_count", 0)
-    cpu_count = os.cpu_count()
-    assert cpu_count is not None
+    cpu_count = available_logical_cores()
     if thread_count == 0:
         thread_count = cpu_count // 2
     disable_cpu_affinity = config["harvester"].get("disable_cpu_affinity", False)

--- a/chia/util/beta_metrics.py
+++ b/chia/util/beta_metrics.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 import psutil
 
 from chia.util.config import load_config
+from chia.util.misc import available_logical_cores
 
 log = logging.getLogger("beta")
 
@@ -23,6 +24,7 @@ def log_static_info() -> None:
     log.debug(f"architecture: {platform.architecture()}")
     log.debug(f"processor: {platform.processor()}")
     log.debug(f"cpu count: {psutil.cpu_count()}")
+    log.debug(f"available logical cores: {available_logical_cores()}")
     log.debug(f"machine: {platform.machine()}")
     log.debug(f"platform: {platform.platform()}")
 

--- a/chia/util/misc.py
+++ b/chia/util/misc.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import dataclasses
 import functools
+import os
 import signal
 import sys
 from dataclasses import dataclass
@@ -403,4 +404,7 @@ class ValuedEvent(Generic[T]):
 
 
 def available_logical_cores() -> int:
+    if sys.platform == "darwin":
+        return os.cpu_count()
+
     return len(psutil.Process().cpu_affinity())

--- a/chia/util/misc.py
+++ b/chia/util/misc.py
@@ -405,6 +405,8 @@ class ValuedEvent(Generic[T]):
 
 def available_logical_cores() -> int:
     if sys.platform == "darwin":
-        return os.cpu_count()
+        count = os.cpu_count()
+        assert count is not None
+        return count
 
     return len(psutil.Process().cpu_affinity())

--- a/chia/util/misc.py
+++ b/chia/util/misc.py
@@ -27,6 +27,7 @@ from typing import (
     final,
 )
 
+import psutil
 from typing_extensions import Protocol
 
 from chia.util.errors import InvalidPathError
@@ -399,3 +400,7 @@ class ValuedEvent(Generic[T]):
         if isinstance(self._value, ValuedEventSentinel):
             raise Exception("Value not set despite event being set")
         return self._value
+
+
+def available_logical_cores() -> int:
+    return len(psutil.Process().cpu_affinity())

--- a/tests/blockchain/test_blockchain.py
+++ b/tests/blockchain/test_blockchain.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-import os
 import random
 import time
 from contextlib import asynccontextmanager
@@ -47,6 +46,7 @@ from chia.util.generator_tools import get_block_header
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64
 from chia.util.merkle_set import MerkleSet
+from chia.util.misc import available_logical_cores
 from chia.util.recursive_replace import recursive_replace
 from chia.util.vdf_prover import get_vdf_info_and_proof
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
@@ -1741,7 +1741,7 @@ class TestPreValidation:
     async def test_pre_validation(self, empty_blockchain, default_1000_blocks, bt):
         blocks = default_1000_blocks[:100]
         start = time.time()
-        n_at_a_time = min(os.cpu_count(), 32)
+        n_at_a_time = min(available_logical_cores(), 32)
         times_pv = []
         times_rb = []
         for i in range(0, len(blocks), n_at_a_time):


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Hand off handling of various cases to psutil.  Similar to https://github.com/Chia-Network/chia-blockchain/pull/6131.

https://psutil.readthedocs.io/en/latest/#psutil.cpu_count
> Note that `psutil.cpu_count()` may not necessarily be equivalent to the actual number of CPUs the current process can use. That can vary in case process CPU affinity has been changed, Linux cgroups are being used or (in case of Windows) on systems using processor groups or having more than 64 CPUs. The number of usable CPUs can be obtained with:

```python-console
>>> len(psutil.Process().cpu_affinity())
1
```

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
