### PR TITLE
Adjust farmer service SSL tests for increased reliability

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -827,7 +827,6 @@ FarmerOneHarvester = Tuple[List[HarvesterService], FarmerService, BlockTools]
 
 @pytest.fixture(scope="function")
 async def farmer_one_harvester(tmp_path: Path, get_b_tools: BlockTools) -> AsyncIterator[FarmerOneHarvester]:
-    asyncio.get_event_loop().set_debug(True)
     async with setup_farmer_multi_harvester(get_b_tools, 1, tmp_path, get_b_tools.constants, start_services=True) as _:
         yield _
 

--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -827,6 +827,7 @@ FarmerOneHarvester = Tuple[List[HarvesterService], FarmerService, BlockTools]
 
 @pytest.fixture(scope="function")
 async def farmer_one_harvester(tmp_path: Path, get_b_tools: BlockTools) -> AsyncIterator[FarmerOneHarvester]:
+    asyncio.get_event_loop().set_debug(True)
     async with setup_farmer_multi_harvester(get_b_tools, 1, tmp_path, get_b_tools.constants, start_services=True) as _:
         yield _
 

--- a/chia/_tests/core/ssl/test_ssl.py
+++ b/chia/_tests/core/ssl/test_ssl.py
@@ -47,7 +47,7 @@ ssl_cert_error = False
 @contextlib.contextmanager
 def suppress_ssl_exception_report():
     loop = asyncio.get_event_loop()
-    loop.set_debug(True)
+    # loop.set_debug(True)
     old_handler = loop.get_exception_handler()
     old_handler_fn = old_handler  # or lambda _loop, ctx: loop.default_exception_handler(ctx)
 
@@ -110,7 +110,8 @@ class TestSSL:
         try:
             with suppress_ssl_exception_report():
                 await establish_connection(farmer_server, self_hostname, ssl_context)
-        except Exception:
+        except Exception as e:
+            print(e)
             assert ssl_cert_error is True
         finally:
             assert ssl_cert_error is True

--- a/chia/_tests/core/ssl/test_ssl.py
+++ b/chia/_tests/core/ssl/test_ssl.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
-import ssl
+import logging
 
 import aiohttp
 import pytest
-import logging
+
 from chia.protocols.shared_protocol import capabilities
 from chia.server.outbound_message import NodeType
 from chia.server.server import ChiaServer, ssl_context_for_client
@@ -39,9 +38,6 @@ async def establish_connection(server: ChiaServer, self_hostname: str, ssl_conte
         )
         await wsc.perform_handshake(server._network_id, dummy_port, NodeType.FULL_NODE)
         await wsc.close()
-
-
-ssl_cert_error = False
 
 
 class TestSSL:
@@ -93,9 +89,11 @@ class TestSSL:
             except Exception:
                 pass  # ignore any exceptions and just check the expected log output below
             finally:
-                assert "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate signature failure" in caplog.text
+                assert (
+                    "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate signature failure"
+                    in caplog.text
+                )
                 asyncio.get_event_loop().set_debug(False)
-
 
     @pytest.mark.anyio
     async def test_full_node(self, simulator_and_wallet, self_hostname):

--- a/chia/_tests/core/ssl/test_ssl.py
+++ b/chia/_tests/core/ssl/test_ssl.py
@@ -54,10 +54,9 @@ def suppress_ssl_exception_report():
     def ignore_exc(_loop, ctx):
         exc = ctx.get("exception")
         if isinstance(exc, ssl.SSLCertVerificationError):
-            print("here")
             global ssl_cert_error
             ssl_cert_error = True
-            raise exc
+            return
 
         old_handler_fn(loop, ctx)
 
@@ -66,6 +65,7 @@ def suppress_ssl_exception_report():
         yield
     finally:
         loop.set_exception_handler(old_handler)
+        loop.set_debug(False)
 
 
 class TestSSL:

--- a/chia/_tests/core/ssl/test_ssl.py
+++ b/chia/_tests/core/ssl/test_ssl.py
@@ -59,7 +59,7 @@ def ignore_ssl_cert_error():
         if isinstance(exc, ssl.SSLCertVerificationError):
             return
 
-        old_handler_fn(loop, ctx)
+        old_handler_fn(loop, ctx)  # pragma: no cover
 
     current_loop.set_exception_handler(find_and_ignore)
     try:


### PR DESCRIPTION
Currently, the SSL tests specifically one test for the farmer is flaky - this seems to have been recently introduced possibly due to changes in aiohttp, but the exact reasons for flakiness are unknown

The end goal of the test is to make sure the server rejects the SSL connection - it seems that due to aiohttp internals, SSL errors are typically silent on the server and the client may not get a consistent error for why the connection was dropped. (see https://github.com/aio-libs/aiohttp/discussions/7325)

Adjust the flaky test as follows:
Using asyncio `debug` mode and setting the test to capture the log, we can look for the SSL certificate failure in the log files as it is output when asyncio is in debug mode. This is further complicated in that on some platforms, when asyncio is in debug mode, an exception is raised that is not catchable by pytest and fails the test - so a new exception handler is used to ignore the SSL exception, as we are only testing the log output.

This is currently very stable in CI. This replaces the fix in https://github.com/Chia-Network/chia-blockchain/pull/17899

I think the value of this particular test is debatable; I currently don't think there is any way to misconfigure the code such that this test would pass - it would have to be some error in SSL, or if all SSL cert verification was turned off.  