### PR TITLE
Use python 3.11 for Arch install tests

### DIFF
--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -151,7 +151,7 @@ jobs:
           # The behavior we follow in install.sh is unique with Arch in that
           # we leave it to the user to install the appropriate version of python,
           # so we need to install python here in order for the test to succeed.
-          pacman --noconfirm -U --needed https://archive.archlinux.org/packages/p/python/python-3.9.9-1-x86_64.pkg.tar.zst
+          pacman --noconfirm -U --needed https://archive.archlinux.org/packages/p/python/python-3.11.8-1-x86_64.pkg.tar.zst
 
       - name: Prepare Debian
         if: ${{ matrix.distribution.type == 'debian' }}


### PR DESCRIPTION
On arch, we have to install a version of python since it doesn't come with it by default. We were using 3.9 which remains a reasonable choice - except that a new but in setuptools_scm results in CI failures (see https://github.com/pypa/setuptools_scm/issues/1038)

Using 3.11 should solve this and also seems a reasonable choice and this should resolve the CI failure in the arch install test.

This failure is related to `git 2.45.0` and `setuptools_scm` and not specifically arch - however arch is often the canary on updating to the latest packages. It would be seen on other linuxes as well with that version of git