### PR TITLE
switch to legacy-keyring as the extra name so it works

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ do
     # non-editable
     i) EDITABLE='';;
     # legacy keyring
-    l) EXTRAS=${EXTRAS}legacy_keyring,;;
+    l) EXTRAS=${EXTRAS}legacy-keyring,;;
     p) PLOTTER_INSTALL=1;;
     # simple install
     s) :;;

--- a/setup.py
+++ b/setup.py
@@ -83,11 +83,11 @@ kwargs = dict(
     python_requires=">=3.8.1, <4",
     keywords="chia blockchain node",
     install_requires=dependencies,
-    extras_require=dict(
-        dev=dev_dependencies,
-        upnp=upnp_dependencies,
-        legacy_keyring=legacy_keyring_dependencies,
-    ),
+    extras_require={
+        "dev": dev_dependencies,
+        "upnp": upnp_dependencies,
+        "legacy-keyring": legacy_keyring_dependencies,
+    },
     packages=find_packages(include=["build_scripts", "chia", "chia.*", "mozilla-ca"]),
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:



<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

https://github.com/Chia-Network/chia-blockchain/actions/runs/8393134572/job/22987463242#step:12:198
> `WARNING: chia-blockchain 2.2.2.dev242 does not provide the extra 'legacy-keyring'`

### New Behavior:

https://github.com/Chia-Network/chia-blockchain/actions/runs/8393857772/job/22989809717?pr=17770#step:12:1

no warning

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
