### PR TITLE
fix reorg from 0

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -249,8 +249,9 @@ class Blockchain(BlockchainInterface):
         # from the current block down to the fork's current peak
         chain, peak_hash = await lookup_fork_chain(
             self,
-            (uint32(fork_info.peak_height), fork_info.peak_hash),
-            (uint32(block.height - 1), block.prev_header_hash),
+            (fork_info.peak_height, fork_info.peak_hash),
+            (block.height - 1, block.prev_header_hash),
+            self.constants,
         )
         # the ForkInfo object is expected to be valid, just having its peak
         # behind the current block
@@ -364,7 +365,10 @@ class Blockchain(BlockchainInterface):
                 # the block we're trying to add doesn't exist in the chain yet,
                 # so we need to start traversing from its prev_header_hash
                 fork_chain, fork_hash = await lookup_fork_chain(
-                    self, (peak.height, peak.header_hash), (uint32(block.height - 1), block.prev_header_hash)
+                    self,
+                    (peak.height, peak.header_hash),
+                    (block.height - 1, block.prev_header_hash),
+                    self.constants,
                 )
                 # now we know how long the fork is, and can compute the fork
                 # height.
@@ -1086,6 +1090,7 @@ class Blockchain(BlockchainInterface):
                     self,
                     (peak.height, peak.header_hash),
                     (prev_block_record.height, prev_block_record.header_hash),
+                    self.constants,
                 )
                 reorg_chain.update(height_to_hash)
 

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1122,7 +1122,7 @@ class FullNode:
                     # against the CoinStore)
                     if not extending_main_chain:
                         if fork_point_height == 0:
-                            fork_info = ForkInfo(-1, -1, bytes32([0] * 32))
+                            fork_info = ForkInfo(-1, -1, self.constants.GENESIS_CHALLENGE)
                         else:
                             fork_hash = self.blockchain.height_to_hash(uint32(fork_point_height - 1))
                             assert fork_hash is not None


### PR DESCRIPTION
### Purpose:

This is addressing the immediate symptom of an issue Dan experienced (not the underlying issue of the node reorging from 0 in the first place).

```
2024-03-15T12:00:12.812 full_node chia.full_node.full_node: ERROR    sync from fork point failed: ValueError: Value -1 does not fit into uint32
Traceback (most recent call last):
  File "chia\util\log_exceptions.py", line 20, in log_exceptions
  File "chia\full_node\full_node.py", line 1176, in sync_from_fork_point
  File "chia\full_node\full_node.py", line 1138, in validate_block_batches
  File "chia\full_node\full_node.py", line 1276, in add_block_batch
  File "chia\consensus\blockchain.py", line 255, in advance_fork_info
  File "chia\util\struct_stream.py", line 71, in __init__
ValueError: Value -1 does not fit into uint32
```

When reorging, one of the first steps is to build a height-to-hash map for the blocks from the fork point to the reorg block. (i.e. the new peak). We use `lookup_fork_chain()` to do this. However, it currently has a limitation where you can't specify -1 as the fork point.

The first block is at height 0, and its previous block hash is `GENESIS_CHALLENGE`. If the first block is being reorged-out, the fork point is -1 and the fork hash is `GENESIS_CHALLENGE`. This edge case was not handled by `lookup_fork_chain()`.
(as you might imagine, it doesn't come up very often).

The main change is in `chia/consensus/find_fork_point.py`, and it has a description of the new behavior.

### Current Behavior:

`lookup_fork_chain()` cannot accept -1 as the fork height.

### New Behavior:

`lookup_fork_chain()`  does accept -1 as the fork height.