### PR TITLE
optimize `validate_removals()`

### DIFF
--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -36,7 +36,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.header_block import HeaderBlock
 from chia.util.ints import uint32
-from chia.util.merkle_set import MerkleSet, confirm_included_already_hashed, confirm_not_included_already_hashed
+from chia.util.merkle_set import confirm_included_already_hashed, confirm_not_included_already_hashed
 from chia.wallet.util.peer_request_cache import PeerRequestCache
 
 log = logging.getLogger(__name__)
@@ -151,12 +151,8 @@ def validate_removals(
         # we must find the ones relevant to our wallets.
 
         # Verify removals root
-        removals_merkle_set = MerkleSet()
-        for name_coin in coins:
-            _, coin = name_coin
-            if coin is not None:
-                removals_merkle_set.add_already_hashed(coin.name())
-        removals_root = removals_merkle_set.get_root()
+        removals_items = [name for name, coin in coins if coin is not None]
+        removals_root = bytes32(compute_merkle_set_root(removals_items))
         if root != removals_root:
             return False
     else:

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -198,7 +198,6 @@ async def request_and_validate_removals(
     )
     if removals_res is None or isinstance(removals_res, RejectRemovalsRequest):
         return False
-    assert removals_res.proofs is not None
     return validate_removals(removals_res.coins, removals_res.proofs, removals_root)
 
 

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -74,7 +74,6 @@ tests.core.test_daemon_rpc
 tests.core.test_db_conversion
 tests.core.test_filter
 tests.core.test_full_node_rpc
-tests.core.test_merkle_set
 tests.core.util.test_cached_bls
 tests.core.util.test_config
 tests.core.util.test_file_keyring_synchronization

--- a/tests/core/test_merkle_set.py
+++ b/tests/core/test_merkle_set.py
@@ -9,12 +9,13 @@ from typing import List
 import pytest
 from chia_rs import compute_merkle_set_root
 
+from chia.simulator.block_tools import BlockTools
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.merkle_set import MerkleSet, confirm_included_already_hashed
 
 
 @pytest.mark.anyio
-async def test_basics(bt):
+async def test_basics(bt: BlockTools) -> None:
     num_blocks = 20
     blocks = bt.get_consecutive_blocks(num_blocks)
 
@@ -50,7 +51,7 @@ def hashdown(buf: bytes) -> bytes32:
 
 
 @pytest.mark.anyio
-async def test_merkle_set_invalid_hash_size():
+async def test_merkle_set_invalid_hash_size() -> None:
     merkle_set = MerkleSet()
 
     # this is too large
@@ -76,7 +77,7 @@ async def test_merkle_set_invalid_hash_size():
 
 
 @pytest.mark.anyio
-async def test_merkle_set_1():
+async def test_merkle_set_1() -> None:
     a = bytes32([0x80] + [0] * 31)
     merkle_set = MerkleSet()
     merkle_set.add_already_hashed(a)
@@ -85,7 +86,7 @@ async def test_merkle_set_1():
 
 
 @pytest.mark.anyio
-async def test_merkle_set_duplicate():
+async def test_merkle_set_duplicate() -> None:
     a = bytes32([0x80] + [0] * 31)
     merkle_set = MerkleSet()
     merkle_set.add_already_hashed(a)
@@ -95,14 +96,14 @@ async def test_merkle_set_duplicate():
 
 
 @pytest.mark.anyio
-async def test_merkle_set_0():
+async def test_merkle_set_0() -> None:
     merkle_set = MerkleSet()
     assert merkle_set.get_root() == bytes32(compute_merkle_set_root([]))
     assert merkle_set.get_root() == bytes32([0] * 32)
 
 
 @pytest.mark.anyio
-async def test_merkle_set_2():
+async def test_merkle_set_2() -> None:
     a = bytes32([0x80] + [0] * 31)
     b = bytes32([0x70] + [0] * 31)
     merkle_set = MerkleSet()
@@ -113,7 +114,7 @@ async def test_merkle_set_2():
 
 
 @pytest.mark.anyio
-async def test_merkle_set_2_reverse():
+async def test_merkle_set_2_reverse() -> None:
     a = bytes32([0x80] + [0] * 31)
     b = bytes32([0x70] + [0] * 31)
     merkle_set = MerkleSet()
@@ -124,7 +125,7 @@ async def test_merkle_set_2_reverse():
 
 
 @pytest.mark.anyio
-async def test_merkle_set_3():
+async def test_merkle_set_3() -> None:
     a = bytes32([0x80] + [0] * 31)
     b = bytes32([0x70] + [0] * 31)
     c = bytes32([0x71] + [0] * 31)
@@ -145,7 +146,7 @@ async def test_merkle_set_3():
 
 
 @pytest.mark.anyio
-async def test_merkle_set_4():
+async def test_merkle_set_4() -> None:
     a = bytes32([0x80] + [0] * 31)
     b = bytes32([0x70] + [0] * 31)
     c = bytes32([0x71] + [0] * 31)
@@ -167,7 +168,7 @@ async def test_merkle_set_4():
 
 
 @pytest.mark.anyio
-async def test_merkle_set_5():
+async def test_merkle_set_5() -> None:
     BLANK = bytes32([0] * 32)
 
     a = bytes32([0x58] + [0] * 31)
@@ -216,7 +217,7 @@ async def test_merkle_set_5():
 
 
 @pytest.mark.anyio
-async def test_merkle_left_edge():
+async def test_merkle_left_edge() -> None:
     BLANK = bytes32([0] * 32)
     a = bytes32([0x80] + [0] * 31)
     b = bytes32([0] * 31 + [1])
@@ -257,7 +258,7 @@ async def test_merkle_left_edge():
 
 
 @pytest.mark.anyio
-async def test_merkle_right_edge():
+async def test_merkle_right_edge() -> None:
     BLANK = bytes32([0] * 32)
     a = bytes32([0x40] + [0] * 31)
     b = bytes32([0xFF] * 31 + [0xFF])
@@ -306,7 +307,7 @@ def rand_hash(rng: random.Random) -> bytes32:
 
 @pytest.mark.anyio
 @pytest.mark.skip("This test is expensive and has already convinced us there are no discrepancies")
-async def test_merkle_set_random_regression():
+async def test_merkle_set_random_regression() -> None:
     rng = random.Random()
     rng.seed(123456)
     for i in range(100):


### PR DESCRIPTION
# Purpose:

transition `validate_removals()` to use the fast function to compute a merkle tree root. The `MerkleSet` class is an inefficient implementation, and very expensive to use. The block validation as well as `validate_additions()` were transitioned to use the fast function when I first introduced it, but must have missed this place.

## history

in #10146 Mariano introduced an `assert removals_res.proofs is not None` which looks wrong, because the function that the proof is passed to handles the case where it's `None`. That's specifically the case this PR focuses on updating.

The fact that nothing has been broken this whole time (as far as I can tell) may suggest that perhaps the feature of omitting the proof when all removals are returned, is unnecessary.

This patch operates under the assumption that it *is* useful. Improves it and removes the assert blocking it.

### Current Behavior:

`validate_removals()` is expensive.
The response to a removals request must include proofs, even when every single removal is included.

### New Behavior:

`validate_removals()` is less expensive.
The response to a removals request may omit proofs if every single removal is included.

### Testing Notes:

Tests have been added.