### PR TITLE
Run core util tests in parallel

### DIFF
--- a/chia/_tests/core/util/config.py
+++ b/chia/_tests/core/util/config.py
@@ -1,4 +1,3 @@
 from __future__ import annotations
 
 checkout_blocks_and_plots = True
-parallel = False


### PR DESCRIPTION
This reverts f77ca01 as PR #17871 addresses an issue that manifests only when running with python 3.12, which is not currently covered by main's CI.