### PR TITLE
Skip problem test_every_simulator_command 

### DIFF
--- a/chia/_tests/cmds/test_sim.py
+++ b/chia/_tests/cmds/test_sim.py
@@ -31,6 +31,7 @@ def get_profile_path(starting_string: str) -> str:
     return starting_string + str(i)
 
 
+@pytest.mark.skip("TODO: Fix this - hangs often in CI - root cause unknown")
 def test_every_simulator_command() -> None:
     starting_str = "ci_test"
     simulator_name = get_profile_path(starting_str)


### PR DESCRIPTION
Skip test that often hangs (~16% of the time on some platforms).