### PR TITLE
use rust types for RecentChainData, ProofBlockHeader and WeightProof

### DIFF
--- a/chia/types/weight_proof.py
+++ b/chia/types/weight_proof.py
@@ -1,50 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import List
-
 import chia_rs
 
-from chia.types.blockchain_format.reward_chain_block import RewardChainBlock
-from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
-from chia.types.header_block import HeaderBlock
-from chia.util.streamable import Streamable, streamable
-
-SubEpochData = chia_rs.SubEpochData
-
-# number of challenge blocks
-# Average iters for challenge blocks
-# |--A-R----R-------R--------R------R----R----------R-----R--R---|       Honest difficulty 1000
-#           0.16
-
-#  compute total reward chain blocks
-# |----------------------------A---------------------------------|       Attackers chain 1000
-#                            0.48
-# total number of challenge blocks == total number of reward chain blocks
-
-
+ProofBlockHeader = chia_rs.ProofBlockHeader
+RecentChainData = chia_rs.RecentChainData
 SubEpochChallengeSegment = chia_rs.SubEpochChallengeSegment
+SubEpochData = chia_rs.SubEpochData
 SubEpochSegments = chia_rs.SubEpochSegments
 SubSlotData = chia_rs.SubSlotData
-
-
-@streamable
-@dataclass(frozen=True)
-# this is used only for serialization to database
-class RecentChainData(Streamable):
-    recent_chain_data: List[HeaderBlock]
-
-
-@streamable
-@dataclass(frozen=True)
-class ProofBlockHeader(Streamable):
-    finished_sub_slots: List[EndOfSubSlotBundle]
-    reward_chain_block: RewardChainBlock
-
-
-@streamable
-@dataclass(frozen=True)
-class WeightProof(Streamable):
-    sub_epochs: List[SubEpochData]
-    sub_epoch_segments: List[SubEpochChallengeSegment]  # sampled sub epoch
-    recent_chain_data: List[HeaderBlock]
+WeightProof = chia_rs.WeightProof


### PR DESCRIPTION
### Purpose:

Like the title suggests, the following types are transitioned to use the rust counterparts, from `chia_rs`:

```
ProofBlockHeader = chia_rs.ProofBlockHeader
RecentChainData = chia_rs.RecentChainData
SubEpochData = chia_rs.SubEpochData
WeightProof = chia_rs.WeightProof
```

The rust types are defined here: https://github.com/Chia-Network/chia_rs/blob/main/crates/chia-protocol/src/weight_proof.rs

This attempts to address one of the issues uncovered here: https://github.com/Chia-Network/chia-blockchain/pull/17168
"serializing the weight proof is slow".

### Current Behavior:

Serializing the weight proof is slow, when responding to a `request_proof_of_weight` request from a peer.

### New Behavior:

Serializing the weight proof is faster.