### PR TITLE
undo some unnecessary int type casts

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -109,14 +109,12 @@ class ForkInfo:
                 self.removals_since_fork[bytes32(spend.coin_id)] = ForkRem(bytes32(spend.puzzle_hash), height)
                 for puzzle_hash, amount, hint in spend.create_coin:
                     coin = Coin(bytes32(spend.coin_id), bytes32(puzzle_hash), uint64(amount))
-                    self.additions_since_fork[coin.name()] = ForkAdd(
-                        coin, uint32(height), uint64(timestamp), hint, False
-                    )
+                    self.additions_since_fork[coin.name()] = ForkAdd(coin, height, timestamp, hint, False)
         for coin in block.get_included_reward_coins():
             assert block.foliage_transaction_block is not None
             timestamp = block.foliage_transaction_block.timestamp
             assert coin.name() not in self.additions_since_fork
-            self.additions_since_fork[coin.name()] = ForkAdd(coin, uint32(block.height), uint64(timestamp), None, True)
+            self.additions_since_fork[coin.name()] = ForkAdd(coin, block.height, timestamp, None, True)
 
     def rollback(self, header_hash: bytes32, height: int) -> None:
         assert height <= self.peak_height
@@ -400,7 +398,7 @@ async def validate_block_body(
                 height,
                 height,
                 False,
-                uint64(block.foliage_transaction_block.timestamp),
+                block.foliage_transaction_block.timestamp,
             )
             removal_coin_records[new_unspent.name] = new_unspent
         else:
@@ -500,7 +498,7 @@ async def validate_block_body(
         block_timestamp: uint64
         if height < constants.SOFT_FORK2_HEIGHT:
             # this does not happen on mainnet. testnet10 only
-            block_timestamp = uint64(block.foliage_transaction_block.timestamp)  # pragma: no cover
+            block_timestamp = block.foliage_transaction_block.timestamp  # pragma: no cover
         else:
             block_timestamp = prev_transaction_block_timestamp
 

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -66,7 +66,7 @@ def validate_unfinished_header_block(
     if genesis_block and header_block.prev_header_hash != constants.GENESIS_CHALLENGE:
         return None, ValidationError(Err.INVALID_PREV_BLOCK_HASH)
 
-    overflow = is_overflow_block(constants, uint8(header_block.reward_chain_block.signage_point_index))
+    overflow = is_overflow_block(constants, header_block.reward_chain_block.signage_point_index)
     if skip_overflow_last_ss_validation and overflow:
         if final_eos_is_already_included(header_block, blocks, expected_sub_slot_iters):
             skip_overflow_last_ss_validation = False
@@ -524,13 +524,13 @@ def validate_unfinished_header_block(
     sp_iters: uint64 = calculate_sp_iters(
         constants,
         expected_sub_slot_iters,
-        uint8(header_block.reward_chain_block.signage_point_index),
+        header_block.reward_chain_block.signage_point_index,
     )
 
     ip_iters: uint64 = calculate_ip_iters(
         constants,
         expected_sub_slot_iters,
-        uint8(header_block.reward_chain_block.signage_point_index),
+        header_block.reward_chain_block.signage_point_index,
         required_iters,
     )
     if header_block.reward_chain_block.challenge_chain_sp_vdf is None:
@@ -876,7 +876,7 @@ def validate_finished_header_block(
     ip_iters: uint64 = calculate_ip_iters(
         constants,
         expected_sub_slot_iters,
-        uint8(header_block.reward_chain_block.signage_point_index),
+        header_block.reward_chain_block.signage_point_index,
         required_iters,
     )
     if not genesis_block:
@@ -983,7 +983,7 @@ def validate_finished_header_block(
 
     # 31. Check infused challenge chain infusion point VDF
     if not genesis_block:
-        overflow = is_overflow_block(constants, uint8(header_block.reward_chain_block.signage_point_index))
+        overflow = is_overflow_block(constants, header_block.reward_chain_block.signage_point_index)
         deficit = calculate_deficit(
             constants,
             header_block.height,

--- a/chia/consensus/full_block_to_block_record.py
+++ b/chia/consensus/full_block_to_block_record.py
@@ -39,7 +39,7 @@ def block_to_block_record(
         sub_slot_iters, _ = get_next_sub_slot_iters_and_difficulty(
             constants, len(block.finished_sub_slots) > 0, prev_b, blocks
         )
-    overflow = is_overflow_block(constants, uint8(block.reward_chain_block.signage_point_index))
+    overflow = is_overflow_block(constants, block.reward_chain_block.signage_point_index)
     deficit = calculate_deficit(
         constants,
         block.height,
@@ -148,7 +148,7 @@ def header_block_to_sub_block_record(
         block.height,
         block.weight,
         block.total_iters,
-        uint8(block.reward_chain_block.signage_point_index),
+        block.reward_chain_block.signage_point_index,
         block.reward_chain_block.challenge_chain_ip_vdf.output,
         icc_output,
         block.reward_chain_block.get_hash(),
@@ -160,9 +160,9 @@ def header_block_to_sub_block_record(
         deficit,
         overflow,
         prev_transaction_block_height,
-        uint64.construct_optional(timestamp),
+        timestamp,
         prev_transaction_block_hash,
-        uint64.construct_optional(fees),
+        fees,
         reward_claims_incorporated,
         finished_challenge_slot_hashes,
         finished_infused_challenge_slot_hashes,

--- a/chia/consensus/full_block_to_block_record.py
+++ b/chia/consensus/full_block_to_block_record.py
@@ -62,8 +62,8 @@ def block_to_block_record(
             blocks,
             block.height,
             blocks.block_record(prev_b.prev_hash),
-            uint64.construct_optional(block.finished_sub_slots[0].challenge_chain.new_difficulty),
-            uint64.construct_optional(block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters),
+            block.finished_sub_slots[0].challenge_chain.new_difficulty,
+            block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters,
         )
         if ses.get_hash() != found_ses_hash:
             raise ValueError(Err.INVALID_SUB_EPOCH_SUMMARY)

--- a/chia/consensus/make_sub_epoch_summary.py
+++ b/chia/consensus/make_sub_epoch_summary.py
@@ -94,7 +94,7 @@ def next_sub_epoch_summary(
     Returns:
         object: the new sub-epoch summary
     """
-    signage_point_index = uint8(block.reward_chain_block.signage_point_index)
+    signage_point_index = block.reward_chain_block.signage_point_index
     prev_b: Optional[BlockRecord] = blocks.try_block_record(block.prev_header_hash)
     if prev_b is None or prev_b.height == 0:
         return None

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -33,7 +33,7 @@ from chia.util.block_cache import BlockCache
 from chia.util.condition_tools import pkm_pairs
 from chia.util.errors import Err, ValidationError
 from chia.util.generator_tools import get_block_header, tx_removals_and_additions
-from chia.util.ints import uint8, uint16, uint32, uint64
+from chia.util.ints import uint16, uint32, uint64
 from chia.util.streamable import Streamable, streamable
 
 log = logging.getLogger(__name__)
@@ -282,7 +282,7 @@ async def pre_validate_blocks_multiprocessing(
             constants, len(block.finished_sub_slots) > 0, prev_b, block_records
         )
 
-        overflow = is_overflow_block(constants, uint8(block.reward_chain_block.signage_point_index))
+        overflow = is_overflow_block(constants, block.reward_chain_block.signage_point_index)
         challenge = get_block_challenge(constants, block, BlockCache(recent_blocks), prev_b is None, overflow, False)
         if block.reward_chain_block.challenge_chain_sp_vdf is None:
             cc_sp_hash: bytes32 = challenge

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2169,7 +2169,7 @@ class FullNode:
             + calculate_sp_iters(
                 self.constants,
                 sub_slot_iters,
-                uint8(unfinished_block.reward_chain_block.signage_point_index),
+                unfinished_block.reward_chain_block.signage_point_index,
             )
         )
 

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -951,9 +951,9 @@ class FullNodeAPI:
                 sub_slot_iters = peak.sub_slot_iters
                 for sub_slot in finished_sub_slots:
                     if sub_slot.challenge_chain.new_difficulty is not None:
-                        difficulty = uint64(sub_slot.challenge_chain.new_difficulty)
+                        difficulty = sub_slot.challenge_chain.new_difficulty
                     if sub_slot.challenge_chain.new_sub_slot_iters is not None:
-                        sub_slot_iters = uint64(sub_slot.challenge_chain.new_sub_slot_iters)
+                        sub_slot_iters = sub_slot.challenge_chain.new_sub_slot_iters
 
             required_iters: uint64 = calculate_iterations_quality(
                 self.full_node.constants.DIFFICULTY_CONSTANT_FACTOR,

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -442,7 +442,7 @@ class WeightProofHandler:
                 None,
                 None,
                 None,
-                uint8(curr.reward_chain_block.signage_point_index),
+                curr.reward_chain_block.signage_point_index,
                 None,
                 None,
                 None,
@@ -549,7 +549,7 @@ class WeightProofHandler:
             curr.challenge_chain_ip_proof,
             icc_ip_proof,
             cc_sp_info,
-            uint8(curr.reward_chain_block.signage_point_index),
+            curr.reward_chain_block.signage_point_index,
             None,
             None,
             None,
@@ -565,7 +565,7 @@ class WeightProofHandler:
         if len(weight_proof.sub_epochs) == 0:
             return False, uint32(0)
 
-        peak_height = uint32(weight_proof.recent_chain_data[-1].reward_chain_block.height)
+        peak_height = weight_proof.recent_chain_data[-1].reward_chain_block.height
         log.info(f"validate weight proof peak height {peak_height}")
         summaries, sub_epoch_weight_list = _validate_sub_epoch_summaries(self.constants, weight_proof)
         if summaries is None:
@@ -746,7 +746,7 @@ async def _challenge_block_vdfs(
         header_block.challenge_chain_ip_proof,
         None,
         cc_sp_info,
-        uint8(header_block.reward_chain_block.signage_point_index),
+        header_block.reward_chain_block.signage_point_index,
         None,
         None,
         None,
@@ -1237,7 +1237,7 @@ def validate_recent_blocks(
                 diff = sub_slot.challenge_chain.new_difficulty
 
         if (challenge is not None) and (prev_challenge is not None):
-            overflow = is_overflow_block(constants, uint8(block.reward_chain_block.signage_point_index))
+            overflow = is_overflow_block(constants, block.reward_chain_block.signage_point_index)
             if not adjusted:
                 assert prev_block_record is not None
                 prev_block_record = dataclasses.replace(
@@ -1521,7 +1521,7 @@ def _get_last_ses_hash(
                         if slot.challenge_chain.subepoch_summary_hash is not None:
                             return (
                                 slot.challenge_chain.subepoch_summary_hash,
-                                uint32(curr.reward_chain_block.height),
+                                curr.reward_chain_block.height,
                             )
                 idx += 1
     return None, uint32(0)
@@ -1645,7 +1645,7 @@ async def validate_weight_proof_inner(
     if len(weight_proof.sub_epochs) == 0:
         return False, []
 
-    peak_height = uint32(weight_proof.recent_chain_data[-1].reward_chain_block.height)
+    peak_height = weight_proof.recent_chain_data[-1].reward_chain_block.height
     log.info(f"validate weight proof peak height {peak_height}")
     seed = summaries[-2].get_hash()
     rng = random.Random(seed)

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -707,7 +707,7 @@ def _create_sub_epoch_data(
 ) -> SubEpochData:
     reward_chain_hash: bytes32 = sub_epoch_summary.reward_chain_hash
     #  Number of subblocks overflow in previous slot
-    previous_sub_epoch_overflows: uint8 = sub_epoch_summary.num_blocks_overflow  # total in sub epoch - expected
+    previous_sub_epoch_overflows = sub_epoch_summary.num_blocks_overflow  # total in sub epoch - expected
     #  New work difficulty and iterations per sub-slot
     sub_slot_iters = sub_epoch_summary.new_sub_slot_iters
     new_difficulty = sub_epoch_summary.new_difficulty
@@ -1558,8 +1558,8 @@ def get_sp_total_iters(
     assert sub_slot_data.cc_ip_vdf_info is not None
     assert sub_slot_data.total_iters is not None
     assert sub_slot_data.signage_point_index is not None
-    sp_iters: uint64 = calculate_sp_iters(constants, ssi, sub_slot_data.signage_point_index)
-    ip_iters: uint64 = sub_slot_data.cc_ip_vdf_info.number_of_iterations
+    sp_iters = calculate_sp_iters(constants, ssi, sub_slot_data.signage_point_index)
+    ip_iters = sub_slot_data.cc_ip_vdf_info.number_of_iterations
     sp_sub_slot_total_iters = uint128(sub_slot_data.total_iters - ip_iters)
     if is_overflow:
         sp_sub_slot_total_iters = uint128(sp_sub_slot_total_iters - ssi)

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -707,7 +707,7 @@ def _create_sub_epoch_data(
 ) -> SubEpochData:
     reward_chain_hash: bytes32 = sub_epoch_summary.reward_chain_hash
     #  Number of subblocks overflow in previous slot
-    previous_sub_epoch_overflows = uint8(sub_epoch_summary.num_blocks_overflow)  # total in sub epoch - expected
+    previous_sub_epoch_overflows: uint8 = sub_epoch_summary.num_blocks_overflow  # total in sub epoch - expected
     #  New work difficulty and iterations per sub-slot
     sub_slot_iters = sub_epoch_summary.new_sub_slot_iters
     new_difficulty = sub_epoch_summary.new_difficulty
@@ -886,7 +886,7 @@ def _map_sub_epoch_summaries(
 
         # if new epoch update diff and iters
         if data.new_difficulty is not None:
-            curr_difficulty = uint64(data.new_difficulty)
+            curr_difficulty = data.new_difficulty
 
         # add to dict
         summaries.append(ses)
@@ -998,7 +998,7 @@ def _validate_segment(
                 return False, uint64(0), uint64(0), uint64(0), []
             assert sub_slot_data.signage_point_index is not None
             ip_iters = ip_iters + calculate_ip_iters(
-                constants, curr_ssi, uint8(sub_slot_data.signage_point_index), required_iters
+                constants, curr_ssi, sub_slot_data.signage_point_index, required_iters
             )
             vdf_list = _get_challenge_block_vdfs(constants, idx, segment.sub_slots, curr_ssi)
             to_validate.extend(vdf_list)
@@ -1025,7 +1025,7 @@ def _get_challenge_block_vdfs(
         assert sub_slot_data.signage_point_index
         sp_input = ClassgroupElement.get_default_element()
         if not sub_slot_data.cc_signage_point.normalized_to_identity and sub_slot_idx >= 1:
-            is_overflow = is_overflow_block(constants, uint8(sub_slot_data.signage_point_index))
+            is_overflow = is_overflow_block(constants, sub_slot_data.signage_point_index)
             prev_ssd = sub_slots[sub_slot_idx - 1]
             sp_input = sub_slot_data_vdf_input(
                 constants, sub_slot_data, sub_slot_idx, sub_slots, is_overflow, prev_ssd.is_end_of_slot(), ssi
@@ -1103,7 +1103,7 @@ def _validate_sub_slot_data(
             assert sub_slot_data.cc_sp_vdf_info
             input = ClassgroupElement.get_default_element()
             if not sub_slot_data.cc_signage_point.normalized_to_identity:
-                is_overflow = is_overflow_block(constants, uint8(sub_slot_data.signage_point_index))
+                is_overflow = is_overflow_block(constants, sub_slot_data.signage_point_index)
                 input = sub_slot_data_vdf_input(
                     constants, sub_slot_data, sub_slot_idx, sub_slots, is_overflow, prev_ssd.is_end_of_slot(), ssi
                 )
@@ -1208,9 +1208,9 @@ def validate_recent_blocks(
     last_blocks_to_validate = 100  # todo remove cap after benchmarks
     for summary in summaries[:ses_idx]:
         if summary.new_sub_slot_iters is not None:
-            ssi = uint64(summary.new_sub_slot_iters)
+            ssi = summary.new_sub_slot_iters
         if summary.new_difficulty is not None:
-            diff = uint64(summary.new_difficulty)
+            diff = summary.new_difficulty
 
     ses_blocks, sub_slots, transaction_blocks = 0, 0, 0
     challenge, prev_challenge = recent_chain.recent_chain_data[0].reward_chain_block.pos_ss_cc_challenge_hash, None
@@ -1226,15 +1226,15 @@ def validate_recent_blocks(
         for sub_slot in block.finished_sub_slots:
             prev_challenge = sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf.challenge
             challenge = sub_slot.challenge_chain.get_hash()
-            deficit = uint8(sub_slot.reward_chain.deficit)
+            deficit = sub_slot.reward_chain.deficit
             if sub_slot.challenge_chain.subepoch_summary_hash is not None:
                 ses = True
                 assert summaries[ses_idx].get_hash() == sub_slot.challenge_chain.subepoch_summary_hash
                 ses_idx += 1
             if sub_slot.challenge_chain.new_sub_slot_iters is not None:
-                ssi = uint64(sub_slot.challenge_chain.new_sub_slot_iters)
+                ssi = sub_slot.challenge_chain.new_sub_slot_iters
             if sub_slot.challenge_chain.new_difficulty is not None:
-                diff = uint64(sub_slot.challenge_chain.new_difficulty)
+                diff = sub_slot.challenge_chain.new_difficulty
 
         if (challenge is not None) and (prev_challenge is not None):
             overflow = is_overflow_block(constants, uint8(block.reward_chain_block.signage_point_index))
@@ -1334,7 +1334,7 @@ def __validate_pospace(
 
     sub_slot_data: SubSlotData = segment.sub_slots[idx]
 
-    if sub_slot_data.signage_point_index and is_overflow_block(constants, uint8(sub_slot_data.signage_point_index)):
+    if sub_slot_data.signage_point_index and is_overflow_block(constants, sub_slot_data.signage_point_index):
         curr_slot = segment.sub_slots[idx - 1]
         assert curr_slot.cc_slot_end_info
         challenge = curr_slot.cc_slot_end_info.challenge
@@ -1391,14 +1391,14 @@ def __get_rc_sub_slot(
     slots_n = 1
     assert first
     assert first.signage_point_index is not None
-    if is_overflow_block(constants, uint8(first.signage_point_index)):
+    if is_overflow_block(constants, first.signage_point_index):
         if idx >= 2 and slots[idx - 2].cc_slot_end is None:
             slots_n = 2
 
     new_diff = None if ses is None else ses.new_difficulty
     new_ssi = None if ses is None else ses.new_sub_slot_iters
     ses_hash: Optional[bytes32] = None if ses is None else ses.get_hash()
-    overflow = is_overflow_block(constants, uint8(first.signage_point_index))
+    overflow = is_overflow_block(constants, first.signage_point_index)
     if overflow:
         if idx >= 2 and slots[idx - 2].cc_slot_end is not None and slots[idx - 1].cc_slot_end is not None:
             ses_hash = None
@@ -1483,9 +1483,9 @@ def _get_curr_diff_ssi(
     curr_ssi = constants.SUB_SLOT_ITERS_STARTING
     for ses in reversed(summaries[0:idx]):
         if ses.new_sub_slot_iters is not None:
-            curr_ssi = uint64(ses.new_sub_slot_iters)
+            curr_ssi = ses.new_sub_slot_iters
             assert ses.new_difficulty is not None
-            curr_difficulty = uint64(ses.new_difficulty)
+            curr_difficulty = ses.new_difficulty
             break
 
     return curr_difficulty, curr_ssi
@@ -1558,7 +1558,7 @@ def get_sp_total_iters(
     assert sub_slot_data.cc_ip_vdf_info is not None
     assert sub_slot_data.total_iters is not None
     assert sub_slot_data.signage_point_index is not None
-    sp_iters: uint64 = calculate_sp_iters(constants, ssi, uint8(sub_slot_data.signage_point_index))
+    sp_iters: uint64 = calculate_sp_iters(constants, ssi, sub_slot_data.signage_point_index)
     ip_iters: uint64 = uint64(sub_slot_data.cc_ip_vdf_info.number_of_iterations)
     sp_sub_slot_total_iters = uint128(sub_slot_data.total_iters - ip_iters)
     if is_overflow:

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1559,7 +1559,7 @@ def get_sp_total_iters(
     assert sub_slot_data.total_iters is not None
     assert sub_slot_data.signage_point_index is not None
     sp_iters: uint64 = calculate_sp_iters(constants, ssi, sub_slot_data.signage_point_index)
-    ip_iters: uint64 = uint64(sub_slot_data.cc_ip_vdf_info.number_of_iterations)
+    ip_iters: uint64 = sub_slot_data.cc_ip_vdf_info.number_of_iterations
     sp_sub_slot_total_iters = uint128(sub_slot_data.total_iters - ip_iters)
     if is_overflow:
         sp_sub_slot_total_iters = uint128(sp_sub_slot_total_iters - ssi)

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -981,8 +981,8 @@ class BlockTools:
                 pending_ses = True
                 ses_hash: Optional[bytes32] = sub_epoch_summary.get_hash()
                 # if the last block is the last block of the epoch, we set the new sub-slot iters and difficulty
-                new_sub_slot_iters: Optional[uint64] = uint64.construct_optional(sub_epoch_summary.new_sub_slot_iters)
-                new_difficulty: Optional[uint64] = uint64.construct_optional(sub_epoch_summary.new_difficulty)
+                new_sub_slot_iters: Optional[uint64] = sub_epoch_summary.new_sub_slot_iters
+                new_difficulty: Optional[uint64] = sub_epoch_summary.new_difficulty
 
                 self.log.info(f"Sub epoch summary: {sub_epoch_summary} for block {latest_block.height+1}")
             else:  # the previous block is not the last block of the sub-epoch or epoch
@@ -1252,8 +1252,8 @@ class BlockTools:
                 num_empty_slots_added += 1
 
             if new_sub_slot_iters is not None and new_difficulty is not None:  # new epoch
-                sub_slot_iters = uint64(new_sub_slot_iters)
-                difficulty = uint64(new_difficulty)
+                sub_slot_iters = new_sub_slot_iters
+                difficulty = new_difficulty
 
     def create_genesis_block(
         self,
@@ -1750,7 +1750,7 @@ def get_icc(
     if len(finished_sub_slots) == 0:
         prev_deficit = latest_block.deficit
     else:
-        prev_deficit = uint8(finished_sub_slots[-1].reward_chain.deficit)
+        prev_deficit = finished_sub_slots[-1].reward_chain.deficit
 
     if deficit == prev_deficit == constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK:
         # new slot / overflow sb to new slot / overflow sb

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -1421,7 +1421,7 @@ class BlockTools:
                         + calculate_sp_iters(
                             self.constants,
                             self.constants.SUB_SLOT_ITERS_STARTING,
-                            uint8(unfinished_block.reward_chain_block.signage_point_index),
+                            unfinished_block.reward_chain_block.signage_point_index,
                         )
                     )
                     return unfinished_block_to_full_block(
@@ -2060,7 +2060,7 @@ def create_block_tools(
 def make_unfinished_block(
     block: FullBlock, constants: ConsensusConstants, *, force_overflow: bool = False
 ) -> UnfinishedBlock:
-    if force_overflow or is_overflow_block(constants, uint8(block.reward_chain_block.signage_point_index)):
+    if force_overflow or is_overflow_block(constants, block.reward_chain_block.signage_point_index):
         finished_ss = block.finished_sub_slots[:-1]
     else:
         finished_ss = block.finished_sub_slots

--- a/chia/timelord/iters_from_block.py
+++ b/chia/timelord/iters_from_block.py
@@ -7,7 +7,7 @@ from chia.consensus.pot_iterations import calculate_ip_iters, calculate_iteratio
 from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
 from chia.types.blockchain_format.reward_chain_block import RewardChainBlock, RewardChainBlockUnfinished
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.ints import uint8, uint32, uint64
+from chia.util.ints import uint32, uint64
 
 
 def iters_from_block(
@@ -40,11 +40,11 @@ def iters_from_block(
         cc_sp,
     )
     return (
-        calculate_sp_iters(constants, sub_slot_iters, uint8(reward_chain_block.signage_point_index)),
+        calculate_sp_iters(constants, sub_slot_iters, reward_chain_block.signage_point_index),
         calculate_ip_iters(
             constants,
             sub_slot_iters,
-            uint8(reward_chain_block.signage_point_index),
+            reward_chain_block.signage_point_index,
             required_iters,
         ),
     )

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -1118,7 +1118,7 @@ class Timelord:
                                     ip,
                                     reader,
                                     writer,
-                                    uint64(info[1].new_proof_of_time.number_of_iterations),
+                                    info[1].new_proof_of_time.number_of_iterations,
                                     info[1].header_hash,
                                     info[1].height,
                                     info[1].field_vdf,
@@ -1170,7 +1170,7 @@ class Timelord:
                     bluebox_process_data = BlueboxProcessData(
                         picked_info.new_proof_of_time.challenge,
                         uint16(self.constants.DISCRIMINANT_SIZE_BITS),
-                        uint64(picked_info.new_proof_of_time.number_of_iterations),
+                        picked_info.new_proof_of_time.number_of_iterations,
                     )
                     proof = await asyncio.get_running_loop().run_in_executor(
                         pool,

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -256,7 +256,7 @@ class Timelord:
             log.warning(f"Received invalid unfinished block: {e}.")
             return None
         block_sp_total_iters = self.last_state.total_iters - ip_iters + block_sp_iters
-        if is_overflow_block(self.constants, uint8(block.reward_chain_block.signage_point_index)):
+        if is_overflow_block(self.constants, block.reward_chain_block.signage_point_index):
             block_sp_total_iters -= self.last_state.get_sub_slot_iters()
         found_index = -1
         for index, (rc, total_iters) in enumerate(self.last_state.reward_challenge_cache):
@@ -279,7 +279,7 @@ class Timelord:
                 )
                 return None
             if self.last_state.reward_challenge_cache[found_index][1] > block_sp_total_iters:
-                if not is_overflow_block(self.constants, uint8(block.reward_chain_block.signage_point_index)):
+                if not is_overflow_block(self.constants, block.reward_chain_block.signage_point_index):
                     log.error(
                         f"Will not infuse unfinished block {block.rc_prev}, sp total iters: {block_sp_total_iters}, "
                         f"because its iters are too low"
@@ -593,7 +593,7 @@ class Timelord:
                     self.last_active_time = time.time()
                     log.debug(f"Generated infusion point for challenge: {challenge} iterations: {iteration}.")
 
-                    overflow = is_overflow_block(self.constants, uint8(block.reward_chain_block.signage_point_index))
+                    overflow = is_overflow_block(self.constants, block.reward_chain_block.signage_point_index)
 
                     if not self.last_state.can_infuse_block(overflow):
                         log.warning("Too many blocks, or overflow in new epoch, cannot infuse, discarding")
@@ -628,7 +628,7 @@ class Timelord:
                         + calculate_sp_iters(
                             self.constants,
                             block.sub_slot_iters,
-                            uint8(block.reward_chain_block.signage_point_index),
+                            block.reward_chain_block.signage_point_index,
                         )
                         - (block.sub_slot_iters if overflow else 0)
                     )

--- a/chia/timelord/timelord_state.py
+++ b/chia/timelord/timelord_state.py
@@ -87,11 +87,11 @@ class LastState:
             self.peak = None
             self.subslot_end = state
             self.last_ip = uint64(0)
-            self.deficit = uint8(state.reward_chain.deficit)
+            self.deficit = state.reward_chain.deficit
             if state.challenge_chain.new_difficulty is not None:
                 assert state.challenge_chain.new_sub_slot_iters is not None
-                self.difficulty = uint64(state.challenge_chain.new_difficulty)
-                self.sub_slot_iters = uint64(state.challenge_chain.new_sub_slot_iters)
+                self.difficulty = state.challenge_chain.new_difficulty
+                self.sub_slot_iters = state.challenge_chain.new_sub_slot_iters
                 self.new_epoch = True
             else:
                 self.new_epoch = False

--- a/chia/timelord/timelord_state.py
+++ b/chia/timelord/timelord_state.py
@@ -59,13 +59,13 @@ class LastState:
                 state.reward_chain_block,
                 state.sub_slot_iters,
                 state.difficulty,
-                uint32(state.reward_chain_block.height),
+                state.reward_chain_block.height,
             )
             self.deficit = state.deficit
             self.sub_epoch_summary = state.sub_epoch_summary
-            self.last_weight = uint128(state.reward_chain_block.weight)
-            self.last_height = uint32(state.reward_chain_block.height)
-            self.total_iters = uint128(state.reward_chain_block.total_iters)
+            self.last_weight = state.reward_chain_block.weight
+            self.last_height = state.reward_chain_block.height
+            self.total_iters = state.reward_chain_block.total_iters
             self.last_peak_challenge = state.reward_chain_block.get_hash()
             self.difficulty = state.difficulty
             self.sub_slot_iters = state.sub_slot_iters

--- a/chia/types/full_block.py
+++ b/chia/types/full_block.py
@@ -39,15 +39,15 @@ class FullBlock(Streamable):
 
     @property
     def height(self) -> uint32:
-        return uint32(self.reward_chain_block.height)
+        return self.reward_chain_block.height
 
     @property
     def weight(self) -> uint128:
-        return uint128(self.reward_chain_block.weight)
+        return self.reward_chain_block.weight
 
     @property
     def total_iters(self) -> uint128:
-        return uint128(self.reward_chain_block.total_iters)
+        return self.reward_chain_block.total_iters
 
     @property
     def header_hash(self) -> bytes32:

--- a/chia/types/header_block.py
+++ b/chia/types/header_block.py
@@ -38,11 +38,11 @@ class HeaderBlock(Streamable):
 
     @property
     def height(self) -> uint32:
-        return uint32(self.reward_chain_block.height)
+        return self.reward_chain_block.height
 
     @property
     def weight(self) -> uint128:
-        return uint128(self.reward_chain_block.weight)
+        return self.reward_chain_block.weight
 
     @property
     def header_hash(self) -> bytes32:
@@ -50,7 +50,7 @@ class HeaderBlock(Streamable):
 
     @property
     def total_iters(self) -> uint128:
-        return uint128(self.reward_chain_block.total_iters)
+        return self.reward_chain_block.total_iters
 
     @property
     def log_string(self) -> str:

--- a/chia/types/unfinished_block.py
+++ b/chia/types/unfinished_block.py
@@ -42,4 +42,4 @@ class UnfinishedBlock(Streamable):
 
     @property
     def total_iters(self) -> uint128:
-        return uint128(self.reward_chain_block.total_iters)
+        return self.reward_chain_block.total_iters

--- a/chia/types/unfinished_header_block.py
+++ b/chia/types/unfinished_header_block.py
@@ -34,4 +34,4 @@ class UnfinishedHeaderBlock(Streamable):
 
     @property
     def total_iters(self) -> uint128:
-        return uint128(self.reward_chain_block.total_iters)
+        return self.reward_chain_block.total_iters

--- a/chia/wallet/util/peer_request_cache.py
+++ b/chia/wallet/util/peer_request_cache.py
@@ -41,7 +41,7 @@ class PeerRequestCache:
         if header_block.is_transaction_block:
             assert header_block.foliage_transaction_block is not None
             if self._timestamps.get(header_block.height) is None:
-                self._timestamps.put(header_block.height, uint64(header_block.foliage_transaction_block.timestamp))
+                self._timestamps.put(header_block.height, header_block.foliage_transaction_block.timestamp)
 
     def get_block_request(self, start: uint32, end: uint32) -> Optional[asyncio.Task[Any]]:
         return self._block_requests.get((start, end))

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -99,8 +99,8 @@ class WalletBlockchain(BlockchainInterface):
             and block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters is not None
         ):
             assert block.finished_sub_slots[0].challenge_chain.new_difficulty is not None  # They both change together
-            sub_slot_iters: uint64 = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters
-            difficulty: uint64 = block.finished_sub_slots[0].challenge_chain.new_difficulty
+            sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters
+            difficulty = block.finished_sub_slots[0].challenge_chain.new_difficulty
         else:
             sub_slot_iters = self._sub_slot_iters
             difficulty = self._difficulty

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -164,7 +164,7 @@ class WalletBlockchain(BlockchainInterface):
         if timestamp is not None:
             self._latest_timestamp = timestamp
         elif block.foliage_transaction_block is not None:
-            self._latest_timestamp = uint64(block.foliage_transaction_block.timestamp)
+            self._latest_timestamp = block.foliage_transaction_block.timestamp
         log.info(f"Peak set to: {self._peak.height} timestamp: {self._latest_timestamp}")
 
     async def get_peak_block(self) -> Optional[HeaderBlock]:

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -99,8 +99,8 @@ class WalletBlockchain(BlockchainInterface):
             and block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters is not None
         ):
             assert block.finished_sub_slots[0].challenge_chain.new_difficulty is not None  # They both change together
-            sub_slot_iters = uint64(block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters)
-            difficulty = uint64(block.finished_sub_slots[0].challenge_chain.new_difficulty)
+            sub_slot_iters: uint64 = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters
+            difficulty: uint64 = block.finished_sub_slots[0].challenge_chain.new_difficulty
         else:
             sub_slot_iters = self._sub_slot_iters
             difficulty = self._difficulty

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1058,7 +1058,7 @@ class WalletNode:
                 self.log.debug(f"get_timestamp_for_height_from_peer use cached block for height {request_height}")
 
             if block is not None and block.foliage_transaction_block is not None:
-                return uint64(block.foliage_transaction_block.timestamp)
+                return block.foliage_transaction_block.timestamp
 
             request_height -= 1
 

--- a/tests/core/full_node/stores/test_coin_store.py
+++ b/tests/core/full_node/stores/test_coin_store.py
@@ -117,7 +117,7 @@ async def test_basic_coin_store(db_version: int, softfork_height: uint32, bt: Bl
                     assert block.foliage_transaction_block is not None
                     await coin_store.new_block(
                         block.height,
-                        uint64(block.foliage_transaction_block.timestamp),
+                        block.foliage_transaction_block.timestamp,
                         block.get_included_reward_coins(),
                         tx_additions,
                         tx_removals,
@@ -127,7 +127,7 @@ async def test_basic_coin_store(db_version: int, softfork_height: uint32, bt: Bl
                         with pytest.raises(Exception):
                             await coin_store.new_block(
                                 block.height,
-                                uint64(block.foliage_transaction_block.timestamp),
+                                block.foliage_transaction_block.timestamp,
                                 block.get_included_reward_coins(),
                                 tx_additions,
                                 tx_removals,
@@ -185,7 +185,7 @@ async def test_set_spent(db_version: int, bt: BlockTools) -> None:
                         assert block.foliage_transaction_block is not None
                         await coin_store.new_block(
                             block.height,
-                            uint64(block.foliage_transaction_block.timestamp),
+                            block.foliage_transaction_block.timestamp,
                             block.get_included_reward_coins(),
                             additions,
                             removals,
@@ -233,7 +233,7 @@ async def test_num_unspent(bt: BlockTools, db_version: int) -> None:
                 additions: List[Coin] = []
                 await coin_store.new_block(
                     block.height,
-                    uint64(block.foliage_transaction_block.timestamp),
+                    block.foliage_transaction_block.timestamp,
                     block.get_included_reward_coins(),
                     additions,
                     removals,
@@ -265,7 +265,7 @@ async def test_rollback(db_version: int, bt: BlockTools) -> None:
                 assert block.foliage_transaction_block is not None
                 await coin_store.new_block(
                     block.height,
-                    uint64(block.foliage_transaction_block.timestamp),
+                    block.foliage_transaction_block.timestamp,
                     block.get_included_reward_coins(),
                     additions,
                     removals,

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -677,7 +677,7 @@ async def test_basic_store(
         blocks[1].reward_chain_sp_proof,
     )
     assert not store.new_signage_point(
-        uint8(blocks[1].reward_chain_block.signage_point_index),
+        blocks[1].reward_chain_block.signage_point_index,
         blockchain,
         peak,
         uint64(blockchain.block_record(blocks[1].header_hash).sp_sub_slot_total_iters(custom_block_tools.constants)),
@@ -979,9 +979,9 @@ async def test_basic_store(
 
         blocks = custom_block_tools.get_consecutive_blocks(2, block_list_input=blocks, guarantee_transaction_block=True)
 
-        i3 = uint8(blocks[-3].reward_chain_block.signage_point_index)
-        i2 = uint8(blocks[-2].reward_chain_block.signage_point_index)
-        i1 = uint8(blocks[-1].reward_chain_block.signage_point_index)
+        i3 = blocks[-3].reward_chain_block.signage_point_index
+        i2 = blocks[-2].reward_chain_block.signage_point_index
+        i1 = blocks[-1].reward_chain_block.signage_point_index
         if (
             len(blocks[-2].finished_sub_slots) == len(blocks[-1].finished_sub_slots) == 0
             and not is_overflow_block(custom_block_tools.constants, signage_point_index=i2)


### PR DESCRIPTION
### Purpose:

In recent changes to transition python classes to rust types, rust's python bindings exposed all integers as plain python `int`, requiring explicit casts in the python code.

Now that rust's python bindings expose integer types as the correct fixed-width integer type, these type casts are unnecessary.

### Current Behavior:

We have unnecessary type casts.

### New Behavior:

Some unnecessary type casts have been removed.