### PR TITLE
Set default datalayer transaction fee to zero

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -677,7 +677,7 @@ data_layer:
   # TODO: what considerations are there in choosing this?
   rpc_port: 8562
   rpc_server_max_request_body_size: 26214400
-  fee: 1000000000
+  fee: 0
 
   # this is a debug and profiling facility that logs all SQLite commands to a
   # separate log file (under logging/data_sql.log).


### PR DESCRIPTION
### Purpose:
Nobody likes an unexpected fee on their transaction.  In the default config.yaml, a fee of 1000000000 mojo was added to every data layer transaction unless a fee was specified.  This isn't done anywhere else in the code, for any other kind of transactions, and is unlikely to be what anyone wants.  I've kept the config option, but is set to zero by default to avoid adding surprise fees to data layer transactions and treating datal ayer transactions the same as any other transaction with regard to fees. 


### Current Behavior:
When sending a data layer transaction, if a fee isn't specified, Chia adds a 1000000000 mojo fee.


### New Behavior:
When sending a data layer transaction, if a fee isn't specified, no fee will be added. 