### PR TITLE
Update Patched Fix HTTP parser (HTTP Request Smuggling) still overly lenient about separators

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ dependencies = [
     "clvm_tools==0.4.9",  # Currying, Program.to, other conveniences
     "chia_rs==0.5.2",
     "clvm-tools-rs==0.1.40",  # Rust implementation of clvm_tools' compiler
-    "aiohttp==3.9.1",  # HTTP server for full node rpc
+    "aiohttp==3.9.2",  # HTTP server for full node rpc
     "aiosqlite==0.20.0",  # asyncio wrapper for sqlite, to store blocks
     "bitstring==4.1.4",  # Binary data management library
     "colorama==0.4.6",  # Colorizes terminal output


### PR DESCRIPTION

## Summary
Security-sensitive parts of the Python HTTP parser retained minor differences in allowable character sets, that must trigger error handling to robustly match frame boundaries of proxies in order to protect against injection of additional requests. Additionally, validation could trigger exceptions that were not handled consistently with processing of other malformed input.

**Details**
 * The expression `HTTP/(\d).(\d)` lacked another backslash to clarify that the separator should be a literal dot, not just any Unicode code point (result: `HTTP/(\d)\.(\d))`.
 * The HTTP version was permitting Unicode digits, where only ASCII digits are standards-compliant.
 * Distinct regular expressions for validating HTTP Method and Header field names were used - though both should (at least) apply the common restrictions of `rfc9110` token.

**PoC**
`GET / HTTP/1ö1`
`GET / HTTP/1.𝟙`
`GET/: HTTP/1.1`
`Content-Encoding?: chunked`

**Impact**
Primarily concerns running an aiohttp server without llhttp:
 * behind a proxy: Being more lenient than internet standards require could, depending on deployment environment, assist in request smuggling.
 * directly accessible or exposed behind proxies relaying malformed input: the unhandled exception could cause excessive resource consumption on the application server and/or its logging facilities.

CVE-2024-23829
CWE-444
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L`


