### PR TITLE
extend chia db validate with checking transaction generator hashes

### DIFF
--- a/chia/cmds/db.py
+++ b/chia/cmds/db.py
@@ -59,13 +59,22 @@ def db_upgrade_cmd(
     is_flag=True,
     help="validate consistency of properties of the encoded blocks and block records",
 )
+@click.option(
+    "--validate-tx-generators",
+    default=False,
+    is_flag=True,
+    help="validate block generator hash (may have been corrupted by running 2.2.0)",
+)
 @click.pass_context
-def db_validate_cmd(ctx: click.Context, in_db_path: Optional[str], validate_blocks: bool) -> None:
+def db_validate_cmd(
+    ctx: click.Context, in_db_path: Optional[str], validate_blocks: bool, validate_tx_generators: bool
+) -> None:
     try:
         db_validate_func(
             Path(ctx.obj["root_path"]),
             None if in_db_path is None else Path(in_db_path),
             validate_blocks=validate_blocks,
+            validate_tx_generators=validate_tx_generators,
         )
     except RuntimeError as e:
         print(f"FAILED: {e}")

--- a/tests/core/test_db_validation.py
+++ b/tests/core/test_db_validation.py
@@ -75,7 +75,7 @@ def test_db_validate_wrong_version() -> None:
             make_version(conn, 3)
 
         with pytest.raises(RuntimeError) as execinfo:
-            validate_v2(db_file, validate_blocks=False)
+            validate_v2(db_file, validate_blocks=False, validate_tx_generators=False)
         assert "Database has the wrong version (3 expected 2)" in str(execinfo.value)
 
 
@@ -85,7 +85,7 @@ def test_db_validate_missing_peak_table() -> None:
             make_version(conn, 2)
 
         with pytest.raises(RuntimeError) as execinfo:
-            validate_v2(db_file, validate_blocks=False)
+            validate_v2(db_file, validate_blocks=False, validate_tx_generators=False)
         assert "Database is missing current_peak table" in str(execinfo.value)
 
 
@@ -98,7 +98,7 @@ def test_db_validate_missing_peak_block() -> None:
             make_block_table(conn)
 
         with pytest.raises(RuntimeError) as execinfo:
-            validate_v2(db_file, validate_blocks=False)
+            validate_v2(db_file, validate_blocks=False, validate_tx_generators=False)
         assert "Database is missing the peak block" in str(execinfo.value)
 
 
@@ -122,10 +122,10 @@ def test_db_validate_in_main_chain(invalid_in_chain: bool) -> None:
 
         if invalid_in_chain:
             with pytest.raises(RuntimeError) as execinfo:
-                validate_v2(db_file, validate_blocks=False)
+                validate_v2(db_file, validate_blocks=False, validate_tx_generators=False)
             assert " (height: 96) is orphaned, but in_main_chain is set" in str(execinfo.value)
         else:
-            validate_v2(db_file, validate_blocks=False)
+            validate_v2(db_file, validate_blocks=False, validate_tx_generators=False)
 
 
 async def make_db(db_file: Path, blocks: List[FullBlock]) -> None:
@@ -154,5 +154,5 @@ async def test_db_validate_default_1000_blocks(default_1000_blocks: List[FullBlo
         # we expect everything to be valid except this is a test chain, so it
         # doesn't have the correct genesis challenge
         with pytest.raises(RuntimeError) as execinfo:
-            validate_v2(db_file, validate_blocks=True)
+            validate_v2(db_file, validate_blocks=True, validate_tx_generators=False)
         assert "Blockchain has invalid genesis challenge" in str(execinfo.value)


### PR DESCRIPTION
### Purpose:

Adds a tool to validate the transaction generator hashes of all blocks a a blockchain database.

```
chia db validate --validate-tx-generators
```