### PR TITLE
tighten up the check for duplicate UnfinishedBlocks before requesting

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -47,7 +47,7 @@ from chia.full_node.block_store import BlockStore
 from chia.full_node.bundle_tools import detect_potential_template_generator
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.full_node_api import FullNodeAPI
-from chia.full_node.full_node_store import FullNodeStore, FullNodeStorePeakResult
+from chia.full_node.full_node_store import FullNodeStore, FullNodeStorePeakResult, UnfinishedBlockEntry
 from chia.full_node.hint_management import get_hints_and_subscription_coin_ids
 from chia.full_node.hint_store import HintStore
 from chia.full_node.mempool_manager import MempoolManager
@@ -1666,19 +1666,27 @@ class FullNode:
             # This is the case where we already had the unfinished block, and asked for this block without
             # the transactions (since we already had them). Therefore, here we add the transactions.
             unfinished_rh: bytes32 = block.reward_chain_block.get_unfinished().get_hash()
-            unf_block: Optional[UnfinishedBlock] = self.full_node_store.get_unfinished_block(unfinished_rh)
+            foliage_hash: Optional[bytes32] = block.foliage.foliage_transaction_block_hash
+            assert foliage_hash is not None
+            unf_entry: Optional[UnfinishedBlockEntry] = self.full_node_store.get_unfinished_block_result(
+                unfinished_rh, foliage_hash
+            )
             if (
-                unf_block is not None
-                and unf_block.transactions_generator is not None
-                and unf_block.foliage_transaction_block == block.foliage_transaction_block
+                unf_entry is not None
+                and unf_entry.unfinished_block is not None
+                and unf_entry.unfinished_block.transactions_generator is not None
+                and unf_entry.unfinished_block.foliage_transaction_block == block.foliage_transaction_block
             ):
                 # We checked that the transaction block is the same, therefore all transactions and the signature
                 # must be identical in the unfinished and finished blocks. We can therefore use the cache.
-                pre_validation_result = self.full_node_store.get_unfinished_block_result(unfinished_rh)
+
+                # this is a transaction block, the foliage hash should be set
+                assert foliage_hash is not None
+                pre_validation_result = unf_entry.result
                 assert pre_validation_result is not None
                 block = block.replace(
-                    transactions_generator=unf_block.transactions_generator,
-                    transactions_generator_ref_list=unf_block.transactions_generator_ref_list,
+                    transactions_generator=unf_entry.unfinished_block.transactions_generator,
+                    transactions_generator_ref_list=unf_entry.unfinished_block.transactions_generator_ref_list,
                 )
             else:
                 # We still do not have the correct information for this block, perhaps there is a duplicate block

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -427,27 +427,25 @@ class FullNodeAPI:
             return None
 
         # This prevents us from downloading the same block from many peers
-        if block_hash in self.full_node.full_node_store.requesting_unfinished_blocks:
-            return None
-
-        # if we've already learned about an unfinished block with this reward
-        # hash via the v2 protocol, and we've requested it. Assume it's the same
-        # block
-        if block_hash in self.full_node.full_node_store.requesting_unfinished_blocks2:
+        requesting, count = self.full_node.full_node_store.is_requesting_unfinished_block(block_hash, None)
+        if requesting:
+            self.log.debug(
+                f"Already have or requesting {count} Unfinished Blocks with partial "
+                f"hash {block_hash}. Ignoring this one"
+            )
             return None
 
         msg = make_msg(
             ProtocolMessageTypes.request_unfinished_block,
             full_node_protocol.RequestUnfinishedBlock(block_hash),
         )
-        self.full_node.full_node_store.requesting_unfinished_blocks.add(block_hash)
+        self.full_node.full_node_store.mark_requesting_unfinished_block(block_hash, None)
 
         # However, we want to eventually download from other peers, if this peer does not respond
         # Todo: keep track of who it was
         async def eventually_clear() -> None:
             await asyncio.sleep(5)
-            if block_hash in self.full_node.full_node_store.requesting_unfinished_blocks:
-                self.full_node.full_node_store.requesting_unfinished_blocks.remove(block_hash)
+            self.full_node.full_node_store.remove_requesting_unfinished_block(block_hash, None)
 
         asyncio.create_task(eventually_clear())
 
@@ -496,7 +494,13 @@ class FullNodeAPI:
             return None
 
         # This prevents us from downloading the same block from many peers
-        if self.full_node.full_node_store.is_requesting_unfinished_block(block_hash, foliage_hash):
+        requesting, count = self.full_node.full_node_store.is_requesting_unfinished_block(block_hash, foliage_hash)
+        if requesting:
+            return None
+        if count >= max_duplicate_unfinished_blocks:
+            self.log.info(
+                f"Already requesting {count} Unfinished Blocks with partial hash {block_hash} ignoring another one"
+            )
             return None
 
         msg = make_msg(

--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -40,8 +40,12 @@ class FullNodeStorePeakResult(Streamable):
 
 @dataclasses.dataclass
 class UnfinishedBlockEntry:
-    unfinished_block: UnfinishedBlock
-    result: PreValidationResult
+    # if this is None, it means we've requested this block but not yet received
+    # it
+    unfinished_block: Optional[UnfinishedBlock]
+    # If this is None, it means we've initiated validation of this block, but it
+    # hasn't completed yet
+    result: Optional[PreValidationResult]
     height: uint32
 
 
@@ -57,12 +61,26 @@ def find_best_block(
 
     all_blocks = list(result.items())
     if len(all_blocks) == 1:
-        return all_blocks[0][0], all_blocks[0][1].unfinished_block
+        foliage_hash, entry = all_blocks[0]
+        # this means we don't have the block yet
+        if entry.unfinished_block is None:
+            return None, None
+        else:
+            return foliage_hash, entry.unfinished_block
+
+    def include_block(item: Tuple[Optional[bytes32], UnfinishedBlockEntry]) -> bool:
+        foliage_hash, entry = item
+        return foliage_hash is not None and entry.unfinished_block is not None
 
     # if there are unfinished blocks with foliage (i.e. not None) we prefer
     # those, so drop the first element
-    all_blocks = [e for e in all_blocks if e[0] is not None]
+    all_blocks = [e for e in all_blocks if include_block(e)]
     all_blocks = sorted(all_blocks)
+
+    # we may have filtered out some blocks that we have only requested, but not
+    # yet received.
+    if len(all_blocks) == 0:
+        return None, None
 
     return all_blocks[0][0], all_blocks[0][1].unfinished_block
 
@@ -84,6 +102,9 @@ class FullNodeStore:
     # There may be multiple different unfinished blocks with the same partial
     # hash (reward chain block hash). They are stored under their partial hash
     # though. The inner dictionary uses the foliage hash as the key
+    # The UnfinishedBlockEntry is a placeholder for UnfinishedBlocks we have
+    # requested (but don't have yet) or that we have but haven't completed
+    # validation of (yet).
     unfinished_blocks: Dict[bytes32, Dict[Optional[bytes32], UnfinishedBlockEntry]]
 
     # Finished slots and sps from the peak's slot onwards
@@ -111,13 +132,6 @@ class FullNodeStore:
     recent_signage_points: LRUCache[bytes32, Tuple[SignagePoint, float]]
     recent_eos: LRUCache[bytes32, Tuple[EndOfSubSlotBundle, float]]
 
-    # Partial hashes of unfinished blocks we are requesting
-    requesting_unfinished_blocks: Set[bytes32]
-
-    # with the updated protocol for UnfinishedBlocks, when we request a block
-    # with a specific foliage hash, we add the outstanding request to this dict
-    requesting_unfinished_blocks2: Dict[bytes32, Set[Optional[bytes32]]]
-
     previous_generator: Optional[CompressorArg]
     pending_tx_request: Dict[bytes32, bytes32]  # tx_id: peer_id
     peers_with_tx: Dict[bytes32, Set[bytes32]]  # tx_id: Set[peer_ids}
@@ -138,8 +152,6 @@ class FullNodeStore:
         self.future_ip_cache = {}
         self.recent_signage_points = LRUCache(500)
         self.recent_eos = LRUCache(50)
-        self.requesting_unfinished_blocks = set()
-        self.requesting_unfinished_blocks2 = {}
         self.previous_generator = None
         self.future_cache_key_times = {}
         self.constants = constants
@@ -152,21 +164,43 @@ class FullNodeStore:
         self.serialized_wp_message_tip = None
         self.max_seen_unfinished_blocks = 1000
 
-    def is_requesting_unfinished_block(self, reward_block_hash: bytes32, foliage_hash: Optional[bytes32]) -> bool:
-        ents = self.requesting_unfinished_blocks2.get(reward_block_hash)
-        return ents is not None and foliage_hash in ents
+    def is_requesting_unfinished_block(
+        self, reward_block_hash: bytes32, foliage_hash: Optional[bytes32]
+    ) -> Tuple[bool, int]:
+        """
+        Asks if we are already requesting this specific unfinished block (given
+        the reward block hash and foliage hash). The returned bool is true if we
+        are and false otherwise. The function also returns the number of
+        variants of an unfinished block with this reward block hash we are
+        currently requesting. This is useful to ensure we limit the number of
+        variants we request.
+        """
+        ents = self.unfinished_blocks.get(reward_block_hash)
+        if ents is None:
+            return (False, 0)
+        elif foliage_hash is None:
+            return (len(ents) > 0, len(ents))
+        else:
+            return (foliage_hash in ents, len(ents))
 
     def mark_requesting_unfinished_block(self, reward_block_hash: bytes32, foliage_hash: Optional[bytes32]) -> None:
-        ents = self.requesting_unfinished_blocks2.setdefault(reward_block_hash, set())
-        ents.add(foliage_hash)
+        ents = self.unfinished_blocks.setdefault(reward_block_hash, {})
+        ents.setdefault(foliage_hash, UnfinishedBlockEntry(None, None, uint32(0)))
 
     def remove_requesting_unfinished_block(self, reward_block_hash: bytes32, foliage_hash: Optional[bytes32]) -> None:
-        ents = self.requesting_unfinished_blocks2.get(reward_block_hash)
+        ents = self.unfinished_blocks.get(reward_block_hash)
         if ents is None:
             return
-        ents.discard(foliage_hash)
+        ent = ents.get(foliage_hash)
+        if ent is None:
+            return
+        if ent.unfinished_block is not None:
+            # in this case we've successfully received the unfinished block,
+            # it's already considered "not requesting", but actually downloaded
+            return
+        del ents[foliage_hash]
         if len(ents) == 0:
-            del self.requesting_unfinished_blocks2[reward_block_hash]
+            del self.unfinished_blocks[reward_block_hash]
 
     def add_candidate_block(
         self, quality_string: bytes32, height: uint32, unfinished_block: UnfinishedBlock, backup: bool = False
@@ -256,7 +290,8 @@ class FullNodeStore:
         if result is None:
             return None, 0, False
         if unfinished_foliage_hash is None:
-            return self.get_unfinished_block(unfinished_reward_hash), len(result), False
+            foliage_hash, block = find_best_block(result)
+            return block, len(result), False
 
         foliage_hash, block = find_best_block(result)
         has_better: bool = foliage_hash is not None and foliage_hash < unfinished_foliage_hash
@@ -268,30 +303,23 @@ class FullNodeStore:
         else:
             return entry.unfinished_block, len(result), has_better
 
-    def get_unfinished_block_result(self, unfinished_reward_hash: bytes32) -> Optional[PreValidationResult]:
+    # we only have PreValidationResults for transaction blocks, and they all
+    # have a foliage hash. That's why unfinished_foliage_hash is not Optional.
+    def get_unfinished_block_result(
+        self, unfinished_reward_hash: bytes32, unfinished_foliage_hash: bytes32
+    ) -> Optional[UnfinishedBlockEntry]:
         result = self.unfinished_blocks.get(unfinished_reward_hash, None)
         if result is None:
             return None
-        return next(iter(result.values())).result
-
-    def get_unfinished_block_result2(
-        self, unfinished_reward_hash: bytes32, unfinished_foliage_hash: Optional[bytes32]
-    ) -> Optional[PreValidationResult]:
-        result = self.unfinished_blocks.get(unfinished_reward_hash, None)
-        if result is None:
-            return None
-        if unfinished_foliage_hash is None:
-            return next(iter(result.values())).result
         else:
-            entry = result.get(unfinished_foliage_hash)
-            return None if entry is None else entry.result
+            return result.get(unfinished_foliage_hash)
 
     # returns all unfinished blocks for the specified height
     def get_unfinished_blocks(self, height: uint32) -> List[UnfinishedBlock]:
         ret: List[UnfinishedBlock] = []
         for entry in self.unfinished_blocks.values():
             for ube in entry.values():
-                if ube.height == height:
+                if ube.height == height and ube.unfinished_block is not None:
                     ret.append(ube.unfinished_block)
         return ret
 

--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -191,18 +191,18 @@ class FullNodeStore:
         ents.setdefault(foliage_hash, UnfinishedBlockEntry(None, None, uint32(0)))
 
     def remove_requesting_unfinished_block(self, reward_block_hash: bytes32, foliage_hash: Optional[bytes32]) -> None:
-        ents = self._unfinished_blocks.get(reward_block_hash)
-        if ents is None:
+        reward_ents = self._unfinished_blocks.get(reward_block_hash)
+        if reward_ents is None:
             return
-        ent = ents.get(foliage_hash)
-        if ent is None:
+        foliage_ent = reward_ents.get(foliage_hash)
+        if foliage_ent is None:
             return
-        if ent.unfinished_block is not None:
+        if foliage_ent.unfinished_block is not None:
             # in this case we've successfully received the unfinished block,
             # it's already considered "not requesting", but actually downloaded
             return
-        del ents[foliage_hash]
-        if len(ents) == 0:
+        del reward_ents[foliage_hash]
+        if len(reward_ents) == 0:
             del self._unfinished_blocks[reward_block_hash]
 
     def add_candidate_block(

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import random
-from typing import AsyncIterator, Dict, List, Optional
+from typing import AsyncIterator, Dict, List, Optional, Tuple
 
 import pytest
 
@@ -117,27 +117,40 @@ async def test_unfinished_block_rank(
 
 
 @pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.parametrize(
     "blocks,expected",
     [
-        ([None, 1, 2, 3], 1),
-        ([None], None),
+        ([(None, True), (1, True), (2, True), (3, True)], 1),
+        ([(None, True), (1, False), (2, True), (3, True)], 2),
+        ([(None, True), (1, False), (2, False), (3, True)], 3),
+        ([(None, True)], None),
         ([], None),
-        ([4, 5, 3], 3),
-        ([4], 4),
+        ([(4, True), (5, True), (3, True)], 3),
+        ([(4, True)], 4),
+        ([(4, False)], None),
     ],
 )
 async def test_find_best_block(
     seeded_random: random.Random,
-    blocks: List[Optional[int]],
+    blocks: List[Tuple[Optional[int], bool]],
     expected: Optional[int],
+    default_400_blocks: List[FullBlock],
+    bt: BlockTools,
 ) -> None:
     result: Dict[Optional[bytes32], UnfinishedBlockEntry] = {}
-    for b in blocks:
-        if b is None:
-            result[b] = UnfinishedBlockEntry(None, None, 123)  # type: ignore
+    i = 0
+    for b, with_unf in blocks:
+        unf: Optional[UnfinishedBlock]
+        if with_unf:
+            unf = make_unfinished_block(default_400_blocks[i], bt.constants)
+            i += 1
         else:
-            result[bytes32(b.to_bytes(1, "big") * 32)] = UnfinishedBlockEntry(None, None, 123)  # type: ignore
+            unf = None
+        if b is None:
+            result[b] = UnfinishedBlockEntry(unf, None, uint32(123))
+        else:
+            result[bytes32(b.to_bytes(1, "big") * 32)] = UnfinishedBlockEntry(unf, None, uint32(123))
 
     foliage_hash, block = find_best_block(result)
     if expected is None:
@@ -224,13 +237,22 @@ async def test_basic_store(
             foliage_hash is not None and dummy_hash > foliage_hash,
         )
 
-        ublock = store.get_unfinished_block_result(unf_block.partial_hash)
-        assert ublock is not None and ublock.required_iters == uint64(123532)
-        ublock = store.get_unfinished_block_result2(
-            unf_block.partial_hash, unf_block.foliage.foliage_transaction_block_hash
-        )
+        # only transaction blocks have PreValidationResults
+        # so get_unfinished_block_result requires the foliage hash
+        if unf_block.foliage.foliage_transaction_block_hash is not None:
+            entry = store.get_unfinished_block_result(
+                unf_block.partial_hash, unf_block.foliage.foliage_transaction_block_hash
+            )
+            assert entry is not None
+            ublock = entry.result
+            assert ublock is not None and ublock.required_iters == uint64(123532)
+            entry = store.get_unfinished_block_result(
+                unf_block.partial_hash, unf_block.foliage.foliage_transaction_block_hash
+            )
+            assert entry is not None
+            ublock = entry.result
 
-        assert ublock is not None and ublock.required_iters == uint64(123532)
+            assert ublock is not None and ublock.required_iters == uint64(123532)
 
         store.remove_unfinished_block(unf_block.partial_hash)
         assert store.get_unfinished_block(unf_block.partial_hash) is None
@@ -289,17 +311,22 @@ async def test_basic_store(
     )
     assert store.get_unfinished_block2(unf4.partial_hash, None) == (unf1, 2, False)
 
-    ublock = store.get_unfinished_block_result(unf1.partial_hash)
+    entry = store.get_unfinished_block_result(unf1.partial_hash, unf1.foliage.foliage_transaction_block_hash)
+    assert entry is not None
+    ublock = entry.result
     assert ublock is not None and ublock.required_iters == uint64(0)
-    ublock = store.get_unfinished_block_result2(unf1.partial_hash, unf1.foliage.foliage_transaction_block_hash)
+    entry = store.get_unfinished_block_result(unf1.partial_hash, unf1.foliage.foliage_transaction_block_hash)
+    assert entry is not None
+    ublock = entry.result
     assert ublock is not None and ublock.required_iters == uint64(0)
     # still, when not specifying a foliage hash, you just get the first ublock
-    ublock = store.get_unfinished_block_result2(unf1.partial_hash, None)
+    entry = store.get_unfinished_block_result(unf1.partial_hash, unf1.foliage.foliage_transaction_block_hash)
+    assert entry is not None
+    ublock = entry.result
     assert ublock is not None and ublock.required_iters == uint64(0)
 
     # negative test cases
-    assert store.get_unfinished_block_result(bytes32([1] * 32)) is None
-    assert store.get_unfinished_block_result2(bytes32([1] * 32), None) is None
+    assert store.get_unfinished_block_result(bytes32([1] * 32), bytes32([2] * 32)) is None
 
     blocks = custom_block_tools.get_consecutive_blocks(
         1,
@@ -1141,50 +1168,50 @@ async def test_mark_requesting(
     b = bytes32.random(seeded_random)
     c = bytes32.random(seeded_random)
 
-    assert not store.is_requesting_unfinished_block(a, a)
-    assert not store.is_requesting_unfinished_block(a, b)
-    assert not store.is_requesting_unfinished_block(a, c)
-    assert not store.is_requesting_unfinished_block(b, b)
-    assert not store.is_requesting_unfinished_block(c, c)
+    assert store.is_requesting_unfinished_block(a, a) == (False, 0)
+    assert store.is_requesting_unfinished_block(a, b) == (False, 0)
+    assert store.is_requesting_unfinished_block(a, c) == (False, 0)
+    assert store.is_requesting_unfinished_block(b, b) == (False, 0)
+    assert store.is_requesting_unfinished_block(c, c) == (False, 0)
 
     store.mark_requesting_unfinished_block(a, b)
-    assert store.is_requesting_unfinished_block(a, b)
-    assert not store.is_requesting_unfinished_block(a, c)
-    assert not store.is_requesting_unfinished_block(a, a)
-    assert not store.is_requesting_unfinished_block(b, c)
-    assert not store.is_requesting_unfinished_block(b, b)
+    assert store.is_requesting_unfinished_block(a, b) == (True, 1)
+    assert store.is_requesting_unfinished_block(a, c) == (False, 1)
+    assert store.is_requesting_unfinished_block(a, a) == (False, 1)
+    assert store.is_requesting_unfinished_block(b, c) == (False, 0)
+    assert store.is_requesting_unfinished_block(b, b) == (False, 0)
 
     store.mark_requesting_unfinished_block(a, c)
-    assert store.is_requesting_unfinished_block(a, b)
-    assert store.is_requesting_unfinished_block(a, c)
-    assert not store.is_requesting_unfinished_block(a, a)
-    assert not store.is_requesting_unfinished_block(b, c)
-    assert not store.is_requesting_unfinished_block(b, b)
+    assert store.is_requesting_unfinished_block(a, b) == (True, 2)
+    assert store.is_requesting_unfinished_block(a, c) == (True, 2)
+    assert store.is_requesting_unfinished_block(a, a) == (False, 2)
+    assert store.is_requesting_unfinished_block(b, c) == (False, 0)
+    assert store.is_requesting_unfinished_block(b, b) == (False, 0)
 
     # this is a no-op
     store.remove_requesting_unfinished_block(a, a)
     store.remove_requesting_unfinished_block(c, a)
 
-    assert store.is_requesting_unfinished_block(a, b)
-    assert store.is_requesting_unfinished_block(a, c)
-    assert not store.is_requesting_unfinished_block(a, a)
-    assert not store.is_requesting_unfinished_block(b, c)
-    assert not store.is_requesting_unfinished_block(b, b)
+    assert store.is_requesting_unfinished_block(a, b) == (True, 2)
+    assert store.is_requesting_unfinished_block(a, c) == (True, 2)
+    assert store.is_requesting_unfinished_block(a, a) == (False, 2)
+    assert store.is_requesting_unfinished_block(b, c) == (False, 0)
+    assert store.is_requesting_unfinished_block(b, b) == (False, 0)
 
     store.remove_requesting_unfinished_block(a, b)
 
-    assert not store.is_requesting_unfinished_block(a, b)
-    assert store.is_requesting_unfinished_block(a, c)
-    assert not store.is_requesting_unfinished_block(a, a)
-    assert not store.is_requesting_unfinished_block(b, c)
-    assert not store.is_requesting_unfinished_block(b, b)
+    assert store.is_requesting_unfinished_block(a, b) == (False, 1)
+    assert store.is_requesting_unfinished_block(a, c) == (True, 1)
+    assert store.is_requesting_unfinished_block(a, a) == (False, 1)
+    assert store.is_requesting_unfinished_block(b, c) == (False, 0)
+    assert store.is_requesting_unfinished_block(b, b) == (False, 0)
 
     store.remove_requesting_unfinished_block(a, c)
 
-    assert not store.is_requesting_unfinished_block(a, b)
-    assert not store.is_requesting_unfinished_block(a, c)
-    assert not store.is_requesting_unfinished_block(a, a)
-    assert not store.is_requesting_unfinished_block(b, c)
-    assert not store.is_requesting_unfinished_block(b, b)
+    assert store.is_requesting_unfinished_block(a, b) == (False, 0)
+    assert store.is_requesting_unfinished_block(a, c) == (False, 0)
+    assert store.is_requesting_unfinished_block(a, a) == (False, 0)
+    assert store.is_requesting_unfinished_block(b, c) == (False, 0)
+    assert store.is_requesting_unfinished_block(b, b) == (False, 0)
 
-    assert len(store.requesting_unfinished_blocks) == 0
+    assert len(store.unfinished_blocks) == 0

--- a/tests/core/full_node/stores/test_full_node_store.py
+++ b/tests/core/full_node/stores/test_full_node_store.py
@@ -1214,4 +1214,4 @@ async def test_mark_requesting(
     assert store.is_requesting_unfinished_block(b, c) == (False, 0)
     assert store.is_requesting_unfinished_block(b, b) == (False, 0)
 
-    assert len(store.unfinished_blocks) == 0
+    assert len(store._unfinished_blocks) == 0


### PR DESCRIPTION
## Purpose:

There are 3 aspects of this PR:

1. Take outstanding *requested* blocks into account, not just received blocks, before determining if we should request another one. This improves DoS mitigation.
2. Address an issue when we receive a `FullBlock` (but we have requested to no have the block generator included). We pick up the block generator from our `FullNodeStore`.
3. Simplify the data structure and improve encapsulation of the `FullNodeStore`.

(1) is the main purpose of this PR.

## Background

The way unfinished blocks are distributed on the network is:

1. You receive a `NewUnfinishedBlock` (or `NewUnfinishedBlock2`) message
4. If you don't have the unfinished block, you send a request to the peer, `RequestUnfinishedBlock` or `RequestUnfinishedBlock2`
5. The peer responds with `RespondUnfinishedBlock` message, which includes the unfinished block.

The new feature in 2.2.0 is that we can distinguish between unfinished blocks based on their foliage hash (in addition to the block reward hash). These would occur if multiple farmers farm the same plots. They will use the same reward block hash, but (likely) different foliage hashes. This was implemented by the two new messages, `NewUnfinishedBlock2` and `RequestUnfinishedBlock2`.

A new kind of abuse enabled by these new messages is for a malicious farmer to generate an infinite number of variants of blocks for a single block-win. We have a limit that we only allow 4 variants of a block reward hash and after that we ignore any additional unfinished blocks for that reward hash.

## Current Behavior:

When we receive a `NewUnfinishedBlock` message, if we have already received > 3 unfinished blocks for this reward hash, we ignore it.

Notably, we don't take into account variants that we've learned about, and requested, but not yet received.

## New Behavior:

When we receive a `NewUnfinishedBlock` message, if we have already received *or requested* > 3 unfinished blocks for this reward hash, we ignore it.

If we receive an *unsolicited* `UnfinishedBlock`, we also ignore it if we have received too many variants.

In support of this, the data structure in `FullNodeStore` was updated to merge the fields `requesting_unfinished_blocks`, `requesting_unfinished_blocks2` into `unfinished_blocks`.

The field `unfinished_blocks` is essentially a dictionary, keyed by reward hash and foliage hash, mapping to the `UnfinishedBlock`, `PreValidationResult` and block height. The values now encompass the state of "requested" and "received". If the `UnfinishedBlock` is `None`, we have requested it, but not yet received it.

## Cached `PreValidationResult`

The change in `chia/full_node/full_node.py`, and the associated change to make `get_unfinished_result()` return the whole `UnfinishedBlockEntry` addresses the potential for `get_unfinished_block()` and `get_unfinished_block_result()` potentially returning different blocks. Having the API perform two separate look-ups is not as robust. We ask for the block and verifies it, then we ask for the result.

With this change we ask for the block *entry*, which contains both the unfinished block and the result.

## Testing notes

I've been running this branch for ~48 hours now, without a single `INVALID_TRANSACTIONS_FILTER_HASH` (whereas the frequency of that error is higher in both `main` and `2.2.0`.