### PR TITLE
Change `macos-latest` to `macos-12` in runners

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,7 +30,7 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              intel: macos-latest
+              intel: macos-12
               arm: [macos, arm64]
           - name: Windows
             matrix: windows

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -31,7 +31,7 @@ jobs:
         python:
           - major-dot-minor: "3.10"
         os:
-          - runs-on: macos-latest
+          - runs-on: macos-12
             matrix: macos
           - runs-on: ubuntu-latest
             matrix: linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       concurrency_name: macos
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
-      runs-on: macos-latest
+      runs-on: macos-12
       collect-junit: false
   ubuntu:
     uses: ./.github/workflows/test-single.yml

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -44,7 +44,7 @@ jobs:
             matrix: macos
             emoji: 🍎
             runs-on:
-              intel: macos-latest
+              intel: macos-12
               arm: [macos, arm64]
           - name: Windows
             matrix: windows


### PR DESCRIPTION
GH has changed macos-latest to default to macos 14 and ARM.

This is ok on main but this branch assumes macos-latest is an intel architecture - switch to using `macos-12`