### PR TITLE
optimize trade store

### DIFF
--- a/chia/wallet/trading/trade_store.py
+++ b/chia/wallet/trading/trade_store.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 import logging
 from time import perf_counter
 from typing import Dict, List, Optional, Set, Tuple
@@ -174,14 +173,25 @@ class TradeStore:
                 )
                 if existing_trades_with_same_offer:
                     raise ValueError("Trade for this offer already exists.")
+            old_trade_record = TradeRecordOld(
+                record.confirmed_at_index,
+                record.accepted_at_time,
+                record.created_at_time,
+                record.is_my_offer,
+                record.sent,
+                record.offer,
+                record.taken_offer,
+                record.coins_of_interest,
+                record.trade_id,
+                record.status,
+                record.sent_to,
+            )
             cursor = await conn.execute(
                 "INSERT OR REPLACE INTO trade_records "
                 "(trade_record, trade_id, status, confirmed_at_index, created_at_time, sent, offer_name, is_my_offer) "
                 "VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
                 (
-                    bytes(
-                        TradeRecordOld(**{k: v for k, v in dataclasses.asdict(record).items() if k != "valid_times"})
-                    ),
+                    bytes(old_trade_record),
                     record.trade_id.hex(),
                     record.status,
                     record.confirmed_at_index,
@@ -491,7 +501,17 @@ class TradeStore:
         return [
             TradeRecord(
                 valid_times=valid_times[record.trade_id] if record.trade_id in valid_times else ConditionValidTimes(),
-                **dataclasses.asdict(record),
+                confirmed_at_index=record.confirmed_at_index,
+                accepted_at_time=record.accepted_at_time,
+                created_at_time=record.created_at_time,
+                is_my_offer=record.is_my_offer,
+                sent=record.sent,
+                offer=record.offer,
+                taken_offer=record.taken_offer,
+                coins_of_interest=record.coins_of_interest,
+                trade_id=record.trade_id,
+                status=record.status,
+                sent_to=record.sent_to,
             )
             for record in old_records
         ]


### PR DESCRIPTION
### Purpose:

make the trade store use significantly less CPU, and make the test run a bit faster (but they seem to be mostly I/O bound anyway).

### Current Behavior:

In order to convert between `TradeRecord` and `TradeRecordOld`, we go via `dataclasses.asdict()`, which performs a deep copy of the whole class. This is expensive, see profile below.

### New Behavior:

Converting between `TradeRecord` and `TradeRecordOld` is simply done by passing in the fields (by reference).


### Testing Notes:

| function | before | after | after/before |
| --- | --- | --- | --- |
| add_trade_record | 33.01% | 26.53 % | 80.37% |
| get_all_trades | 11.62% | 4.41% | 37.95% |

The run time of the test is not materially affected:

```
before: 435.29s (0:07:15)
after: 423.02s (0:07:03)
```

#### before

![before](https://github.com/Chia-Network/chia-blockchain/assets/661450/3f321896-9d11-4458-8a55-650caf89cf8c)


#### after

![after](https://github.com/Chia-Network/chia-blockchain/assets/661450/58c949bf-9134-4c8c-932c-088275fcac21)
