### PR TITLE
make junit collection optional and disable for now

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -32,6 +32,10 @@ on:
       runs-on:
         required: true
         type: string
+      collect-junit:
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   # SHA is added to the end if on `main` to let all main workflows run
@@ -229,6 +233,7 @@ jobs:
           mv notchia/ chia/
 
       - name: Publish JUnit results
+        if: inputs.collect-junit
         uses: actions/upload-artifact@v4
         with:
           name: junit-data-${{ env.JOB_FILE_NAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}--${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}
   cancel-in-progress: true
 
+env:
+    collect-junit: false
+
 jobs:
   configure:
     name: Configure matrix
@@ -61,6 +64,7 @@ jobs:
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
       runs-on: macos-latest
+      collect-junit: ${{ env.collect-junit == 'true' }}
   ubuntu:
     uses: ./.github/workflows/test-single.yml
     needs: configure
@@ -73,6 +77,7 @@ jobs:
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
       runs-on: ubuntu-latest
+      collect-junit: ${{ env.collect-junit == 'true' }}
   windows:
     uses: ./.github/workflows/test-single.yml
     needs: configure
@@ -85,6 +90,7 @@ jobs:
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
       runs-on: windows-latest
+      collect-junit: ${{ env.collect-junit == 'true' }}
 
   coverage:
     name: ${{ matrix.os.emoji }} Coverage - ${{ matrix.python.name }}
@@ -119,6 +125,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Results
+        if: ${{ env.collect-junit == 'true' }}
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
@@ -126,6 +133,7 @@ jobs:
           path: junit-data
 
       - name: Format JUnit data and prepare results
+        if: ${{ env.collect-junit == 'true' }}
         run: |
           sudo snap install yq
           ls junit-data/*.xml | xargs --max-procs=10 --replace={} yq eval '.testsuites.testsuite.testcase |= sort_by(.+@classname, .+@name)' --inplace {}
@@ -136,6 +144,7 @@ jobs:
           ls junit-results/*.xml | xargs --max-procs=10 --replace={} yq eval '.testsuites.testsuite |= sort_by(.+@name) | .testsuites.testsuite[].testcase |= sort_by(.+@classname, .+@name)' --inplace {}
 
       - name: Publish formatted JUnit data
+        if: ${{ env.collect-junit == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: junit-data
@@ -168,7 +177,7 @@ jobs:
           python -m chia._tests.process_junit            --type time_out_assert --xml junit-results/junit.xml --markdown --link-prefix ${{ github.event.repository.html_url }}/blob/${{ github.sha }}/ --link-line-separator \#L >> junit-results/time_out_assert.md
 
       - name: Publish JUnit results
-        if: always()
+        if: always() && ${{ env.collect-junit == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: junit-results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
       runs-on: macos-latest
-      collect-junit: ${{ env.collect-junit == 'true' }}
+      collect-junit: false
   ubuntu:
     uses: ./.github/workflows/test-single.yml
     needs: configure
@@ -74,7 +74,7 @@ jobs:
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
       runs-on: ubuntu-latest
-      collect-junit: ${{ env.collect-junit == 'true' }}
+      collect-junit: false
   windows:
     uses: ./.github/workflows/test-single.yml
     needs: configure
@@ -87,7 +87,7 @@ jobs:
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
       runs-on: windows-latest
-      collect-junit: ${{ env.collect-junit == 'true' }}
+      collect-junit: false
 
   coverage:
     name: ${{ matrix.os.emoji }} Coverage - ${{ matrix.python.name }}
@@ -174,7 +174,7 @@ jobs:
           python -m chia._tests.process_junit            --type time_out_assert --xml junit-results/junit.xml --markdown --link-prefix ${{ github.event.repository.html_url }}/blob/${{ github.sha }}/ --link-line-separator \#L >> junit-results/time_out_assert.md
 
       - name: Publish JUnit results
-        if: always() && ${{ env.collect-junit == 'true' }}
+        if: always() && false
         uses: actions/upload-artifact@v4
         with:
           name: junit-results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,6 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}--${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}
   cancel-in-progress: true
 
-env:
-  collect-junit: false
-
 jobs:
   configure:
     name: Configure matrix
@@ -125,7 +122,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Results
-        if: ${{ env.collect-junit == 'true' }}
+        if: false
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
@@ -133,7 +130,7 @@ jobs:
           path: junit-data
 
       - name: Format JUnit data and prepare results
-        if: ${{ env.collect-junit == 'true' }}
+        if: false
         run: |
           sudo snap install yq
           ls junit-data/*.xml | xargs --max-procs=10 --replace={} yq eval '.testsuites.testsuite.testcase |= sort_by(.+@classname, .+@name)' --inplace {}
@@ -144,7 +141,7 @@ jobs:
           ls junit-results/*.xml | xargs --max-procs=10 --replace={} yq eval '.testsuites.testsuite |= sort_by(.+@name) | .testsuites.testsuite[].testcase |= sort_by(.+@classname, .+@name)' --inplace {}
 
       - name: Publish formatted JUnit data
-        if: ${{ env.collect-junit == 'true' }}
+        if: false
         uses: actions/upload-artifact@v4
         with:
           name: junit-data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-    collect-junit: false
+  collect-junit: false
 
 jobs:
   configure:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: chia-network/actions/activate-venv@main
 
       - name: Add time out assert results to workflow summary
-        if: always()
+        if: always() && false
         run: |
           python -m chia._tests.process_junit --limit 50 --type time_out_assert --xml junit-results/junit.xml --markdown --link-prefix ${{ github.event.repository.html_url }}/blob/${{ github.sha }}/ --link-line-separator \#L >> "$GITHUB_STEP_SUMMARY"
           python -m chia._tests.process_junit            --type time_out_assert --xml junit-results/junit.xml --markdown --link-prefix ${{ github.event.repository.html_url }}/blob/${{ github.sha }}/ --link-line-separator \#L >> junit-results/time_out_assert.md


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Between the JUnit and coverage artifacts we seem to be exceeding 1000 artifacts for the test workflow.  There seems to be a limit here as the upload steps upload but the download step finds exactly 1000 artifacts and downloads exactly 1000 artifacts between the JUnit and coverage groups.  This does not appear to be documented at https://github.com/actions/upload-artifact#limitations, only the 500 artifact limit per job.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
