### PR TITLE
Trusted wallet peer enhancements

### DIFF
--- a/chia/cmds/peer_funcs.py
+++ b/chia/cmds/peer_funcs.py
@@ -102,6 +102,8 @@ async def print_connections(rpc_client: RpcClient, trusted_peers: Dict[str, Any]
                 f"{last_connect}  "
                 f"{mb_up:7.1f}|{mb_down:<7.1f}"
             )
+            if trusted:
+                con_str += f"    -Trusted: {trusted}"
         print(con_str)
 
 

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -92,7 +92,7 @@ class PeerSubscriptions:
         added: Set[bytes32] = set()
 
         def limit_reached() -> Set[bytes32]:
-            log.info(
+            log.warning(
                 "Peer %s attempted to exceed the subscription limit while adding puzzle subscriptions.",
                 peer_id,
             )

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -92,7 +92,7 @@ class PeerSubscriptions:
         added: Set[bytes32] = set()
 
         def limit_reached() -> Set[bytes32]:
-            log.warning(
+            log.info(
                 "Peer %s attempted to exceed the subscription limit while adding puzzle subscriptions.",
                 peer_id,
             )


### PR DESCRIPTION
### Purpose:

Recently, the SpaceFamers pool encountered significant difficulties in maintaining wallet integrity. Over time, it gradually lost track of coins. The wallet's peer ID had been incorporated into the node configuration, rendering it trusted. However, due to an unknown cause, the incorrect peer ID was configured. It took us a considerable amount of time to identify the root of the issue.

This pull request aims to enhance the experience for farmers who also operate wallets with substantial coin holdings while being limited by the node without clear indication.

### Current Behavior:

Neither the wallet nor the node notifies the user when limits have been reached. Additionally, the wallet is not marked as trusted in the `chia peer full_node -c` CLI command. Consequently, there is currently no method to verify if a trusted peer has been configured accurately.

### New Behavior:

This pull request indicates the peer as trusted, confirming the success of the configuration update. Additionally, it prompts a warning in the node log when subscription limits are exceeded. Perhaps there are better ways to warn the user (eg. in the wallet log), I'm looking forward to any suggestions. 

![Screenshot](https://github.com/Chia-Network/chia-blockchain/assets/97022238/c5abae32-67a4-47c0-9642-e3088c26564d)
