### PR TITLE
Fallback to linux timings on unknown platform types (#17988)

### DIFF
--- a/chia/util/timing.py
+++ b/chia/util/timing.py
@@ -25,7 +25,10 @@ if os.environ.get("GITHUB_ACTIONS") == "true":
     # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
     _system_delay = system_delays["github"][sys.platform]
 else:
-    _system_delay = system_delays["local"][sys.platform]
+    try:
+        _system_delay = system_delays["local"][sys.platform]
+    except KeyError:
+        _system_delay = system_delays["local"]["linux"]
 
 
 @overload


### PR DESCRIPTION
### Purpose:
Allow chia to run on systems with unrecognized sys.platform


<!-- Does this PR introduce a breaking change? -->
No

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
None
