### PR TITLE
DL run cleanup without foreign keys.

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -199,7 +199,7 @@ class DataLayer:
             database=self.db_path, sql_log_path=sql_log_path, foreign_keys=False
         ) as data_store_cleanup:
             try:
-                async with self.data_store.transaction() as writer:
+                async with data_store_cleanup.db_wrapper.writer() as writer:
                     await data_store_cleanup.clean_node_table(writer)
             except asyncio.CancelledError:
                 return

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -199,7 +199,7 @@ class DataLayer:
             database=self.db_path, sql_log_path=sql_log_path, foreign_keys=False
         ) as data_store_cleanup:
             try:
-                async with data_store_cleanup.db_wrapper.writer() as writer:
+                async with data_store_cleanup.transaction() as writer:
                     await data_store_cleanup.clean_node_table(writer)
             except asyncio.CancelledError:
                 return

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -199,7 +199,7 @@ class DataLayer:
             database=self.db_path, sql_log_path=sql_log_path, foreign_keys=False
         ) as data_store_cleanup:
             try:
-                async with data_store_cleanup.transaction() as writer:
+                async with data_store_cleanup.db_wrapper.writer() as writer:
                     await data_store_cleanup.clean_node_table(writer)
             except asyncio.CancelledError:
                 return

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -57,7 +57,11 @@ class DataStore:
     @classmethod
     @contextlib.asynccontextmanager
     async def managed(
-        cls, database: Union[str, Path], uri: bool = False, sql_log_path: Optional[Path] = None
+        cls,
+        database: Union[str, Path],
+        uri: bool = False,
+        sql_log_path: Optional[Path] = None,
+        foreign_keys: bool = True,
     ) -> AsyncIterator[DataStore]:
         async with DBWrapper2.managed(
             database=database,
@@ -68,7 +72,7 @@ class DataStore:
             synchronous="FULL",
             # If foreign key checking gets turned off, please add corresponding check
             # methods and enable foreign key checking in the tests.
-            foreign_keys=True,
+            foreign_keys=foreign_keys,
             row_factory=aiosqlite.Row,
             log_path=sql_log_path,
         ) as db_wrapper:

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -3189,7 +3189,7 @@ async def test_node_table_cleanup(
             )
 
         await data_store.rollback_to_generation(tree_id, 1)
-        async with data_layer.data_store.db_wrapper.reader() as reader:
+        async with data_store.db_wrapper.reader() as reader:
             async with reader.execute("SELECT COUNT(*) FROM node") as cursor:
                 row_count = await cursor.fetchone()
                 assert row_count is not None
@@ -3198,7 +3198,7 @@ async def test_node_table_cleanup(
     async with init_data_layer(wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path) as data_layer:
         data_store = data_layer.data_store
 
-        async with data_layer.data_store.db_wrapper.reader() as reader:
+        async with data_store.db_wrapper.reader() as reader:
             async with reader.execute("SELECT COUNT(*) FROM node") as cursor:
                 row_count = await cursor.fetchone()
                 assert row_count is not None

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -3196,7 +3196,6 @@ async def test_node_table_cleanup(
                 assert row_count[0] > 1
 
     async with init_data_layer(wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path) as data_layer:
-        data_rpc_api = DataLayerRpcApi(data_layer)
         data_store = data_layer.data_store
 
         async with data_layer.data_store.db_wrapper.reader() as reader:

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -3165,7 +3165,6 @@ async def test_node_table_cleanup(
         self_hostname, one_wallet_and_one_simulator_services
     )
     async with init_data_layer(wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path) as data_layer:
-        data_rpc_api = DataLayerRpcApi(data_layer)
         data_store = data_layer.data_store
 
         tree_id = bytes32(range(32))

--- a/tests/core/data_layer/test_data_rpc.py
+++ b/tests/core/data_layer/test_data_rpc.py
@@ -3171,7 +3171,7 @@ async def test_node_table_cleanup(
         tree_id = bytes32(range(32))
         await data_store.create_tree(tree_id=tree_id, status=Status.COMMITTED)
 
-        hint_keys_values = {}
+        hint_keys_values: Dict[bytes32, bytes32] = {}
         for key in range(5):
             await data_store.autoinsert(
                 key=key.to_bytes(1, byteorder="big"),


### PR DESCRIPTION
Runs the expensive call `clean_node_table` at startup, with foreign keys disabled, to execute quicker.