### PR TITLE
avoid 3.9+ type indexing in runtime code, relegate to hints

### DIFF
--- a/chia/_tests/util/test_async_pool.py
+++ b/chia/_tests/util/test_async_pool.py
@@ -93,7 +93,7 @@ async def test_does_not_exceed_expected_concurrency(count: int) -> None:
 async def test_worker_id_counts() -> None:
     expected_results = [0, 1, 2, 3, 4, 5]
 
-    result_queue = asyncio.Queue[int]()
+    result_queue: asyncio.Queue[int] = asyncio.Queue()
 
     async def worker(
         worker_id: int,
@@ -128,8 +128,8 @@ async def test_worker_exception_logged(caplog: pytest.LogCaptureFixture) -> None
         def __init__(self) -> None:
             super().__init__(expected_message)
 
-    work_queue = asyncio.Queue[Optional[Exception]]()
-    result_queue = asyncio.Queue[None]()
+    work_queue: asyncio.Queue[Optional[Exception]] = asyncio.Queue()
+    result_queue: asyncio.Queue[None] = asyncio.Queue()
 
     async def worker(
         worker_id: int,
@@ -175,8 +175,8 @@ async def test_simple_queue_example() -> None:
     inputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     expected_results = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
 
-    work_queue = asyncio.Queue[int]()
-    result_queue = asyncio.Queue[int]()
+    work_queue: asyncio.Queue[int] = asyncio.Queue()
+    result_queue: asyncio.Queue[int] = asyncio.Queue()
 
     async def worker(
         worker_id: int,
@@ -208,8 +208,8 @@ async def test_simple_queue_example_using_queued() -> None:
     inputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     expected_results = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100]
 
-    work_queue = asyncio.Queue[Job[int]]()
-    result_queue = asyncio.Queue[int]()
+    work_queue: asyncio.Queue[Job[int]] = asyncio.Queue()
+    result_queue: asyncio.Queue[int] = asyncio.Queue()
 
     async def worker(
         worker_id: int,
@@ -243,8 +243,8 @@ async def test_queued_pre_cancel() -> None:
     inputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     expected_results = [1, 4, 9, 25, 36, 64, 81, 100]
 
-    work_queue = asyncio.Queue[Job[int]]()
-    result_queue = asyncio.Queue[int]()
+    work_queue: asyncio.Queue[Job[int]] = asyncio.Queue()
+    result_queue: asyncio.Queue[int] = asyncio.Queue()
 
     async def worker(
         worker_id: int,
@@ -281,8 +281,8 @@ async def test_queued_active_cancel() -> None:
     inputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     expected_results = [1, 4, 9, 25, 36, 64, 81, 100]
 
-    work_queue = asyncio.Queue[Job[int]]()
-    result_queue = asyncio.Queue[int]()
+    work_queue: asyncio.Queue[Job[int]] = asyncio.Queue()
+    result_queue: asyncio.Queue[int] = asyncio.Queue()
 
     async def worker(
         worker_id: int,
@@ -323,8 +323,8 @@ async def test_queued_raises() -> None:
     inputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     expected_results = [1, 4, 9, 25, 36, 64, 81, 100]
 
-    work_queue = asyncio.Queue[Job[int]]()
-    result_queue = asyncio.Queue[int]()
+    work_queue: asyncio.Queue[Job[int]] = asyncio.Queue()
+    result_queue: asyncio.Queue[int] = asyncio.Queue()
 
     async def worker(
         worker_id: int,

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -817,7 +817,7 @@ class DataLayer:
                             f"Can't subscribe to locally stored {local_id}: {type(e)} {e} {traceback.format_exc()}"
                         )
 
-            work_queue = asyncio.Queue[Job[Subscription]]()
+            work_queue: asyncio.Queue[Job[Subscription]] = asyncio.Queue()
             async with QueuedAsyncPool.managed(
                 name="DataLayer subscription update pool",
                 worker_async_callable=self.update_subscription,

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1594,7 +1594,7 @@ class FullNodeAPI:
         max_items -= len(states)
 
         hint_coin_ids = await self.full_node.hint_store.get_coin_ids_multi(
-            cast(set[bytes], puzzle_hashes), max_items=max_items
+            cast(Set[bytes], puzzle_hashes), max_items=max_items
         )
 
         hint_states: List[CoinState] = []


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Fix errors in release CI for older Python versions.

Slipped through nightly CI because we don't monitor it.  Slipped through Python 3.8 mypy checks because of https://github.com/python/mypy/issues/15773.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Cast to `set`

### New Behavior:

Cast to `Set`

