### PR TITLE
Add new command class framework for easier testing

### DIFF
--- a/chia/_tests/cmds/test_cmd_framework.py
+++ b/chia/_tests/cmds/test_cmd_framework.py
@@ -219,14 +219,6 @@ def test_typing() -> None:
     with pytest.raises(TypeError):
 
         @chia_command(cmd, "temp_cmd_optional_bad", "blah")
-        class TempCMDOptionalBad:
-            optional: Optional[int] = option("--optional")
-
-            def run(self) -> None: ...
-
-    with pytest.raises(TypeError):
-
-        @chia_command(cmd, "temp_cmd_optional_bad", "blah")
         class TempCMDOptionalBad2:
             optional: Optional[int] = option("--optional", required=True)
 

--- a/chia/_tests/cmds/test_cmd_framework.py
+++ b/chia/_tests/cmds/test_cmd_framework.py
@@ -392,3 +392,8 @@ async def test_wallet_rpc_helper(wallet_environments: WalletTestFramework) -> No
 
     async with expected_command.rpc_info.wallet_rpc(consume_errors=False) as client_info:
         assert await client_info.client.get_logged_in_fingerprint() == fingerprint
+
+    # We don't care about setting the correct arg type here
+    test_present_client_info = TempCMD(rpc_info=NeedsWalletRPC(client_info="hello world"))  # type: ignore[arg-type]
+    async with test_present_client_info.rpc_info.wallet_rpc(consume_errors=False) as client_info:
+        assert client_info == "hello world"  # type: ignore[comparison-overlap]

--- a/chia/_tests/cmds/test_cmd_framework.py
+++ b/chia/_tests/cmds/test_cmd_framework.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import textwrap
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -63,9 +64,17 @@ def test_cmd_bases() -> None:
         ["--help"],
         catch_exceptions=False,
     )
-    assert result.output == (
-        "Usage: cmd [OPTIONS] COMMAND [ARGS]...\n\nOptions:\n  --help  Show this "
-        "message and exit.\n\nCommands:\n  temp_cmd        blah\n  temp_cmd_async  blah\n"
+    assert result.output == textwrap.dedent(
+        """\
+        Usage: cmd [OPTIONS] COMMAND [ARGS]...
+
+        Options:
+          --help  Show this message and exit.
+
+        Commands:
+          temp_cmd        blah
+          temp_cmd_async  blah
+        """
     )
     result = runner.invoke(
         cmd,

--- a/chia/_tests/cmds/test_cmd_framework.py
+++ b/chia/_tests/cmds/test_cmd_framework.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Dict, List, Optional, Sequence
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from chia._tests.conftest import ConsensusMode
+from chia._tests.environments.wallet import WalletTestFramework
+from chia._tests.wallet.conftest import *  # noqa
+from chia.cmds.cmd_classes import ChiaCommand, Context, NeedsWalletRPC, chia_command, option
+from chia.types.blockchain_format.sized_bytes import bytes32
+
+
+def check_click_parsing(cmd: ChiaCommand, *args: str) -> None:
+    @click.group()
+    def _cmd() -> None:
+        pass
+
+    mock_type = type(cmd.__class__.__name__, (cmd.__class__,), {})
+
+    def dict_compare_with_ignore_context(one: Dict[str, Any], two: Dict[str, Any]) -> None:
+        for k, v in one.items():
+            if k == "context":
+                continue
+            elif isinstance(v, dict):
+                dict_compare_with_ignore_context(v, two[k])
+            else:
+                assert v == two[k]
+
+    def new_run(self: Any) -> None:
+        # cmd is appropriately not recognized as a dataclass but I'm not sure how to hint that something is a dataclass
+        dict_compare_with_ignore_context(asdict(cmd), asdict(self))  # type: ignore[call-overload]
+
+    setattr(mock_type, "run", new_run)
+    chia_command(_cmd, "_", "")(mock_type)
+
+    runner = CliRunner()
+    result = runner.invoke(_cmd, ["_", *args], catch_exceptions=False)
+    assert result.output == ""
+
+
+def test_cmd_bases() -> None:
+    @click.group()
+    def cmd() -> None:
+        pass
+
+    @chia_command(cmd, "temp_cmd", "blah")
+    class TempCMD:
+        def run(self) -> None:
+            print("syncronous")
+
+    @chia_command(cmd, "temp_cmd_async", "blah")
+    class TempCMDAsync:
+        async def run(self) -> None:
+            print("asyncronous")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cmd,
+        ["--help"],
+        catch_exceptions=False,
+    )
+    assert result.output == (
+        "Usage: cmd [OPTIONS] COMMAND [ARGS]...\n\nOptions:\n  --help  Show this "
+        "message and exit.\n\nCommands:\n  temp_cmd        blah\n  temp_cmd_async  blah\n"
+    )
+    result = runner.invoke(
+        cmd,
+        ["temp_cmd"],
+        catch_exceptions=False,
+    )
+    assert result.output == "syncronous\n"
+    result = runner.invoke(
+        cmd,
+        ["temp_cmd_async"],
+        catch_exceptions=False,
+    )
+    assert result.output == "asyncronous\n"
+
+
+def test_option_loading() -> None:
+    @click.group()
+    def cmd() -> None:
+        pass
+
+    @chia_command(cmd, "temp_cmd", "blah")
+    class TempCMD:
+        some_option: int = option("-o", "--some-option", required=True, type=int)
+
+        def run(self) -> None:
+            print(self.some_option)
+
+    @chia_command(cmd, "temp_cmd_2", "blah")
+    class TempCMD2:
+        some_option: int = option("-o", "--some-option", required=True, type=int, default=13)
+
+        def run(self) -> None:
+            print(self.some_option)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cmd,
+        ["temp_cmd"],
+        catch_exceptions=False,
+    )
+    assert "Missing option '-o' / '--some-option'" in result.output
+    result = runner.invoke(
+        cmd,
+        [
+            "temp_cmd",
+            "-o",
+            "13",
+        ],
+        catch_exceptions=False,
+    )
+    assert "13\n" == result.output
+    result = runner.invoke(
+        cmd,
+        [
+            "temp_cmd_2",
+        ],
+        catch_exceptions=False,
+    )
+    assert "13\n" == result.output
+
+    assert TempCMD2() == TempCMD2(some_option=13)
+
+
+def test_context_requirement() -> None:
+    @click.group()
+    @click.pass_context
+    def cmd(ctx: click.Context) -> None:
+        ctx.obj = {"foo": "bar"}
+
+    @chia_command(cmd, "temp_cmd", "blah")
+    class TempCMD:
+        context: Context
+
+        def run(self) -> None:
+            assert self.context["foo"] == "bar"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cmd,
+        ["temp_cmd"],
+        catch_exceptions=False,
+    )
+    assert result.output == ""
+
+    # Test that other variables named context are disallowed
+    with pytest.raises(ValueError, match="context"):
+
+        @chia_command(cmd, "shouldnt_work", "blah")
+        class BadCMD:
+            context: int
+
+            def run(self) -> None: ...
+
+
+def test_typing() -> None:
+    @click.group()
+    def cmd() -> None:
+        pass
+
+    @chia_command(cmd, "temp_cmd", "blah")
+    class TempCMD:
+        integer: int = option("--integer", default=1, required=False)
+        text: str = option("--text", default="1", required=False)
+        boolean: bool = option("--boolean", default=True, required=False)
+        floating_point: float = option("--floating-point", default=1.1, required=False)
+        blob: bytes = option("--blob", default=b"foo", required=False)
+        blob32: bytes32 = option("--blob32", default=bytes32([1] * 32), required=False)
+        choice: str = option("--choice", default="a", type=click.Choice(["a", "b"]), required=False)
+
+        def run(self) -> None: ...
+
+    check_click_parsing(TempCMD())
+    check_click_parsing(
+        TempCMD(),
+        "--integer",
+        "1",
+        "--text",
+        "1",
+        "--boolean",
+        "true",
+        "--floating-point",
+        "1.1",
+        "--blob",
+        "0x666f6f",
+        "--blob32",
+        "0x0101010101010101010101010101010101010101010101010101010101010101",
+        "--choice",
+        "a",
+    )
+
+    # Test optional
+    @chia_command(cmd, "temp_cmd_optional", "blah")
+    class TempCMDOptional:
+        optional: Optional[int] = option("--optional", required=False)
+
+        def run(self) -> None: ...
+
+    check_click_parsing(TempCMDOptional(optional=None))
+    check_click_parsing(TempCMDOptional(optional=1), "--optional", "1")
+
+    # Test optional failure
+    with pytest.raises(TypeError):
+
+        @chia_command(cmd, "temp_cmd_optional_bad", "blah")
+        class TempCMDOptionalBad:
+            optional: Optional[int] = option("--optional")
+
+            def run(self) -> None: ...
+
+    with pytest.raises(TypeError):
+
+        @chia_command(cmd, "temp_cmd_optional_bad", "blah")
+        class TempCMDOptionalBad2:
+            optional: Optional[int] = option("--optional", required=True)
+
+            def run(self) -> None: ...
+
+    with pytest.raises(TypeError):
+
+        @chia_command(cmd, "temp_cmd_optional_bad", "blah")
+        class TempCMDOptionalBad3:
+            optional: Optional[int] = option("--optional", default="string", required=False)
+
+            def run(self) -> None: ...
+
+    @chia_command(cmd, "temp_cmd_optional_fine", "blah")
+    class TempCMDOptionalBad4:
+        optional: Optional[int] = option("--optional", default=None, required=False)
+
+        def run(self) -> None: ...
+
+    # Test multiple
+    @chia_command(cmd, "temp_cmd_sequence", "blah")
+    class TempCMDSequence:
+        sequence: Sequence[int] = option("--sequence", multiple=True)
+
+        def run(self) -> None: ...
+
+    check_click_parsing(TempCMDSequence(sequence=tuple()))
+    check_click_parsing(TempCMDSequence(sequence=(1, 2)), "--sequence", "1", "--sequence", "2")
+
+    # Test sequence failure
+    with pytest.raises(TypeError):
+
+        @chia_command(cmd, "temp_cmd_sequence_bad", "blah")
+        class TempCMDSequenceBad:
+            sequence: Sequence[int] = option("--sequence")
+
+            def run(self) -> None: ...
+
+    with pytest.raises(TypeError):
+
+        @chia_command(cmd, "temp_cmd_sequence_bad", "blah")
+        class TempCMDSequenceBad2:
+            sequence: int = option("--sequence", multiple=True)
+
+            def run(self) -> None: ...
+
+    with pytest.raises(ValueError):
+
+        @chia_command(cmd, "temp_cmd_sequence_bad", "blah")
+        class TempCMDSequenceBad3:
+            sequence: Sequence[int] = option("--sequence", default=[1, 2, 3], multiple=True)
+
+            def run(self) -> None: ...
+
+    with pytest.raises(TypeError):
+
+        @chia_command(cmd, "temp_cmd_sequence_bad", "blah")
+        class TempCMDSequenceBad4:
+            sequence: Sequence[int] = option("--sequence", default=(1, 2, "3"), multiple=True)
+
+            def run(self) -> None: ...
+
+    # Test invalid type
+    with pytest.raises(TypeError):
+
+        @chia_command(cmd, "temp_cmd_bad_type", "blah")
+        class TempCMDBadType:
+            sequence: List[int] = option("--sequence")
+
+            def run(self) -> None: ...
+
+    # Test invalid default
+    with pytest.raises(TypeError):
+
+        @chia_command(cmd, "temp_cmd_bad_default", "blah")
+        class TempCMDBadDefault:
+            integer: int = option("--int", default="string")
+
+            def run(self) -> None: ...
+
+    # Test bytes parsing
+    @chia_command(cmd, "temp_cmd_bad_bytes", "blah")
+    class TempCMDBadBytes:
+        blob: bytes = option("--blob", required=True)
+
+        def run(self) -> None: ...
+
+    @chia_command(cmd, "temp_cmd_bad_bytes32", "blah")
+    class TempCMDBadBytes32:
+        blob32: bytes32 = option("--blob32", required=True)
+
+        def run(self) -> None: ...
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cmd,
+        ["temp_cmd_bad_bytes", "--blob", "not a blob"],
+        catch_exceptions=False,
+    )
+    assert "not a valid hex string" in result.output
+
+    result = runner.invoke(
+        cmd,
+        ["temp_cmd_bad_bytes32", "--blob32", "0xdeadbeef"],
+        catch_exceptions=False,
+    )
+    assert "not a valid 32-byte hex string" in result.output
+
+
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="doesn't matter")
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [
+        {
+            "num_environments": 1,
+            "blocks_needed": [1],
+            "trusted": True,
+            "reuse_puzhash": False,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.anyio
+async def test_wallet_rpc_helper(wallet_environments: WalletTestFramework) -> None:
+    port: int = wallet_environments.environments[0].rpc_client.port
+
+    assert wallet_environments.environments[0].node.logged_in_fingerprint is not None
+    fingerprint: int = wallet_environments.environments[0].node.logged_in_fingerprint
+
+    @click.group()
+    def cmd() -> None:
+        pass
+
+    @chia_command(cmd, "temp_cmd", "blah")
+    class TempCMD:
+        rpc_info: NeedsWalletRPC
+
+        def run(self) -> None:
+            pass
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cmd,
+        [
+            "temp_cmd",
+            "-wp",
+            str(port),
+            "-f",
+            str(fingerprint),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.output == ""
+
+    result = runner.invoke(
+        cmd,
+        [
+            "temp_cmd",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.output == ""
+
+    expected_command = TempCMD(
+        rpc_info=NeedsWalletRPC(
+            context={"root_path": wallet_environments.environments[0].node.root_path},
+            wallet_rpc_port=port,
+            fingerprint=fingerprint,
+        ),
+    )
+    check_click_parsing(expected_command, "-wp", str(port), "-f", str(fingerprint))
+
+    async with expected_command.rpc_info.wallet_rpc(consume_errors=False) as client_info:
+        assert await client_info.client.get_logged_in_fingerprint() == fingerprint

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -166,7 +166,7 @@ def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
                 needs_context = True
                 kwarg_names.append(field_name)
         elif "option_args" in _field.metadata:
-            option_args: Dict[str, Any] = {"multiple": False}
+            option_args: Dict[str, Any] = {"multiple": False, "required": False}
             option_args.update(_field.metadata["option_args"])
 
             if "type" not in option_args:
@@ -187,7 +187,7 @@ def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
                 elif option_args["multiple"]:
                     raise TypeError("Options with multiple=True must be Sequence[T]")
                 elif is_type_SpecificOptional(hints[field_name]):
-                    if "required" not in option_args or option_args["required"]:
+                    if option_args["required"]:
                         raise TypeError("Optional only allowed for options with required=False")
                     type_arg = get_args(hints[field_name])[0]
                     if "default" in option_args and (

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -98,7 +98,7 @@ class _CommandParsingStage:
         if self._needs_context:
             return True
         else:
-            return any([subclass.needs_context() for subclass in self.my_subclasses.values()])
+            return any(subclass.needs_context() for subclass in self.my_subclasses.values())
 
     def get_all_option_decorators(self) -> List[Callable[[SyncCmd], SyncCmd]]:
         all_option_decorators: List[Callable[[SyncCmd], SyncCmd]] = self.my_option_decorators

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -32,7 +32,7 @@ from chia.util.streamable import is_type_SpecificOptional
 
 SyncCmd = Callable[..., None]
 
-COMMAND_HELPER_ATTRIBUTE_NAME = "__command_helper__"
+COMMAND_HELPER_ATTRIBUTE_NAME = "_is_command_helper"
 
 
 class SyncChiaCommand(Protocol):

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -150,17 +150,13 @@ def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
         field_name = _field.name
         if getattr(hints[field_name], COMMAND_HELPER_ATTRIBUTE_NAME, False):
             subclasses[field_name] = _generate_command_parser(hints[field_name])
-        else:
-            if field_name == "context":
-                if hints[field_name] != Context:
-                    raise ValueError("only Context can be the hint for variables named 'context'")
-                else:
-                    needs_context = True
-                    kwarg_names.append(field_name)
-                    continue
-
-            if "option_args" not in _field.metadata:
-                continue
+        elif field_name == "context":
+            if hints[field_name] != Context:
+                raise ValueError("only Context can be the hint for variables named 'context'")
+            else:
+                needs_context = True
+                kwarg_names.append(field_name)
+        elif "option_args" in _field.metadata:
             option_args = _field.metadata["option_args"]
 
             if "type" not in option_args:

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -157,12 +157,13 @@ def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
                 needs_context = True
                 kwarg_names.append(field_name)
         elif "option_args" in _field.metadata:
-            option_args = _field.metadata["option_args"]
+            option_args: Dict[str, Any] = {"multiple": False}
+            option_args.update(_field.metadata["option_args"])
 
             if "type" not in option_args:
                 origin = get_origin(hints[field_name])
                 if origin == collections.abc.Sequence:
-                    if "multiple" not in option_args or not option_args["multiple"]:
+                    if not option_args["multiple"]:
                         raise TypeError("Can only use Sequence with multiple=True")
                     else:
                         type_arg = get_args(hints[field_name])[0]
@@ -174,7 +175,7 @@ def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
                                 f"Default {option_args['default']} is not a tuple "
                                 f"or all of its elements are not of type {type_arg}"
                             )
-                elif "multiple" in option_args:
+                elif option_args["multiple"]:
                     raise TypeError("Options with multiple=True must be Sequence[T]")
                 elif is_type_SpecificOptional(hints[field_name]):
                     if "required" not in option_args or option_args["required"]:

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -146,11 +146,7 @@ def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
 
     for _field in _fields:
         field_name = _field.name
-        if (
-            isinstance(hints[field_name], type)
-            and hasattr(hints[field_name], "__command_helper__")
-            and hints[field_name].__command_helper__
-        ):
+        if hasattr(hints[field_name], "__command_helper__") and hints[field_name].__command_helper__:
             subclasses[field_name] = _generate_command_parser(hints[field_name])
         else:
             if field_name == "context":

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -70,8 +70,8 @@ class HexString(click.ParamType):
             return value
         try:
             return hexstr_to_bytes(value)
-        except ValueError:
-            self.fail(f"{value} is not a valid hex string", param, ctx)
+        except ValueError as e:
+            self.fail(f"not a valid hex string: {value!r} ({e})", param, ctx)
 
 
 class HexString32(click.ParamType):
@@ -82,8 +82,8 @@ class HexString32(click.ParamType):
             return value
         try:
             return bytes32.from_hexstr(value)
-        except ValueError:
-            self.fail(f"{value} is not a valid 32-byte hex string", param, ctx)
+        except ValueError as e:
+            self.fail(f"not a valid 32-byte hex string: {value!r} ({e})", param, ctx)
 
 
 @dataclass(frozen=True)

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -148,7 +148,7 @@ def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
 
     for _field in _fields:
         field_name = _field.name
-        if hasattr(hints[field_name], COMMAND_HELPER_ATTRIBUTE_NAME) and hints[field_name].__command_helper__:
+        if getattr(hints[field_name], COMMAND_HELPER_ATTRIBUTE_NAME, False):
             subclasses[field_name] = _generate_command_parser(hints[field_name])
         else:
             if field_name == "context":

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -88,6 +88,12 @@ class HexString32(click.ParamType):
             self.fail(f"not a valid 32-byte hex string: {value!r} ({e})", param, ctx)
 
 
+_CLASS_TYPES_TO_CLICK_TYPES = {
+    bytes: HexString(),
+    bytes32: HexString32(),
+}
+
+
 @dataclass
 class _CommandParsingStage:
     my_dataclass: Type[ChiaCommand]
@@ -197,10 +203,8 @@ def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
                 elif origin is not None:
                     raise TypeError(f"Type {origin} invalid as a click type")
                 else:
-                    if hints[field_name] == bytes:
-                        type_arg = HexString()
-                    elif hints[field_name] == bytes32:
-                        type_arg = HexString32()
+                    if hints[field_name] in _CLASS_TYPES_TO_CLICK_TYPES:
+                        type_arg = _CLASS_TYPES_TO_CLICK_TYPES[hints[field_name]]
                     else:
                         type_arg = hints[field_name]
                     if "default" in option_args and not isinstance(option_args["default"], hints[field_name]):

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -213,7 +213,7 @@ def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
                 click.option(
                     *option_args["param_decls"],
                     type=type_arg,
-                    **{k: v for k, v in option_args.items() if k not in ("param_decls", "is_command_option", "type")},
+                    **{k: v for k, v in option_args.items() if k not in ("param_decls", "type")},
                 )
             )
 

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -32,6 +32,8 @@ from chia.util.streamable import is_type_SpecificOptional
 
 SyncCmd = Callable[..., None]
 
+COMMAND_HELPER_ATTRIBUTE_NAME = "__command_helper__"
+
 
 class SyncChiaCommand(Protocol):
     def run(self) -> None: ...
@@ -146,7 +148,7 @@ def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
 
     for _field in _fields:
         field_name = _field.name
-        if hasattr(hints[field_name], "__command_helper__") and hints[field_name].__command_helper__:
+        if hasattr(hints[field_name], COMMAND_HELPER_ATTRIBUTE_NAME) and hints[field_name].__command_helper__:
             subclasses[field_name] = _generate_command_parser(hints[field_name])
         else:
             if field_name == "context":
@@ -267,7 +269,7 @@ def command_helper(cls: Type[Any]) -> Type[Any]:
         new_cls = dataclass(frozen=True)(cls)  # pragma: no cover
     else:
         new_cls = dataclass(frozen=True, kw_only=True)(cls)
-    setattr(new_cls, "__command_helper__", True)
+    setattr(new_cls, COMMAND_HELPER_ATTRIBUTE_NAME, True)
     return new_cls
 
 

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -14,6 +14,7 @@ from typing import (
     List,
     Optional,
     Protocol,
+    Tuple,
     Type,
     Union,
     get_args,
@@ -46,6 +47,15 @@ class AsyncChiaCommand(Protocol):
 ChiaCommand = Union[SyncChiaCommand, AsyncChiaCommand]
 
 
+@dataclass(frozen=True)
+class OptionArgs:
+    param_decls: Tuple[str, ...]
+    multiple: bool
+    required: bool
+    type: Optional[Any]
+    kwargs: Dict[str, Any]
+
+
 def option(*param_decls: str, **kwargs: Any) -> Any:
     if sys.version_info < (3, 10):  # versions < 3.10 don't know about kw_only and they complain about lacks of defaults
         # Can't get coverage on this because we only test on one version
@@ -55,9 +65,12 @@ def option(*param_decls: str, **kwargs: Any) -> Any:
 
     return field(  # pylint: disable=invalid-field-call
         metadata=dict(
-            option_args=dict(
+            option_args=OptionArgs(
                 param_decls=tuple(param_decls),
-                **kwargs,
+                multiple=kwargs.get("multiple", False),
+                required=kwargs.get("required", False),
+                type=kwargs.get("type", None),
+                kwargs=kwargs,
             ),
         ),
         default=kwargs.get("default", default_default),
@@ -172,34 +185,34 @@ def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
                 needs_context = True
                 kwarg_names.append(field_name)
         elif "option_args" in _field.metadata:
-            option_args: Dict[str, Any] = {"multiple": False, "required": False}
-            option_args.update(_field.metadata["option_args"])
+            option_args: OptionArgs = _field.metadata["option_args"]
 
-            if "type" not in option_args:
+            if option_args.type is None:
                 origin = get_origin(hints[field_name])
                 if origin == collections.abc.Sequence:
-                    if not option_args["multiple"]:
+                    if not option_args.multiple:
                         raise TypeError("Can only use Sequence with multiple=True")
                     else:
                         type_arg = get_args(hints[field_name])[0]
-                        if "default" in option_args and (
-                            not isinstance(option_args["default"], tuple)
-                            or any(not isinstance(item, type_arg) for item in option_args["default"])
+                        if "default" in option_args.kwargs and (
+                            not isinstance(option_args.kwargs["default"], tuple)
+                            or any(not isinstance(item, type_arg) for item in option_args.kwargs["default"])
                         ):
                             raise TypeError(
-                                f"Default {option_args['default']} is not a tuple "
+                                f"Default {option_args.kwargs['default']} is not a tuple "
                                 f"or all of its elements are not of type {type_arg}"
                             )
-                elif option_args["multiple"]:
+                elif option_args.multiple:
                     raise TypeError("Options with multiple=True must be Sequence[T]")
                 elif is_type_SpecificOptional(hints[field_name]):
-                    if option_args["required"]:
+                    if option_args.required:
                         raise TypeError("Optional only allowed for options with required=False")
                     type_arg = get_args(hints[field_name])[0]
-                    if "default" in option_args and (
-                        not isinstance(option_args["default"], type_arg) and option_args["default"] is not None
+                    if "default" in option_args.kwargs and (
+                        not isinstance(option_args.kwargs["default"], type_arg)
+                        and option_args.kwargs["default"] is not None
                     ):
-                        raise TypeError(f"Default {option_args['default']} is not type {type_arg} or None")
+                        raise TypeError(f"Default {option_args.kwargs['default']} is not type {type_arg} or None")
                 elif origin is not None:
                     raise TypeError(f"Type {origin} invalid as a click type")
                 else:
@@ -207,17 +220,19 @@ def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
                         type_arg = _CLASS_TYPES_TO_CLICK_TYPES[hints[field_name]]
                     else:
                         type_arg = hints[field_name]
-                    if "default" in option_args and not isinstance(option_args["default"], hints[field_name]):
-                        raise TypeError(f"Default {option_args['default']} is not type {type_arg}")
+                    if "default" in option_args.kwargs and not isinstance(
+                        option_args.kwargs["default"], hints[field_name]
+                    ):
+                        raise TypeError(f"Default {option_args.kwargs['default']} is not type {type_arg}")
             else:
-                type_arg = option_args["type"]
+                type_arg = option_args.type
 
             kwarg_names.append(field_name)
             option_decorators.append(
                 click.option(
-                    *option_args["param_decls"],
+                    *option_args.param_decls,
                     type=type_arg,
-                    **{k: v for k, v in option_args.items() if k not in ("param_decls", "type")},
+                    **{k: v for k, v in option_args.kwargs.items() if k not in ("param_decls", "type")},
                 )
             )
 

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import asyncio
+import collections
+import inspect
+import sys
+from contextlib import asynccontextmanager
+from dataclasses import MISSING, dataclass, field, fields
+from typing import (
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    Type,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+import click
+from typing_extensions import dataclass_transform
+
+from chia.cmds.cmds_util import get_wallet_client
+from chia.rpc.wallet_rpc_client import WalletRpcClient
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.byte_types import hexstr_to_bytes
+from chia.util.streamable import is_type_SpecificOptional
+
+SyncCmd = Callable[..., None]
+
+
+class SyncChiaCommand(Protocol):
+    def run(self) -> None: ...
+
+
+class AsyncChiaCommand(Protocol):
+    async def run(self) -> None: ...
+
+
+ChiaCommand = Union[SyncChiaCommand, AsyncChiaCommand]
+
+
+def option(*param_decls: str, **kwargs: Any) -> Any:
+    if sys.version_info < (3, 10):  # versions < 3.10 don't know about kw_only and they complain about lacks of defaults
+        # Can't get coverage on this because we only test on one version
+        default_default = None  # pragma: no cover
+    else:
+        default_default = MISSING
+
+    return field(  # pylint: disable=invalid-field-call
+        metadata=dict(
+            option_args=dict(
+                param_decls=tuple(param_decls),
+                **kwargs,
+            ),
+        ),
+        default=kwargs.get("default", default_default),
+    )
+
+
+class HexString(click.ParamType):
+    name = "hexstring"
+
+    def convert(self, value: str, param: Optional[click.Parameter], ctx: Optional[click.Context]) -> bytes:
+        if isinstance(value, bytes):  # This if is due to some poor handling on click's part
+            return value
+        try:
+            return hexstr_to_bytes(value)
+        except ValueError:
+            self.fail(f"{value} is not a valid hex string", param, ctx)
+
+
+class HexString32(click.ParamType):
+    name = "hexstring32"
+
+    def convert(self, value: str, param: Optional[click.Parameter], ctx: Optional[click.Context]) -> bytes32:
+        if isinstance(value, bytes32):  # This if is due to some poor handling on click's part
+            return value
+        try:
+            return bytes32.from_hexstr(value)
+        except ValueError:
+            self.fail(f"{value} is not a valid 32-byte hex string", param, ctx)
+
+
+@dataclass(frozen=True)
+class _CommandParsingStage:
+    my_dataclass: Type[ChiaCommand]
+    my_option_decorators: List[Callable[[SyncCmd], SyncCmd]]
+    my_subclasses: Dict[str, _CommandParsingStage]
+    my_kwarg_names: List[str]
+    _needs_context: bool
+
+    def needs_context(self) -> bool:
+        if self._needs_context:
+            return True
+        else:
+            return any([subclass.needs_context() for subclass in self.my_subclasses.values()])
+
+    def get_all_option_decorators(self) -> List[Callable[[SyncCmd], SyncCmd]]:
+        all_option_decorators: List[Callable[[SyncCmd], SyncCmd]] = self.my_option_decorators
+        for subclass in self.my_subclasses.values():
+            all_option_decorators.extend(subclass.get_all_option_decorators())
+        return all_option_decorators
+
+    def initialize_instance(self, **kwargs: Any) -> ChiaCommand:
+        kwargs_to_pass: Dict[str, Any] = {}
+        for kwarg_name in self.my_kwarg_names:
+            kwargs_to_pass[kwarg_name] = kwargs[kwarg_name]
+
+        for subclass_arg_name, subclass in self.my_subclasses.items():
+            kwargs_to_pass[subclass_arg_name] = subclass.initialize_instance(**kwargs)
+
+        return self.my_dataclass(**kwargs_to_pass)
+
+    def apply_decorators(self, cmd: SyncCmd) -> SyncCmd:
+        cmd_to_return = cmd
+        if self.needs_context():
+
+            def strip_click_context(func: SyncCmd) -> SyncCmd:
+                def _inner(ctx: click.Context, **kwargs: Any) -> None:
+                    context: Dict[str, Any] = ctx.obj if ctx.obj is not None else {}
+                    func(context=context, **kwargs)
+
+                return _inner
+
+            cmd_to_return = click.pass_context(strip_click_context(cmd_to_return))
+
+        for decorator in self.get_all_option_decorators():
+            cmd_to_return = decorator(cmd_to_return)
+
+        return cmd_to_return
+
+
+def _generate_command_parser(cls: Type[ChiaCommand]) -> _CommandParsingStage:
+    option_decorators: List[Callable[[SyncCmd], SyncCmd]] = []
+    kwarg_names: List[str] = []
+    subclasses: Dict[str, _CommandParsingStage] = {}
+    needs_context: bool = False
+
+    hints = get_type_hints(cls)
+    _fields = fields(cls)  # type: ignore[arg-type]
+
+    for _field in _fields:
+        field_name = _field.name
+        if (
+            isinstance(hints[field_name], type)
+            and hasattr(hints[field_name], "__command_helper__")
+            and hints[field_name].__command_helper__
+        ):
+            subclasses[field_name] = _generate_command_parser(hints[field_name])
+        else:
+            if field_name == "context":
+                if hints[field_name] != Context:
+                    raise ValueError("only Context can be the hint for variables named 'context'")
+                else:
+                    needs_context = True
+                    kwarg_names.append(field_name)
+                    continue
+
+            if "option_args" not in _field.metadata:
+                continue
+            option_args = _field.metadata["option_args"]
+
+            if "type" not in option_args:
+                origin = get_origin(hints[field_name])
+                if origin == collections.abc.Sequence:
+                    if "multiple" not in option_args or not option_args["multiple"]:
+                        raise TypeError("Can only use Sequence with multiple=True")
+                    else:
+                        type_arg = get_args(hints[field_name])[0]
+                        if "default" in option_args and (
+                            not isinstance(option_args["default"], tuple)
+                            or any(not isinstance(item, type_arg) for item in option_args["default"])
+                        ):
+                            raise TypeError(
+                                f"Default {option_args['default']} is not a tuple "
+                                f"or all of its elements are not of type {type_arg}"
+                            )
+                elif "multiple" in option_args:
+                    raise TypeError("Options with multiple=True must be Sequence[T]")
+                elif is_type_SpecificOptional(hints[field_name]):
+                    if "required" not in option_args or option_args["required"]:
+                        raise TypeError("Optional only allowed for options with required=False")
+                    type_arg = get_args(hints[field_name])[0]
+                    if "default" in option_args and (
+                        not isinstance(option_args["default"], type_arg) and option_args["default"] is not None
+                    ):
+                        raise TypeError(f"Default {option_args['default']} is not type {type_arg} or None")
+                elif origin is not None:
+                    raise TypeError(f"Type {origin} invalid as a click type")
+                else:
+                    if hints[field_name] == bytes:
+                        type_arg = HexString()
+                    elif hints[field_name] == bytes32:
+                        type_arg = HexString32()
+                    else:
+                        type_arg = hints[field_name]
+                    if "default" in option_args and not isinstance(option_args["default"], hints[field_name]):
+                        raise TypeError(f"Default {option_args['default']} is not type {type_arg}")
+            else:
+                type_arg = option_args["type"]
+
+            kwarg_names.append(field_name)
+            option_decorators.append(
+                click.option(
+                    *option_args["param_decls"],
+                    type=type_arg,
+                    **{k: v for k, v in option_args.items() if k not in ("param_decls", "is_command_option", "type")},
+                )
+            )
+
+    return _CommandParsingStage(
+        my_dataclass=cls,
+        my_option_decorators=option_decorators,
+        my_subclasses=subclasses,
+        my_kwarg_names=kwarg_names,
+        _needs_context=needs_context,
+    )
+
+
+def _convert_class_to_function(cls: Type[ChiaCommand]) -> SyncCmd:
+    command_parser = _generate_command_parser(cls)
+
+    if inspect.iscoroutinefunction(cls.run):
+
+        async def async_base_cmd(*args: Any, **kwargs: Any) -> None:
+            await command_parser.initialize_instance(*args, **kwargs).run()  # type: ignore[misc]
+
+        def base_cmd(*args: Any, **kwargs: Any) -> None:
+            coro = async_base_cmd(*args, **kwargs)
+            assert coro is not None
+            asyncio.run(coro)
+
+    else:
+
+        def base_cmd(*args: Any, **kwargs: Any) -> None:
+            command_parser.initialize_instance(*args, **kwargs).run()
+
+    return command_parser.apply_decorators(base_cmd)
+
+
+@dataclass_transform()
+def chia_command(cmd: click.Group, name: str, help: str) -> Callable[[Type[ChiaCommand]], Type[ChiaCommand]]:
+    def _chia_command(cls: Type[ChiaCommand]) -> Type[ChiaCommand]:
+        # The type ignores here are largely due to the fact that the class information is not preserved after being
+        # passed through the dataclass wrapper.  Not sure what to do about this right now.
+        if sys.version_info < (3, 10):  # pragma: no cover
+            # stuff below 3.10 doesn't know about kw_only
+            wrapped_cls: Type[ChiaCommand] = dataclass(  # type: ignore[assignment]
+                frozen=True,
+            )(cls)
+        else:
+            wrapped_cls: Type[ChiaCommand] = dataclass(  # type: ignore[assignment]
+                frozen=True,
+                kw_only=True,
+            )(cls)
+
+        cmd.command(name, help=help)(_convert_class_to_function(wrapped_cls))
+        return wrapped_cls
+
+    return _chia_command
+
+
+@dataclass_transform()
+def command_helper(cls: Type[Any]) -> Type[Any]:
+    if sys.version_info < (3, 10):  # stuff below 3.10 doesn't support kw_only
+        new_cls = dataclass(frozen=True)(cls)  # pragma: no cover
+    else:
+        new_cls = dataclass(frozen=True, kw_only=True)(cls)
+    setattr(new_cls, "__command_helper__", True)
+    return new_cls
+
+
+Context = Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class WalletClientInfo:
+    client: WalletRpcClient
+    fingerprint: int
+    config: Dict[str, Any]
+
+
+@command_helper
+class NeedsWalletRPC:
+    context: Context = field(default_factory=dict)  # pylint: disable=invalid-field-call
+    client_info: Optional[WalletClientInfo] = None
+    wallet_rpc_port: Optional[int] = option(
+        "-wp",
+        "--wallet-rpc_port",
+        help=(
+            "Set the port where the Wallet is hosting the RPC interface."
+            "See the rpc_port under wallet in config.yaml."
+        ),
+        type=int,
+        default=None,
+    )
+    fingerprint: Optional[int] = option(
+        "-f",
+        "--fingerprint",
+        help="Fingerprint of the wallet to use",
+        type=int,
+        default=None,
+    )
+
+    @asynccontextmanager
+    async def wallet_rpc(self, **kwargs: Any) -> AsyncIterator[WalletClientInfo]:
+        if self.client_info is not None:
+            yield self.client_info
+        else:
+            if "root_path" not in kwargs:
+                kwargs["root_path"] = self.context["root_path"]  # pylint: disable=unsubscriptable-object
+            async with get_wallet_client(self.wallet_rpc_port, self.fingerprint, **kwargs) as (
+                wallet_client,
+                fp,
+                config,
+            ):
+                yield WalletClientInfo(wallet_client, fp, config)


### PR DESCRIPTION
This PR creates a new optional framework with which to make commands.  The idea is to separate the testing of argument parsing from strings and the testing of the actual functionality underneath.

Right now it is impossible to use commands as the top of our integration tests because click + async don't go very well together.  This removes click from the equation.  You can instead create an instance of the underlying command class and use its `.run()` method to simulate user input in tests.