### PR TITLE
Fix negative plot sync durations not crashing the harvester

### DIFF
--- a/chia/plot_sync/sender.py
+++ b/chia/plot_sync/sender.py
@@ -299,7 +299,7 @@ class Sender:
         self._add_list_batched(ProtocolMessageTypes.plot_sync_keys_missing, PlotSyncPathList, no_key_list)
         duplicates_list = self._plot_manager.get_duplicates().copy()
         self._add_list_batched(ProtocolMessageTypes.plot_sync_duplicates, PlotSyncPathList, duplicates_list)
-        self._add_message(ProtocolMessageTypes.plot_sync_done, PlotSyncDone, uint64(int(duration)))
+        self._add_message(ProtocolMessageTypes.plot_sync_done, PlotSyncDone, uint64(max(0, int(duration))))
 
     def _finalize_sync(self) -> None:
         log.debug(f"_finalize_sync {self}")

--- a/tests/plot_sync/test_sender.py
+++ b/tests/plot_sync/test_sender.py
@@ -113,7 +113,4 @@ def test_sync_done_with_negative_duration_does_not_crash(bt: BlockTools) -> None
     sender = Sender(bt.plot_manager, HarvestingMode.CPU)
     sender.sync_start(0, True)
 
-    try:
-        sender.sync_done([], -1)
-    except Exception as e:
-        assert False, f"'sender.sync_done' raised an exception: {e}"
+    sender.sync_done([], -1)

--- a/tests/plot_sync/test_sender.py
+++ b/tests/plot_sync/test_sender.py
@@ -107,3 +107,13 @@ def test_set_response(bt: BlockTools) -> None:
     # Test invalid message-type
     sender._response = new_expected_response(3, 0, ProtocolMessageTypes.plot_sync_start)
     assert not sender.set_response(new_response_message(3, 0, ProtocolMessageTypes.plot_sync_loaded))
+
+
+def test_sync_done_with_negative_duration_does_not_crash(bt: BlockTools) -> None:
+    sender = Sender(bt.plot_manager, HarvestingMode.CPU)
+    sender.sync_start(0, True)
+
+    try:
+        sender.sync_done([], -1)
+    except Exception as e:
+        assert False, f"'sender.sync_done' raised an exception: {e}"


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Ensure negative durations do not crash the harvester.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
A negative duration will crash the harvester.


### New Behavior:
A negative duration will not crash the harvester.

### Side note:
I don't know why the bug report was closed without any comment half a year ago, but this issue was present since 1.3.4 and still is in the latest chia version as of writing. This occurring might be rare but it does happen and should not just be closed, especially when the fix is a one liner.


Fixes https://github.com/Chia-Network/chia-blockchain/issues/15027