### PR TITLE
remove unused current_inner from PoolState

### DIFF
--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -219,20 +219,12 @@ class PoolWallet:
             curr_spend_i -= 1
 
         assert pool_state is not None
-        current_inner = pool_state_to_inner_puzzle(
-            pool_state,
-            launcher_coin.name(),
-            self.wallet_state_manager.constants.GENESIS_CHALLENGE,
-            delayed_seconds,
-            delayed_puzhash,
-        )
         return PoolWalletInfo(
             pool_state,
             self.target_state,
             launcher_coin,
             launcher_id,
             p2_singleton_puzzle_hash,
-            current_inner,
             tip_singleton_coin.name(),
             last_singleton_spend_height,
         )

--- a/chia/pools/pool_wallet_info.py
+++ b/chia/pools/pool_wallet_info.py
@@ -8,7 +8,6 @@ from chia_rs import G1Element
 
 from chia.protocols.pool_protocol import POOL_PROTOCOL_VERSION
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint8, uint32
@@ -116,6 +115,5 @@ class PoolWalletInfo(Streamable):
     launcher_coin: Coin
     launcher_id: bytes32
     p2_singleton_puzzle_hash: bytes32
-    current_inner: Program  # Inner puzzle in current singleton, not revealed yet
     tip_singleton_coin_id: bytes32
     singleton_block_height: uint32  # Block height that current PoolState is from


### PR DESCRIPTION

### Purpose:

We generate this puzzle regularly, it's expensive, and we don't use it.
Save the cost of generating the puzzle for this field.

| function | before | after | after / before |
| --- | --- | --- | --- |
| get_current_state() | 11.75% | 3.71% | 0.316 |


### Current Behavior:

Have a `current_inner` field in `PlotState`

### New Behavior:

Don't have a `current_inner` field in `PlotState`

### before profile:

![chia-hotspot-36](https://github.com/Chia-Network/chia-blockchain/assets/661450/ee43912b-29c4-412a-a071-36ddd4462fa9)

### after profile:

![chia-hotspot-142](https://github.com/Chia-Network/chia-blockchain/assets/661450/db984f73-be4f-4a33-a9db-e7514c8cf7df)
