### PR TITLE
Set repo content updater actions reviewers

### DIFF
--- a/.repo-content-updater.yml
+++ b/.repo-content-updater.yml
@@ -1,0 +1,2 @@
+var_overrides:
+  DEPENDABOT_ACTIONS_REVIEWERS: "[\"cmmarslender\", \"altendky\"]"

--- a/.repo-content-updater.yml
+++ b/.repo-content-updater.yml
@@ -1,2 +1,2 @@
 var_overrides:
-  DEPENDABOT_ACTIONS_REVIEWERS: "[\"cmmarslender\", \"altendky\"]"
+  DEPENDABOT_ACTIONS_REVIEWERS: '["cmmarslender", "altendky"]'


### PR DESCRIPTION
This is already the current setting: https://github.com/Chia-Network/chia-blockchain/blob/main/.github/dependabot.yml#L44

The defaults in repo-content-updater are changing to IPS though, so this is to ensure the same reviewers apply to this repo