### PR TITLE
Change Wallet API get_transaction to use wallet_id parameter. Add test.

### DIFF
--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -144,7 +144,7 @@ class WalletRpcClient(RpcClient):
         return cast(Dict[str, Dict[str, Any]], response["wallet_balances"])
 
     async def get_transaction(self, wallet_id: int, transaction_id: bytes32) -> TransactionRecord:
-        request = {"walled_id": wallet_id, "transaction_id": transaction_id.hex()}
+        request = {"wallet_id": wallet_id, "transaction_id": transaction_id.hex()}
         response = await self.fetch("get_transaction", request)
         return TransactionRecord.from_json_dict_convenience(response["transaction"])
 

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -346,7 +346,7 @@ async def send_xch_wallet1_to_wallet2(env: WalletRpcTestEnvironment) -> Optional
 
     transaction_id = tx.name
     assert tx.spend_bundle is not None
-    assert tx.confirmed == False  # flake8: noqa E712
+    assert tx.confirmed == False  # noqa: E712 # flake8: E712
 
     await time_out_assert(20, tx_in_mempool, True, client, transaction_id)
     return tx
@@ -362,9 +362,12 @@ async def test_wallet_rpc_client_get_transaction(wallet_rpc_environment: WalletR
     tx = await client.get_transaction(1, sent_tx.name)
     assert tx.wallet_id == 1
     assert tx.is_in_mempool()
+    # The transaction is expected to be from the wallet_id specified in the request
     with pytest.raises(ValueError):
         tx = await client.get_transaction(7, sent_tx.name)
         print(tx)
+    # Reached only if client.get_transaction() does not throw
+    assert tx.wallet_id == sent_tx.wallet_id
 
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")

--- a/tests/wallet/rpc/test_wallet_rpc.py
+++ b/tests/wallet/rpc/test_wallet_rpc.py
@@ -286,7 +286,7 @@ def update_verify_signature_request(request: Dict[str, Any], prefix_hex_values: 
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0], reason="save time")
 @pytest.mark.anyio
-async def test_send_transaction(wallet_rpc_environment: WalletRpcTestEnvironment) -> bytes32:
+async def test_send_transaction(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
     env: WalletRpcTestEnvironment = wallet_rpc_environment
 
     wallet_2: Wallet = env.wallet_2.wallet
@@ -331,7 +331,6 @@ async def test_send_transaction(wallet_rpc_environment: WalletRpcTestEnvironment
     assert list(tx_confirmed.get_memos().keys())[0] in [a.name() for a in spend_bundle.additions()]
 
     await time_out_assert(20, get_confirmed_balance, generated_funds - tx_amount, client, 1)
-    return transaction_id
 
 
 async def send_xch_wallet1_to_wallet2(env: WalletRpcTestEnvironment) -> Optional[TransactionRecord]:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:


`WalletRpcApi.get_transaction()` would never look at the `wallet_id` parameter, therefore returned Transactions were never filtered by `wallet_id`.

<!-- Does this PR introduce a breaking change? -->

Breaking Change! See below.

### Current Behavior:

Would always return requested transaction, regardless of requested wallet.

### New Behavior:

Will only return the transaction if it belongs to the 
Fails if an invalid `wallet_id` parameter is supplied, or if `wallet_id` is missing


### Security Notes

checking the `wallet_id` does not confer any security benefits. Anyone with access to the wallet API likely has access to the wallet db.

### Design Notes

Personally, I would remove the `wallet_id` parameter entirely. Its only use currently is a sanity check, and that check could be built into the RPC receiver. All `TransactionRecord`s contain their `wallet_id`.

We need to get rid of the local `wallet_id` int for wallet identity purposes. One of the many issues this causes us is that wallet "IDs" can change after a wallet rebuild or chain reorg. 

### Code notes

I'm guessing `get_transaction` was introduced as a quick to implement alternative to extending `get_transactions`

If that is correct, and it is not used in many places, we might consider deprecating `get_transaction`, especially if all the current use is in-house.

We might want to consider folding this into `get_transactions`. I'll link the PR for that.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
