### PR TITLE
fix error codes and add more test coverage for message conditions

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -266,7 +266,7 @@ def db_version(request) -> int:
     return request.param
 
 
-SOFTFORK_HEIGHTS = [1000000, 5496000, 5496100]
+SOFTFORK_HEIGHTS = [1000000, 5496000, 5496100, 5650000]
 
 
 @pytest.fixture(scope="function", params=SOFTFORK_HEIGHTS)

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -2370,6 +2370,28 @@ class TestGeneratorConditions:
 
         assert npc_result.error == expect_error
 
+    @pytest.mark.parametrize("mempool", [True, False])
+    @pytest.mark.parametrize(
+        "condition, expect_error",
+        [
+            ('(66 0 "foo") (67 0 "bar")', Err.MESSAGE_NOT_SENT_OR_RECEIVED.value),
+            ('(66 0 "foo") (67 0 "foo")', None),
+        ],
+    )
+    def test_message_condition(
+        self, mempool: bool, condition: str, expect_error: Optional[int], softfork_height: uint32
+    ):
+        npc_result = generator_condition_tester(condition, mempool_mode=mempool, height=softfork_height)
+        print(npc_result)
+
+        # the message conditions are only activated with soft fork 4, so
+        # before then there are no errors.
+        # In mempool mode, the message conditions activated immediately.
+        if softfork_height < test_constants.SOFT_FORK4_HEIGHT and not mempool:
+            expect_error = None
+
+        assert npc_result.error == expect_error
+
 
 # the tests below are malicious generator programs
 

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -186,10 +186,12 @@ class Err(Enum):
     # raised if a spend issues too many assert spend, assert puzzle,
     # assert announcement or create announcement
     TOO_MANY_ANNOUNCEMENTS = 144
+    # the message mode in SEND_MESSAGE or RECEIVE_MESSAGE condition is not valid
+    INVALID_MESSAGE_MODE = 145
     # the specified coin ID is not valid
-    INVALID_COIN_ID = 145
+    INVALID_COIN_ID = 146
     # message not sent/received
-    MESSAGE_NOT_SENT_OR_RECEIVED = 146
+    MESSAGE_NOT_SENT_OR_RECEIVED = 147
 
 
 class ValidationError(Exception):


### PR DESCRIPTION
### Purpose:

* Add more test coverage for the message conditions from the python side
* fix incorrectly mapped error codes related to the message conditions

See: https://github.com/Chia-Network/chia_rs/blob/main/crates/chia-consensus/src/gen/validation_error.rs#L142-L144