### PR TITLE
Fix memo plotid

### DIFF
--- a/chia/plotting/create_plots.py
+++ b/chia/plotting/create_plots.py
@@ -215,7 +215,7 @@ async def create_plots(
                 plot_str = args.plotid.hex()  # Convert bytes to hex string
             else:
                 plot_str = args.plotid
-            plot_id = bytes32(bytes.fromhex(plot_str))
+            plot_id = bytes.fromhex(plot_str)
 
         if args.memo is not None:
             print(f"Type of args.memo: {type(args.memo)}")  # Should print: <class 'str'>
@@ -225,7 +225,7 @@ async def create_plots(
                 memo_str = args.memo.hex()  # Convert bytes to hex string
             else:
                 memo_str = args.memo
-            plot_memo = bytes32.fromhex(memo_str)
+            plot_memo = bytes.fromhex(memo_str)
 
         dt_string = datetime.now().strftime("%Y-%m-%d-%H-%M")
 

--- a/chia/plotting/create_plots.py
+++ b/chia/plotting/create_plots.py
@@ -202,7 +202,7 @@ async def create_plots(
         # The plot id is based on the harvester, farmer, and pool keys
         if keys.pool_public_key is not None:
             plot_id: bytes32 = calculate_plot_id_pk(keys.pool_public_key, plot_public_key)
-            plot_memo: stream_plot_info_pk(keys.pool_public_key, keys.farmer_public_key, sk)
+            plot_memo: bytes32 = stream_plot_info_pk(keys.pool_public_key, keys.farmer_public_key, sk)
         else:
             assert keys.pool_contract_puzzle_hash is not None
             plot_id = calculate_plot_id_ph(keys.pool_contract_puzzle_hash, plot_public_key)

--- a/chia/plotting/create_plots.py
+++ b/chia/plotting/create_plots.py
@@ -215,7 +215,7 @@ async def create_plots(
                 plot_str = args.plotid.hex()  # Convert bytes to hex string
             else:
                 plot_str = args.plotid
-            plot_id = bytes.fromhex(plot_str)
+            plot_id = bytes32.fromhex(plot_str)
 
         if args.memo is not None:
             print(f"Type of args.memo: {type(args.memo)}")  # Should print: <class 'str'>

--- a/chia/plotting/create_plots.py
+++ b/chia/plotting/create_plots.py
@@ -210,11 +210,22 @@ async def create_plots(
 
         if args.plotid is not None:
             log.info(f"Debug plot ID: {args.plotid}")
-            plot_id = bytes32(bytes.fromhex(args.plotid))
+            # Check if args.memo is of type bytes and convert it to a string if so
+            if isinstance(args.plotid, bytes):
+                plot_str = args.plotid.hex()  # Convert bytes to hex string
+            else:
+                plot_str = args.plotid
+            plot_id = bytes32(bytes.fromhex(plot_str))
 
         if args.memo is not None:
+            print(f"Type of args.memo: {type(args.memo)}")  # Should print: <class 'str'>
             log.info(f"Debug memo: {args.memo}")
-            plot_memo = bytes32.fromhex(args.memo)
+            # Check if args.memo is of type bytes and convert it to a string if so
+            if isinstance(args.memo, bytes):
+                memo_str = args.memo.hex()  # Convert bytes to hex string
+            else:
+                memo_str = args.memo
+            plot_memo = bytes32.fromhex(memo_str)
 
         dt_string = datetime.now().strftime("%Y-%m-%d-%H-%M")
 

--- a/chia/plotting/create_plots.py
+++ b/chia/plotting/create_plots.py
@@ -202,7 +202,7 @@ async def create_plots(
         # The plot id is based on the harvester, farmer, and pool keys
         if keys.pool_public_key is not None:
             plot_id: bytes32 = calculate_plot_id_pk(keys.pool_public_key, plot_public_key)
-            plot_memo: bytes32 = stream_plot_info_pk(keys.pool_public_key, keys.farmer_public_key, sk)
+            plot_memo: stream_plot_info_pk(keys.pool_public_key, keys.farmer_public_key, sk)
         else:
             assert keys.pool_contract_puzzle_hash is not None
             plot_id = calculate_plot_id_ph(keys.pool_contract_puzzle_hash, plot_public_key)
@@ -218,7 +218,6 @@ async def create_plots(
             plot_id = bytes32.fromhex(plot_str)
 
         if args.memo is not None:
-            print(f"Type of args.memo: {type(args.memo)}")  # Should print: <class 'str'>
             log.info(f"Debug memo: {args.memo}")
             # Check if args.memo is of type bytes and convert it to a string if so
             if isinstance(args.memo, bytes):

--- a/chia/plotting/create_plots.py
+++ b/chia/plotting/create_plots.py
@@ -202,7 +202,7 @@ async def create_plots(
         # The plot id is based on the harvester, farmer, and pool keys
         if keys.pool_public_key is not None:
             plot_id: bytes32 = calculate_plot_id_pk(keys.pool_public_key, plot_public_key)
-            plot_memo: bytes32 = stream_plot_info_pk(keys.pool_public_key, keys.farmer_public_key, sk)
+            plot_memo: bytes = stream_plot_info_pk(keys.pool_public_key, keys.farmer_public_key, sk)
         else:
             assert keys.pool_contract_puzzle_hash is not None
             plot_id = calculate_plot_id_ph(keys.pool_contract_puzzle_hash, plot_public_key)

--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -258,10 +258,10 @@ def parse_plot_info(memo: bytes) -> Tuple[Union[G1Element, bytes32], G1Element, 
 
 
 def stream_plot_info_pk(
-        pool_public_key: G1Element,
-        farmer_public_key: G1Element,
-        local_master_sk: PrivateKey,
-) -> object:
+    pool_public_key: G1Element,
+    farmer_public_key: G1Element,
+    local_master_sk: PrivateKey,
+):
     # There are two ways to stream plot info: with a pool public key, or with a pool contract puzzle hash.
     # This one streams the public key, into bytes
     data = bytes(pool_public_key) + bytes(farmer_public_key) + bytes(local_master_sk)

--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -258,10 +258,10 @@ def parse_plot_info(memo: bytes) -> Tuple[Union[G1Element, bytes32], G1Element, 
 
 
 def stream_plot_info_pk(
-    pool_public_key: G1Element,
-    farmer_public_key: G1Element,
-    local_master_sk: PrivateKey,
-):
+        pool_public_key: G1Element,
+        farmer_public_key: G1Element,
+        local_master_sk: PrivateKey,
+) -> object:
     # There are two ways to stream plot info: with a pool public key, or with a pool contract puzzle hash.
     # This one streams the public key, into bytes
     data = bytes(pool_public_key) + bytes(farmer_public_key) + bytes(local_master_sk)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Fixes issues where "chia plotters" command is returning bytes and causing type issues. This also removed the bytes32 for the hex arg, which is 128 bytes.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Created and duplicated plots using the plot ID and memo using "chia plots create" and "chia plotters chiapos"


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
