### PR TITLE
Instruct the use of coin_puzzle_hash index to get_unspent_lineage_info_for_puzzle_hash

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -598,7 +598,7 @@ class CoinStore:
                 "unspent.coin_parent, "
                 "parent.amount, "
                 "parent.coin_parent "
-                "FROM coin_record AS unspent "
+                "FROM coin_record AS unspent INDEXED BY coin_puzzle_hash "
                 "LEFT JOIN coin_record AS parent ON unspent.coin_parent = parent.coin_name "
                 "WHERE unspent.spent_index = 0 "
                 "AND parent.spent_index > 0 "


### PR DESCRIPTION
Arvid suspected the slowness is caused by the query taking too long and here are the numbers.

Before:
```
sqlite> .eqp on
sqlite> .timer on
sqlite> SELECT unspent.coin_name,
unspent.amount,
unspent.coin_parent,
parent.amount,
parent.coin_parent
FROM coin_record AS unspent
LEFT JOIN coin_record AS parent ON unspent.coin_parent = parent.coin_name
WHERE unspent.spent_index = 0
AND parent.spent_index > 0
AND unspent.puzzle_hash = x'e3c000a395f8f69d5e263a9548f13bffb1c4b701ab8f3faa03f7647c8750d077'
AND parent.puzzle_hash = unspent.puzzle_hash;
QUERY PLAN
|--SEARCH unspent USING INDEX coin_spent_index (spent_index=?)
`--SEARCH parent USING INDEX sqlite_autoindex_coin_record_1 (coin_name=?)
Run Time: real 267.195 user 97.814884 sys 40.527740
```

After:

```
SELECT unspent.coin_name,
unspent.amount,
unspent.coin_parent,
parent.amount,
parent.coin_parent
FROM coin_record AS unspent INDEXED BY coin_puzzle_hash 
LEFT JOIN coin_record AS parent ON unspent.coin_parent = parent.coin_name
WHERE unspent.spent_index = 0
AND parent.spent_index > 0
AND unspent.puzzle_hash = x'e3c000a395f8f69d5e263a9548f13bffb1c4b701ab8f3faa03f7647c8750d077'
AND parent.puzzle_hash = unspent.puzzle_hash;
QUERY PLAN
|--SEARCH unspent USING INDEX coin_puzzle_hash (puzzle_hash=?)
`--SEARCH parent USING INDEX sqlite_autoindex_coin_record_1 (coin_name=?)
Run Time: real 0.024 user 0.000000 sys 0.003187
```