### PR TITLE
Speedup test_request_block_headers_rejected

### DIFF
--- a/tests/wallet/sync/test_wallet_sync.py
+++ b/tests/wallet/sync/test_wallet_sync.py
@@ -35,6 +35,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.block_cache import BlockCache
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64, uint128
+from chia.util.misc import to_batches
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.payment import Payment
 from chia.wallet.util.compute_memos import compute_memos
@@ -109,7 +110,7 @@ async def test_request_block_headers(
 # )
 @pytest.mark.anyio
 async def test_request_block_headers_rejected(
-    simulator_and_wallet: OldSimulatorsAndWallets, default_1000_blocks: List[FullBlock]
+    simulator_and_wallet: OldSimulatorsAndWallets, default_400_blocks: List[FullBlock]
 ) -> None:
     # Tests the edge case of receiving funds right before the recent blocks  in weight proof
     [full_node_api], _, _ = simulator_and_wallet
@@ -122,8 +123,8 @@ async def test_request_block_headers_rejected(
     assert msg is not None
     assert msg.type == ProtocolMessageTypes.reject_block_headers.value
 
-    for block in default_1000_blocks[:150]:
-        await full_node_api.full_node.add_block(block)
+    for block_batch in to_batches(default_400_blocks[:150], 64):
+        await full_node_api.full_node.add_block_batch(block_batch.entries, PeerInfo("0.0.0.0", 0), None)
 
     msg = await full_node_api.request_block_headers(wallet_protocol.RequestBlockHeaders(uint32(80), uint32(99), False))
     assert msg is not None


### PR DESCRIPTION
Local testing:
* before: 1 passed in 17.15s
* after: 1 passed in 8.70s

Before:
![test_request_block_headers_rejected_before](https://github.com/Chia-Network/chia-blockchain/assets/352225/b60e1e77-7803-4a36-88e1-2d94f0b878aa)


After:
![test_request_block_headers_rejected_after](https://github.com/Chia-Network/chia-blockchain/assets/352225/ceb855a7-e5f4-41ac-bfe3-d62c76a19310)

