### PR TITLE
Wait for synced in NFT test

### DIFF
--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -445,6 +445,10 @@ async def test_nft_wallet_creation_and_transfer(wallet_environments: WalletTestF
         ReorgProtocol(uint32(height - 1), uint32(height + 2), bytes32([0] * 32), None)
     )
 
+    await full_node_api.wait_for_self_synced()
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_0, peak_height=uint32(height + 2))
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_1, peak_height=uint32(height + 2))
+
     await env_0.change_balances(
         {
             "nft": {


### PR DESCRIPTION
This should fix some occasional flakes with this test.

As a note, this problem could likely be avoided in the future with a version of `process_pending_states` but for tracking state through reorgs instead of chain progression.