### PR TITLE
Rename softfork

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -190,12 +190,12 @@ def get_keychain():
 class ConsensusMode(Enum):
     PLAIN = 0
     HARD_FORK_2_0 = 1
-    SOFT_FORK_3 = 2
+    SOFT_FORK_4 = 2
 
 
 @pytest.fixture(
     scope="session",
-    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.SOFT_FORK_3],
+    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.SOFT_FORK_4],
 )
 def consensus_mode(request):
     return request.param
@@ -205,10 +205,10 @@ def consensus_mode(request):
 def blockchain_constants(consensus_mode) -> ConsensusConstants:
     if consensus_mode == ConsensusMode.PLAIN:
         return test_constants
-    if consensus_mode == ConsensusMode.SOFT_FORK_3:
+    if consensus_mode == ConsensusMode.SOFT_FORK_4:
         return dataclasses.replace(
             test_constants,
-            SOFT_FORK3_HEIGHT=uint32(2),
+            SOFT_FORK4_HEIGHT=uint32(2),
         )
     if consensus_mode == ConsensusMode.HARD_FORK_2_0:
         return dataclasses.replace(

--- a/chia/_tests/core/full_node/test_conditions.py
+++ b/chia/_tests/core/full_node/test_conditions.py
@@ -376,7 +376,7 @@ class TestConditions:
         pre-v2-softfork, and rejects more than the announcement limit afterward.
         """
 
-        if condition1.startswith("(66") and consensus_mode != ConsensusMode.SOFT_FORK_3:
+        if condition1.startswith("(66") and consensus_mode != ConsensusMode.SOFT_FORK_4:
             # The message conditions aren't enabled until Soft-fork 3, so there
             # won't be any errors unless it's activated
             expect_err = None

--- a/chia/_tests/util/test_testnet_overrides.py
+++ b/chia/_tests/util/test_testnet_overrides.py
@@ -10,7 +10,7 @@ def test_testnet10() -> None:
     update_testnet_overrides("testnet10", overrides)
     assert overrides == {
         "SOFT_FORK2_HEIGHT": 3000000,
-        "SOFT_FORK3_HEIGHT": 4465000,
+        "SOFT_FORK4_HEIGHT": 4465000,
         "HARD_FORK_HEIGHT": 2997292,
         "HARD_FORK_FIX_HEIGHT": 3426000,
         "PLOT_FILTER_128_HEIGHT": 3061804,
@@ -23,7 +23,7 @@ def test_testnet11() -> None:
     overrides: Dict[str, Any] = {}
     update_testnet_overrides("testnet11", overrides)
     assert overrides == {
-        "SOFT_FORK3_HEIGHT": 641500,
+        "SOFT_FORK4_HEIGHT": 641500,
     }
 
 
@@ -38,7 +38,7 @@ def test_testnet10_existing() -> None:
     update_testnet_overrides("testnet10", overrides)
     assert overrides == {
         "SOFT_FORK2_HEIGHT": 3000000,
-        "SOFT_FORK3_HEIGHT": 4465000,
+        "SOFT_FORK4_HEIGHT": 4465000,
         "HARD_FORK_HEIGHT": 42,
         "HARD_FORK_FIX_HEIGHT": 3426000,
         "PLOT_FILTER_128_HEIGHT": 42,

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -66,7 +66,7 @@ class ConsensusConstants:
     SOFT_FORK2_HEIGHT: uint32
 
     # soft fork initiated in 2.3.0 release
-    SOFT_FORK3_HEIGHT: uint32
+    SOFT_FORK4_HEIGHT: uint32
 
     # the hard fork planned with the 2.0 release
     # this is the block with the first plot filter adjustment

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -63,7 +63,7 @@ DEFAULT_CONSTANTS = ConsensusConstants(
     MAX_GENERATOR_REF_LIST_SIZE=uint32(512),  # Number of references allowed in the block generator ref list
     POOL_SUB_SLOT_ITERS=uint64(37600000000),  # iters limit * NUM_SPS
     SOFT_FORK2_HEIGHT=uint32(0),
-    SOFT_FORK3_HEIGHT=uint32(5650000),
+    SOFT_FORK4_HEIGHT=uint32(5650000),
     # June 2024
     HARD_FORK_HEIGHT=uint32(5496000),
     HARD_FORK_FIX_HEIGHT=uint32(5496000),
@@ -82,8 +82,8 @@ def update_testnet_overrides(network_id: str, overrides: Dict[str, Any]) -> None
         # these numbers are supposed to match initial-config.yaml
         if "SOFT_FORK2_HEIGHT" not in overrides:
             overrides["SOFT_FORK2_HEIGHT"] = 3000000
-        if "SOFT_FORK3_HEIGHT" not in overrides:
-            overrides["SOFT_FORK3_HEIGHT"] = 4465000
+        if "SOFT_FORK4_HEIGHT" not in overrides:
+            overrides["SOFT_FORK4_HEIGHT"] = 4465000
         if "HARD_FORK_HEIGHT" not in overrides:
             overrides["HARD_FORK_HEIGHT"] = 2997292
         if "HARD_FORK_FIX_HEIGHT" not in overrides:
@@ -95,5 +95,5 @@ def update_testnet_overrides(network_id: str, overrides: Dict[str, Any]) -> None
         if "PLOT_FILTER_32_HEIGHT" not in overrides:
             overrides["PLOT_FILTER_32_HEIGHT"] = 13056556
     if network_id == "testnet11":
-        if "SOFT_FORK3_HEIGHT" not in overrides:
-            overrides["SOFT_FORK3_HEIGHT"] = 641500
+        if "SOFT_FORK4_HEIGHT" not in overrides:
+            overrides["SOFT_FORK4_HEIGHT"] = 641500

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -45,7 +45,7 @@ def get_flags_for_height_and_constants(height: int, constants: ConsensusConstant
     if height >= constants.SOFT_FORK2_HEIGHT:
         flags = flags | NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
 
-    if height >= constants.SOFT_FORK3_HEIGHT:
+    if height >= constants.SOFT_FORK4_HEIGHT:
         flags = flags | ENABLE_MESSAGE_CONDITIONS
 
     if height >= constants.HARD_FORK_HEIGHT:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -74,7 +74,7 @@ network_overrides: &network_overrides
       MEMPOOL_BLOCK_BUFFER: 10
       MIN_PLOT_SIZE: 18
       SOFT_FORK2_HEIGHT: 3000000
-      SOFT_FORK3_HEIGHT: 4465000
+      SOFT_FORK4_HEIGHT: 4465000
       # planned 2.0 release is July 26, height 2965036 on testnet
       # 1 week later
       HARD_FORK_HEIGHT: 2997292
@@ -101,7 +101,7 @@ network_overrides: &network_overrides
       # Forks activated from the beginning on this network
       HARD_FORK_HEIGHT: 0
       HARD_FORK_FIX_HEIGHT: 0
-      SOFT_FORK3_HEIGHT: 641500
+      SOFT_FORK4_HEIGHT: 641500
       PLOT_FILTER_128_HEIGHT: 6029568
       PLOT_FILTER_64_HEIGHT: 11075328
       PLOT_FILTER_32_HEIGHT: 16121088


### PR DESCRIPTION
### Purpose:

a recent PR introduced soft-fork 3, to activate message conditions. We've already had a soft-fork 3, and it's activated and removed from the code base.

This PR renames the recent soft-fork to soft-fork 4 to avoid any confusion.

It also removes two disabled tests from the (cancelled and reverted CHIP-13 patch) that refer to soft-fork 4 as the CHIP-13 soft fork.

### Current Behavior:

The next soft-fork is called 3.

### New Behavior:

The next soft-fork is called 4.

### tests

With this change:
```
$ git grep SOFT_FORK3
CHANGELOG.md:- Bump SOFT_FORK3_HEIGHT to align with the next release cycle
```

That's the changelog mentioning the previous soft-fork 3

```
$ git grep SOFT_FORK_3
```

Returns no hits