### PR TITLE
Patched Fix HTTP parser (the python one, not llhttp) still overly lenient about separators

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ dependencies = [
     "clvm_tools==0.4.8",  # Currying, Program.to, other conveniences
     "chia_rs==0.5.2",
     "clvm-tools-rs==0.1.40",  # Rust implementation of clvm_tools' compiler
-    "aiohttp==3.9.1",  # HTTP server for full node rpc
+    "aiohttp==3.9.2",  # HTTP server for full node rpc
     "aiosqlite==0.19.0",  # asyncio wrapper for sqlite, to store blocks
     "bitstring==4.1.4",  # Binary data management library
     "colorama==0.4.6",  # Colorizes terminal output


### PR DESCRIPTION

## Description
Security-sensitive parts of the Python HTTP parser retained minor differences in allowable character sets, that must trigger error handling to robustly match frame boundaries of proxies in order to protect against injection of additional requests. Additionally, validation could trigger exceptions that were not handled consistently with processing of other malformed input.

**PoC:**
```
GET / HTTP/1ö1
GET / HTTP/1.𝟙
GET/: HTTP/1.1
Content-Encoding?: chunked
```
CWE-444
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L`

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:



<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
