### PR TITLE
DL migrate DB.

### DIFF
--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -3446,6 +3446,7 @@ async def test_unsubmitted_batch_db_migration(
     monkeypatch: Any,
 ) -> None:
     with monkeypatch.context() as m:
+
         class OldStatus(IntEnum):
             PENDING = 1
             COMMITTED = 2

--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -3446,10 +3446,10 @@ async def test_unsubmitted_batch_db_migration(
     monkeypatch: Any,
 ) -> None:
     with monkeypatch.context() as m:
-        OldStatus = IntEnum("Status", [(name, member.value) for name, member in Status.__members__.items()])
+        OldStatus = IntEnum("Status", [(name, member.value) for name, member in Status.__members__.items()])  # type: ignore
         ModifiedStatus = IntEnum(
             "Status", [(name, member.value) for name, member in Status.__members__.items() if name != "PENDING_BATCH"]
-        )
+        )  # type: ignore
         m.setattr("chia.data_layer.data_layer_util.Status", ModifiedStatus)
         m.setattr("chia.data_layer.data_store.Status", ModifiedStatus)
         m.setattr("chia.data_layer.data_layer.Status", ModifiedStatus)

--- a/chia/_tests/core/data_layer/test_data_store.py
+++ b/chia/_tests/core/data_layer/test_data_store.py
@@ -1916,3 +1916,16 @@ async def test_insert_key_already_present(data_store: DataStore, tree_id: bytes3
     )
     with pytest.raises(Exception, match=f"Key already present: {key.hex()}"):
         await data_store.insert(key=key, value=value, tree_id=tree_id, reference_node_hash=None, side=None)
+
+
+@pytest.mark.anyio
+async def test_migration_unknown_version(data_store: DataStore) -> None:
+    async with data_store.db_wrapper.writer() as writer:
+        await writer.execute(
+            "INSERT INTO schema(version_id) VALUES(:version_id)",
+            {
+                "version_id": "unknown version",
+            },
+        )
+    with pytest.raises(Exception, match="Unknown version"):
+        await data_store.migrate_db()

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -200,6 +200,7 @@ class DataLayer:
         async with DataStore.managed(database=self.db_path, sql_log_path=sql_log_path) as self._data_store:
             self._wallet_rpc = await self.wallet_rpc_init
 
+            await self._data_store.migrate_db()
             self.periodically_manage_data_task = asyncio.create_task(self.periodically_manage_data())
             try:
                 yield

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -157,6 +157,14 @@ class DataStore:
                 )
                 await writer.execute(
                     """
+                    CREATE TABLE IF NOT EXISTS schema(
+                        version_id TEXT PRIMARY KEY,
+                        applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+                await writer.execute(
+                    """
                     CREATE INDEX IF NOT EXISTS node_hash ON root(node_hash)
                     """
                 )
@@ -172,6 +180,40 @@ class DataStore:
     async def transaction(self) -> AsyncIterator[None]:
         async with self.db_wrapper.writer():
             yield
+
+    async def migrate_db(self) -> None:
+        async with self.db_wrapper.reader() as reader:
+            cursor = await reader.execute("SELECT * FROM schema")
+            row = await cursor.fetchone()
+            if row is not None:
+                version = row["version_id"]
+                if version != "v1.0":
+                    raise Exception("Unknown version")
+                log.info(f"Found DB schema version {version}. No migration needed.")
+                return
+
+        version = "v1.0"
+        log.info(f"Initiating migration to version {version}")
+        async with self.db_wrapper.writer(foreign_key_enforcement_enabled=False) as writer:
+            await writer.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS new_root(
+                    tree_id BLOB NOT NULL CHECK(length(tree_id) == 32),
+                    generation INTEGER NOT NULL CHECK(generation >= 0),
+                    node_hash BLOB,
+                    status INTEGER NOT NULL CHECK(
+                        {" OR ".join(f"status == {status}" for status in Status)}
+                    ),
+                    PRIMARY KEY(tree_id, generation),
+                    FOREIGN KEY(node_hash) REFERENCES node(hash)
+                )
+                """
+            )
+            await writer.execute("INSERT INTO new_root SELECT * FROM root")
+            await writer.execute("DROP TABLE root")
+            await writer.execute("ALTER TABLE new_root RENAME TO root")
+            await writer.execute("INSERT INTO schema (version_id) VALUES (?)", (version,))
+            log.info(f"Finished migrating DB to version {version}")
 
     async def _insert_root(
         self,

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -213,7 +213,7 @@ class DataStore:
             await writer.execute("DROP TABLE root")
             await writer.execute("ALTER TABLE new_root RENAME TO root")
             await writer.execute("INSERT INTO schema (version_id) VALUES (?)", (version,))
-            log.info(f"Finished migrating DB to version {version}")
+        log.info(f"Finished migrating DB to version {version}")
 
     async def _insert_root(
         self,


### PR DESCRIPTION
Old DB constrains won't allow `Status.PENDING_BATCH` as a potential root status, due to this check:

```
status INTEGER NOT NULL CHECK(
 {" OR ".join(f"status == {status}" for status in Status)}
 ),
 ```
 
 This PR introduces a one time migration which will update the check with `Status.PENDING_BATCH` as well