### PR TITLE
move shfmt execution from the super linter to pre-commit

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -73,7 +73,6 @@ jobs:
           VALIDATE_JSON: true
           VALIDATE_MD: true
           VALIDATE_POWERSHELL: true
-          VALIDATE_SHELL_SHFMT: true
           VALIDATE_TYPESCRIPT_ES: true
           VALIDATE_YAML: true
           DISABLE_ERRORS: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,11 @@ repos:
     hooks:
       - id: prettier
         types_or: [ini, json, toml, yaml]
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.8.0-1
+    hooks:
+      - id: shfmt
+        args: ["-i", "2"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     rev: v3.8.0-1
     hooks:
       - id: shfmt
-        args: ["-i", "2"]
+        args: ["--diff", "--write", "-i", "2"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/activated.sh
+++ b/activated.sh
@@ -2,7 +2,10 @@
 
 set -o errexit
 
-SCRIPT_DIRECTORY=$(cd -- "$(dirname -- "$0")"; pwd)
+SCRIPT_DIRECTORY=$(
+  cd -- "$(dirname -- "$0")"
+  pwd
+)
 # shellcheck disable=SC1091
 . "${SCRIPT_DIRECTORY}/venv/bin/activate"
 

--- a/build_scripts/build_license_directory.sh
+++ b/build_scripts/build_license_directory.sh
@@ -13,21 +13,20 @@ printf "%s\n" "$sum"
 license_list=$(license-checker --json | jq -r '.[].licenseFile' | grep -v null)
 
 # Split the license list by newline character into an array
-IFS=$'\n' read -rd '' -a licenses_array <<< "$license_list"
+IFS=$'\n' read -rd '' -a licenses_array <<<"$license_list"
 
 #print the contents of the array
 printf '%s\n' "${licenses_array[@]}"
 
 for i in "${licenses_array[@]}"; do
-    dirname="licenses/$(dirname "$i" | awk -F'/' '{print $NF}')"
-    mkdir -p "$dirname"
-    echo "$dirname"
-    cp "$i" "$dirname"
+  dirname="licenses/$(dirname "$i" | awk -F'/' '{print $NF}')"
+  mkdir -p "$dirname"
+  echo "$dirname"
+  cp "$i" "$dirname"
 done
 
 mv licenses/ ../build_scripts/dist/daemon
 cd ../build_scripts || exit 1
-
 
 # PULL IN THE LICENSES FROM PIP-LICENSE
 pip install pip-licenses || pip3 install pip-licenses
@@ -40,8 +39,8 @@ license_path_array=()
 
 # read the output line by line into the array
 while IFS= read -r line; do
-    license_path_array+=("$line")
-done <<< "$output"
+  license_path_array+=("$line")
+done <<<"$output"
 
 # create a dir for each license and copy the license file over
 for i in "${license_path_array[@]}"; do

--- a/build_scripts/build_linux_deb-1-gui.sh
+++ b/build_scripts/build_linux_deb-1-gui.sh
@@ -19,8 +19,8 @@ npm ci
 npm run build
 LAST_EXIT_CODE=$?
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then
-	echo >&2 "npm run build failed!"
-	exit $LAST_EXIT_CODE
+  echo >&2 "npm run build failed!"
+  exit $LAST_EXIT_CODE
 fi
 
 # Remove unused packages
@@ -40,8 +40,8 @@ rm -rf packages/wallets
 cd ./packages/gui/node_modules || exit 1
 echo "Remove unused node_modules in the gui package to make cache slim more"
 rm -rf electron/dist # ~186MB
-rm -rf "@mui" # ~71MB
-rm -rf typescript # ~63MB
+rm -rf "@mui"        # ~71MB
+rm -rf typescript    # ~63MB
 
 # Remove `packages/gui/node_modules/@chia-network` because it causes an error on later `electron-packager` command
 rm -rf "@chia-network"

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -4,11 +4,11 @@ set -o errexit
 
 if [ ! "$1" ]; then
   echo "This script requires either amd64 of arm64 as an argument"
-	exit 1
+  exit 1
 elif [ "$1" = "amd64" ]; then
-	PLATFORM="amd64"
+  PLATFORM="amd64"
 else
-	PLATFORM="arm64"
+  PLATFORM="arm64"
 fi
 export PLATFORM
 
@@ -19,8 +19,8 @@ git submodule
 # set, this will attempt to Notarize the signed DMG
 
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
-	echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
-	CHIA_INSTALLER_VERSION="0.0.0"
+  echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
+  CHIA_INSTALLER_VERSION="0.0.0"
 fi
 echo "Chia Installer Version is: $CHIA_INSTALLER_VERSION"
 export CHIA_INSTALLER_VERSION
@@ -39,15 +39,14 @@ SPEC_FILE=$(python -c 'import sys; from pathlib import Path; path = Path(sys.arg
 pyinstaller --log-level=INFO "$SPEC_FILE"
 LAST_EXIT_CODE=$?
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then
-	echo >&2 "pyinstaller failed!"
-	exit $LAST_EXIT_CODE
+  echo >&2 "pyinstaller failed!"
+  exit $LAST_EXIT_CODE
 fi
 
 # Creates a directory of licenses
 echo "Building pip and NPM license directory"
 pwd
 bash ./build_license_directory.sh
-
 
 # Builds CLI only .deb
 # need j2 for templating the control file
@@ -64,7 +63,8 @@ mkdir -p "dist/$CLI_DEB_BASE/opt/chia"
 mkdir -p "dist/$CLI_DEB_BASE/usr/bin"
 mkdir -p "dist/$CLI_DEB_BASE/DEBIAN"
 mkdir -p "dist/$CLI_DEB_BASE/etc/systemd/system"
-CHIA_DEB_CONTROL_VERSION=$(format_deb_version_string "$CHIA_INSTALLER_VERSION"); export CHIA_DEB_CONTROL_VERSION
+CHIA_DEB_CONTROL_VERSION=$(format_deb_version_string "$CHIA_INSTALLER_VERSION")
+export CHIA_DEB_CONTROL_VERSION
 j2 -o "dist/$CLI_DEB_BASE/DEBIAN/control" assets/deb/control.j2
 cp assets/systemd/*.service "dist/$CLI_DEB_BASE/etc/systemd/system/"
 cp -r dist/daemon/* "dist/$CLI_DEB_BASE/opt/chia/"
@@ -80,7 +80,7 @@ cd ../chia-blockchain-gui/packages/gui || exit 1
 
 # sets the version for chia-blockchain in package.json
 cp package.json package.json.orig
-jq --arg VER "$CHIA_INSTALLER_VERSION" '.version=$VER' package.json > temp.json && mv temp.json package.json
+jq --arg VER "$CHIA_INSTALLER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
 
 echo "Building Linux(deb) Electron app"
 PRODUCT_NAME="chia"
@@ -126,8 +126,8 @@ ls -l dist/linux*-unpacked/resources
 mv package.json.orig package.json
 
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then
-	echo >&2 "electron-builder failed!"
-	exit $LAST_EXIT_CODE
+  echo >&2 "electron-builder failed!"
+  exit $LAST_EXIT_CODE
 fi
 
 GUI_DEB_NAME=chia-blockchain_${CHIA_INSTALLER_VERSION}_${PLATFORM}.deb

--- a/build_scripts/build_linux_rpm-1-gui.sh
+++ b/build_scripts/build_linux_rpm-1-gui.sh
@@ -18,8 +18,8 @@ npm ci
 npm run build
 LAST_EXIT_CODE=$?
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then
-	echo >&2 "npm run build failed!"
-	exit $LAST_EXIT_CODE
+  echo >&2 "npm run build failed!"
+  exit $LAST_EXIT_CODE
 fi
 
 # Remove unused packages
@@ -39,8 +39,8 @@ rm -rf packages/wallets
 cd ./packages/gui/node_modules || exit 1
 echo "Remove unused node_modules in the gui package to make cache slim more"
 rm -rf electron/dist # ~186MB
-rm -rf "@mui" # ~71MB
-rm -rf typescript # ~63MB
+rm -rf "@mui"        # ~71MB
+rm -rf typescript    # ~63MB
 
 # Remove `packages/gui/node_modules/@chia-network` because it causes an error on later `electron-packager` command
 rm -rf "@chia-network"

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -7,19 +7,19 @@ git submodule
 
 if [ ! "$1" ]; then
   echo "This script requires either amd64 of arm64 as an argument"
-	exit 1
+  exit 1
 elif [ "$1" = "amd64" ]; then
-	export REDHAT_PLATFORM="x86_64"
+  export REDHAT_PLATFORM="x86_64"
 else
-	export REDHAT_PLATFORM="arm64"
+  export REDHAT_PLATFORM="arm64"
 fi
 
 # If the env variable NOTARIZE and the username and password variables are
 # set, this will attempt to Notarize the signed DMG
 
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
-	echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
-	CHIA_INSTALLER_VERSION="0.0.0"
+  echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
+  CHIA_INSTALLER_VERSION="0.0.0"
 fi
 echo "Chia Installer Version is: $CHIA_INSTALLER_VERSION"
 
@@ -37,8 +37,8 @@ SPEC_FILE=$(python -c 'import sys; from pathlib import Path; path = Path(sys.arg
 pyinstaller --log-level=INFO "$SPEC_FILE"
 LAST_EXIT_CODE=$?
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then
-	echo >&2 "pyinstaller failed!"
-	exit $LAST_EXIT_CODE
+  echo >&2 "pyinstaller failed!"
+  exit $LAST_EXIT_CODE
 fi
 
 # Creates a directory of licenses
@@ -90,10 +90,10 @@ cd ../chia-blockchain-gui/packages/gui || exit 1
 
 # sets the version for chia-blockchain in package.json
 cp package.json package.json.orig
-jq --arg VER "$CHIA_INSTALLER_VERSION" '.version=$VER' package.json > temp.json && mv temp.json package.json
+jq --arg VER "$CHIA_INSTALLER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
 
 export FPM_EDITOR="cat >../../../build_scripts/dist/gui.spec <"
-jq '.rpm.fpm |= . + ["--edit"]' ../../../build_scripts/electron-builder.json > temp.json && mv temp.json ../../../build_scripts/electron-builder.json
+jq '.rpm.fpm |= . + ["--edit"]' ../../../build_scripts/electron-builder.json >temp.json && mv temp.json ../../../build_scripts/electron-builder.json
 
 echo "Building Linux(rpm) Electron app"
 OPT_ARCH="--x64"
@@ -118,8 +118,8 @@ ls -l dist/linux*-unpacked/resources
 mv package.json.orig package.json
 
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then
-	echo >&2 "electron-builder failed!"
-	exit $LAST_EXIT_CODE
+  echo >&2 "electron-builder failed!"
+  exit $LAST_EXIT_CODE
 fi
 
 GUI_RPM_NAME="chia-blockchain-${CHIA_INSTALLER_VERSION}-1.${REDHAT_PLATFORM}.rpm"

--- a/build_scripts/build_macos-1-gui.sh
+++ b/build_scripts/build_macos-1-gui.sh
@@ -19,8 +19,8 @@ npm ci
 npm run build
 LAST_EXIT_CODE=$?
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then
-	echo >&2 "npm run build failed!"
-	exit $LAST_EXIT_CODE
+  echo >&2 "npm run build failed!"
+  exit $LAST_EXIT_CODE
 fi
 
 # Remove unused packages
@@ -40,8 +40,8 @@ rm -rf packages/wallets
 cd ./packages/gui/node_modules || exit 1
 echo "Remove unused node_modules in the gui package to make cache slim more"
 rm -rf electron/dist # ~186MB
-rm -rf "@mui" # ~71MB
-rm -rf typescript # ~63MB
+rm -rf "@mui"        # ~71MB
+rm -rf typescript    # ~63MB
 
 # Remove `packages/gui/node_modules/@chia-network` because it causes an error on later `electron-packager` command
 rm -rf "@chia-network"

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -9,8 +9,8 @@ git submodule
 # set, this will attempt to Notarize the signed DMG.
 
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
-	echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
-	CHIA_INSTALLER_VERSION="0.0.0"
+  echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
+  CHIA_INSTALLER_VERSION="0.0.0"
 fi
 echo "Chia Installer Version is: $CHIA_INSTALLER_VERSION"
 
@@ -28,10 +28,9 @@ SPEC_FILE=$(python -c 'import sys; from pathlib import Path; path = Path(sys.arg
 pyinstaller --log-level=INFO "$SPEC_FILE"
 LAST_EXIT_CODE=$?
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then
-	echo >&2 "pyinstaller failed!"
-	exit $LAST_EXIT_CODE
+  echo >&2 "pyinstaller failed!"
+  exit $LAST_EXIT_CODE
 fi
-
 
 # Creates a directory of licenses
 echo "Building pip and NPM license directory"
@@ -45,7 +44,7 @@ cd ../chia-blockchain-gui/packages/gui || exit 1
 # sets the version for chia-blockchain in package.json
 brew install jq
 cp package.json package.json.orig
-jq --arg VER "$CHIA_INSTALLER_VERSION" '.version=$VER' package.json > temp.json && mv temp.json package.json
+jq --arg VER "$CHIA_INSTALLER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
 
 echo "Building macOS Electron app"
 OPT_ARCH="--x64"
@@ -54,14 +53,14 @@ if [ "$(arch)" = "arm64" ]; then
 fi
 PRODUCT_NAME="Chia"
 if [ "$NOTARIZE" == true ]; then
-	echo "Setting credentials for signing"
-	export CSC_LINK=$APPLE_DEV_ID_APP
-	export CSC_KEY_PASSWORD=$APPLE_DEV_ID_APP_PASS
-	export PUBLISH_FOR_PULL_REQUEST=true
-	export CSC_FOR_PULL_REQUEST=true
+  echo "Setting credentials for signing"
+  export CSC_LINK=$APPLE_DEV_ID_APP
+  export CSC_KEY_PASSWORD=$APPLE_DEV_ID_APP_PASS
+  export PUBLISH_FOR_PULL_REQUEST=true
+  export CSC_FOR_PULL_REQUEST=true
 else
-	echo "Not on ci or no secrets so not signing"
-	export CSC_IDENTITY_AUTO_DISCOVERY=false
+  echo "Not on ci or no secrets so not signing"
+  export CSC_IDENTITY_AUTO_DISCOVERY=false
 fi
 echo npx electron-builder build --mac "${OPT_ARCH}" --config.productName="$PRODUCT_NAME" --config.mac.minimumSystemVersion="11" --config ../../../build_scripts/electron-builder.json
 npx electron-builder build --mac "${OPT_ARCH}" --config.productName="$PRODUCT_NAME" --config.mac.minimumSystemVersion="11" --config ../../../build_scripts/electron-builder.json
@@ -72,8 +71,8 @@ ls -l dist/mac*/chia.app/Contents/Resources/app.asar
 mv package.json.orig package.json
 
 if [ "$LAST_EXIT_CODE" -ne 0 ]; then
-	echo >&2 "electron-builder failed!"
-	exit $LAST_EXIT_CODE
+  echo >&2 "electron-builder failed!"
+  exit $LAST_EXIT_CODE
 fi
 
 mv dist/* ../../../build_scripts/dist/
@@ -90,13 +89,13 @@ mv dist/"$DMG_NAME" final_installer/
 ls -lh final_installer
 
 if [ "$NOTARIZE" == true ]; then
-	echo "Notarize $DMG_NAME on ci"
-	cd final_installer || exit 1
+  echo "Notarize $DMG_NAME on ci"
+  cd final_installer || exit 1
   xcrun notarytool submit --wait --apple-id "$APPLE_NOTARIZE_USERNAME" --password "$APPLE_NOTARIZE_PASSWORD" --team-id "$APPLE_TEAM_ID" "$DMG_NAME"
   xcrun stapler staple "$DMG_NAME"
   echo "Notarization step complete"
 else
-	echo "Not on ci or no secrets so skipping Notarize"
+  echo "Not on ci or no secrets so skipping Notarize"
 fi
 
 # Notes on how to manually notarize

--- a/build_scripts/build_win_license_dir.sh
+++ b/build_scripts/build_win_license_dir.sh
@@ -13,7 +13,7 @@ printf "%s\n" "$sum"
 license_list=$(license-checker --json | jq -r '.[].licenseFile' | grep -v null)
 
 # Split the license list by newline character into an array
-IFS=$'\n' read -rd '' -a licenses_array <<< "$license_list"
+IFS=$'\n' read -rd '' -a licenses_array <<<"$license_list"
 
 #print the contents of the array
 printf '%s\n' "${licenses_array[@]}"
@@ -39,8 +39,8 @@ license_path_array=()
 
 # read the output line by line into the array
 while IFS= read -r line; do
-    license_path_array+=("$line")
-done <<< "$output"
+  license_path_array+=("$line")
+done <<<"$output"
 
 # create a dir for each license and copy the license file over
 for i in "${license_path_array[@]}"; do

--- a/build_scripts/clean-runner.sh
+++ b/build_scripts/clean-runner.sh
@@ -15,7 +15,7 @@ rm -rf chia-blockchain-gui/build || true
 rm -rf chia-blockchain-gui/daemon || true
 rm -rf chia-blockchain-gui/node_modules || true
 rm chia-blockchain-gui/temp.json || true
-( cd "$PWD/chia-blockchain-gui" && git checkout HEAD -- package-lock.json ) || true
+(cd "$PWD/chia-blockchain-gui" && git checkout HEAD -- package-lock.json) || true
 cd "$PWD" || true
 
 # Clean up old globally installed node_modules that might conflict with the current build

--- a/install-gui.sh
+++ b/install-gui.sh
@@ -4,7 +4,10 @@ set -o errexit
 
 export NODE_OPTIONS="--max-old-space-size=3000"
 
-SCRIPT_DIR=$(cd -- "$(dirname -- "$0")"; pwd)
+SCRIPT_DIR=$(
+  cd -- "$(dirname -- "$0")"
+  pwd
+)
 
 if [ "${SCRIPT_DIR}" != "$(pwd)" ]; then
   echo "Please change working directory by the command below"
@@ -26,14 +29,14 @@ fi
 # Allows overriding the branch or commit to build in chia-blockchain-gui
 SUBMODULE_BRANCH=$1
 
-nodejs_is_installed(){
+nodejs_is_installed() {
   if ! npm version >/dev/null 2>&1; then
     return 1
   fi
   return 0
 }
 
-do_install_npm_locally(){
+do_install_npm_locally() {
   NODEJS_VERSION="$(node -v | cut -d'.' -f 1 | sed -e 's/^v//')"
   NPM_VERSION="$(npm -v | cut -d'.' -f 1)"
 
@@ -89,7 +92,7 @@ do_install_npm_locally(){
 
 # Work around for inconsistent `npm` exec path issue
 # https://github.com/Chia-Network/chia-blockchain/pull/10460#issuecomment-1054492495
-patch_inconsistent_npm_issue(){
+patch_inconsistent_npm_issue() {
   node_module_dir=$1
   if [ ! -d "$node_module_dir" ]; then
     mkdir "$node_module_dir"
@@ -110,11 +113,11 @@ if [ "$(uname)" = "Linux" ]; then
     # Debian/Ubuntu
 
     # Check if we are running a Raspberry PI 4
-    if [ "$(uname -m)" = "aarch64" ] \
-    && [ "$(uname -n)" = "raspberrypi" ]; then
+    if [ "$(uname -m)" = "aarch64" ] &&
+      [ "$(uname -n)" = "raspberrypi" ]; then
       # Check if NodeJS & NPM is installed
       type npm >/dev/null 2>&1 || {
-          echo >&2 "Please install NODEJS&NPM manually"
+        echo >&2 "Please install NODEJS&NPM manually"
       }
     else
       if ! nodejs_is_installed; then
@@ -124,7 +127,7 @@ if [ "$(uname)" = "Linux" ]; then
       fi
       do_install_npm_locally
     fi
-  elif type yum >/dev/null 2>&1 &&  [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f /etc/rocky-release ] && [ ! -f /etc/fedora-release ]; then
+  elif type yum >/dev/null 2>&1 && [ ! -f "/etc/redhat-release" ] && [ ! -f "/etc/centos-release" ] && [ ! -f /etc/rocky-release ] && [ ! -f /etc/fedora-release ]; then
     # AMZN 2
     if ! nodejs_is_installed; then
       echo "Installing nodejs on Amazon Linux 2."
@@ -191,8 +194,7 @@ if [ ! "$CI" ]; then
   git submodule update
   cd chia-blockchain-gui
 
-  if [ "$SUBMODULE_BRANCH" ];
-  then
+  if [ "$SUBMODULE_BRANCH" ]; then
     git fetch --all
     git reset --hard "$SUBMODULE_BRANCH"
     echo ""

--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -15,20 +15,26 @@ usage() {
 
 INSTALL_PYTHON_DEV=1
 
-while getopts nh flag
-do
+while getopts nh flag; do
   case "${flag}" in
-    # development
-    n) INSTALL_PYTHON_DEV=;;
-    h) usage; exit 0;;
-    *) echo; usage; exit 1;;
+  # development
+  n) INSTALL_PYTHON_DEV= ;;
+  h)
+    usage
+    exit 0
+    ;;
+  *)
+    echo
+    usage
+    exit 1
+    ;;
   esac
 done
 
 if [ -z "$VIRTUAL_ENV" ]; then
   echo "This requires the chia python virtual environment."
   echo "Execute '. ./activate' before running."
-	exit 1
+  exit 1
 fi
 
 echo "Timelord requires CMake 3.14+ to compile vdf_client."
@@ -47,92 +53,91 @@ THE_PATH=$(python -c 'import pkg_resources; print( pkg_resources.get_distributio
 CHIAVDF_VERSION=$(python -c 'import os; os.environ["CHIA_SKIP_SETUP"] = "1"; from setup import dependencies; t = [_ for _ in dependencies if _.startswith("chiavdf")][0]; print(t)')
 
 ubuntu_cmake_install() {
-	UBUNTU_PRE_2004=$(python -c 'import subprocess; id = subprocess.run(["lsb_release", "-is"], stdout=subprocess.PIPE); version = subprocess.run(["lsb_release", "-rs"], stdout=subprocess.PIPE); print(id.stdout.decode("ascii") == "Ubuntu\n" and float(version.stdout) < float(20.04))')
-	if [ "$UBUNTU_PRE_2004" = "True" ]; then
-		echo "Installing CMake with snap."
-		sudo apt-get install snapd -y
-		sudo apt-get remove --purge cmake -y
-		hash -r
-		sudo snap install cmake --classic
-		# shellcheck disable=SC1091
-		. /etc/profile
-	else
-		echo "Ubuntu 20.04LTS and newer support CMake 3.16+"
-		sudo apt-get install cmake -y
-	fi
+  UBUNTU_PRE_2004=$(python -c 'import subprocess; id = subprocess.run(["lsb_release", "-is"], stdout=subprocess.PIPE); version = subprocess.run(["lsb_release", "-rs"], stdout=subprocess.PIPE); print(id.stdout.decode("ascii") == "Ubuntu\n" and float(version.stdout) < float(20.04))')
+  if [ "$UBUNTU_PRE_2004" = "True" ]; then
+    echo "Installing CMake with snap."
+    sudo apt-get install snapd -y
+    sudo apt-get remove --purge cmake -y
+    hash -r
+    sudo snap install cmake --classic
+    # shellcheck disable=SC1091
+    . /etc/profile
+  else
+    echo "Ubuntu 20.04LTS and newer support CMake 3.16+"
+    sudo apt-get install cmake -y
+  fi
 }
 
 symlink_vdf_bench() {
-	if [ ! -e vdf_bench ] && [ -e venv/lib/"$1"/site-packages/vdf_bench ]; then
-		echo ln -s venv/lib/"$1"/site-packages/vdf_bench
-		ln -s venv/lib/"$1"/site-packages/vdf_bench .
-	elif [ ! -e venv/lib/"$1"/site-packages/vdf_bench ]; then
-		echo "ERROR: Could not find venv/lib/$1/site-packages/vdf_bench"
-	else
-		echo "./vdf_bench link exists."
-	fi
+  if [ ! -e vdf_bench ] && [ -e venv/lib/"$1"/site-packages/vdf_bench ]; then
+    echo ln -s venv/lib/"$1"/site-packages/vdf_bench
+    ln -s venv/lib/"$1"/site-packages/vdf_bench .
+  elif [ ! -e venv/lib/"$1"/site-packages/vdf_bench ]; then
+    echo "ERROR: Could not find venv/lib/$1/site-packages/vdf_bench"
+  else
+    echo "./vdf_bench link exists."
+  fi
 }
 
 if [ "$(uname)" = "Linux" ] && type apt-get; then
-	UBUNTU_DEBIAN=true
-	echo "Found Ubuntu/Debian."
+  UBUNTU_DEBIAN=true
+  echo "Found Ubuntu/Debian."
 
 elif [ "$(uname)" = "Linux" ] && type dnf || yum; then
-	RHEL_BASED=true
-	echo "Found RedHat."
+  RHEL_BASED=true
+  echo "Found RedHat."
 
-	if [ "$INSTALL_PYTHON_DEV" ]; then
-		yumcmd="sudo yum install $PYTHON_VERSION-devel gcc gcc-c++ gmp-devel libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y"
-  	else
-		yumcmd="sudo yum install gcc gcc-c++ gmp-devel libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y"
-	fi
+  if [ "$INSTALL_PYTHON_DEV" ]; then
+    yumcmd="sudo yum install $PYTHON_VERSION-devel gcc gcc-c++ gmp-devel libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y"
+  else
+    yumcmd="sudo yum install gcc gcc-c++ gmp-devel libtool make autoconf automake openssl-devel libevent-devel boost-devel python3 cmake -y"
+  fi
 
 elif [ "$(uname)" = "Darwin" ]; then
-	MACOS=true
-	echo "Found MacOS."
+  MACOS=true
+  echo "Found MacOS."
 fi
 
-
 if [ -e "$THE_PATH" ]; then
-	echo "$THE_PATH"
-	echo "vdf_client already exists, no action taken"
+  echo "$THE_PATH"
+  echo "vdf_client already exists, no action taken"
 else
-	if [ -e venv/bin/python ] && test "$UBUNTU_DEBIAN"; then
-		echo "Installing chiavdf dependencies on Ubuntu/Debian"
-		# If Ubuntu version is older than 20.04LTS then upgrade CMake
-		ubuntu_cmake_install
-		# Install remaining needed development tools - assumes venv and prior run of install.sh
-		echo "apt-get install libgmp-dev libboost-python-dev $PYTHON_DEV_DEPENDENCY libboost-system-dev build-essential -y"
-		sudo apt-get install libgmp-dev libboost-python-dev "$PYTHON_DEV_DEPENDENCY" libboost-system-dev build-essential -y
-		echo "Installing chiavdf from source on Ubuntu/Debian"
-		echo venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
-		venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
-		symlink_vdf_bench "$PYTHON_VERSION"
-	elif [ -e venv/bin/python ] && test "$RHEL_BASED"; then
-		echo "Installing chiavdf dependencies on RedHat/CentOS/Fedora"
-		# Install remaining needed development tools - assumes venv and prior run of install.sh
-		echo "$yumcmd"
-		${yumcmd}
-		echo "Installing chiavdf from source on RedHat/CentOS/Fedora"
-		echo venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
-		venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
-		symlink_vdf_bench "$PYTHON_VERSION"
-	elif [ -e venv/bin/python ] && test "$MACOS"; then
-		echo "Installing chiavdf dependencies for MacOS."
-		brew install boost cmake gmp
-		echo "Installing chiavdf from source."
-		# User needs to provide required packages
-		echo venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
-		venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
-		symlink_vdf_bench "$PYTHON_VERSION"
-	elif [ -e venv/bin/python ]; then
-		echo "Installing chiavdf from source."
-		# User needs to provide required packages
-		echo venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
-		venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
-		symlink_vdf_bench "$PYTHON_VERSION"
-	else
-		echo "No venv created yet, please run install.sh."
-	fi
+  if [ -e venv/bin/python ] && test "$UBUNTU_DEBIAN"; then
+    echo "Installing chiavdf dependencies on Ubuntu/Debian"
+    # If Ubuntu version is older than 20.04LTS then upgrade CMake
+    ubuntu_cmake_install
+    # Install remaining needed development tools - assumes venv and prior run of install.sh
+    echo "apt-get install libgmp-dev libboost-python-dev $PYTHON_DEV_DEPENDENCY libboost-system-dev build-essential -y"
+    sudo apt-get install libgmp-dev libboost-python-dev "$PYTHON_DEV_DEPENDENCY" libboost-system-dev build-essential -y
+    echo "Installing chiavdf from source on Ubuntu/Debian"
+    echo venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
+    venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
+    symlink_vdf_bench "$PYTHON_VERSION"
+  elif [ -e venv/bin/python ] && test "$RHEL_BASED"; then
+    echo "Installing chiavdf dependencies on RedHat/CentOS/Fedora"
+    # Install remaining needed development tools - assumes venv and prior run of install.sh
+    echo "$yumcmd"
+    ${yumcmd}
+    echo "Installing chiavdf from source on RedHat/CentOS/Fedora"
+    echo venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
+    venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
+    symlink_vdf_bench "$PYTHON_VERSION"
+  elif [ -e venv/bin/python ] && test "$MACOS"; then
+    echo "Installing chiavdf dependencies for MacOS."
+    brew install boost cmake gmp
+    echo "Installing chiavdf from source."
+    # User needs to provide required packages
+    echo venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
+    venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
+    symlink_vdf_bench "$PYTHON_VERSION"
+  elif [ -e venv/bin/python ]; then
+    echo "Installing chiavdf from source."
+    # User needs to provide required packages
+    echo venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
+    venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"
+    symlink_vdf_bench "$PYTHON_VERSION"
+  else
+    echo "No venv created yet, please run install.sh."
+  fi
 fi
 echo "To estimate a timelord on this CPU try './vdf_bench square_asm 400000' for an ips estimate."

--- a/install.sh
+++ b/install.sh
@@ -22,22 +22,28 @@ EXTRAS=
 PLOTTER_INSTALL=
 EDITABLE='-e'
 
-while getopts adilpsh flag
-do
+while getopts adilpsh flag; do
   case "${flag}" in
-    # automated
-    a) :;;
-    # development
-    d) EXTRAS=${EXTRAS}dev,;;
-    # non-editable
-    i) EDITABLE='';;
-    # legacy keyring
-    l) EXTRAS=${EXTRAS}legacy-keyring,;;
-    p) PLOTTER_INSTALL=1;;
-    # simple install
-    s) :;;
-    h) usage; exit 0;;
-    *) echo; usage; exit 1;;
+  # automated
+  a) : ;;
+  # development
+  d) EXTRAS=${EXTRAS}dev, ;;
+  # non-editable
+  i) EDITABLE='' ;;
+  # legacy keyring
+  l) EXTRAS=${EXTRAS}legacy-keyring, ;;
+  p) PLOTTER_INSTALL=1 ;;
+  # simple install
+  s) : ;;
+  h)
+    usage
+    exit 0
+    ;;
+  *)
+    echo
+    usage
+    exit 1
+    ;;
   esac
 done
 
@@ -53,7 +59,6 @@ if [ "$(uname -m)" = "armv7l" ]; then
 fi
 # Get submodules
 git submodule update --init mozilla-ca
-
 
 # You can specify preferred python version by exporting `INSTALL_PYTHON_VERSION`
 # e.g. `export INSTALL_PYTHON_VERSION=3.8`

--- a/start-gui.sh
+++ b/start-gui.sh
@@ -4,11 +4,14 @@ set -o errexit
 
 export NODE_OPTIONS="--max-old-space-size=3000"
 
-SCRIPT_DIR=$(cd -- "$(dirname -- "$0")"; pwd)
+SCRIPT_DIR=$(
+  cd -- "$(dirname -- "$0")"
+  pwd
+)
 
 echo "### Checking GUI dependencies"
 
-if [ -d  "${SCRIPT_DIR}/.n" ]; then
+if [ -d "${SCRIPT_DIR}/.n" ]; then
   export N_PREFIX="${SCRIPT_DIR}/.n"
   export PATH="${N_PREFIX}/bin:${PATH}"
   echo "Loading nodejs/npm from"

--- a/tools/run_benchmark.sh
+++ b/tools/run_benchmark.sh
@@ -3,24 +3,24 @@
 # pass in the name of the test run as the first argument
 
 run_benchmark() {
-   # shellcheck disable=SC2086
-   python -m tools.test_full_sync run $3 --profile --test-constants "$1" &
-   test_pid=$!
-   python -m tools.cpu_utilization $test_pid
-   mkdir -p "$2"
-   mv test-full-sync.log cpu.png cpu-usage.log plot-cpu.gnuplot "$2"
-   python -m tools.test_full_sync analyze
-   mv slow-batch-*.profile slow-batch-*.png "$2"
-   # python -m chia.util.profiler profile-node >"$2/node-profile.txt"
-   # mv profile-node "$2"
+  # shellcheck disable=SC2086
+  python -m tools.test_full_sync run $3 --profile --test-constants "$1" &
+  test_pid=$!
+  python -m tools.cpu_utilization $test_pid
+  mkdir -p "$2"
+  mv test-full-sync.log cpu.png cpu-usage.log plot-cpu.gnuplot "$2"
+  python -m tools.test_full_sync analyze
+  mv slow-batch-*.profile slow-batch-*.png "$2"
+  # python -m chia.util.profiler profile-node >"$2/node-profile.txt"
+  # mv profile-node "$2"
 }
 
 cd ..
 
 if [ "$1" = "" ]; then
-    TEST_NAME="node-benchmark"
+  TEST_NAME="node-benchmark"
 else
-    TEST_NAME=$1
+  TEST_NAME=$1
 fi
 
 # generate the test blockchain databases by running:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

I have no idea what shell formatter we should use.  But, https://github.com/Chia-Network/chia-blockchain/pull/17906 was updating the super linter and it started complaining a lot and I really dislike having formatting tools executed in the super linter since that doesn't integrate into our local checks and thus people have to manually apply the super linter results to their local copy.  So, this moves the super linter choice of shfmt into our pre-commit setup which runs both locally and in CI.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
