### PR TITLE
Speedup test_get_balance

### DIFF
--- a/tests/wallet/test_wallet_node.py
+++ b/tests/wallet/test_wallet_node.py
@@ -24,6 +24,7 @@ from chia.util.config import load_config
 from chia.util.errors import Err
 from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.keychain import Keychain, KeyData, generate_mnemonic
+from chia.util.misc import to_batches
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.wallet_node import Balance, WalletNode
 from tests.conftest import ConsensusMode
@@ -413,8 +414,8 @@ async def test_get_balance(
     #       with that to a KeyError when applying the race cache if there are less than WEIGHT_PROOF_RECENT_BLOCKS
     #       blocks but we still have a peak stored in the DB. So we need to add enough blocks for a weight proof here to
     #       be able to restart the wallet in this test.
-    for block in default_400_blocks:
-        await full_node_api.full_node.add_block(block)
+    for block_batch in to_batches(default_400_blocks, 64):
+        await full_node_api.full_node.add_block_batch(block_batch.entries, PeerInfo("0.0.0.0", 0), None)
 
     # Initially there should be no sync and no balance
     assert not wallet_synced()


### PR DESCRIPTION
Local testing:
* before: 1 passed in 49.00s
* after: 1 passed in 25.25s

Before:
![test_get_balance_before](https://github.com/Chia-Network/chia-blockchain/assets/352225/7804c5e0-37d2-4602-8d36-89b7cc234f67)


After:
![test_get_balance_after](https://github.com/Chia-Network/chia-blockchain/assets/352225/f5db0e64-97b9-4ca1-a4c8-e4e49bc8ff0c)

