### PR TITLE
Fix for freebsd suggested by user alghmma

### DIFF
--- a/chia/util/timing.py
+++ b/chia/util/timing.py
@@ -23,6 +23,8 @@ system_delays = {
 
 if os.environ.get("GITHUB_ACTIONS") == "true":
     # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+    _system_delay = system_delays["github"][sys.platform]
+else:
     try:
         _system_delay = system_delays["local"][sys.platform]
     except KeyError:

--- a/chia/util/timing.py
+++ b/chia/util/timing.py
@@ -23,9 +23,10 @@ system_delays = {
 
 if os.environ.get("GITHUB_ACTIONS") == "true":
     # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-    _system_delay = system_delays["github"][sys.platform]
-else:
-    _system_delay = system_delays["local"][sys.platform]
+    try:
+        _system_delay = system_delays["local"][sys.platform]
+    except KeyError:
+        _system_delay = system_delays["local"]["linux"]
 
 
 @overload


### PR DESCRIPTION
### Purpose:

Built 2.3.0 on Freebsd 14, won't run because of missing system_delays for this platform.

see

https://github.com/Chia-Network/chia-blockchain/issues/17988

and

https://github.com/Chia-Network/chia-blockchain/pull/17989

and thanks to alghmma for his suggested PR which this PR duplicates.

### Current Behavior:

Exception thrown

### New Behavior:

Linux default used

### Testing Notes:

N/A