### PR TITLE
Added `--skip-keyring` option to `chia start xxx` command

### DIFF
--- a/chia/_tests/cmds/config.py
+++ b/chia/_tests/cmds/config.py
@@ -1,3 +1,4 @@
 from __future__ import annotations
 
 checkout_blocks_and_plots = True
+parallel = False

--- a/chia/_tests/cmds/config.py
+++ b/chia/_tests/cmds/config.py
@@ -1,4 +1,3 @@
 from __future__ import annotations
 
 checkout_blocks_and_plots = True
-parallel = False

--- a/chia/_tests/cmds/test_daemon.py
+++ b/chia/_tests/cmds/test_daemon.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
+from _pytest.capture import CaptureFixture
 from pytest_mock import MockerFixture
 
 from chia.cmds.start_funcs import create_start_daemon_connection
@@ -11,13 +10,13 @@ from chia.simulator.block_tools import BlockTools
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("skip_keyring", [False, True])
-async def test_daemon(skip_keyring: bool, mocker: MockerFixture, bt: BlockTools, capsys: Any) -> None:
+async def test_daemon(skip_keyring: bool, mocker: MockerFixture, bt: BlockTools, capsys: CaptureFixture[str]) -> None:
     mocker.patch("sys.argv", ["chia", "start", "daemon"])
     daemon = await create_start_daemon_connection(bt.root_path, bt.config, skip_keyring=skip_keyring)
     assert daemon is not None
     captured = capsys.readouterr()
     assert captured.err == ""
     if skip_keyring:
-        assert captured.out == "Daemon not started yet\nStarting daemon\nSkipping to unlock keyring\n"
+        assert captured.out.endswith("Skipping to unlock keyring\n")
     else:
-        assert captured.out == "Daemon not started yet\nStarting daemon\n"
+        assert not captured.out.endswith("Skipping to unlock keyring\n")

--- a/chia/_tests/cmds/test_daemon.py
+++ b/chia/_tests/cmds/test_daemon.py
@@ -18,10 +18,6 @@ async def test_daemon(skip_keyring: bool, mocker: MockerFixture, capsys: Capture
         async def is_keyring_locked() -> bool:
             return False
 
-        @staticmethod
-        async def unlock_keyring() -> None:
-            return None
-
     async def connect_to_daemon_and_validate(_root_path: Path, _config: Dict[str, Any]) -> DummyConnection:
         return DummyConnection()
 

--- a/chia/_tests/cmds/test_daemon.py
+++ b/chia/_tests/cmds/test_daemon.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import pytest
 from _pytest.capture import CaptureFixture
 from pytest_mock import MockerFixture
@@ -12,6 +14,11 @@ from chia.simulator.block_tools import BlockTools
 @pytest.mark.parametrize("skip_keyring", [False, True])
 async def test_daemon(skip_keyring: bool, mocker: MockerFixture, bt: BlockTools, capsys: CaptureFixture[str]) -> None:
     mocker.patch("sys.argv", ["chia", "start", "daemon"])
+
+    def get_current_passphrase() -> Optional[str]:
+        return "some-passphrase"
+
+    mocker.patch("chia.cmds.passphrase_funcs.get_current_passphrase", side_effect=get_current_passphrase)
     daemon = await create_start_daemon_connection(bt.root_path, bt.config, skip_keyring=skip_keyring)
     assert daemon is not None
     captured = capsys.readouterr()

--- a/chia/_tests/cmds/test_daemon.py
+++ b/chia/_tests/cmds/test_daemon.py
@@ -13,7 +13,7 @@ from chia.simulator.block_tools import BlockTools
 @pytest.mark.parametrize("skip_keyring", [False, True])
 async def test_daemon(skip_keyring: bool, mocker: MockerFixture, bt: BlockTools, capsys: Any) -> None:
     mocker.patch("sys.argv", ["chia", "start", "daemon"])
-    daemon = await create_start_daemon_connection(bt.root_path, bt.config, skip_keyring)
+    daemon = await create_start_daemon_connection(bt.root_path, bt.config, skip_keyring=skip_keyring)
     assert daemon is not None
     captured = capsys.readouterr()
     assert captured.err == ""

--- a/chia/_tests/cmds/test_daemon.py
+++ b/chia/_tests/cmds/test_daemon.py
@@ -11,7 +11,7 @@ from chia.simulator.block_tools import BlockTools
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("skip_keyring", [False, True])
-async def test_daemon(skip_keyring: bool, mocker: MockerFixture, bt: BlockTools, capsys: Any):
+async def test_daemon(skip_keyring: bool, mocker: MockerFixture, bt: BlockTools, capsys: Any) -> None:
     mocker.patch("sys.argv", ["chia", "start", "daemon"])
     daemon = await create_start_daemon_connection(bt.root_path, bt.config, skip_keyring)
     assert daemon is not None

--- a/chia/_tests/cmds/test_daemon.py
+++ b/chia/_tests/cmds/test_daemon.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from chia.cmds.start_funcs import create_start_daemon_connection
+from chia.simulator.block_tools import BlockTools
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("skip_keyring", [False, True])
+async def test_daemon(skip_keyring: bool, mocker: MockerFixture, bt: BlockTools, capsys: Any):
+    mocker.patch("sys.argv", ["chia", "start", "daemon"])
+    daemon = await create_start_daemon_connection(bt.root_path, bt.config, skip_keyring)
+    assert daemon is not None
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    if skip_keyring:
+        assert captured.out == "Daemon not started yet\nStarting daemon\nSkipping to unlock keyring\n"
+    else:
+        assert captured.out == "Daemon not started yet\nStarting daemon\n"

--- a/chia/_tests/cmds/test_daemon.py
+++ b/chia/_tests/cmds/test_daemon.py
@@ -70,8 +70,8 @@ def test_start_daemon(tmp_path: Path, empty_keyring: Any, mocker: MockerFixture)
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["--root-path", tmp_path, "init"],
+        ["--root-path", str(tmp_path), "init"],
     )
     assert result.exit_code == 0
-    result = runner.invoke(cli, ["--root-path", tmp_path, "start", "daemon", "-s"])
+    result = runner.invoke(cli, ["--root-path", str(tmp_path), "start", "daemon", "-s"])
     assert result.exit_code == 0

--- a/chia/_tests/cmds/test_daemon.py
+++ b/chia/_tests/cmds/test_daemon.py
@@ -8,12 +8,11 @@ from _pytest.capture import CaptureFixture
 from pytest_mock import MockerFixture
 
 from chia.cmds.start_funcs import create_start_daemon_connection
-from chia.simulator.block_tools import BlockTools
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("skip_keyring", [False, True])
-async def test_daemon(skip_keyring: bool, mocker: MockerFixture, bt: BlockTools, capsys: CaptureFixture[str]) -> None:
+async def test_daemon(skip_keyring: bool, mocker: MockerFixture, capsys: CaptureFixture[str]) -> None:
     class DummyConnection:
         @staticmethod
         async def is_keyring_locked() -> bool:
@@ -28,7 +27,7 @@ async def test_daemon(skip_keyring: bool, mocker: MockerFixture, bt: BlockTools,
 
     mocker.patch("chia.cmds.start_funcs.connect_to_daemon_and_validate", side_effect=connect_to_daemon_and_validate)
 
-    daemon = await create_start_daemon_connection(bt.root_path, bt.config, skip_keyring=skip_keyring)
+    daemon = await create_start_daemon_connection(Path("/path-not-exist"), {}, skip_keyring=skip_keyring)
     assert daemon is not None
     captured = capsys.readouterr()
     assert captured.err == ""

--- a/chia/_tests/cmds/test_daemon.py
+++ b/chia/_tests/cmds/test_daemon.py
@@ -1,27 +1,46 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pytest
 from _pytest.capture import CaptureFixture
+from click.testing import CliRunner
 from pytest_mock import MockerFixture
 
+from chia.cmds.chia import cli
 from chia.cmds.start_funcs import create_start_daemon_connection
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("skip_keyring", [False, True])
-async def test_daemon(skip_keyring: bool, mocker: MockerFixture, capsys: CaptureFixture[str]) -> None:
+@pytest.mark.parametrize("unlock_keyring", [False, True])
+async def test_daemon(
+    skip_keyring: bool, unlock_keyring: bool, mocker: MockerFixture, capsys: CaptureFixture[str]
+) -> None:
     class DummyConnection:
         @staticmethod
         async def is_keyring_locked() -> bool:
-            return False
+            return unlock_keyring
+
+        @staticmethod
+        async def unlock_keyring(_passphrase: str) -> bool:
+            return True
 
     async def connect_to_daemon_and_validate(_root_path: Path, _config: Dict[str, Any]) -> DummyConnection:
         return DummyConnection()
 
+    class DummyKeychain:
+        @staticmethod
+        def get_cached_master_passphrase() -> Optional[str]:
+            return None
+
+    def get_current_passphrase() -> Optional[str]:
+        return "a-passphrase"
+
     mocker.patch("chia.cmds.start_funcs.connect_to_daemon_and_validate", side_effect=connect_to_daemon_and_validate)
+    mocker.patch("chia.cmds.start_funcs.Keychain", new=DummyKeychain)
+    mocker.patch("chia.cmds.start_funcs.get_current_passphrase", side_effect=get_current_passphrase)
 
     daemon = await create_start_daemon_connection(Path("/path-not-exist"), {}, skip_keyring=skip_keyring)
     assert daemon is not None
@@ -31,3 +50,28 @@ async def test_daemon(skip_keyring: bool, mocker: MockerFixture, capsys: Capture
         assert captured.out.endswith("Skipping to unlock keyring\n")
     else:
         assert not captured.out.endswith("Skipping to unlock keyring\n")
+
+
+def test_start_daemon(tmp_path: Path, empty_keyring: Any, mocker: MockerFixture) -> None:
+    class DummyDaemon:
+        @staticmethod
+        async def close() -> None:
+            return None
+
+    async def create_start_daemon_connection_dummy(
+        root_path: Path, config: Dict[str, Any], *, skip_keyring: bool
+    ) -> DummyDaemon:
+        return DummyDaemon()
+
+    mocker.patch(
+        "chia.cmds.start_funcs.create_start_daemon_connection", side_effect=create_start_daemon_connection_dummy
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--root-path", tmp_path, "init"],
+    )
+    assert result.exit_code == 0
+    result = runner.invoke(cli, ["--root-path", tmp_path, "start", "daemon", "-s"])
+    assert result.exit_code == 0

--- a/chia/_tests/core/util/config.py
+++ b/chia/_tests/core/util/config.py
@@ -1,3 +1,4 @@
 from __future__ import annotations
 
 checkout_blocks_and_plots = True
+parallel = False

--- a/chia/cmds/sim_funcs.py
+++ b/chia/cmds/sim_funcs.py
@@ -291,7 +291,7 @@ async def async_config_wizard(
     print("Starting Simulator now...\n\n")
 
     sys.argv[0] = str(Path(sys.executable).parent / "chia")  # fix path for tests
-    await async_start(root_path, config, ("simulator",), False, False)
+    await async_start(root_path, config, ("simulator",), restart=False, skip_keyring=False)
 
     # now we make sure the simulator has a genesis block
     print("Please wait, generating genesis block.")

--- a/chia/cmds/sim_funcs.py
+++ b/chia/cmds/sim_funcs.py
@@ -291,7 +291,7 @@ async def async_config_wizard(
     print("Starting Simulator now...\n\n")
 
     sys.argv[0] = str(Path(sys.executable).parent / "chia")  # fix path for tests
-    await async_start(root_path, config, ("simulator",), False)
+    await async_start(root_path, config, ("simulator",), False, False)
 
     # now we make sure the simulator has a genesis block
     print("Please wait, generating genesis block.")

--- a/chia/cmds/start.py
+++ b/chia/cmds/start.py
@@ -21,4 +21,4 @@ def start_cmd(ctx: click.Context, restart: bool, skip_keyring: bool, group: tupl
     root_path = ctx.obj["root_path"]
     config = load_config(root_path, "config.yaml")
     warn_if_beta_enabled(config)
-    asyncio.run(async_start(root_path, config, group, restart, skip_keyring))
+    asyncio.run(async_start(root_path, config, group, restart, skip_keyring=skip_keyring))

--- a/chia/cmds/start.py
+++ b/chia/cmds/start.py
@@ -8,9 +8,10 @@ from chia.util.service_groups import all_groups
 
 @click.command("start", help="Start service groups")
 @click.option("-r", "--restart", is_flag=True, type=bool, help="Restart running services")
+@click.option("-s", "--skip-keyring", is_flag=True, type=bool, help="Skip to unlock keyring")
 @click.argument("group", type=click.Choice(list(all_groups())), nargs=-1, required=True)
 @click.pass_context
-def start_cmd(ctx: click.Context, restart: bool, group: tuple[str, ...]) -> None:
+def start_cmd(ctx: click.Context, restart: bool, skip_keyring: bool, group: tuple[str, ...]) -> None:
     import asyncio
 
     from chia.cmds.beta_funcs import warn_if_beta_enabled
@@ -20,4 +21,4 @@ def start_cmd(ctx: click.Context, restart: bool, group: tuple[str, ...]) -> None
     root_path = ctx.obj["root_path"]
     config = load_config(root_path, "config.yaml")
     warn_if_beta_enabled(config)
-    asyncio.run(async_start(root_path, config, group, restart))
+    asyncio.run(async_start(root_path, config, group, restart, skip_keyring))

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -31,7 +31,9 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
     return process
 
 
-async def create_start_daemon_connection(root_path: Path, config: Dict[str, Any]) -> Optional[DaemonProxy]:
+async def create_start_daemon_connection(
+    root_path: Path, config: Dict[str, Any], skip_keyring: bool
+) -> Optional[DaemonProxy]:
     connection = await connect_to_daemon_and_validate(root_path, config)
     if connection is None:
         print("Starting daemon")
@@ -44,24 +46,29 @@ async def create_start_daemon_connection(root_path: Path, config: Dict[str, Any]
         # it prints "daemon: listening"
         connection = await connect_to_daemon_and_validate(root_path, config)
     if connection:
-        passphrase = None
-        if await connection.is_keyring_locked():
-            passphrase = Keychain.get_cached_master_passphrase()
-            if passphrase is None or not Keychain.master_passphrase_is_valid(passphrase):
-                with ThreadPoolExecutor(max_workers=1, thread_name_prefix="get_current_passphrase") as executor:
-                    passphrase = await asyncio.get_running_loop().run_in_executor(executor, get_current_passphrase)
+        if skip_keyring:
+            print("Skipping to unlock keyring")
+        else:
+            passphrase = None
+            if await connection.is_keyring_locked():
+                passphrase = Keychain.get_cached_master_passphrase()
+                if passphrase is None or not Keychain.master_passphrase_is_valid(passphrase):
+                    with ThreadPoolExecutor(max_workers=1, thread_name_prefix="get_current_passphrase") as executor:
+                        passphrase = await asyncio.get_running_loop().run_in_executor(executor, get_current_passphrase)
 
-        if passphrase:
-            print("Unlocking daemon keyring")
-            await connection.unlock_keyring(passphrase)
+            if passphrase:
+                print("Unlocking daemon keyring")
+                await connection.unlock_keyring(passphrase)
 
         return connection
     return None
 
 
-async def async_start(root_path: Path, config: Dict[str, Any], group: tuple[str, ...], restart: bool) -> None:
+async def async_start(
+    root_path: Path, config: Dict[str, Any], group: tuple[str, ...], restart: bool, skip_keyring: bool
+) -> None:
     try:
-        daemon = await create_start_daemon_connection(root_path, config)
+        daemon = await create_start_daemon_connection(root_path, config, skip_keyring)
     except KeychainMaxUnlockAttempts:
         print("Failed to unlock keyring")
         return None

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -32,7 +32,7 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
 
 
 async def create_start_daemon_connection(
-    root_path: Path, config: Dict[str, Any], skip_keyring: bool
+    root_path: Path, config: Dict[str, Any], *, skip_keyring: bool
 ) -> Optional[DaemonProxy]:
     connection = await connect_to_daemon_and_validate(root_path, config)
     if connection is None:
@@ -65,10 +65,10 @@ async def create_start_daemon_connection(
 
 
 async def async_start(
-    root_path: Path, config: Dict[str, Any], group: tuple[str, ...], restart: bool, skip_keyring: bool
+    root_path: Path, config: Dict[str, Any], group: tuple[str, ...], restart: bool, *, skip_keyring: bool
 ) -> None:
     try:
-        daemon = await create_start_daemon_connection(root_path, config, skip_keyring)
+        daemon = await create_start_daemon_connection(root_path, config, skip_keyring=skip_keyring)
     except KeychainMaxUnlockAttempts:
         print("Failed to unlock keyring")
         return None


### PR DESCRIPTION
This PR fixes https://github.com/Chia-Network/chia-blockchain/issues/17848

When GUI starts up, it calls `chia start daemon`.
In some circumstance, the process of `chia start daemon` wait for user input and never exit.
(The circumstance: Enabled passphrase protection. Not storing passphrase to OS's credential store)

This PR adds `-s/--skip-keyring` option to `chia start daemon` which won't wait for user input for passphrase in the above circumstance.

Todo:
- Update GUI to launch daemon by `chia start daemon --skip-keyring`