### PR TITLE
add forced ruby dotenv version for arm64 installer build

### DIFF
--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -100,6 +100,7 @@ if [ "$PLATFORM" = "arm64" ]; then
   # ERROR:  Error installing fpm:
   #     The last version of dotenv (>= 0) to support your Ruby & RubyGems was 2.8.1. Try installing it with `gem install dotenv -v 2.8.1` and then running the current command again
   #     dotenv requires Ruby version >= 3.0. The current ruby version is 2.7.0.0.
+  # @TODO Once ruby 3.0 can be installed on `apt install ruby`, installing dotenv below should be removed.
   sudo gem install dotenv -v 2.8.1
   sudo gem install fpm
   echo USE_SYSTEM_FPM=true npx electron-builder build --linux deb --arm64 \

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -97,6 +97,10 @@ if [ "$PLATFORM" = "arm64" ]; then
   # @TODO Maybe versions of sub dependencies should be managed by gem lock file.
   # @TODO Once ruby 2.6 can be installed on `apt install ruby`, installing public_suffix below should be removed.
   sudo gem install public_suffix -v 4.0.7
+  # ERROR:  Error installing fpm:
+  #     The last version of dotenv (>= 0) to support your Ruby & RubyGems was 2.8.1. Try installing it with `gem install dotenv -v 2.8.1` and then running the current command again
+  #     dotenv requires Ruby version >= 3.0. The current ruby version is 2.7.0.0.
+  sudo gem install dotenv -v 2.8.1
   sudo gem install fpm
   echo USE_SYSTEM_FPM=true npx electron-builder build --linux deb --arm64 \
     --config.extraMetadata.name=chia-blockchain \


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

https://github.com/Chia-Network/chia-blockchain/actions/runs/7875372913/job/21491001287?pr=17347#step:19:5805
```
ERROR:  Error installing fpm:
	The last version of dotenv (>= 0) to support your Ruby & RubyGems was 2.8.1. Try installing it with `gem install dotenv -v 2.8.1` and then running the current command again
	dotenv requires Ruby version >= 3.0. The current ruby version is 2.7.0.0.
```

Adjacent to https://github.com/Chia-Network/chia-blockchain/pull/17545.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
