### PR TITLE
improve legibility of source vs. installed test checks

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -207,6 +207,7 @@ jobs:
 
       - name: Verify source and installed tests collect and match
         run: |
+          pytest --collect-only -qq --import-mode=prepend chia/_tests/
           echo '==== collecting source tests ===='
           if ! pytest --collect-only -qq --import-mode=prepend chia/_tests/ > source_tests_raw
           then

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -205,12 +205,32 @@ jobs:
           sh install-timelord.sh -n
           ./vdf_bench square_asm 400000
 
-      - name: Verify source and installed tests match
+      - name: Verify source and installed tests collect and match
         run: |
           echo '==== collecting source tests ===='
-          pytest --collect-only -qq --import-mode=prepend chia/_tests/ | sed -n 's;^\(chia/_tests/.*\);\1;p' | sort | tee source_tests
+          if ! pytest --collect-only -qq --import-mode=prepend chia/_tests/ 1> source_tests_raw
+          then
+            echo '    ==== source test collection failure'
+            cat source_tests_raw
+            exit 1
+          fi
+
           echo '==== collecting installed tests ===='
-          pytest --collect-only -qq --import-mode=append --pyargs chia._tests | sed -n 's;^venv/.*/\(chia/_tests/.*\);\1;p' | sort | tee installed_tests
+          if ! pytest --collect-only -qq --import-mode=append --pyargs chia._tests 1> installed_tests_raw
+          then
+            echo '    ==== installed test collection failure'
+            cat source_tests_raw
+            exit 1
+          fi
+
+          echo '==== processing collected tests ===='
+          for mode in source installed
+          do
+            echo "::group::collected ${mode} tests"
+            cat ${mode}_tests_raw | sed -n 's;^venv/.*/\(chia/_tests/.*\);\1;p' | sort | tee ${mode}_tests
+            echo '::endgroup::'
+          done
+
           echo '==== diffing collected tests ===='
           diff --unified source_tests installed_tests
 

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -207,7 +207,6 @@ jobs:
 
       - name: Verify source and installed tests collect and match
         run: |
-          pytest --collect-only -qq --import-mode=prepend chia/_tests/
           echo '==== collecting source tests ===='
           if pytest --collect-only -qq --import-mode=prepend chia/_tests/ > source_tests_raw
           then

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Verify source and installed tests collect and match
         run: |
           echo '==== collecting source tests ===='
-          if ! pytest --collect-only -qq --import-mode=prepend chia/_tests/ 1> source_tests_raw
+          if ! pytest --collect-only -qq --import-mode=prepend chia/_tests/ > source_tests_raw
           then
             echo '    ==== source test collection failure'
             cat source_tests_raw
@@ -216,7 +216,7 @@ jobs:
           fi
 
           echo '==== collecting installed tests ===='
-          if ! pytest --collect-only -qq --import-mode=append --pyargs chia._tests 1> installed_tests_raw
+          if ! pytest --collect-only -qq --import-mode=append --pyargs chia._tests > installed_tests_raw
           then
             echo '    ==== installed test collection failure'
             cat source_tests_raw

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -221,6 +221,7 @@ jobs:
           if pytest --collect-only -qq --import-mode=append --pyargs chia._tests > installed_tests_raw
           then
             cat installed_tests_raw | sed -n 's;^venv/.*/\(chia/_tests/.*\);\1;p' | sort > installed_tests
+          else
             echo '    ==== installed test collection failure'
             cat installed_tests_raw
             exit 1

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -209,32 +209,35 @@ jobs:
         run: |
           pytest --collect-only -qq --import-mode=prepend chia/_tests/
           echo '==== collecting source tests ===='
-          if ! pytest --collect-only -qq --import-mode=prepend chia/_tests/ > source_tests_raw
+          if pytest --collect-only -qq --import-mode=prepend chia/_tests/ > source_tests_raw
           then
+            cat source_tests_raw | sed -n 's;^\(chia/_tests/.*\);\1;p' | sort > source_tests
+          else
             echo '    ==== source test collection failure'
             cat source_tests_raw
             exit 1
           fi
 
           echo '==== collecting installed tests ===='
-          if ! pytest --collect-only -qq --import-mode=append --pyargs chia._tests > installed_tests_raw
+          if pytest --collect-only -qq --import-mode=append --pyargs chia._tests > installed_tests_raw
           then
+            cat installed_tests_raw | sed -n 's;^venv/.*/\(chia/_tests/.*\);\1;p' | sort > installed_tests
             echo '    ==== installed test collection failure'
-            cat source_tests_raw
+            cat installed_tests_raw
             exit 1
           fi
 
-          echo '==== processing collected tests ===='
+          echo '==== collected tests ===='
           for mode in source installed
           do
             echo "::group::collected ${mode} tests"
-            cat ${mode}_tests_raw | sed -n 's;^venv/.*/\(chia/_tests/.*\);\1;p' | sort | tee ${mode}_tests
+            cat ${mode}_tests
             echo '::endgroup::'
           done
 
           echo '==== diffing collected tests ===='
           echo "::group::collected tests diff"
-          diff --unified source_tests installed_tests
+          diff --unified source_tests installed_tests; DIFF_EXIT_CODE=$?
           echo '::endgroup::'
 
       - name: Move chia/ so we test the installed code

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -232,7 +232,9 @@ jobs:
           done
 
           echo '==== diffing collected tests ===='
+          echo "::group::collected tests diff"
           diff --unified source_tests installed_tests
+          echo '::endgroup::'
 
       - name: Move chia/ so we test the installed code
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Generate matrix configuration
         id: configure
         run: |
-          python chia/_tests/build-job-matrix.py --per directory --verbose --only clvm > matrix.json
+          python chia/_tests/build-job-matrix.py --per directory --verbose > matrix.json
           cat matrix.json
           echo configuration=$(cat matrix.json) >> "$GITHUB_OUTPUT"
           echo matrix_mode=${{ ( github.event_name == 'schedule' ) && 'all' || ( github.event_name == 'workflow_dispatch' ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository != 'Chia-Network/chia-blockchain' ) && 'limited' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && github.ref == 'refs/heads/main' ) && 'main' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.ref, 'refs/heads/release/') ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.base_ref, 'release/') ) && 'all' || 'main' }} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Generate matrix configuration
         id: configure
         run: |
-          python chia/_tests/build-job-matrix.py --per directory --verbose > matrix.json
+          python chia/_tests/build-job-matrix.py --per directory --verbose --only clvm > matrix.json
           cat matrix.json
           echo configuration=$(cat matrix.json) >> "$GITHUB_OUTPUT"
           echo matrix_mode=${{ ( github.event_name == 'schedule' ) && 'all' || ( github.event_name == 'workflow_dispatch' ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository != 'Chia-Network/chia-blockchain' ) && 'limited' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && github.ref == 'refs/heads/main' ) && 'main' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.ref, 'refs/heads/release/') ) && 'all' || ( github.repository_owner == 'Chia-Network' && github.repository == 'Chia-Network/chia-blockchain' && startsWith(github.base_ref, 'release/') ) && 'all' || 'main' }} >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Without this change the source vs. installed tests checking doesn't help you at all when the test collection itself fails.  With this change it does.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Collection failures are not shown.

### New Behavior:

Collections failures are shown.  Also, job run output groups were added for easy expand/collapse of the big lists of collected tests.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

source collection failure testing in https://github.com/Chia-Network/chia-blockchain/pull/17832
https://github.com/Chia-Network/chia-blockchain/actions/runs/8572091670/job/23493876260?pr=17832#step:15:1
```
==== collecting source tests ====
ImportError while loading conftest '/home/runner/work/chia-blockchain/chia-blockchain/chia/_tests/conftest.py'.
chia/_tests/conftest.py:20: in <module>
    import aaa
E   ModuleNotFoundError: No module named 'aaa'
    ==== source test collection failure
```

installed collection failure testing in https://github.com/Chia-Network/chia-blockchain/pull/17833
https://github.com/Chia-Network/chia-blockchain/actions/runs/8572093206/job/23493874955?pr=17833#step:15:1
```
==== collecting source tests ====
==== collecting installed tests ====
    ==== installed test collection failure

==================================== ERRORS ====================================
________ ERROR collecting venv/lib/python3.10/site-packages/chia/_tests ________
/opt/hostedtoolcache/Python/3.10.14/x[64](https://github.com/Chia-Network/chia-blockchain/actions/runs/8572093206/job/23493874955?pr=17833#step:15:65)/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1050: in _gcd_import
    ???
<frozen importlib._bootstrap>:1027: in _find_and_load
    ???
<frozen importlib._bootstrap>:1006: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:[68](https://github.com/Chia-Network/chia-blockchain/actions/runs/8572093206/job/23493874955?pr=17833#step:15:69)8: in _load_unlocked
    ???
venv/lib/python3.10/site-packages/_pytest/assertion/rewrite.py:178: in exec_module
    exec(co, module.__dict__)
venv/lib/python3.10/site-packages/chia/_tests/conftest.py:28: in <module>
    import tools
E   ModuleNotFoundError: No module named 'tools'
=========================== short test summary info ============================
ERROR venv/lib/python3.10/site-packages/chia/_tests - ModuleNotFoundError: No module named 'tools'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
no tests collected, 1 error in 0.32s
```

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
