### PR TITLE
add foreign key delay

### DIFF
--- a/chia/_tests/db/test_db_wrapper.py
+++ b/chia/_tests/db/test_db_wrapper.py
@@ -438,7 +438,7 @@ async def test_cancelled_reader_does_not_cancel_writer() -> None:
 @pytest.mark.anyio
 async def test_foreign_key_pragma_controlled_by_writer(initial: bool, forced: bool) -> None:
     async with DBConnection(2, foreign_keys=initial) as db_wrapper:
-        async with db_wrapper.writer(foreign_keys=forced) as writer:
+        async with db_wrapper.writer(foreign_key_enforcement_enabled=forced) as writer:
             async with writer.execute("PRAGMA foreign_keys") as cursor:
                 result = await cursor.fetchone()
                 assert result is not None
@@ -477,7 +477,7 @@ async def test_foreign_key_pragma_rolls_back_on_foreign_key_error() -> None:
 
         # make sure the writer raises a foreign key error on exit
         with pytest.raises(ForeignKeyError):
-            async with db_wrapper.writer(foreign_keys=False) as writer:
+            async with db_wrapper.writer(foreign_key_enforcement_enabled=False) as writer:
                 async with writer.execute("DELETE FROM people WHERE id = 1"):
                     pass
 
@@ -536,7 +536,7 @@ async def test_foreign_key_check_failure_error_message(case: RowFactoryCase) -> 
 
         # make sure the writer raises a foreign key error on exit
         with pytest.raises(ForeignKeyError) as error:
-            async with db_wrapper.writer(foreign_keys=False) as writer:
+            async with db_wrapper.writer(foreign_key_enforcement_enabled=False) as writer:
                 async with writer.execute("DELETE FROM people WHERE id = 1"):
                     pass
 
@@ -561,5 +561,5 @@ async def test_delayed_foreign_key_request_fails_when_nested(initial: bool) -> N
     async with DBConnection(2, foreign_keys=initial) as db_wrapper:
         async with db_wrapper.writer():
             with pytest.raises(NestedForeignKeyDelayedRequestError):
-                async with db_wrapper.writer(foreign_keys=True):
+                async with db_wrapper.writer(foreign_key_enforcement_enabled=True):
                     pass  # pragma: no cover

--- a/chia/_tests/util/db_connection.py
+++ b/chia/_tests/util/db_connection.py
@@ -3,15 +3,28 @@ from __future__ import annotations
 import tempfile
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import AsyncIterator
+from typing import AsyncIterator, Optional, Type
+
+import aiosqlite
 
 from chia.util.db_wrapper import DBWrapper2, generate_in_memory_db_uri
 
 
 @asynccontextmanager
-async def DBConnection(db_version: int) -> AsyncIterator[DBWrapper2]:
+async def DBConnection(
+    db_version: int,
+    foreign_keys: Optional[bool] = None,
+    row_factory: Optional[Type[aiosqlite.Row]] = None,
+) -> AsyncIterator[DBWrapper2]:
     db_uri = generate_in_memory_db_uri()
-    async with DBWrapper2.managed(database=db_uri, uri=True, reader_count=4, db_version=db_version) as _db_wrapper:
+    async with DBWrapper2.managed(
+        database=db_uri,
+        uri=True,
+        reader_count=4,
+        db_version=db_version,
+        foreign_keys=foreign_keys,
+        row_factory=row_factory,
+    ) as _db_wrapper:
         yield _db_wrapper
 
 

--- a/chia/_tests/util/misc.py
+++ b/chia/_tests/util/misc.py
@@ -438,6 +438,16 @@ def named_datacases(name: str) -> DataCasesDecorator:
     return functools.partial(datacases, _name=name)
 
 
+def boolean_datacases(name: str, false: str, true: str) -> pytest.MarkDecorator:
+    return pytest.mark.parametrize(
+        argnames=name,
+        argvalues=[
+            pytest.param(False, id=false),
+            pytest.param(True, id=true),
+        ],
+    )
+
+
 @dataclasses.dataclass
 class CoinGenerator:
     _seed: int = -1

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -309,7 +309,7 @@ class DBWrapper2:
         async with self._lock:
             async with contextlib.AsyncExitStack() as exit_stack:
                 if foreign_keys is not None:
-                    await exit_stack.enter_async_context(self._set_foreign_keys(enabled=foreign_keys))
+                    await exit_stack.enter_async_context(self._set_foreign_key_enforcement(enabled=foreign_keys))
 
                 async with self._savepoint_ctx():
                     self._current_writer = task
@@ -322,7 +322,7 @@ class DBWrapper2:
                         self._current_writer = None
 
     @contextlib.asynccontextmanager
-    async def _set_foreign_keys(self, enabled: bool) -> AsyncIterator[None]:
+    async def _set_foreign_key_enforcement(self, enabled: bool) -> AsyncIterator[None]:
         if self._current_writer is not None:
             raise InternalError("Unable to set foreign key enforcement state while a writer is held")
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Some db activities take a long time due to repeated foreign key validation.  This adds an option when acquiring a writer connection to temporarily disable the foreign key checks.  If disabled, then a foreign key check is done when leaving the writer context such that a failure will result in a rollback.  The foreign key enforcement will be returned to the original state on exit.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
