### PR TITLE
add ability to profile the farmer process

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import sys
 import time
 import traceback
 from dataclasses import dataclass
@@ -47,6 +48,7 @@ from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
 from chia.util.keychain import Keychain
 from chia.util.logging import TimedDuplicateFilter
+from chia.util.profiler import profile_task
 from chia.wallet.derive_keys import (
     find_authentication_sk,
     find_owner_sk,
@@ -190,6 +192,12 @@ class Farmer:
                     self.started = True
                     return
                 await asyncio.sleep(1)
+
+        if self.config.get("enable_profiler", False):
+            if sys.getprofile() is not None:
+                self.log.warning("not enabling profiler, getprofile() is already set")
+            else:
+                asyncio.create_task(profile_task(self._root_path, "farmer", self.log))
 
         asyncio.create_task(start_task())
         try:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -275,6 +275,11 @@ farmer:
   start_rpc_server: True
   rpc_port: 8559
 
+  # when enabled, the farmer will print a pstats profile to the
+  # root_dir/profile-farmer directory every second.
+  # analyze with python -m chia.util.profiler <path>
+  enable_profiler: False
+
   # To send a share to a pool, a proof of space must have required_iters less than this number
   pool_share_threshold: 1000
   logging: *logging
@@ -448,8 +453,9 @@ full_node:
   # from at least 3 peers, or until we've waitied this many seconds
   max_sync_wait: 30
 
-  # when enabled, the full node will print a pstats profile to the root_dir/profile every second
-  # analyze with chia/utils/profiler.py
+  # when enabled, the full node will print a pstats profile to the
+  # root_dir/profile-node directory every second.
+  # analyze with python -m chia.util.profiler <path>
   enable_profiler: False
 
   # when enabled, each time a block is validated, the python profiler is
@@ -541,6 +547,9 @@ introducer:
 wallet:
   rpc_port: 9256
 
+  # when enabled, the wallet will print a pstats profile to the
+  # root_dir/profile-wallet directory every second.
+  # analyze with python -m chia.util.profiler <path>
   enable_profiler: False
 
   enable_memory_profiler: False


### PR DESCRIPTION
### Purpose:

To help finding performance bottlenecks in the farmer process.

### New Behavior:

`enable_profiler: true` can be added to the `farmer:` section in the config, to have it generate regular CPU profiles.