### PR TITLE
Warn users before combining many coins with no fee

### DIFF
--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -182,6 +182,9 @@ async def async_combine(
         if is_xch and total_amount - final_fee <= 0:
             print("Total amount is less than 0 after fee, exiting.")
             return
+        if final_fee < 1:
+            print("You are about to submit a transaction without fees.")
+            cli_confirm("Are you sure? (y/n): ")
         target_ph: bytes32 = decode_puzzle_hash(await wallet_client.get_next_address(wallet_id, False))
         additions = [{"amount": (total_amount - final_fee) if is_xch else total_amount, "puzzle_hash": target_ph}]
         transaction: TransactionRecord = await wallet_client.send_transaction_multi(


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Current behavior is that if a user runs `chia wallet coins combine` without specifying a fee, 0 will be used and all coins in the wallet can be locked in the spend bundle. This can be RBF'ed but much better to make sure the user really wants no fee on their combine.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
In default options - can create a large spend bundle with no fee.


### New Behavior:
User has to confirm they mean to use no fee


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Confirmed working on mainnet


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
