### PR TITLE
drop deprecated `authentication_public_key` from pool config

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -18,7 +18,7 @@ from chia.consensus.constants import ConsensusConstants
 from chia.daemon.keychain_proxy import KeychainProxy, connect_to_keychain_and_validate, wrap_local_keychain
 from chia.plot_sync.delta import Delta
 from chia.plot_sync.receiver import Receiver
-from chia.pools.pool_config import PoolWalletConfig, add_auth_key, load_pool_config, update_pool_url
+from chia.pools.pool_config import PoolWalletConfig, load_pool_config, update_pool_url
 from chia.protocols import farmer_protocol, harvester_protocol
 from chia.protocols.pool_protocol import (
     AuthenticationPayload,
@@ -522,8 +522,6 @@ class Farmer:
                 if authentication_sk is None:
                     self.log.error(f"Could not find authentication sk for {p2_singleton_puzzle_hash}")
                     continue
-
-                add_auth_key(self._root_path, pool_config, authentication_sk.get_g1())
 
                 if p2_singleton_puzzle_hash not in self.pool_state:
                     self.pool_state[p2_singleton_puzzle_hash] = {

--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -107,21 +107,20 @@ def update_pool_config_entry(
 ) -> None:
     with lock_and_load_config(root_path, "config.yaml") as config:
         pool_list = config["pool"].get("pool_list", [])
+        if pool_list is None:
+            return
         updated = False
-        if pool_list is not None:
-            for pool_config_dict in pool_list:
-                try:
-                    if hexstr_to_bytes(pool_config_dict["owner_public_key"]) == bytes(
-                        pool_wallet_config.owner_public_key
-                    ):
-                        if update_closure(pool_config_dict):
-                            updated = True
-                except Exception as e:
-                    log.error(f"Exception updating config: {pool_config_dict} {e}")
-        if updated:
-            log.info(update_log_message)
-            config["pool"]["pool_list"] = pool_list
-            save_config(root_path, "config.yaml", config)
+        for pool_config_dict in pool_list:
+            try:
+                if hexstr_to_bytes(pool_config_dict["owner_public_key"]) == bytes(pool_wallet_config.owner_public_key):
+                    if update_closure(pool_config_dict):
+                        updated = True
+            except Exception as e:
+                log.error(f"Exception updating config: {pool_config_dict} {e}")
+    if updated:
+        log.info(update_log_message)
+        config["pool"]["pool_list"] = pool_list
+        save_config(root_path, "config.yaml", config)
 
 
 async def update_pool_config(root_path: Path, pool_config_list: List[PoolWalletConfig]) -> None:

--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -62,26 +62,6 @@ def load_pool_config(root_path: Path) -> List[PoolWalletConfig]:
     return ret_list
 
 
-# TODO: remove this a few versions after 1.3, since authentication_public_key is deprecated. This is here to support
-# downgrading to versions older than 1.3.
-def add_auth_key(root_path: Path, pool_wallet_config: PoolWalletConfig, auth_key: G1Element) -> None:
-    def update_auth_pub_key_for_entry(config_entry: Dict[str, Any]) -> bool:
-        auth_key_hex = bytes(auth_key).hex()
-        if config_entry.get("authentication_public_key", "") != auth_key_hex:
-            config_entry["authentication_public_key"] = auth_key_hex
-
-            return True
-
-        return False
-
-    update_pool_config_entry(
-        root_path=root_path,
-        pool_wallet_config=pool_wallet_config,
-        update_closure=update_auth_pub_key_for_entry,
-        update_log_message=f"Updating pool config for auth key: {auth_key}",
-    )
-
-
 def update_pool_url(root_path: Path, pool_wallet_config: PoolWalletConfig, pool_url: str) -> None:
     def update_pool_url_for_entry(config_entry: Dict[str, Any]) -> bool:
         if config_entry.get("pool_url", "") != pool_url:


### PR DESCRIPTION
### Purpose:

As the TODO-comment explains:

> TODO: remove this a few versions after 1.3, since authentication_public_key is deprecated. This is here to support
> downgrading to versions older than 1.3.

I think it's safe to remove this. I discovered this as the current implementation of this backwards-compatibility also is not working right. It causes the `_periodically_update_pool_state_task` to run continuously. The reason is that calling `add_auth_key()` loads and re-saves the config file, thus bumping its "mtime". We use the mtime to determine whether ewe need to run this task early, rather than waiting the 60 secons we are supposed to.

Running the task calls `add_auth_key()` resulting in continuously running the task, wasting CPU and disk I/O.

This is especially apparent when you have multiple plotnfts.

### Current Behavior:

When having many plotnfts, the farmer process pegs the CPU every 2 seconds. See the profile attached below.

### New Behavior:

Having many plotnfts only causes the farmer process to perform the expensive work every 60 seconds. (There's still room for improvements in this regard, but this patch covers 95% of the problems).

### Testing Notes:

I profiled the farmer process, depending on https://github.com/Chia-Network/chia-blockchain/pull/17953

### profile:

![chia-hotspot-2](https://github.com/Chia-Network/chia-blockchain/assets/661450/20c15bc2-8613-4729-9bbf-9823c0bbfe9e)
