### PR TITLE
Increase in-memory DB URI randomness

### DIFF
--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import functools
-import random
+import secrets
 import sqlite3
 import sys
 from dataclasses import dataclass, field
@@ -53,7 +53,7 @@ class InternalError(DBWrapperError):
 
 def generate_in_memory_db_uri() -> str:
     # We need to use shared cache as our DB wrapper uses different types of connections
-    return f"file:db_{random.randint(0, 99999999)}?mode=memory&cache=shared"
+    return f"file:db_{secrets.token_hex(16)}?mode=memory&cache=shared"
 
 
 async def execute_fetchone(


### PR DESCRIPTION
This addresses an occurrence of:
```
venv/lib/python3.11/site-packages/anyio/pytest_plugin.py:75: in wrapper
    yield from runner.run_asyncgen_fixture(func, kwargs)
venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py:1932: in run_asyncgen_fixture
    fixturevalue: T_Retval = self.get_loop().run_until_complete(
/usr/lib/python3.11/asyncio/base_events.py:653: in run_until_complete
    return future.result()
venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py:1924: in _call_in_runner_task
    return await future
venv/lib/python3.11/site-packages/anyio/_backends/_asyncio.py:1899: in _run_tests_and_fixtures
    retval = await coro
chia/_tests/conftest.py:600: in wallet_nodes
    async with setup_simulators_and_wallets(
/usr/lib/python3.11/contextlib.py:204: in __aenter__
    return await anext(self.gen)
chia/_tests/util/setup_nodes.py:169: in setup_simulators_and_wallets
    async with setup_simulators_and_wallets_inner(
/usr/lib/python3.11/contextlib.py:204: in __aenter__
    return await anext(self.gen)
chia/_tests/util/setup_nodes.py:267: in setup_simulators_and_wallets_inner
    simulators: List[SimulatorFullNodeService] = [
chia/_tests/util/setup_nodes.py:268: in <listcomp>
    await async_exit_stack.enter_async_context(
/usr/lib/python3.11/contextlib.py:638: in enter_async_context
    result = await _enter(cm)
/usr/lib/python3.11/contextlib.py:204: in __aenter__
    return await anext(self.gen)
chia/simulator/setup_services.py:127: in setup_full_node
    connection.execute("CREATE TABLE database_version(version int)")
E   sqlite3.OperationalError: table database_version already exists
```