### PR TITLE
Move get_network_info endpoint to the base rpc server class

### DIFF
--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -106,7 +106,6 @@ class FullNodeRpcApi:
             # this function is just here for backwards-compatibility. It will probably
             # be removed in the future
             "/get_initial_freeze_period": self.get_initial_freeze_period,
-            "/get_network_info": self.get_network_info,
             "/get_recent_signage_point_or_eos": self.get_recent_signage_point_or_eos,
             # Coins
             "/get_coin_records_by_puzzle_hash": self.get_coin_records_by_puzzle_hash,
@@ -284,11 +283,6 @@ class FullNodeRpcApi:
         }
         self.cached_blockchain_state = dict(response["blockchain_state"])
         return response
-
-    async def get_network_info(self, _: Dict[str, Any]) -> EndpointResult:
-        network_name = self.service.config["selected_network"]
-        address_prefix = self.service.config["network_overrides"]["config"][network_name]["address_prefix"]
-        return {"network_name": network_name, "network_prefix": address_prefix}
 
     async def get_recent_signage_point_or_eos(self, request: Dict[str, Any]) -> EndpointResult:
         if "sp_hash" not in request:

--- a/chia/rpc/rpc_server.py
+++ b/chia/rpc/rpc_server.py
@@ -132,6 +132,7 @@ class RpcServer(Generic[_T_RpcApiProtocol]):
     service_name: str
     ssl_context: SSLContext
     ssl_client_context: SSLContext
+    net_config: Dict[str, Any]
     webserver: Optional[WebServer] = None
     daemon_heartbeat: int = 300
     daemon_connection_task: Optional[asyncio.Task[None]] = None
@@ -163,6 +164,7 @@ class RpcServer(Generic[_T_RpcApiProtocol]):
             service_name,
             ssl_context,
             ssl_client_context,
+            net_config,
             daemon_heartbeat=daemon_heartbeat,
             prefer_ipv6=prefer_ipv6,
         )
@@ -235,6 +237,7 @@ class RpcServer(Generic[_T_RpcApiProtocol]):
     def _get_routes(self) -> Dict[str, Endpoint]:
         return {
             **self.rpc_api.get_routes(),
+            "/get_network_info": self.get_network_info,
             "/get_connections": self.get_connections,
             "/open_connection": self.open_connection,
             "/close_connection": self.close_connection,
@@ -248,6 +251,11 @@ class RpcServer(Generic[_T_RpcApiProtocol]):
             "success": True,
             "routes": list(self._get_routes().keys()),
         }
+
+    async def get_network_info(self, _: Dict[str, Any]) -> EndpointResult:
+        network_name = self.net_config["selected_network"]
+        address_prefix = self.net_config["network_overrides"]["config"][network_name]["address_prefix"]
+        return {"network_name": network_name, "network_prefix": address_prefix}
 
     async def get_connections(self, request: Dict[str, Any]) -> EndpointResult:
         request_node_type: Optional[NodeType] = None

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -160,7 +160,6 @@ class WalletRpcApi:
             # this function is just here for backwards-compatibility. It will probably
             # be removed in the future
             "/get_initial_freeze_period": self.get_initial_freeze_period,
-            "/get_network_info": self.get_network_info,
             # Wallet management
             "/get_wallets": self.get_wallets,
             "/create_new_wallet": self.create_new_wallet,
@@ -593,11 +592,6 @@ class WalletRpcApi:
     async def get_height_info(self, request: Dict[str, Any]) -> EndpointResult:
         height = await self.service.wallet_state_manager.blockchain.get_finished_sync_up_to()
         return {"height": height}
-
-    async def get_network_info(self, request: Dict[str, Any]) -> EndpointResult:
-        network_name = self.service.config["selected_network"]
-        address_prefix = self.service.config["network_overrides"]["config"][network_name]["address_prefix"]
-        return {"network_name": network_name, "network_prefix": address_prefix}
 
     async def push_tx(self, request: Dict[str, Any]) -> EndpointResult:
         nodes = self.service.server.get_connections(NodeType.FULL_NODE)

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -571,8 +571,7 @@ async def test_get_network_info(one_wallet_and_one_simulator_services, self_host
         )
         await validate_get_routes(client, full_node_service_1.rpc_server.rpc_api)
         network_info = await client.fetch("get_network_info", {})
-        assert network_info["network_name"] == "testnet0"
-        assert network_info["network_prefix"] == "txch"
+        assert network_info == {**network_info, "network_name": "testnet0", "network_prefix": "txch"}
     finally:
         # Checks that the RPC manages to stop the node
         client.close()

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -561,7 +561,6 @@ async def test_signage_points(two_nodes_sim_and_wallets_services, empty_blockcha
 async def test_get_network_info(one_wallet_and_one_simulator_services, self_hostname):
     nodes, _, bt = one_wallet_and_one_simulator_services
     (full_node_service_1,) = nodes
-    full_node_api_1 = full_node_service_1._api
 
     try:
         client = await FullNodeRpcClient.create(

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -570,7 +570,7 @@ async def test_get_network_info(one_wallet_and_one_simulator_services, self_host
     ) as client:
         await validate_get_routes(client, full_node_service_1.rpc_server.rpc_api)
         network_info = await client.fetch("get_network_info", {})
-        assert network_info == {**network_info, "network_name": "testnet0", "network_prefix": "txch"}
+        assert network_info == {**network_info, "network_name": "testnet0", "network_prefix": "txch", "success": True}
 
 
 @pytest.mark.anyio

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -562,20 +562,15 @@ async def test_get_network_info(one_wallet_and_one_simulator_services, self_host
     nodes, _, bt = one_wallet_and_one_simulator_services
     (full_node_service_1,) = nodes
 
-    try:
-        client = await FullNodeRpcClient.create(
-            self_hostname,
-            full_node_service_1.rpc_server.listen_port,
-            full_node_service_1.root_path,
-            full_node_service_1.config,
-        )
+    async with FullNodeRpcClient.create_as_context(
+        self_hostname,
+        full_node_service_1.rpc_server.listen_port,
+        full_node_service_1.root_path,
+        full_node_service_1.config,
+    ) as client:
         await validate_get_routes(client, full_node_service_1.rpc_server.rpc_api)
         network_info = await client.fetch("get_network_info", {})
         assert network_info == {**network_info, "network_name": "testnet0", "network_prefix": "txch"}
-    finally:
-        # Checks that the RPC manages to stop the node
-        client.close()
-        await client.await_closed()
 
 
 @pytest.mark.anyio

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -570,7 +570,7 @@ async def test_get_network_info(one_wallet_and_one_simulator_services, self_host
     ) as client:
         await validate_get_routes(client, full_node_service_1.rpc_server.rpc_api)
         network_info = await client.fetch("get_network_info", {})
-        assert network_info == {**network_info, "network_name": "testnet0", "network_prefix": "txch", "success": True}
+        assert network_info == {"network_name": "testnet0", "network_prefix": "txch", "success": True}
 
 
 @pytest.mark.anyio

--- a/tests/core/test_full_node_rpc.py
+++ b/tests/core/test_full_node_rpc.py
@@ -558,6 +558,29 @@ async def test_signage_points(two_nodes_sim_and_wallets_services, empty_blockcha
 
 
 @pytest.mark.anyio
+async def test_get_network_info(one_wallet_and_one_simulator_services, self_hostname):
+    nodes, _, bt = one_wallet_and_one_simulator_services
+    (full_node_service_1,) = nodes
+    full_node_api_1 = full_node_service_1._api
+
+    try:
+        client = await FullNodeRpcClient.create(
+            self_hostname,
+            full_node_service_1.rpc_server.listen_port,
+            full_node_service_1.root_path,
+            full_node_service_1.config,
+        )
+        await validate_get_routes(client, full_node_service_1.rpc_server.rpc_api)
+        network_info = await client.fetch("get_network_info", {})
+        assert network_info["network_name"] == "testnet0"
+        assert network_info["network_prefix"] == "txch"
+    finally:
+        # Checks that the RPC manages to stop the node
+        client.close()
+        await client.await_closed()
+
+
+@pytest.mark.anyio
 async def test_get_blockchain_state(one_wallet_and_one_simulator_services, self_hostname):
     num_blocks = 5
     nodes, _, bt = one_wallet_and_one_simulator_services

--- a/tests/util/rpc.py
+++ b/tests/util/rpc.py
@@ -10,6 +10,7 @@ async def validate_get_routes(client: RpcClient, api: RpcApiProtocol) -> None:
     routes_api = list(api.get_routes().keys())
     # TODO: avoid duplication of RpcServer.get_routes()
     routes_server = [
+        "/get_network_info",
         "/get_connections",
         "/open_connection",
         "/close_connection",


### PR DESCRIPTION
I needed network info when running crawler. The method was already duplicated on the full_node and wallet rpc servers, so seemed more appropriate to move to the base rpc server class. Now we can get network info from any running rpc server.