### PR TITLE
Use static SQLite variable limit everywhere

### DIFF
--- a/chia/_tests/core/full_node/stores/test_block_store.py
+++ b/chia/_tests/core/full_node/stores/test_block_store.py
@@ -27,7 +27,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.vdf import VDFProof
 from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
-from chia.util.db_wrapper import get_host_parameter_limit
+from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER
 from chia.util.full_block_utils import GeneratorBlockInfo
 from chia.util.ints import uint8, uint32, uint64
 
@@ -369,7 +369,7 @@ async def test_get_blocks_by_hash(tmp_dir: Path, bt: BlockTools, db_version: int
             await store.get_block_bytes_by_hash([bytes32.from_bytes(b"yolo" * 8)])
 
         with pytest.raises(AssertionError):
-            await store.get_block_bytes_by_hash([bytes32.from_bytes(b"yolo" * 8)] * (get_host_parameter_limit() + 1))
+            await store.get_block_bytes_by_hash([bytes32.from_bytes(b"yolo" * 8)] * (SQLITE_MAX_VARIABLE_NUMBER + 1))
 
 
 @pytest.mark.limit_consensus_modes(reason="save time")

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -961,7 +961,9 @@ class TestFullNodeProtocol:
         new_transaction = fnp.NewTransaction(bytes32.random(seeded_random), uint64(10000000), uint64(1))
         await full_node_1.new_transaction(new_transaction, fake_peer)
         assert full_node_1.full_node.mempool_manager.mempool.at_full_capacity(10000000 * group_size)
-        assert full_node_2.full_node.mempool_manager.mempool.at_full_capacity(10000000 * group_size)
+        await time_out_assert(
+            30, full_node_2.full_node.mempool_manager.mempool.at_full_capacity, True, 10000000 * group_size
+        )
 
         await time_out_assert(10, new_transaction_not_requested, True, incoming_queue, new_transaction)
 

--- a/chia/_tests/wallet/test_transaction_store.py
+++ b/chia/_tests/wallet/test_transaction_store.py
@@ -10,6 +10,7 @@ from chia._tests.util.db_connection import DBConnection
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
+from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER
 from chia.util.errors import Err
 from chia.util.ints import uint8, uint32, uint64
 from chia.wallet.conditions import ConditionValidTimes
@@ -888,7 +889,7 @@ async def test_large_tx_record_query() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletTransactionStore.create(db_wrapper)
         tx_records_to_insert = []
-        for _ in range(db_wrapper.host_parameter_limit + 1):
+        for _ in range(SQLITE_MAX_VARIABLE_NUMBER + 1):
             name = bytes32.random()
             record = TransactionRecordOld(
                 confirmed_at_height=uint32(0),
@@ -934,7 +935,7 @@ async def test_large_tx_record_query() -> None:
             )
 
         all_transactions = await store.get_all_transactions_for_wallet(1)
-        assert len(all_transactions) == db_wrapper.host_parameter_limit + 1
+        assert len(all_transactions) == SQLITE_MAX_VARIABLE_NUMBER + 1
         # Check that all transaction record items have correct valid times
         empty_valid_times = ConditionValidTimes()
         assert all(tx.valid_times == empty_valid_times for tx in all_transactions[:-1])

--- a/chia/_tests/wallet/test_wallet_trade_store.py
+++ b/chia/_tests/wallet/test_wallet_trade_store.py
@@ -10,6 +10,7 @@ from chia._tests.util.db_connection import DBConnection
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle
+from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER
 from chia.util.ints import uint32, uint64
 from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.trade_record import TradeRecord, TradeRecordOld
@@ -176,7 +177,7 @@ async def test_large_trade_record_query() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await TradeStore.create(db_wrapper)
         trade_records_to_insert = []
-        for _ in range(db_wrapper.host_parameter_limit + 1):
+        for _ in range(SQLITE_MAX_VARIABLE_NUMBER + 1):
             offer_name = bytes32.random()
             trade_record_old = TradeRecordOld(
                 confirmed_at_index=uint32(0),
@@ -211,7 +212,7 @@ async def test_large_trade_record_query() -> None:
                 (offer_name, bytes(ConditionValidTimes(min_height=uint32(42)))),
             )
         all_trades = await store.get_all_trades()
-        assert len(all_trades) == db_wrapper.host_parameter_limit + 1
+        assert len(all_trades) == SQLITE_MAX_VARIABLE_NUMBER + 1
         # Check that all trade_record items have correct valid_times
         empty = ConditionValidTimes()
         assert all(trade.valid_times == empty for trade in all_trades[:-1])

--- a/chia/cmds/db_upgrade_func.py
+++ b/chia/cmds/db_upgrade_func.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional
 import zstd
 
 from chia.util.config import load_config, lock_and_load_config, save_config
-from chia.util.db_wrapper import get_host_parameter_limit
+from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER
 from chia.util.path import path_from_root
 
 
@@ -180,7 +180,7 @@ def convert_v1_to_v2(in_path: Path, out_path: Path) -> None:
             """
         )
         conn.commit()
-        parameter_limit = get_host_parameter_limit()
+        parameter_limit = SQLITE_MAX_VARIABLE_NUMBER
         start_time = monotonic()
         block_start_time = start_time
         rowids: List[int] = []

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -45,6 +45,7 @@ from chia.types.header_block import HeaderBlock
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.types.unfinished_header_block import UnfinishedHeaderBlock
 from chia.types.weight_proof import SubEpochChallengeSegment
+from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER
 from chia.util.errors import ConsensusError, Err
 from chia.util.generator_tools import get_block_header
 from chia.util.hash import std_hash
@@ -967,7 +968,7 @@ class Blockchain(BlockchainInterface):
         """
         records: List[BlockRecord] = []
         hashes: List[bytes32] = []
-        assert batch_size < self.block_store.db_wrapper.host_parameter_limit
+        assert batch_size < SQLITE_MAX_VARIABLE_NUMBER
         for height in heights:
             header_hash: Optional[bytes32] = self.height_to_hash(height)
             if header_hash is None:

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -13,7 +13,7 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.weight_proof import SubEpochChallengeSegment, SubEpochSegments
-from chia.util.db_wrapper import DBWrapper2, execute_fetchone
+from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER, DBWrapper2, execute_fetchone
 from chia.util.errors import Err
 from chia.util.full_block_utils import GeneratorBlockInfo, block_info_from_block, generator_from_block
 from chia.util.ints import uint32
@@ -370,7 +370,7 @@ class BlockStore:
         if len(header_hashes) == 0:
             return []
 
-        assert len(header_hashes) < self.db_wrapper.host_parameter_limit
+        assert len(header_hashes) < SQLITE_MAX_VARIABLE_NUMBER
         formatted_str = (
             f'SELECT header_hash, block from full_blocks WHERE header_hash in ({"?," * (len(header_hashes) - 1)}?)'
         )

--- a/chia/wallet/trading/trade_store.py
+++ b/chia/wallet/trading/trade_store.py
@@ -8,7 +8,7 @@ import aiosqlite
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.util.db_wrapper import DBWrapper2
+from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER, DBWrapper2
 from chia.util.errors import Err
 from chia.util.ints import uint8, uint32
 from chia.wallet.conditions import ConditionValidTimes
@@ -486,8 +486,8 @@ class TradeStore:
         empty_valid_times = ConditionValidTimes()
         async with self.db_wrapper.reader_no_transaction() as conn:
             chunked_records: List[List[TradeRecordOld]] = [
-                old_records[i : min(len(old_records), i + self.db_wrapper.host_parameter_limit)]
-                for i in range(0, len(old_records), self.db_wrapper.host_parameter_limit)
+                old_records[i : min(len(old_records), i + SQLITE_MAX_VARIABLE_NUMBER)]
+                for i in range(0, len(old_records), SQLITE_MAX_VARIABLE_NUMBER)
             ]
             for records_chunk in chunked_records:
                 cursor = await conn.execute(

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -9,7 +9,7 @@ import aiosqlite
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.util.db_wrapper import DBWrapper2
+from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER, DBWrapper2
 from chia.util.errors import Err
 from chia.util.ints import uint8, uint32
 from chia.wallet.conditions import ConditionValidTimes
@@ -433,8 +433,8 @@ class WalletTransactionStore:
         empty_valid_times = ConditionValidTimes()
         async with self.db_wrapper.reader_no_transaction() as conn:
             chunked_records: List[List[TransactionRecordOld]] = [
-                old_records[i : min(len(old_records), i + self.db_wrapper.host_parameter_limit)]
-                for i in range(0, len(old_records), self.db_wrapper.host_parameter_limit)
+                old_records[i : min(len(old_records), i + SQLITE_MAX_VARIABLE_NUMBER)]
+                for i in range(0, len(old_records), SQLITE_MAX_VARIABLE_NUMBER)
             ]
             for records_chunk in chunked_records:
                 cursor = await conn.execute(


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Replaces the dynamic SQLite variable limit with the static constant in all places throughout the code. This is to fix certain situations where the value returned does not actually represent the maximum, and is instead higher, causing queries to fail.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

In some places we use `get_host_parameter_limit` to calculate a limit at runtime if the Python version is >= 3.11

### New Behavior:

Use `SQLITE_MAX_VARIABLE_NUMBER` instead.