### PR TITLE
Fix defaults in send_transaction_multi

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1174,6 +1174,10 @@ class WalletRpcApi:
         if await self.service.wallet_state_manager.synced() is False:
             raise ValueError("Wallet needs to be fully synced before sending transactions")
 
+        # This is required because this is a "@tx_endpoint" that calls other @tx_endpoints
+        request.setdefault("push", True)
+        request.setdefault("merge_spends", True)
+
         wallet_id = uint32(request["wallet_id"])
         wallet = self.service.wallet_state_manager.wallets[wallet_id]
 


### PR DESCRIPTION
This https://github.com/Chia-Network/chia-blockchain/pull/17436 was an accidentally breaking change to the default behavior of this RPC.  This PR restores those defaults.