### PR TITLE
Added `chia start daemon`

### DIFF
--- a/chia/_tests/util/test_service_groups.py
+++ b/chia/_tests/util/test_service_groups.py
@@ -10,7 +10,6 @@ def test_services_for_groups() -> None:
         i += 1
     assert i == 1
 
-    i = 0
     for _ in services_for_groups(["daemon"]):
-        i += 1
-    assert i == 0
+        # The loop should never be run
+        assert False  # pragma: no cover

--- a/chia/_tests/util/test_service_groups.py
+++ b/chia/_tests/util/test_service_groups.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from chia.util.service_groups import services_for_groups
 
 
-def test_services_for_groups():
+def test_services_for_groups() -> None:
     i = 0
     for service in services_for_groups(["harvester"]):
         assert service == "chia_harvester"

--- a/chia/_tests/util/test_service_groups.py
+++ b/chia/_tests/util/test_service_groups.py
@@ -1,0 +1,14 @@
+from chia.util.service_groups import services_for_groups
+
+
+def test_services_for_groups():
+    i = 0
+    for service in services_for_groups(["harvester"]):
+        assert service == "chia_harvester"
+        i += 1
+    assert i == 1
+
+    i = 0
+    for _ in services_for_groups(["daemon"]):
+        i += 1
+    assert i == 0

--- a/chia/cmds/stop.py
+++ b/chia/cmds/stop.py
@@ -49,7 +49,7 @@ async def async_stop(root_path: Path, config: Dict[str, Any], group: tuple[str, 
 
 @click.command("stop", help="Stop services")
 @click.option("-d", "--daemon", is_flag=True, type=bool, help="Stop daemon")
-@click.argument("group", type=click.Choice(list(all_groups())), nargs=-1, required=True)
+@click.argument("group", type=click.Choice([g for g in list(all_groups()) if g != "daemon"]), nargs=-1, required=True)
 @click.pass_context
 def stop_cmd(ctx: click.Context, daemon: bool, group: tuple[str, ...]) -> None:
     from chia.cmds.beta_funcs import warn_if_beta_enabled

--- a/chia/util/service_groups.py
+++ b/chia/util/service_groups.py
@@ -40,9 +40,7 @@ def all_groups() -> KeysView[str]:
 
 def services_for_groups(groups: Iterable[str]) -> Generator[str, None, None]:
     for group in groups:
-        service = SERVICES_FOR_GROUP[group]
-        if service:
-            yield from service
+        yield from SERVICES_FOR_GROUP[group]
 
 
 def validate_service(service: str) -> bool:

--- a/chia/util/service_groups.py
+++ b/chia/util/service_groups.py
@@ -40,7 +40,8 @@ def all_groups() -> KeysView[str]:
 
 def services_for_groups(groups: Iterable[str]) -> Generator[str, None, None]:
     for group in groups:
-        yield from SERVICES_FOR_GROUP[group]
+        if SERVICES_FOR_GROUP[group] is not None:
+            yield from SERVICES_FOR_GROUP[group]
 
 
 def validate_service(service: str) -> bool:

--- a/chia/util/service_groups.py
+++ b/chia/util/service_groups.py
@@ -13,6 +13,7 @@ SERVICES_FOR_GROUP = {
         "chia_data_layer",
         "chia_data_layer_http",
     ],
+    "daemon": [],
     # TODO: should this be `data_layer`?
     "data": ["chia_wallet", "chia_data_layer"],
     "data_layer_http": ["chia_data_layer_http"],

--- a/chia/util/service_groups.py
+++ b/chia/util/service_groups.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Generator, Iterable, KeysView
+from typing import Dict, Generator, Iterable, KeysView
 
-SERVICES_FOR_GROUP = {
+SERVICES_FOR_GROUP: Dict[str, list[str]] = {
     "all": [
         "chia_harvester",
         "chia_timelord_launcher",
@@ -40,8 +40,9 @@ def all_groups() -> KeysView[str]:
 
 def services_for_groups(groups: Iterable[str]) -> Generator[str, None, None]:
     for group in groups:
-        if SERVICES_FOR_GROUP[group] is not None:
-            yield from SERVICES_FOR_GROUP[group]
+        service = SERVICES_FOR_GROUP[group]
+        if service:
+            yield from service
 
 
 def validate_service(service: str) -> bool:


### PR DESCRIPTION
Now `chia start daemon` can be invoked.
The difference between `chia run_daemon` and `chia start daemon` is that the former captures its terminal until the process exists while the latter immediately returns control after the cli command.

This PR is required to fix a GUI bug where GUI never exits until its child process (`daemon`) stop by leaked file descriptors in Linux system.