### PR TITLE
Bump chia rs 0.5.2

### DIFF
--- a/benchmarks/mempool-long-lived.py
+++ b/benchmarks/mempool-long-lived.py
@@ -106,7 +106,7 @@ async def run_mempool_benchmark() -> None:
 
         # add 10 transactions to the mempool
         for i in range(10):
-            coin = Coin(make_hash(height * 10 + i), IDENTITY_PUZZLE_HASH, height * 100000 + i * 100)
+            coin = Coin(make_hash(height * 10 + i), IDENTITY_PUZZLE_HASH, uint64(height * 100000 + i * 100))
             sb = make_spend_bundle(coin, height)
             # make this coin available via get_coin_record, which is called
             # by mempool_manager

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -48,7 +48,7 @@ class ConsensusConstants:
     # Size of mempool = 10x the size of block
     MEMPOOL_BLOCK_BUFFER: int
     # Max coin amount uint(1 << 64). This allows coin amounts to fit in 64 bits. This is around 18M chia.
-    MAX_COIN_AMOUNT: int
+    MAX_COIN_AMOUNT: uint64
     # Max block cost in clvm cost units
     MAX_BLOCK_COST_CLVM: int
     # Cost per byte of generator program

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -434,7 +434,7 @@ class MempoolManager:
             removal_names.add(coin_id)
             spend_additions = []
             for puzzle_hash, amount, _ in spend.create_coin:
-                child_coin = Coin(coin_id, puzzle_hash, amount)
+                child_coin = Coin(coin_id, puzzle_hash, uint64(amount))
                 spend_additions.append(child_coin)
                 additions_dict[child_coin.name()] = child_coin
                 addition_amount = addition_amount + child_coin.amount

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -709,8 +709,8 @@ def _create_sub_epoch_data(
     #  Number of subblocks overflow in previous slot
     previous_sub_epoch_overflows = uint8(sub_epoch_summary.num_blocks_overflow)  # total in sub epoch - expected
     #  New work difficulty and iterations per sub-slot
-    sub_slot_iters: Optional[int] = sub_epoch_summary.new_sub_slot_iters
-    new_difficulty: Optional[int] = sub_epoch_summary.new_difficulty
+    sub_slot_iters = sub_epoch_summary.new_sub_slot_iters
+    new_difficulty = sub_epoch_summary.new_difficulty
     return SubEpochData(reward_chain_hash, previous_sub_epoch_overflows, sub_slot_iters, new_difficulty)
 
 

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -46,9 +46,9 @@ class DedupCoinSpend:
 @dataclasses.dataclass(frozen=True)
 class UnspentLineageInfo:
     coin_id: bytes32
-    coin_amount: int
+    coin_amount: uint64
     parent_id: bytes32
-    parent_amount: int
+    parent_amount: uint64
     parent_parent_id: bytes32
 
 

--- a/chia/types/spend_bundle_conditions.py
+++ b/chia/types/spend_bundle_conditions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
-from chia_rs import ELIGIBLE_FOR_DEDUP, Spend, SpendBundleConditions
+import chia_rs
 
-__all__ = ["Spend", "SpendBundleConditions", "ELIGIBLE_FOR_DEDUP"]
+ELIGIBLE_FOR_DEDUP = chia_rs.ELIGIBLE_FOR_DEDUP
+Spend = chia_rs.Spend
+SpendBundleConditions = chia_rs.SpendBundleConditions

--- a/chia/util/condition_tools.py
+++ b/chia/util/condition_tools.py
@@ -80,7 +80,7 @@ def make_aggsig_final_message(
     if isinstance(spend, Coin):
         coin = spend
     elif isinstance(spend, Spend):
-        coin = Coin(spend.parent_id, spend.puzzle_hash, spend.coin_amount)
+        coin = Coin(spend.parent_id, spend.puzzle_hash, uint64(spend.coin_amount))
     else:
         raise ValueError(f"Expected Coin or Spend, got {type(spend)}")  # pragma: no cover
 

--- a/chia/util/generator_tools.py
+++ b/chia/util/generator_tools.py
@@ -51,7 +51,7 @@ def additions_for_npc(npc_result: NPCResult) -> List[Coin]:
         return []
     for spend in npc_result.conds.spends:
         for puzzle_hash, amount, _ in spend.create_coin:
-            coin = Coin(spend.coin_id, puzzle_hash, amount)
+            coin = Coin(spend.coin_id, puzzle_hash, uint64(amount))
             additions.append(coin)
 
     return additions

--- a/chia/wallet/cat_wallet/dao_cat_wallet.py
+++ b/chia/wallet/cat_wallet/dao_cat_wallet.py
@@ -291,7 +291,7 @@ class DAOCATWallet:
                 primaries = [
                     Payment(
                         new_innerpuzzle.get_tree_hash(),
-                        uint64(vote_amount),
+                        vote_amount,
                         [standard_inner_puz.get_tree_hash()],
                     )
                 ]
@@ -301,12 +301,12 @@ class DAOCATWallet:
                     conditions=(CreatePuzzleAnnouncement(message),),
                 )
             else:
-                vote_amount = amount - running_sum
+                vote_amount = uint64(amount - running_sum)
                 running_sum = running_sum + coin.amount
                 primaries = [
                     Payment(
                         new_innerpuzzle.get_tree_hash(),
-                        uint64(vote_amount),
+                        vote_amount,
                         [standard_inner_puz.get_tree_hash()],
                     ),
                 ]

--- a/chia/wallet/dao_wallet/dao_wallet.py
+++ b/chia/wallet/dao_wallet/dao_wallet.py
@@ -646,7 +646,7 @@ class DAOWallet:
 
         genesis_launcher_puz = SINGLETON_LAUNCHER
         # launcher coin contains singleton launcher, launcher coin ID == singleton_id == treasury_id
-        launcher_coin = Coin(origin.name(), genesis_launcher_puz.get_tree_hash(), 1)
+        launcher_coin = Coin(origin.name(), genesis_launcher_puz.get_tree_hash(), uint64(1))
 
         if cat_tail_hash is None:
             assert amount_of_cats_to_create is not None

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dependencies = [
     "chiapos==2.0.3",  # proof of space
     "clvm==0.9.8",
     "clvm_tools==0.4.7",  # Currying, Program.to, other conveniences
-    "chia_rs==0.4.0",
+    "chia_rs==0.5.2",
     "clvm-tools-rs==0.1.40",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.9.1",  # HTTP server for full node rpc
     "aiosqlite==0.19.0",  # asyncio wrapper for sqlite, to store blocks

--- a/tests/core/consensus/test_block_creation.py
+++ b/tests/core/consensus/test_block_creation.py
@@ -9,15 +9,15 @@ from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.ints import uint32
+from chia.util.ints import uint32, uint64
 from tests.core.make_block_generator import make_block_generator
 
 
 @pytest.mark.parametrize("add_amount", [[0], [1, 2, 3], []])
 @pytest.mark.parametrize("rem_amount", [[0], [1, 2, 3], []])
 def test_compute_block_fee(add_amount: List[int], rem_amount: List[int]) -> None:
-    additions: List[Coin] = [Coin(bytes32.random(), bytes32.random(), amt) for amt in add_amount]
-    removals: List[Coin] = [Coin(bytes32.random(), bytes32.random(), amt) for amt in rem_amount]
+    additions: List[Coin] = [Coin(bytes32.random(), bytes32.random(), uint64(amt)) for amt in add_amount]
+    removals: List[Coin] = [Coin(bytes32.random(), bytes32.random(), uint64(amt)) for amt in rem_amount]
 
     # the fee is the left-overs from the removals (spent) coins after deducting
     # the newly created coins (additions)

--- a/tests/core/custom_types/test_coin.py
+++ b/tests/core/custom_types/test_coin.py
@@ -78,32 +78,32 @@ def test_construction() -> None:
 
     with pytest.raises(OverflowError, match="int too big to convert"):
         # overflow
-        Coin(H1, H2, 0x10000000000000000)
+        Coin(H1, H2, 0x10000000000000000)  # type: ignore[arg-type]
 
     with pytest.raises(OverflowError, match="can't convert negative int to unsigned"):
         # overflow
-        Coin(H1, H2, -1)
+        Coin(H1, H2, -1)  # type: ignore[arg-type]
 
     H1_short = b"a" * 31
     H1_long = b"a" * 33
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="could not convert slice to array"):
         # short hash
-        Coin(H1_short, H2, 1)
+        Coin(H1_short, H2, uint64(1))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="could not convert slice to array"):
         # long hash
-        Coin(H1_long, H2, 1)
+        Coin(H1_long, H2, uint64(1))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="could not convert slice to array"):
         # short hash
-        Coin(H2, H1_short, 1)
+        Coin(H2, H1_short, uint64(1))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="could not convert slice to array"):
         # long hash
-        Coin(H2, H1_long, 1)
+        Coin(H2, H1_long, uint64(1))
 
-    c = Coin(H1, H2, 1000)
+    c = Coin(H1, H2, uint64(1000))
     assert c.parent_coin_info == H1
     assert c.puzzle_hash == H2
     assert c.amount == 1000

--- a/tests/core/custom_types/test_spend_bundle.py
+++ b/tests/core/custom_types/test_spend_bundle.py
@@ -14,6 +14,7 @@ from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.errors import ValidationError
+from chia.util.ints import uint64
 
 BLANK_SPEND_BUNDLE = SpendBundle(coin_spends=[], aggregated_signature=G2Element())
 NULL_SIGNATURE = "0xc" + "0" * 191
@@ -59,8 +60,8 @@ def create_spends(num: int) -> Tuple[List[CoinSpend], List[Coin]]:
     for i in range(num):
         target_ph = rand_hash(rng)
         conditions = [[ConditionOpcode.CREATE_COIN, target_ph, 1]]
-        coin = Coin(rand_hash(rng), puzzle_hash, 1000)
-        new_coin = Coin(coin.name(), target_ph, 1)
+        coin = Coin(rand_hash(rng), puzzle_hash, uint64(1000))
+        new_coin = Coin(coin.name(), target_ph, uint64(1))
         create_coin.append(new_coin)
         spends.append(make_spend(coin, puzzle, Program.to(conditions)))
 

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -667,7 +667,7 @@ async def test_batch_many_coin_states(db_version: int, cut_off_middle: bool) -> 
         await coin_store._add_coin_records(
             [
                 CoinRecord(
-                    coin=Coin(std_hash(b"extra coin"), ph, 0),
+                    coin=Coin(std_hash(b"extra coin"), ph, uint64(0)),
                     # Insert a coin record in the middle between heights 10 and 12.
                     # Or after all of the other coins if testing the batch limit.
                     confirmed_block_index=uint32(11 if cut_off_middle else 50),
@@ -694,9 +694,9 @@ async def test_unsupported_version() -> None:
 
 TEST_COIN_ID = b"c" * 32
 TEST_PUZZLEHASH = b"p" * 32
-TEST_AMOUNT = 1337
+TEST_AMOUNT = uint64(1337)
 TEST_PARENT_ID = Coin(b"a" * 32, TEST_PUZZLEHASH, TEST_AMOUNT).name()
-TEST_PARENT_DIFFERENT_AMOUNT = 5
+TEST_PARENT_DIFFERENT_AMOUNT = uint64(5)
 TEST_PARENT_ID_DIFFERENT_AMOUNT = Coin(b"a" * 32, TEST_PUZZLEHASH, TEST_PARENT_DIFFERENT_AMOUNT).name()
 TEST_PARENT_PARENT_ID = b"f" * 32
 

--- a/tests/core/full_node/test_hint_management.py
+++ b/tests/core/full_node/test_hint_management.py
@@ -19,13 +19,13 @@ parent_ids = [std_hash(i.to_bytes(4, "big")) for i in range(10)]
 phs = [std_hash(i.to_bytes(4, "big")) for i in range(10)]
 removals = [(coin_ids[0], phs[0]), (coin_ids[2], phs[0]), (coin_ids[1], phs[7])]
 additions = [
-    (Coin(coin_ids[0], phs[2], 123), None),
-    (Coin(coin_ids[0], phs[4], 3), b"1" * 32),
-    (Coin(coin_ids[2], phs[7], 123), None),
-    (Coin(coin_ids[2], phs[4], 6), None),
-    (Coin(coin_ids[2], phs[9], 123), b"1" * 32),
-    (Coin(coin_ids[1], phs[5], 123), None),
-    (Coin(coin_ids[1], phs[6], 5), b"1" * 3),
+    (Coin(coin_ids[0], phs[2], uint64(123)), None),
+    (Coin(coin_ids[0], phs[4], uint64(3)), b"1" * 32),
+    (Coin(coin_ids[2], phs[7], uint64(123)), None),
+    (Coin(coin_ids[2], phs[4], uint64(6)), None),
+    (Coin(coin_ids[2], phs[9], uint64(123)), b"1" * 32),
+    (Coin(coin_ids[1], phs[5], uint64(123)), None),
+    (Coin(coin_ids[1], phs[6], uint64(5)), b"1" * 3),
 ]
 
 

--- a/tests/core/mempool/test_mempool.py
+++ b/tests/core/mempool/test_mempool.py
@@ -2748,7 +2748,7 @@ def rand_hash() -> bytes32:
 
 def item_cost(cost: int, fee_rate: float) -> MempoolItem:
     fee = cost * fee_rate
-    amount = int(fee + 100)
+    amount = uint64(fee + 100)
     coin = Coin(rand_hash(), rand_hash(), amount)
     return mk_item([coin], cost=cost, fee=int(cost * fee_rate))
 
@@ -2837,7 +2837,7 @@ def test_limit_expiring_transactions(height: bool, items: List[int], expected: L
     fee_rate = 2.7
     for cost in items:
         fee = cost * fee_rate
-        amount = int(fee + 100)
+        amount = uint64(fee + 100)
         coin = Coin(rand_hash(), rand_hash(), amount)
         if height:
             ret = mempool.add_to_pool(mk_item([coin], cost=cost, fee=int(cost * fee_rate), assert_before_height=15))

--- a/tests/core/mempool/test_mempool_manager.py
+++ b/tests/core/mempool/test_mempool_manager.py
@@ -404,7 +404,7 @@ def make_bundle_spends_map_and_fee(
         coin_id = bytes32(spend.coin_id)
         spend_additions = []
         for puzzle_hash, amount, _ in spend.create_coin:
-            spend_additions.append(Coin(coin_id, puzzle_hash, amount))
+            spend_additions.append(Coin(coin_id, puzzle_hash, uint64(amount)))
             additions_amount += amount
         eligibility_and_additions[coin_id] = EligibilityAndAdditions(
             is_eligible_for_dedup=bool(spend.flags & ELIGIBLE_FOR_DEDUP),
@@ -681,7 +681,7 @@ async def test_ephemeral_timelock(
     )
 
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1]]
-    created_coin = Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, 1)
+    created_coin = Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, uint64(1))
     sb1 = spend_bundle_from_conditions(conditions)
     sb2 = spend_bundle_from_conditions([[opcode, lock_value]], created_coin)
     # sb spends TEST_COIN and creates created_coin which gets spent too
@@ -739,7 +739,7 @@ def mk_item(
 def make_test_coins() -> List[Coin]:
     ret: List[Coin] = []
     for i in range(5):
-        ret.append(Coin(height_hash(i), height_hash(i + 100), i * 100))
+        ret.append(Coin(height_hash(i), height_hash(i + 100), uint64(i * 100)))
     return ret
 
 
@@ -1042,7 +1042,7 @@ async def test_create_bundle_from_mempool_on_max_cost(num_skipped_items: int, ca
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, sb2_coin.amount - 200_000]]
     sb2, _, res = await generate_and_add_spendbundle(mempool_manager, conditions, sb2_coin)
     assert res[1] == MempoolInclusionStatus.SUCCESS
-    sb2_addition = Coin(sb2_coin.name(), IDENTITY_PUZZLE_HASH, sb2_coin.amount - 200_000)
+    sb2_addition = Coin(sb2_coin.name(), IDENTITY_PUZZLE_HASH, uint64(sb2_coin.amount - 200_000))
     # Create 4 extra spend bundles with smaller FPC and smaller costs
     extra_sbs = []
     extra_additions = []
@@ -1053,7 +1053,7 @@ async def test_create_bundle_from_mempool_on_max_cost(num_skipped_items: int, ca
             conditions.append([ConditionOpcode.AGG_SIG_UNSAFE, G1Element(), IDENTITY_PUZZLE_HASH])
         sb, _, res = await generate_and_add_spendbundle(mempool_manager, conditions, coins[i])
         extra_sbs.append(sb)
-        coin = Coin(coins[i].name(), IDENTITY_PUZZLE_HASH, coins[i].amount - 30_000)
+        coin = Coin(coins[i].name(), IDENTITY_PUZZLE_HASH, uint64(coins[i].amount - 30_000))
         extra_additions.append(coin)
         assert res[1] == MempoolInclusionStatus.SUCCESS
 
@@ -1345,7 +1345,7 @@ def test_dedup_info_nothing_to_do() -> None:
     )
     assert unique_coin_spends == sb.coin_spends
     assert cost_saving == 0
-    assert unique_additions == [Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, 1)]
+    assert unique_additions == [Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, uint64(1))]
     assert eligible_coin_spends == EligibleCoinSpends()
 
 
@@ -1366,8 +1366,8 @@ def test_dedup_info_eligible_1st_time() -> None:
     assert unique_coin_spends == sb.coin_spends
     assert cost_saving == 0
     assert set(unique_additions) == {
-        Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, 1),
-        Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, 2),
+        Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, uint64(1)),
+        Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, uint64(2)),
     }
     assert eligible_coin_spends == EligibleCoinSpends({TEST_COIN_ID: DedupCoinSpend(solution=solution, cost=None)})
 
@@ -1412,7 +1412,7 @@ def test_dedup_info_eligible_2nd_time_and_another_1st_time() -> None:
     assert unique_coin_spends == sb2.coin_spends
     saved_cost = uint64(3600044)
     assert cost_saving == saved_cost
-    assert unique_additions == [Coin(TEST_COIN_ID2, IDENTITY_PUZZLE_HASH, 3)]
+    assert unique_additions == [Coin(TEST_COIN_ID2, IDENTITY_PUZZLE_HASH, uint64(3))]
     # The coin we encountered a second time has its cost and additions properly updated
     # The coin we encountered for the first time gets cost None and an empty set of additions
     expected_eligible_spends = EligibleCoinSpends(
@@ -1456,7 +1456,7 @@ def test_dedup_info_eligible_3rd_time_another_2nd_time_and_one_non_eligible() ->
     assert unique_coin_spends == sb3.coin_spends
     saved_cost2 = uint64(1800044)
     assert cost_saving == saved_cost + saved_cost2
-    assert unique_additions == [Coin(TEST_COIN_ID3, IDENTITY_PUZZLE_HASH, 4)]
+    assert unique_additions == [Coin(TEST_COIN_ID3, IDENTITY_PUZZLE_HASH, uint64(4))]
     expected_eligible_spends = EligibleCoinSpends(
         {
             TEST_COIN_ID: DedupCoinSpend(initial_solution, saved_cost),
@@ -1476,7 +1476,7 @@ async def test_coin_spending_different_ways_then_finding_it_spent_in_new_peak(ne
     the reorg code paths
     """
     new_height = uint32(TEST_HEIGHT + new_height_step)
-    coin = Coin(IDENTITY_PUZZLE_HASH, IDENTITY_PUZZLE_HASH, 100)
+    coin = Coin(IDENTITY_PUZZLE_HASH, IDENTITY_PUZZLE_HASH, uint64(100))
     coin_id = coin.name()
     test_coin_records = {coin_id: CoinRecord(coin, uint32(0), uint32(0), False, uint64(0))}
 

--- a/tests/core/mempool/test_singleton_fast_forward.py
+++ b/tests/core/mempool/test_singleton_fast_forward.py
@@ -79,7 +79,7 @@ async def test_process_fast_forward_spends_unknown_ff() -> None:
             return None
         assert False  # pragma: no cover
 
-    test_coin = Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, 1)
+    test_coin = Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, uint64(1))
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1]]
     sb = spend_bundle_from_conditions(conditions, test_coin)
     item = mempool_item_from_spendbundle(sb)
@@ -107,7 +107,7 @@ async def test_process_fast_forward_spends_latest_unspent() -> None:
     we don't need to fast forward, we just need to set the next version from
     our additions to chain ff spends.
     """
-    test_amount = 3
+    test_amount = uint64(3)
     test_coin = Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, test_amount)
     test_unspent_lineage_info = UnspentLineageInfo(
         coin_id=test_coin.name(),
@@ -164,7 +164,7 @@ def test_perform_the_fast_forward() -> None:
     """
     test_parent_id = bytes32.from_hexstr("0x039759eda861cd44c0af6c9501300f66fe4f5de144b8ae4fc4e8da35701f38ac")
     test_ph = bytes32.from_hexstr("0x9ae0917f3ca301f934468ec60412904c0a88b232aeabf220c01ef53054e0281a")
-    test_amount = 1337
+    test_amount = uint64(1337)
     test_coin = Coin(test_parent_id, test_ph, test_amount)
     test_child_coin = Coin(test_coin.name(), test_ph, test_amount)
     latest_unspent_coin = Coin(test_child_coin.name(), test_ph, test_amount)

--- a/tests/core/test_cost_calculation.py
+++ b/tests/core/test_cost_calculation.py
@@ -169,7 +169,7 @@ async def test_mempool_mode(softfork_height: int, bt: BlockTools) -> None:
     coin = Coin(
         bytes32.fromhex("3d2331635a58c0d49912bc1427d7db51afe3f20a7b4bcaffa17ee250dcbcbfaa"),
         bytes32.fromhex("14947eb0e69ee8fc8279190fc2d38cb4bbb61ba28f1a270cfd643a0e8d759576"),
-        300,
+        uint64(300),
     )
     spend_info = get_puzzle_and_solution_for_coin(generator, coin, softfork_height, bt.constants)
     assert spend_info.puzzle.to_program() == puzzle

--- a/tests/farmer_harvester/test_third_party_harvesters.py
+++ b/tests/farmer_harvester/test_third_party_harvesters.py
@@ -343,7 +343,7 @@ def prepare_sp_and_pos_for_fee_test(
             pool_public_key=None,
             pool_contract_puzzle_hash=None,
             plot_public_key=pubkey,
-            size=len(proof),
+            size=uint8(len(proof)),
             proof=proof,
         ),
         signage_point_index=uint8(0),

--- a/tests/util/test_condition_tools.py
+++ b/tests/util/test_condition_tools.py
@@ -15,6 +15,7 @@ from chia.types.spend_bundle_conditions import Spend, SpendBundleConditions
 from chia.util.condition_tools import parse_sexp_to_conditions, pkm_pairs, pkm_pairs_for_conditions_dict
 from chia.util.errors import ConsensusError
 from chia.util.hash import std_hash
+from chia.util.ints import uint64
 
 H1 = bytes32(b"a" * 32)
 H2 = bytes32(b"b" * 32)
@@ -23,7 +24,7 @@ H3 = bytes32(b"c" * 32)
 PK1 = G1Element.generator()
 PK2 = G1Element.generator()
 
-TEST_COIN = Coin(H1, H2, 123)
+TEST_COIN = Coin(H1, H2, uint64(123))
 
 
 def mk_agg_sig_conditions(

--- a/tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/tests/wallet/cat_wallet/test_cat_wallet.py
@@ -686,7 +686,7 @@ async def test_cat_max_amount_send(
             spendable_name_set.add(record.coin.name())
         puzzle_hash = construct_cat_puzzle(CAT_MOD, cat_wallet.cat_info.limitations_program_hash, cat_2).get_tree_hash()
         for i in range(1, 50):
-            coin = Coin(spent_coint.name(), puzzle_hash, i)
+            coin = Coin(spent_coint.name(), puzzle_hash, uint64(i))
             if coin.name() not in spendable_name_set:
                 return False
         return True

--- a/tests/wallet/cat_wallet/test_offer_lifecycle.py
+++ b/tests/wallet/cat_wallet/test_offer_lifecycle.py
@@ -67,7 +67,7 @@ async def generate_coins(
                         CAT_MOD,
                         [
                             SpendableCAT(
-                                Coin(parent_coin.name(), cat_puzzle_hash, amount),
+                                Coin(parent_coin.name(), cat_puzzle_hash, uint64(amount)),
                                 tail_hash,
                                 acs,
                                 Program.to([[51, acs_ph, amount], [51, 0, -113, tail, []]]),

--- a/tests/wallet/dao_wallet/test_dao_clvm.py
+++ b/tests/wallet/dao_wallet/test_dao_clvm.py
@@ -555,7 +555,7 @@ def test_validator() -> None:
         1200,
     )
     full_proposal = SINGLETON_MOD.curry(proposal_struct, proposal)
-    proposal_amt = 10
+    proposal_amt = uint64(10)
     proposal_coin_id = Coin(parent_id, full_proposal.get_tree_hash(), proposal_amt).name()
     solution = Program.to(
         [
@@ -696,7 +696,7 @@ def test_merge_p2_singleton() -> None:
 
     # Merge Spend (not output creator)
     output_parent_id = Program.to("output_parent").get_tree_hash()
-    output_coin_amount = 100
+    output_coin_amount = uint64(100)
     aggregator_sol = Program.to([my_id, my_puzhash, 300, 0, [output_parent_id, output_coin_amount]])
     merge_p2_singleton_sol = Program.to([aggregator_sol, 0, 0, 0, 0])
     conds = conditions_dict_for_solution(p2_singleton, merge_p2_singleton_sol, INFINITE_COST)
@@ -706,7 +706,7 @@ def test_merge_p2_singleton() -> None:
 
     # Merge Spend (output creator)
     fake_parent_id = Program.to("fake_parent").get_tree_hash()
-    merged_coin_id = Coin(fake_parent_id, my_puzhash, 200).name()
+    merged_coin_id = Coin(fake_parent_id, my_puzhash, uint64(200)).name()
     merge_sol = Program.to([[my_id, my_puzhash, 100, [[fake_parent_id, my_puzhash, 200]], 0]])
     conds = conditions_dict_for_solution(p2_singleton, merge_sol, INFINITE_COST)
     assert len(conds) == 7
@@ -719,7 +719,7 @@ def test_merge_p2_singleton() -> None:
         Program.to("fake_parent_2").get_tree_hash(),
         Program.to("fake_parent_3").get_tree_hash(),
     ]
-    amounts = [1000, 2000, 3000]
+    amounts = [uint64(1000), uint64(2000), uint64(3000)]
     parent_puzhash_amounts = []
     merge_coin_ids: List[bytes32] = []
     for pid, amt in zip(parent_ids, amounts):
@@ -843,7 +843,7 @@ def test_treasury() -> None:
     assert len(conds.as_python()) == 3
 
     # Proposal Spend
-    proposal_amt = 10
+    proposal_amt = uint64(10)
     proposal_coin_id = Coin(parent_id, full_proposal.get_tree_hash(), proposal_amt).name()
     solution = Program.to(
         [
@@ -1090,7 +1090,7 @@ def test_proposal_lifecycle() -> None:
     )
     full_proposal: Program = SINGLETON_MOD.curry(proposal_singleton_struct, proposal)
     full_proposal_puzhash: bytes32 = full_proposal.get_tree_hash()
-    proposal_amt = 11
+    proposal_amt = uint64(11)
     proposal_coin_id = Coin(parent_id, full_proposal_puzhash, proposal_amt).name()
 
     treasury_solution: Program = Program.to(

--- a/tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -478,7 +478,7 @@ async def test_subscribe_for_hint(simulator_and_wallet: OldSimulatorsAndWallets,
     coins = await full_node_api.full_node.coin_store.get_coin_records_by_puzzle_hashes(False, [ph])
     coin_spent = coins[0].coin
     hint_puzzle_hash = 32 * b"\2"
-    amount = 1
+    amount = uint64(1)
     amount_bin = int_to_bytes(1)
     hint = bytes32(32 * b"\5")
 
@@ -581,7 +581,7 @@ async def test_subscribe_for_hint_long_sync(
     coins = await full_node_api.full_node.coin_store.get_coin_records_by_puzzle_hashes(False, [ph])
     coin_spent = coins[0].coin
     hint_puzzle_hash = 32 * b"\2"
-    amount = 1
+    amount = uint64(1)
     amount_bin = int_to_bytes(1)
     hint = bytes32(32 * b"\5")
 

--- a/tests/wallet/test_debug_spend_bundle.py
+++ b/tests/wallet/test_debug_spend_bundle.py
@@ -12,6 +12,7 @@ from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.hash import std_hash
+from chia.util.ints import uint64
 from chia.wallet.util.debug_spend_bundle import debug_spend_bundle
 
 
@@ -22,9 +23,9 @@ def test_debug_spend_bundle() -> None:
     sig = AugSchemeMPL.sign(sk, msg)
     ACS = Program.to(15).curry(Program.to("hey").curry("now")).curry("brown", "cow")
     ACS_PH = ACS.get_tree_hash()
-    coin: Coin = Coin(bytes32([0] * 32), ACS_PH, 3)
-    child_coin: Coin = Coin(coin.name(), ACS_PH, 0)
-    coin_bad_reveal: Coin = Coin(bytes32([0] * 32), bytes32([0] * 32), 0)
+    coin: Coin = Coin(bytes32([0] * 32), ACS_PH, uint64(3))
+    child_coin: Coin = Coin(coin.name(), ACS_PH, uint64(0))
+    coin_bad_reveal: Coin = Coin(bytes32([0] * 32), bytes32([0] * 32), uint64(0))
     solution = Program.to(
         [
             [ConditionOpcode.AGG_SIG_UNSAFE, pk, msg],

--- a/tests/wallet/test_sign_coin_spends.py
+++ b/tests/wallet/test_sign_coin_spends.py
@@ -13,7 +13,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.db_wrapper import DBWrapper2, manage_connection
-from chia.util.ints import uint32
+from chia.util.ints import uint32, uint64
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
@@ -44,7 +44,7 @@ msg2: bytes = b"msg2"
 
 additional_data: bytes32 = bytes32(DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA)
 
-coin: Coin = Coin(bytes32([0] * 32), bytes32([0] * 32), 0)
+coin: Coin = Coin(bytes32([0] * 32), bytes32([0] * 32), uint64(0))
 puzzle = SerializedProgram.from_bytes(b"\x01")
 solution_h = SerializedProgram.from_program(
     Program.to([[ConditionOpcode.AGG_SIG_UNSAFE, pk1_h, msg1], [ConditionOpcode.AGG_SIG_ME, pk2_h, msg2]])

--- a/tests/wallet/test_singleton_store.py
+++ b/tests/wallet/test_singleton_store.py
@@ -25,7 +25,7 @@ def get_record(wallet_id: uint32 = uint32(2)) -> SingletonRecord:
     inner_puz_hash = inner_puz.get_tree_hash()
     parent_puz = create_singleton_puzzle(inner_puz, launcher_id)
     parent_puz_hash = parent_puz.get_tree_hash()
-    parent_coin = Coin(launcher_id, parent_puz_hash, 1)
+    parent_coin = Coin(launcher_id, parent_puz_hash, uint64(1))
     inner_sol = Program.to([[51, inner_puz_hash, 1]])
     lineage_proof = LineageProof(launcher_id, inner_puz.get_tree_hash(), uint64(1))
     parent_sol = Program.to([lineage_proof.to_program(), 1, inner_sol])
@@ -71,7 +71,7 @@ class TestSingletonStore:
         async with DBConnection(1) as wrapper:
             db = await WalletSingletonStore.create(wrapper)
             record = get_record()
-            child_coin = Coin(record.coin.name(), record.coin.puzzle_hash, 1)
+            child_coin = Coin(record.coin.name(), record.coin.puzzle_hash, uint64(1))
             parent_coinspend = record.parent_coinspend
 
             # test add spend
@@ -82,7 +82,7 @@ class TestSingletonStore:
             # Test adding a non-singleton will fail
             inner_puz = Program.to(1)
             inner_puz_hash = inner_puz.get_tree_hash()
-            bad_coin = Coin(record.singleton_id, inner_puz_hash, 1)
+            bad_coin = Coin(record.singleton_id, inner_puz_hash, uint64(1))
             inner_sol = Program.to([[51, inner_puz_hash, 1]])
             bad_coinspend = make_spend(bad_coin, inner_puz, inner_sol)
             with pytest.raises(RuntimeError) as e_info:

--- a/tests/wallet/test_wallet_node.py
+++ b/tests/wallet/test_wallet_node.py
@@ -500,7 +500,7 @@ async def test_add_states_from_peer_untrusted_shutdown(
     wallet_node._close()
     coin_generator = CoinGenerator()
     # Generate enough coin states to fill up the max number validation/add tasks.
-    coin_states = [CoinState(coin_generator.get().coin, i, i) for i in range(3000)]
+    coin_states = [CoinState(coin_generator.get().coin, uint32(i), uint32(i)) for i in range(3000)]
     with caplog.at_level(logging.INFO):
         assert not await wallet_node.add_states_from_peer(coin_states, list(wallet_server.all_connections.values())[0])
         assert "Terminating receipt and validation due to shut down request" in caplog.text

--- a/tests/wallet/test_wallet_state_manager.py
+++ b/tests/wallet/test_wallet_state_manager.py
@@ -10,7 +10,7 @@ from chia.server.outbound_message import NodeType
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
-from chia.util.ints import uint32
+from chia.util.ints import uint32, uint64
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
 from chia.wallet.util.wallet_types import WalletType
@@ -93,5 +93,5 @@ async def test_determine_coin_type(simulator_and_wallet: OldSimulatorsAndWallets
     wallet_state_manager: WalletStateManager = wallet_node.wallet_state_manager
     peer = wallet_node.server.get_connections(NodeType.FULL_NODE)[0]
     assert (None, None) == await wallet_state_manager.determine_coin_type(
-        peer, CoinState(Coin(bytes32(b"1" * 32), bytes32(b"1" * 32), 0), uint32(0), uint32(0)), None
+        peer, CoinState(Coin(bytes32(b"1" * 32), bytes32(b"1" * 32), uint64(0)), uint32(0), uint32(0)), None
     )

--- a/tests/wallet/test_wallet_utils.py
+++ b/tests/wallet/test_wallet_utils.py
@@ -6,19 +6,19 @@ import pytest
 from chia_rs import Coin, CoinState
 
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.ints import uint64
+from chia.util.ints import uint32, uint64
 from chia.wallet.util.peer_request_cache import PeerRequestCache
 from chia.wallet.util.wallet_sync_utils import sort_coin_states
 
 coin_states = [
     CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\00" * 32), uint64(1)), None, None),
-    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\11" * 32), uint64(1)), None, 1),
-    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\22" * 32), uint64(1)), 1, 1),
-    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\33" * 32), uint64(1)), 1, 1),
-    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\44" * 32), uint64(1)), 2, 1),
-    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\55" * 32), uint64(1)), 2, 2),
-    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\66" * 32), uint64(1)), 20, 10),
-    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\77" * 32), uint64(1)), None, 20),
+    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\11" * 32), uint64(1)), None, uint32(1)),
+    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\22" * 32), uint64(1)), uint32(1), uint32(1)),
+    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\33" * 32), uint64(1)), uint32(1), uint32(1)),
+    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\44" * 32), uint64(1)), uint32(2), uint32(1)),
+    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\55" * 32), uint64(1)), uint32(2), uint32(2)),
+    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\66" * 32), uint64(1)), uint32(20), uint32(10)),
+    CoinState(Coin(bytes32(b"\00" * 32), bytes32(b"\77" * 32), uint64(1)), None, uint32(20)),
 ]
 
 
@@ -32,7 +32,11 @@ def assert_race_cache(cache: PeerRequestCache, expected_entries: Dict[int, Set[C
 
 
 def dummy_coin_state(*, created_height: Optional[int], spent_height: Optional[int]) -> CoinState:
-    return CoinState(Coin(bytes(b"0" * 32), bytes(b"0" * 32), 0), spent_height, created_height)
+    return CoinState(
+        Coin(bytes(b"0" * 32), bytes(b"0" * 32), uint64(0)),
+        uint32.construct_optional(spent_height),
+        uint32.construct_optional(created_height),
+    )
 
 
 def heights(coin_states: Collection[CoinState]) -> List[Tuple[Optional[int], Optional[int]]]:


### PR DESCRIPTION
### Purpose:

bump the `chia_rs` dependency to the most recent version. One noteworthy change is that integer types are now exported as our `uint8`, `int8`, etc. fixed width integer types. This makes the rust types (more) seamless drop-in replacements).

This has the upshot of rust types that previously just took `int` now actually take the correct, fixed width integer. So there's some more casting required. That's the second commit.

## Current Behavior:

rust types use `int` in their python bindings, and we lose out on some type checking.

### New Behavior:

rust types use the corresponding fixed width integer from `chia-blockchain`.