### PR TITLE
remove unnecessary function, dataclass_to_json_dict()

### DIFF
--- a/chia/rpc/farmer_rpc_client.py
+++ b/chia/rpc/farmer_rpc_client.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, cast
 from chia.rpc.farmer_rpc_api import PlotInfoRequestData, PlotPathRequestData
 from chia.rpc.rpc_client import RpcClient
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.misc import dataclass_to_json_dict
+from chia.util.streamable import recurse_jsonify
 
 
 class FarmerRpcClient(RpcClient):
@@ -67,16 +67,16 @@ class FarmerRpcClient(RpcClient):
         return await self.fetch("get_harvesters_summary", {})
 
     async def get_harvester_plots_valid(self, request: PlotInfoRequestData) -> Dict[str, Any]:
-        return await self.fetch("get_harvester_plots_valid", dataclass_to_json_dict(request))
+        return await self.fetch("get_harvester_plots_valid", recurse_jsonify(request))
 
     async def get_harvester_plots_invalid(self, request: PlotPathRequestData) -> Dict[str, Any]:
-        return await self.fetch("get_harvester_plots_invalid", dataclass_to_json_dict(request))
+        return await self.fetch("get_harvester_plots_invalid", recurse_jsonify(request))
 
     async def get_harvester_plots_keys_missing(self, request: PlotPathRequestData) -> Dict[str, Any]:
-        return await self.fetch("get_harvester_plots_keys_missing", dataclass_to_json_dict(request))
+        return await self.fetch("get_harvester_plots_keys_missing", recurse_jsonify(request))
 
     async def get_harvester_plots_duplicates(self, request: PlotPathRequestData) -> Dict[str, Any]:
-        return await self.fetch("get_harvester_plots_duplicates", dataclass_to_json_dict(request))
+        return await self.fetch("get_harvester_plots_duplicates", recurse_jsonify(request))
 
     async def get_pool_login_link(self, launcher_id: bytes32) -> Optional[str]:
         try:

--- a/chia/util/misc.py
+++ b/chia/util/misc.py
@@ -12,13 +12,11 @@ from inspect import getframeinfo, stack
 from pathlib import Path
 from types import FrameType
 from typing import (
-    Any,
     AsyncContextManager,
     AsyncIterator,
     ClassVar,
     Collection,
     ContextManager,
-    Dict,
     Generic,
     Iterable,
     Iterator,
@@ -39,7 +37,7 @@ from typing_extensions import Protocol
 
 from chia.util.errors import InvalidPathError
 from chia.util.ints import uint16, uint32, uint64
-from chia.util.streamable import Streamable, recurse_jsonify, streamable
+from chia.util.streamable import Streamable, streamable
 
 T = TypeVar("T")
 
@@ -123,11 +121,6 @@ def prompt_yes_no(prompt: str) -> bool:
 
 def get_list_or_len(list_in: Sequence[object], length: bool) -> Union[int, Sequence[object]]:
     return len(list_in) if length else list_in
-
-
-def dataclass_to_json_dict(instance: Any) -> Dict[str, Any]:
-    ret: Dict[str, Any] = recurse_jsonify(instance)
-    return ret
 
 
 def validate_directory_writable(path: Path) -> None:


### PR DESCRIPTION
### Purpose:

Simplify code. `dataclass_to_json_dict()` is essentially just an alias for `recurse_jsonify()`. Remove it and call the latter directly.