### PR TITLE
Add get_network_info to daemon

### DIFF
--- a/chia/_tests/core/daemon/test_daemon.py
+++ b/chia/_tests/core/daemon/test_daemon.py
@@ -13,7 +13,7 @@ from pytest_mock import MockerFixture
 
 from chia._tests.util.misc import Marks, datacases
 from chia._tests.util.time_out_assert import time_out_assert_not_none
-from chia.daemon.client import connect_to_daemon, DaemonProxy
+from chia.daemon.client import DaemonProxy, connect_to_daemon
 from chia.daemon.keychain_server import (
     DeleteLabelRequest,
     GetKeyRequest,

--- a/chia/_tests/core/daemon/test_daemon.py
+++ b/chia/_tests/core/daemon/test_daemon.py
@@ -13,7 +13,7 @@ from pytest_mock import MockerFixture
 
 from chia._tests.util.misc import Marks, datacases
 from chia._tests.util.time_out_assert import time_out_assert_not_none
-from chia.daemon.client import connect_to_daemon
+from chia.daemon.client import connect_to_daemon, DaemonProxy
 from chia.daemon.keychain_server import (
     DeleteLabelRequest,
     GetKeyRequest,
@@ -582,6 +582,17 @@ async def test_get_routes(mock_lonely_daemon):
     assert response == {
         "success": True,
         "routes": ["get_routes", "example_one", "example_two", "example_three"],
+    }
+
+
+@pytest.mark.anyio
+async def test_get_network_info(daemon_client_with_config_and_keys: DaemonProxy):
+    client = daemon_client_with_config_and_keys
+    response = await client.get_network_info()
+    assert response["data"] == {
+        "success": True,
+        "network_name": "testnet0",
+        "network_prefix": "txch",
     }
 
 

--- a/chia/daemon/client.py
+++ b/chia/daemon/client.py
@@ -97,6 +97,12 @@ class DaemonProxy:
         response = await self._get(request)
         return response
 
+    async def get_network_info(self) -> WsRpcMessage:
+        data: Dict[str, Any] = {}
+        request = self.format_request("get_network_info", data)
+        response = await self._get(request)
+        return response
+
     async def start_service(self, service_name: str) -> WsRpcMessage:
         data = {"service": service_name}
         request = self.format_request("start_service", data)

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -459,7 +459,14 @@ class WebSocketServer:
             "get_routes": self.get_routes,
             "get_wallet_addresses": self.get_wallet_addresses,
             "get_keys_for_plotting": self.get_keys_for_plotting,
+            "get_network_info": self.get_network_info,
         }
+
+    async def get_network_info(self, websocket: WebSocketResponse, request: Dict[str, Any]) -> Dict[str, Any]:
+        network_name = self.net_config["selected_network"]
+        address_prefix = self.net_config["network_overrides"]["config"][network_name]["address_prefix"]
+        response: Dict[str, Any] = {"success": True, "network_name": network_name, "network_prefix": address_prefix}
+        return response
 
     async def is_keyring_locked(self, websocket: WebSocketResponse, request: Dict[str, Any]) -> Dict[str, Any]:
         locked: bool = Keychain.is_keyring_locked()


### PR DESCRIPTION
Already added to the base RPC server. This is also useful information to have in general from the daemon (vs having to know which service is up that you can ask) so adding here as well.