### PR TITLE
bump timeout for publishing macOS installers to avoid timeout

### DIFF
--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: ${{ matrix.os.runs-on }}
     needs:
       - build
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Purpose:

this workflow times out quite frequently, e.g.

https://github.com/Chia-Network/chia-blockchain/actions/runs/8935001240/job/24543564631?pr=17951

### Current Behavior:

timeout is 5 inutes

### New Behavior:

timeout is 10 minutes
