### PR TITLE
fix confusion between prompt and don't prompt in the plotnft CLI

### DIFF
--- a/chia/cmds/plotnft.py
+++ b/chia/cmds/plotnft.py
@@ -94,7 +94,11 @@ def create_cmd(
         print("  pool_url argument (-u) is required for pool starting state")
         return
     valid_initial_states = {"pool": "FARMING_TO_POOL", "local": "SELF_POOLING"}
-    asyncio.run(create(wallet_rpc_port, fingerprint, pool_url, valid_initial_states[state], Decimal(fee), dont_prompt))
+    asyncio.run(
+        create(
+            wallet_rpc_port, fingerprint, pool_url, valid_initial_states[state], Decimal(fee), prompt=not dont_prompt
+        )
+    )
 
 
 @plotnft_cmd.command("join", help="Join a plot NFT to a Pool")
@@ -133,7 +137,7 @@ def join_cmd(
             pool_url=pool_url,
             fee=Decimal(fee),
             wallet_id=id,
-            prompt=dont_prompt,
+            prompt=not dont_prompt,
         )
     )
 
@@ -170,7 +174,7 @@ def self_pool_cmd(wallet_rpc_port: Optional[int], fingerprint: int, id: int, fee
             fingerprint=fingerprint,
             fee=Decimal(fee),
             wallet_id=id,
-            prompt=dont_prompt,
+            prompt=not dont_prompt,
         )
     )
 

--- a/chia/cmds/plotnft_funcs.py
+++ b/chia/cmds/plotnft_funcs.py
@@ -61,7 +61,7 @@ async def create_pool_args(pool_url: str) -> Dict[str, Any]:
 
 
 async def create(
-    wallet_rpc_port: Optional[int], fingerprint: int, pool_url: Optional[str], state: str, fee: Decimal, prompt: bool
+    wallet_rpc_port: Optional[int], fingerprint: int, pool_url: Optional[str], state: str, fee: Decimal, *, prompt: bool
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fingerprint) as (wallet_client, fingerprint, _):
         fee_mojos = uint64(int(fee * units["chia"]))


### PR DESCRIPTION
### Purpose:

Fix bugs where `dont_prompt` turned into `prompt`, inverting the meaning.

Enforcing named parameters did not help avoid this mistake. It probably makes sense to unify all functions to just use the `dont_prompt` form of this bool, and not the inverse.

While I was at it, I also harmonized the confirmation function in plotnft to use the `cli_confirm()` utility function. This was a separate commit and affects indentation, please review commits independently and ignore whitespace.

### Current Behavior:

`chia wallet plotnft create -y` prompts for confirmation.

### New Behavior:

`chia wallet plotnft create` does not prompt for confirmation.