### PR TITLE
Make `block_size_limit_factor` configurable

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -278,6 +278,7 @@ class FullNode:
                 get_coin_records=self.coin_store.get_coin_records,
                 consensus_constants=self.constants,
                 multiprocessing_context=self.multiprocessing_context,
+                block_size_limit_factor=max(min(float(self.config.get("block_size_limit_factor", 0.6)), 1), 0),
                 single_threaded=single_threaded,
             )
 

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -180,6 +180,7 @@ class MempoolManager:
         *,
         single_threaded: bool = False,
         max_tx_clvm_cost: Optional[uint64] = None,
+        block_size_limit_factor: float = 0.6,
     ):
         self.constants: ConsensusConstants = consensus_constants
 
@@ -193,8 +194,8 @@ class MempoolManager:
         # spends.
         self.nonzero_fee_minimum_fpc = 5
 
-        BLOCK_SIZE_LIMIT_FACTOR = 0.6
-        self.max_block_clvm_cost = uint64(self.constants.MAX_BLOCK_COST_CLVM * BLOCK_SIZE_LIMIT_FACTOR)
+        log.info(f"Using block_size_limit_factor={block_size_limit_factor}")
+        self.max_block_clvm_cost = uint64(self.constants.MAX_BLOCK_COST_CLVM * block_size_limit_factor)
         self.max_tx_clvm_cost = (
             max_tx_clvm_cost if max_tx_clvm_cost is not None else uint64(self.constants.MAX_BLOCK_COST_CLVM // 2)
         )


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Currently it is not possible to adjust the `BLOCK_SIZE_LIMIT_FACTOR` without modifying the source code. This PR adds support for configuring the `BLOCK_SIZE_LIMIT_FACTOR` using config option `block_size_limit_factor` in the full node section of the `config.yaml`.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
`BLOCK_SIZE_LIMIT_FACTOR` is hardcoded to 0.5 and 0.6 (0.6 since 2.2.0)


### New Behavior:
Defaults to 0.6 (the current hardcoded value) but is configurable.
