### PR TITLE
Remove `tx_records` from `dl_update_multiple` RPC (breaking change)

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -4193,17 +4193,10 @@ class WalletRpcApi:
                     extra_conditions=extra_conditions,
                 )
                 tx_records.extend(records)
-            # Now that we have all the txs, we need to aggregate them all into just one spend
-            modified_txs: List[TransactionRecord] = []
-            aggregate_spend = SpendBundle([], G2Element())
-            for tx in tx_records:
-                if tx.spend_bundle is not None:
-                    aggregate_spend = SpendBundle.aggregate([aggregate_spend, tx.spend_bundle])
-                    modified_txs.append(dataclasses.replace(tx, spend_bundle=None))
-            modified_txs[0] = dataclasses.replace(modified_txs[0], spend_bundle=aggregate_spend)
+
             return {
-                "tx_records": [rec.to_json_dict_convenience(self.service.config) for rec in modified_txs],
-                "transactions": [rec.to_json_dict_convenience(self.service.config) for rec in modified_txs],
+                "tx_records": [rec.to_json_dict_convenience(self.service.config) for rec in tx_records],
+                "transactions": [rec.to_json_dict_convenience(self.service.config) for rec in tx_records],
             }
 
     async def dl_history(self, request: Dict[str, Any]) -> EndpointResult:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -4195,7 +4195,6 @@ class WalletRpcApi:
                 tx_records.extend(records)
 
             return {
-                "tx_records": [rec.to_json_dict_convenience(self.service.config) for rec in tx_records],
                 "transactions": [rec.to_json_dict_convenience(self.service.config) for rec in tx_records],
             }
 

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -1168,7 +1168,7 @@ class WalletRpcClient(RpcClient):
             **timelock_info.to_json_dict(),
         }
         response = await self.fetch("dl_update_multiple", request)
-        return [TransactionRecord.from_json_dict_convenience(tx) for tx in response["tx_records"]]
+        return [TransactionRecord.from_json_dict_convenience(tx) for tx in response["transactions"]]
 
     async def dl_history(
         self,


### PR DESCRIPTION
This RPC is not very used so instead of adding to the backwards compatibility special cases here: https://github.com/Chia-Network/chia-blockchain/blob/main/chia/rpc/util.py#L147 I would prefer to just delete this old value in favor of the newer one.

There's also some code deletion in this PR which is redundant after the addition of the new `@marshal` decorator.