### PR TITLE
use click.Path for make_offer command filename

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import pathlib
 from decimal import Decimal
 from typing import List, Optional, Sequence
 
@@ -443,7 +444,13 @@ def add_token_cmd(wallet_rpc_port: Optional[int], asset_id: str, token_name: str
     help="A wallet id of an asset to receive and the amount you wish to receive (formatted like wallet_id:amount)",
     multiple=True,
 )
-@click.option("-p", "--filepath", help="The path to write the generated offer file to", required=True)
+@click.option(
+    "-p",
+    "--filepath",
+    help="The path to write the generated offer file to",
+    required=True,
+    type=click.Path(dir_okay=False, writable=True, path_type=pathlib.Path),
+)
 @click.option(
     "-m", "--fee", help="A fee to add to the offer when it gets taken, in XCH", default="0", show_default=True
 )
@@ -459,7 +466,7 @@ def make_offer_cmd(
     fingerprint: int,
     offer: Sequence[str],
     request: Sequence[str],
-    filepath: str,
+    filepath: pathlib.Path,
     fee: str,
     reuse: bool,
     override: bool,

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -413,7 +413,7 @@ async def make_offer(
     d_fee: Decimal,
     offers: Sequence[str],
     requests: Sequence[str],
-    filepath: str,
+    filepath: pathlib.Path,
     reuse_puzhash: Optional[bool],
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
@@ -550,23 +550,24 @@ async def make_offer(
 
                 cli_confirm("Confirm (y/n): ", "Not creating offer...")
 
-                offer, trade_record = await wallet_client.create_offer_for_ids(
-                    offer_dict,
-                    driver_dict=driver_dict,
-                    fee=fee,
-                    tx_config=CMDTXConfigLoader(
-                        reuse_puzhash=reuse_puzhash,
-                    ).to_tx_config(units["chia"], config, fingerprint),
-                )
-                if offer is not None:
-                    with open(pathlib.Path(filepath), "w") as file:
-                        file.write(offer.to_bech32())
-                    print(f"Created offer with ID {trade_record.trade_id}")
-                    print(
-                        f"Use chia wallet get_offers --id " f"{trade_record.trade_id} -f {fingerprint} to view status"
+                with filepath.open(mode="w") as file:
+                    offer, trade_record = await wallet_client.create_offer_for_ids(
+                        offer_dict,
+                        driver_dict=driver_dict,
+                        fee=fee,
+                        tx_config=CMDTXConfigLoader(
+                            reuse_puzhash=reuse_puzhash,
+                        ).to_tx_config(units["chia"], config, fingerprint),
                     )
-                else:
-                    print("Error creating offer")
+                    if offer is not None:
+                        file.write(offer.to_bech32())
+                        print(f"Created offer with ID {trade_record.trade_id}")
+                        print(
+                            f"Use chia wallet get_offers --id "
+                            f"{trade_record.trade_id} -f {fingerprint} to view status"
+                        )
+                    else:
+                        print("Error creating offer")
 
 
 def timestamp_to_time(timestamp: int) -> str:


### PR DESCRIPTION
Fixes #10920

Addresses several issues with the seldom used `make_offer` CLI option. Uses `click.Path` type to avoid problems with using a directory or a non-writable file and added a couple of tests for those. This allows `click` to handle most error cases upfront.

Also, make sure to only make the offer after opening the file for writing, which would help to prevent other problems with creating the offer while being unable to write out to the file. Doesn't address all situations like running out of disk space, but this likely works for the large majority of failure cases.