### PR TITLE
new_unfinished_block2 support in seeder

### DIFF
--- a/chia/seeder/crawler_api.py
+++ b/chia/seeder/crawler_api.py
@@ -60,6 +60,12 @@ class CrawlerAPI:
     ) -> Optional[Message]:
         pass
 
+    @api_request()
+    async def new_unfinished_block2(
+        self, new_unfinished_block: full_node_protocol.NewUnfinishedBlock2
+    ) -> Optional[Message]:
+        pass
+
     @api_request(peer_required=True)
     async def new_compact_vdf(
         self, request: full_node_protocol.NewCompactVDF, peer: WSChiaConnection


### PR DESCRIPTION
### Purpose:

Eliminate unknown new_unfinished_block2 message

### Current Behavior:

Logging that new_unfinished_block2 is unknown

### New Behavior:

No more logging

### Testing Notes:
