### PR TITLE
Calculate royalty details locally if the NFT mint is part of an NFT offer

### DIFF
--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -28,6 +28,7 @@ from chia.util.config import selected_network_address_prefix
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.conditions import CreateCoinAnnouncement, CreatePuzzleAnnouncement
 from chia.wallet.nft_wallet.nft_info import NFTInfo
+from chia.wallet.nft_wallet.uncurry_nft import UncurriedNFT
 from chia.wallet.outer_puzzles import AssetType
 from chia.wallet.puzzle_drivers import PuzzleInfo
 from chia.wallet.trade_record import TradeRecord
@@ -720,7 +721,13 @@ async def take_offer(
         royalty_asset_dict: Dict[Any, Tuple[Any, uint16]] = {}
         for royalty_asset_id in nft_coin_ids_supporting_royalties_from_offer(offer):
             if royalty_asset_id.hex() in offered:
-                percentage, address = await get_nft_royalty_percentage_and_address(royalty_asset_id, wallet_client)
+                eve_spend = next((cs for cs in offer.coin_spends() if cs.coin.parent_coin_info == royalty_asset_id), None)
+                if eve_spend:
+                    uncurried_nft = UncurriedNFT.uncurry(*eve_spend.puzzle_reveal.uncurry())
+                    percentage = uncurried_nft.trade_price_percentage
+                    address = uncurried_nft.royalty_address
+                else:
+                    percentage, address = await get_nft_royalty_percentage_and_address(royalty_asset_id, wallet_client)
                 royalty_asset_dict[encode_puzzle_hash(royalty_asset_id, AddressType.NFT.hrp(config))] = (
                     encode_puzzle_hash(address, AddressType.XCH.hrp(config)),
                     percentage,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
This fix enables the Chia wallet to take an offer where the NFT mint is part of the spend bundle.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
The royalty calculation fails, since it wants to look up the latest NFT spend on chain, which it can't find.


### New Behavior:
If the eve coin of an NFT is part of the spend, it will use that to figure out the royalty percentage and address, instead of asking the full node.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
As far as I could tell, there is no unit test for an XCH/NFT trade on this level.

For manual testing, here is an offer that mints and trades an NFT on testnet11:
`offer1qqr83wcuu2rykcmqvpsxzgqqemhmlaekcenaz02ma6hs5w600dhjlvfjn477nkwz369h88kll73h37fefnwk3qqnz8s0lle04zh8se9ldh0venenns820n90dtl39xxrc20da7uh049cqsap5dkzkvz89hs85v8hejakl8jkrllqd6d2ckwn3xzlltsa80gmsu8haht3hajrmrmyl8ljdeshvqaauzdn93dt0aedsaruqm44svk9xre0exuzs525lusx6xk8t9067adhzdld0l0884vd6463k9vm4e7t480320ulv7r5whfwp7uk87fs028a6qs3dr2rrshzp6j6mkeylc0jn8u2gz95z35sxasgyxksena37adulsl5vwcwt5z95mrjllreqswv7nvcqz4lqczgwzw7u9qkjlxr43psc9vprj8wck9qwwu4r7e3ppferx9qse9s8w3uv3w9j87wzar4xsc9c7qfggx2xdv8d700qm4w6xyrt2j2p2z3gp43egw47zc9aqqd0pcqfw2lvqp7eq4qwemmqramvy6y0tvsn234v3p4glsnvknqwvp49hcyu9u0egmz2nhehqxrweql624rur7hwte7hpme4ymd6wwjfa7agl8z0az8nrzg5k7afeltrftx8e2dn7c0549fuqgfqlftaegm45umf0xwe2ht36j577az29uhlyknj77swcj4fkgzmlu7ze07y997c8qv7m7lvmtqef4k092uk5kdjexapupl7k8xexr6pj5y2cwuhya6vlte66xakl7vpckddax0vhesxrd77l8emswfd6epqxvc25r9l7atelw5zu7e4ett0l7deh9q4td60nhvm2m8dugyn0eav2uhva0t4hsd24m8fadtet66kx9yg02w7tecw80wj497cht3d6v2n7ds7pg4mdkm4fawqe2uv98m3el78j6lstxyej6lam0ldw83z3nk98m6c5rqnla9cumft83lyu84234shsqjk6mzlsp9ttcek8sh04y2cln09h5ps7p9lp8um8qz8ujkae9wrmdz55ynkuk7mdkcxfn5dre9acxwhnal45345hs3u6fngjv228twa60e4k060pxmac64fhamwnn27t935zpfyq2p82x9rquzxgnjydf9lyc92flsp903v9j94fpkxf9z78v6r7xcrzgjgaewfsujrnucsj5wpvxwl7m2zkemul6ew0a9n7rhk8eyec0rsunh77h7n8l687uxg5449jc7stdekfur6n0e0wga44u4d79xc2lwqwwl7g4drqmleekhf8r5wmnxzth0ljmcgrxp2tyr8r2wsk85apfrvfl8g2suycuxffkzy95ekuz4k6q9p62pvs6cw5nc338vp5exqxxyasq0muyl3leyxst0lle0l4l6qv9r5jj2pkz2tuljjvddxg5n2ve39xlnevesk77ze3wghzutetpzev6trdpc85jnhkec4hzz3desev5dn2ps95468v32ky7znwes9umak2pm2yhmxg9dtqhjltdyhqjt72p3842j7fen9ada7den4lzrmvfgy565l4wgyzuzgvee8w653teq9uw73jyvq5lln4vcyjxaeaxy84706tkwl7mtae7vafymyxuvymr90997aj9e9m8el7ljj9lghg304w3w4vur7rlghjnfc5ns5hv4f8x8ps3yk5jqemy4s5ye8wek93w5lrpu98vlyj6t0n0nnlqdm2ljavq4h4najl7vez2vjanupq5lhrtr2jjex7axyq39fx86axqct5c5rspalar4wnqsrd8lgkf37x0cgggrtqucd4jhr3whjv967fsdpteulp87w0s3p83kdrqsg73k2tgk5njqnaff9d5pu94z6q8vj5mg0guwq5gy343zu3pzqqj494rgsu579q2xqu4uvzyc8c5vzgp9p3yplr437ydnevutcw93sfprsymtnkgrlvd9g8ccsvzzlgvey7vphzy797qkjqr3pxdqu2vuz8zhgqe27k0lpwpxmqm6puf8cg4qjncts9knusrgk28yyqqqsukpedq6pznw5`

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
