### PR TITLE
Augment match_clawback_puzzle to accept both types of programs

### DIFF
--- a/chia/wallet/puzzles/clawback/drivers.py
+++ b/chia/wallet/puzzles/clawback/drivers.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional, Set, Union
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
@@ -121,17 +122,15 @@ def create_merkle_solution(
 
 
 def match_clawback_puzzle(
-    uncurried: UncurriedPuzzle, inner_puzzle: Program, inner_solution: Program
+    uncurried: UncurriedPuzzle,
+    inner_puzzle: Union[Program, SerializedProgram],
+    inner_solution: Union[Program, SerializedProgram],
 ) -> Optional[ClawbackMetadata]:
     # Check if the inner puzzle is a P2 puzzle
     if MOD != uncurried.mod:
         return None
     # Fetch Remark condition
-    conditions = conditions_for_solution(
-        inner_puzzle,
-        inner_solution,
-        DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM // 8,
-    )
+    conditions = conditions_for_solution(inner_puzzle, inner_solution, DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM // 8)
     metadata: Optional[ClawbackMetadata] = None
     new_puzhash: Set[bytes32] = set()
     if conditions is not None:


### PR DESCRIPTION
`match_clawback_puzzle` takes puzzles and solutions, and fetches conditions by passing those to `conditions_for_solution` which accepts both types of programs.

This is part of an effort to use serialized programs without the need to convert them into programs.