### PR TITLE
Optimize clean_node_table's query

### DIFF
--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -1300,8 +1300,12 @@ class DataStore:
                 WHERE n.right IS NOT NULL
             )
             DELETE FROM node
-            WHERE hash NOT IN (SELECT hash FROM ancestors)
-            AND hash NOT IN (SELECT hash FROM pending_nodes)
+            WHERE hash IN (
+                SELECT n.hash FROM node n
+                LEFT JOIN ancestors a ON n.hash = a.hash
+                LEFT JOIN pending_nodes pn ON n.hash = pn.hash
+                WHERE a.hash IS NULL AND pn.hash IS NULL
+            )
             """,
             {
                 "pending_status": Status.PENDING.value,


### PR DESCRIPTION
Before: `real 37.100 user 21.069570 sys 16.029508` (`87118718474 cycles`)
After: `real 23.564 user 18.518647 sys 5.043768` (`53341553604 cycles`)

Before:
```
QUERY PLAN
|--USING INDEX sqlite_autoindex_ancestors_1 FOR IN-OPERATOR
|--LIST SUBQUERY 5
|  |--MATERIALIZE pending_nodes
|  |  |--SETUP
|  |  |  `--SCAN root
|  |  `--RECURSIVE STEP
|  |     `--COMPOUND QUERY
|  |        |--LEFT-MOST SUBQUERY
|  |        |  |--SCAN pn
|  |        |  `--SEARCH n USING INDEX sqlite_autoindex_node_1 (hash=?)
|  |        `--UNION ALL
|  |           |--SCAN pn
|  |           `--SEARCH n USING INDEX sqlite_autoindex_node_1 (hash=?)
|  `--SCAN pending_nodes
`--SCAN node
```

After:
```
QUERY PLAN
|--LIST SUBQUERY 4
|  |--MATERIALIZE pending_nodes
|  |  |--SETUP
|  |  |  `--SCAN root
|  |  `--RECURSIVE STEP
|  |     `--COMPOUND QUERY
|  |        |--LEFT-MOST SUBQUERY
|  |        |  |--SCAN pn
|  |        |  `--SEARCH n USING INDEX sqlite_autoindex_node_1 (hash=?)
|  |        `--UNION ALL
|  |           |--SCAN pn
|  |           `--SEARCH n USING INDEX sqlite_autoindex_node_1 (hash=?)
|  |--SCAN n USING COVERING INDEX sqlite_autoindex_node_1
|  |--SEARCH a USING COVERING INDEX sqlite_autoindex_ancestors_1 (hash=?) LEFT-JOIN
|  |--CREATE AUTOMATIC INDEX ON pending_nodes(hash)
|  |--BLOOM FILTER ON pn (hash=?)
|  `--SEARCH pn USING AUTOMATIC COVERING INDEX (hash=?) LEFT-JOIN
`--SEARCH node USING COVERING INDEX sqlite_autoindex_node_1 (hash=?)
```