### PR TITLE
Run core util tests sequential

### DIFF
--- a/chia/_tests/core/util/config.py
+++ b/chia/_tests/core/util/config.py
@@ -1,3 +1,4 @@
 from __future__ import annotations
 
 checkout_blocks_and_plots = True
+parallel = False


### PR DESCRIPTION
### Purpose:

These tests appear to be failing consistently on python 3.12 when run in parallel.

### Current Behavior:

core.util tests run in parallel

### New Behavior:

core.util tests run sequentially

### Testing Notes:

Example of failure: https://github.com/Chia-Network/chia-blockchain/actions/runs/8673266545/job/23849589076?pr=17857