### PR TITLE
Specify unconfirmed transactions to delete in a backwards-compatible way

### DIFF
--- a/chia/cmds/plotnft_funcs.py
+++ b/chia/cmds/plotnft_funcs.py
@@ -106,7 +106,7 @@ async def create(
                 start = time.time()
                 while time.time() - start < 10:
                     await asyncio.sleep(0.1)
-                    tx = await wallet_client.get_transaction(1, tx_record.name)
+                    tx = await wallet_client.get_transaction(tx_record.name)
                     if len(tx.sent_to) > 0:
                         print(transaction_submitted_msg(tx))
                         print(transaction_status_msg(fingerprint, tx_record.name))

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -29,6 +29,7 @@ log = logging.getLogger(__name__)
 max_message_size = 50 * 1024 * 1024  # 50MB
 
 
+"""EndpointResult should always contain an entry "success" of type bool"""
 EndpointResult = Dict[str, Any]
 Endpoint = Callable[[Dict[str, object]], Awaitable[EndpointResult]]
 _T_RpcApiProtocol = TypeVar("_T_RpcApiProtocol", bound="RpcApiProtocol")

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1257,19 +1257,42 @@ class WalletRpcApi:
         }
 
     async def delete_unconfirmed_transactions(self, request: Dict[str, Any]) -> EndpointResult:
+        """
+        Only removes the transaction locally. If a transaction was successfully submitted, it's in the
+        mempool and farmer's hands now, and may be confirmed, even if our wallet doesn't know that yet.
+
+        Removing a transaction from our local TX DB will stop the wallet from re-submitting it to the network
+        """
+        state_mgr = self.service.wallet_state_manager
         wallet_id = uint32(request["wallet_id"])
-        if wallet_id not in self.service.wallet_state_manager.wallets:
+        if wallet_id not in state_mgr.wallets:
             raise ValueError(f"Wallet id {wallet_id} does not exist")
-        if await self.service.wallet_state_manager.synced() is False:
+        if await state_mgr.synced() is False:
             raise ValueError("Wallet needs to be fully synced.")
 
-        async with self.service.wallet_state_manager.db_wrapper.writer():
-            await self.service.wallet_state_manager.tx_store.delete_unconfirmed_transactions(wallet_id)
-            wallet = self.service.wallet_state_manager.wallets[wallet_id]
+        # Specifying tx_ids means "Delete only these (non-trade) transactions, and only if unconfirmed"
+        # A missing or null tx_ids input parameter, means "delete all unconfirmed (non-trade) transactions"
+        # A malformed parameter aborts the operation
+        tx_ids = None
+        tx_ids_param: Optional[List[str]] = request.get("tx_ids")
+        if tx_ids_param is not None:
+            tx_ids = set([bytes32.from_hexstr(hex_id) for hex_id in tx_ids_param])
+
+        async with state_mgr.lock:
+            unconfirmed_txs_before: List[TransactionRecord] = await state_mgr.tx_store.get_unconfirmed_for_wallet(
+                wallet_id
+            )
+        async with state_mgr.db_wrapper.writer():
+            await state_mgr.tx_store.delete_unconfirmed_transactions(wallet_id, tx_ids=tx_ids)
+            wallet = state_mgr.wallets[wallet_id]
             if wallet.type() == WalletType.POOLING_WALLET.value:
                 assert isinstance(wallet, PoolWallet)
                 wallet.target_state = None
-            return {}
+        async with state_mgr.lock:
+            unconfirmed_tx_after: List[TransactionRecord] = await state_mgr.tx_store.get_unconfirmed_for_wallet(
+                wallet_id
+            )
+        return {"unconfirmed_transactions_removed": list(set(unconfirmed_txs_before) - set(unconfirmed_tx_after))}
 
     async def select_coins(
         self,

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -274,7 +274,7 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("spend_clawback_coins", request)
         return response
 
-    async def delete_unconfirmed_transactions(self, wallet_id: int) -> None:
+    async def delete_unconfirmed_transactions(self, wallet_id: int, tx_ids: Optional[List[bytes32]] = None) -> None:
         await self.fetch("delete_unconfirmed_transactions", {"wallet_id": wallet_id})
 
     async def get_current_derivation_index(self) -> str:

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -6,6 +6,7 @@ from chia.data_layer.data_layer_util import DLProof, VerifyProofResponse
 from chia.data_layer.data_layer_wallet import Mirror, SingletonRecord
 from chia.pools.pool_wallet_info import PoolWalletInfo
 from chia.rpc.rpc_client import RpcClient
+from chia.rpc.rpc_server import EndpointResult
 from chia.rpc.wallet_request_types import GetNotifications, GetNotificationsResponse
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
@@ -274,8 +275,14 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("spend_clawback_coins", request)
         return response
 
-    async def delete_unconfirmed_transactions(self, wallet_id: int, tx_ids: Optional[List[bytes32]] = None) -> None:
-        await self.fetch("delete_unconfirmed_transactions", {"wallet_id": wallet_id})
+    async def delete_unconfirmed_transactions(
+        self, wallet_id: int, tx_ids: Optional[List[bytes32]] = None
+    ) -> EndpointResult:
+        if tx_ids is None:
+            request: Dict[str, Any] = {"wallet_id": wallet_id}
+        else:
+            request = {"wallet_id": wallet_id, "tx_ids": [id.hex() for id in tx_ids]}
+        return await self.fetch("delete_unconfirmed_transactions", request)
 
     async def get_current_derivation_index(self) -> str:
         response = await self.fetch("get_current_derivation_index", {})

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -33,6 +33,8 @@ def filter_ok_mempool_status(sent_to: List[Tuple[str, uint8, Optional[str]]]) ->
 class WalletTransactionStore:
     """
     WalletTransactionStore stores transaction history for the wallet.
+
+    Note that table transaction_record uses bundle_id and table tx_times uses txid. They are the same
     """
 
     db_wrapper: DBWrapper2
@@ -366,7 +368,9 @@ class WalletTransactionStore:
             )
         return 0 if len(rows) == 0 else rows[0][0]
 
-    async def get_all_transactions_for_wallet(self, wallet_id: int, type: int = None) -> List[TransactionRecord]:
+    async def get_all_transactions_for_wallet(
+        self, wallet_id: int, type: Optional[int] = None
+    ) -> List[TransactionRecord]:
         """
         Returns all stored transactions.
         """
@@ -416,21 +420,20 @@ class WalletTransactionStore:
             await (await conn.execute("DELETE FROM transaction_record WHERE confirmed_at_height>?", (height,))).close()
 
     async def delete_unconfirmed_transactions(self, wallet_id: int, tx_ids: Optional[Set[bytes32]] = None):
-        tx_id_qualifier = ""
-        if tx_ids is not None:
-            tx_id_qualifier = f"AND txid IN ({','.join(tx_ids)})"
+        sql_cmd = "DELETE FROM transaction_record WHERE confirmed=0 AND wallet_id=? AND type not in (?,?)"
+        args = (
+            wallet_id,
+            TransactionType.INCOMING_CLAWBACK_SEND.value,
+            TransactionType.INCOMING_CLAWBACK_RECEIVE.value,
+        )
+        if tx_ids is not None and len(tx_ids) > 0:
+            tx_id_qualifier = f"AND bundle_id IN ({','.join('?' * len(tx_ids))})"
+            args += tuple(tx_id for tx_id in tx_ids)
+            sql_cmd += f" {tx_id_qualifier}"
+        print(f"SQL:  {sql_cmd}")
+        print(f"args: {args}")
         async with self.db_wrapper.writer_maybe_transaction() as conn:
-            await (
-                await conn.execute(
-                    f"DELETE FROM transaction_record WHERE confirmed=0 AND wallet_id=? AND type not in (?,?)"
-                    f" {tx_id_qualifier}",
-                    (
-                        wallet_id,
-                        TransactionType.INCOMING_CLAWBACK_SEND.value,
-                        TransactionType.INCOMING_CLAWBACK_RECEIVE.value,
-                    ),
-                )
-            ).close()
+            await (await conn.execute(sql_cmd, args)).close()
 
     async def _get_new_tx_records_from_old(self, old_records: List[TransactionRecordOld]) -> List[TransactionRecord]:
         tx_id_to_valid_times: Dict[bytes, ConditionValidTimes] = {}

--- a/tests/cmds/cmd_test_utils.py
+++ b/tests/cmds/cmd_test_utils.py
@@ -65,7 +65,7 @@ class TestRpcClient:
         for k, v in expected_calls.items():
             assert k in self.rpc_log, f"key '{k}' not in rpc_log, rpc log's keys are: '{list(self.rpc_log.keys())}'"
             if v is not None:  # None means we don't care about the value used when calling the rpc.
-                assert self.rpc_log[k] == v, f"for key '{k}'\n'{self.rpc_log[k]}'\n!=\n'{v}'"
+                assert self.rpc_log[k] == v, f"for key '{k}'\nACTUAL:   '{self.rpc_log[k]}'\nEXPECTED: '{v}'"
         self.rpc_log = {}
 
 
@@ -107,8 +107,8 @@ class TestWalletRpcClient(TestRpcClient):
             raise ValueError(f"Invalid fingerprint: {self.fingerprint}")
         return [{"id": 1, "type": w_type}]
 
-    async def get_transaction(self, wallet_id: int, transaction_id: bytes32) -> TransactionRecord:
-        self.add_to_log("get_transaction", (wallet_id, transaction_id))
+    async def get_transaction(self, transaction_id: bytes32) -> TransactionRecord:
+        self.add_to_log("get_transaction", (transaction_id,))
         return TransactionRecord(
             confirmed_at_height=uint32(1),
             created_at_time=uint64(1234),

--- a/tests/cmds/wallet/test_wallet.py
+++ b/tests/cmds/wallet/test_wallet.py
@@ -50,7 +50,7 @@ def test_get_transaction(capsys: object, get_test_cli_clients: Tuple[TestRpcClie
     inst_rpc_client = TestWalletRpcClient()  # pylint: disable=no-value-for-parameter
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
     # get output with all options but verbose
-    command_args = ["wallet", "get_transaction", WALLET_ID_ARG, "-tx", bytes32_hexstr]
+    command_args = ["wallet", "get_transaction", "-tx", bytes32_hexstr]
     assert_list = [
         "Transaction 0202020202020202020202020202020202020202020202020202020202020202",
         "Status: In mempool",
@@ -76,9 +76,9 @@ def test_get_transaction(capsys: object, get_test_cli_clients: Tuple[TestRpcClie
         "get_wallets": [(None,), (None,), (None,)],
         "get_cat_name": [(1,)],
         "get_transaction": [
-            (37, bytes32.from_hexstr(bytes32_hexstr)),
-            (37, bytes32.from_hexstr(bytes32_hexstr)),
-            (37, bytes32.from_hexstr(bytes32_hexstr)),
+            (bytes32.from_hexstr(bytes32_hexstr),),
+            (bytes32.from_hexstr(bytes32_hexstr),),
+            (bytes32.from_hexstr(bytes32_hexstr),),
         ],
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
@@ -395,7 +395,7 @@ def test_send(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Path])
     run_cli_command_and_assert(capsys, root_dir, command_args + [FINGERPRINT_ARG], assert_list)
     run_cli_command_and_assert(capsys, root_dir, command_args + [CAT_FINGERPRINT_ARG], cat_assert_list)
     # these are various things that should be in the output
-    expected_calls: logType = {
+    expected_output: logType = {
         "get_wallets": [(None,), (None,)],
         "send_transaction": [
             (
@@ -433,9 +433,9 @@ def test_send(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Path])
                 None,
             )
         ],
-        "get_transaction": [(1, get_bytes32(2)), (1, get_bytes32(2))],
+        "get_transaction": [(get_bytes32(2),), (get_bytes32(2),)],
     }
-    test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
+    test_rpc_clients.wallet_rpc_client.check_log(expected_output)
 
 
 def test_get_address(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Path]) -> None:
@@ -510,9 +510,9 @@ def test_del_unconfirmed_tx(capsys: object, get_test_cli_clients: Tuple[TestRpcC
 
     # set RPC Client
     class UnconfirmedTxRpcClient(TestWalletRpcClient):
-        async def delete_unconfirmed_transactions(self, wallet_id: int) -> None:
+        async def delete_unconfirmed_transactions(self, wallet_id: int) -> Dict[str, Any]:
             self.add_to_log("delete_unconfirmed_transactions", (wallet_id,))
-            return None
+            return {"success": True, "unconfirmed_transactions_deleted": [f"{bytes32_hexstr}"]}
 
     inst_rpc_client = UnconfirmedTxRpcClient()  # pylint: disable=no-value-for-parameter
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
@@ -521,8 +521,8 @@ def test_del_unconfirmed_tx(capsys: object, get_test_cli_clients: Tuple[TestRpcC
         "delete_unconfirmed_transactions",
         WALLET_ID_ARG,
         FINGERPRINT_ARG,
-    ]
-    assert_list = [f"Successfully deleted all unconfirmed transactions for wallet id {WALLET_ID} on key {FINGERPRINT}"]
+    ]  # xxx
+    assert_list = [f"Successfully deleted unconfirmed transactions for wallet id {WALLET_ID} on key {FINGERPRINT}"]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     # these are various things that should be in the output
     expected_calls: logType = {

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -142,9 +142,9 @@ async def farm_block_check_singleton(
     await full_node_api.wait_for_wallet_synced(wallet_node=wallet, timeout=10)
 
 
-async def is_transaction_confirmed(user_wallet_id: uint32, api: WalletRpcApi, tx_id: bytes32) -> bool:
+async def is_transaction_confirmed(api: WalletRpcApi, tx_id: bytes32) -> bool:
     try:
-        val = await api.get_transaction({"wallet_id": user_wallet_id, "transaction_id": tx_id.hex()})
+        val = await api.get_transaction({"transaction_id": tx_id.hex()})
     except ValueError:  # pragma: no cover
         return False
 
@@ -156,7 +156,7 @@ async def farm_block_with_spend(
 ) -> None:
     await time_out_assert(10, check_mempool_spend_count, True, full_node_api, 1)
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-    await time_out_assert(10, is_transaction_confirmed, True, "this is unused", wallet_rpc_api, tx_rec)
+    await time_out_assert(10, is_transaction_confirmed, True, wallet_rpc_api, tx_rec)
 
 
 def check_mempool_spend_count(full_node_api: FullNodeSimulator, num_of_spends: int) -> bool:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
If we make the state of in-progress transactions more visible, we need to have a way to say "stop broadcasting this transaction"

### Discussion:

If we unify the idea of "deleted from local wallet transaction database" with "we are no longer tracking or re-submitting this transaction", then this change is sufficient to allow the user to manage their submitted transactions. However, it is (and always was) possible to have a transaction confirmed after it is deleted locally, so special care needs to be taken when messaging how this works to the user.

Another issue I'd like input on: If we delete an outstanding transaction locally, and that transaction is then confirmed, we lose all metadata not held in the transaction itself, or not indexable from the data in the SpendBundle. Personally, I think that all data associated with a transaction (held outside the chain) should be implemented this way. But we must make this clear to wallet developers.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Fully backwards compatible.

### New Behavior:

Overview: For the  delete_unconfirmed Wallet RPC call, You are now allowed to add a  parameter "tx_ids", which is a list of
The old behaviour, with no arguments is preserved - it deletes ALL unconfirmed transactions in that case.

New behaviour is extensively documented in tests/wallet/rpc/test_wallet_rpc.py



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
