### PR TITLE
move `RecordingWebServer` to `tests.util.misc`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ from chia.wallet.wallet_node_api import WalletNodeAPI
 from tests.core.data_layer.util import ChiaRoot
 from tests.core.node_height import node_height_at_least
 from tests.simulation.test_simulation import test_constants_modified
-from tests.util.misc import BenchmarkRunner, GcMode, _AssertRuntime, measure_overhead
+from tests.util.misc import BenchmarkRunner, GcMode, RecordingWebServer, _AssertRuntime, measure_overhead
 from tests.util.setup_nodes import (
     OldSimulatorsAndWallets,
     SimulatorsAndWallets,
@@ -1175,3 +1175,15 @@ async def farmer_harvester_2_simulators_zero_bits_plot_filter(
         )
 
         yield farmer_service, harvester_service, simulators[0], simulators[1], bt
+
+
+@pytest.fixture(name="recording_web_server")
+async def recording_web_server_fixture(self_hostname: str) -> AsyncIterator[RecordingWebServer]:
+    server = await RecordingWebServer.create(
+        hostname=self_hostname,
+        port=uint16(0),
+    )
+    try:
+        yield server
+    finally:
+        await server.await_closed()


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

This makes the `RecordingWebServer` available to all tests instead of just the DataLayer tests it was written for.  Additionally, the value of a `"response"` key in the request will be used, if present, as the response.  This allows for testing success and failure handling in the RPC client, for example.  This work is being done in support of https://github.com/Chia-Network/chia-blockchain/pull/17460.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
