### PR TITLE
Puzzle hash optimizations

### DIFF
--- a/chia/_tests/clvm/test_curry_and_treehash.py
+++ b/chia/_tests/clvm/test_curry_and_treehash.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
+from typing import List
+
+import pytest
+
 from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.wallet.puzzles import p2_delegated_puzzle_or_hidden_puzzle  # import (puzzle_for_pk, puzzle_hash_for_pk, MOD)
-from chia.wallet.util.curry_and_treehash import calculate_hash_of_quoted_mod_hash, curry_and_treehash
+from chia.wallet.util.curry_and_treehash import (
+    calculate_hash_of_quoted_mod_hash,
+    curry_and_treehash,
+    shatree_atom,
+    shatree_atom_list,
+    shatree_int,
+)
 
 
 def test_curry_and_treehash() -> None:
@@ -21,3 +32,26 @@ def test_curry_and_treehash() -> None:
         hashed_args = [Program.to(_).get_tree_hash() for _ in args]
         puzzle_hash_via_f = curry_and_treehash(quoted_mod_hash, *hashed_args)
         assert puzzle_hash_via_curry == puzzle_hash_via_f
+
+
+@pytest.mark.parametrize(
+    "value", [[], [bytes32([3] * 32)], [bytes32([0] * 32), bytes32([1] * 32)], [bytes([1]), bytes([1, 2, 3])]]
+)
+def test_shatree_atom_list(value: List[bytes]) -> None:
+    h1 = shatree_atom_list(value)
+    h2 = Program.to(value).get_tree_hash()
+    assert h1 == h2
+
+
+@pytest.mark.parametrize("value", [0, -1, 1, 0x7F, 0x80, 100000000, -10000000])
+def test_shatree_int(value: int) -> None:
+    h1 = shatree_int(value)
+    h2 = Program.to(value).get_tree_hash()
+    assert h1 == h2
+
+
+@pytest.mark.parametrize("value", [bytes([1] * 1), bytes([]), bytes([5] * 1000)])
+def test_shatree_atom(value: bytes) -> None:
+    h1 = shatree_atom(value)
+    h2 = Program.to(value).get_tree_hash()
+    assert h1 == h2

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -1313,7 +1313,7 @@ class TestDIDWallet:
                 wallet_node_1.wallet_state_manager,
                 wallet,
                 uint64(101),
-                [bytes(ph)],
+                [bytes32(ph)],
                 uint64(1),
                 {"Twitter": "Test", "GitHub": "测试"},
                 fee=fee,

--- a/chia/pools/pool_puzzles.py
+++ b/chia/pools/pool_puzzles.py
@@ -205,7 +205,7 @@ def create_travel_spend(
         log.debug(
             f"create_travel_spend: waitingroom: target PoolState bytes:\n{bytes(target).hex()}\n"
             f"{target}"
-            f"hash:{Program.to(bytes(target)).get_tree_hash()}"
+            f"hash:{shatree_atom(bytes(target))}"
         )
         # key_value_list is:
         # "p" -> poolstate as bytes

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -110,7 +110,7 @@ from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.address_type import AddressType, is_valid_address
 from chia.wallet.util.compute_hints import compute_spend_hints_and_additions
 from chia.wallet.util.compute_memos import compute_memos
-from chia.wallet.util.curry_and_treehash import NULL_TREEHASH
+from chia.wallet.util.curry_and_treehash import NIL_TREEHASH
 from chia.wallet.util.query_filter import HashFilter, TransactionTypeFilter
 from chia.wallet.util.transaction_type import CLAWBACK_INCOMING_TRANSACTION_TYPES, TransactionType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, CoinSelectionConfig, CoinSelectionConfigLoader, TXConfig
@@ -2333,7 +2333,7 @@ class WalletRpcApi:
             )
             full_puzzle = create_singleton_puzzle(did_puzzle, launcher_id)
             did_puzzle_empty_recovery = DID_INNERPUZ_MOD.curry(
-                our_inner_puzzle, NULL_TREEHASH, uint64(0), singleton_struct, metadata
+                our_inner_puzzle, NIL_TREEHASH, uint64(0), singleton_struct, metadata
             )
             # Check if we have the DID wallet
             did_wallet: Optional[DIDWallet] = None
@@ -2423,7 +2423,7 @@ class WalletRpcApi:
                     inner_solution: Program = full_solution.rest().rest().first()
                     recovery_list: List[bytes32] = []
                     backup_required: int = num_verification.as_int()
-                    if recovery_list_hash != NULL_TREEHASH:
+                    if recovery_list_hash != NIL_TREEHASH:
                         try:
                             for did in inner_solution.rest().rest().rest().rest().rest().as_python():
                                 recovery_list.append(did[0])

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -110,6 +110,7 @@ from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.address_type import AddressType, is_valid_address
 from chia.wallet.util.compute_hints import compute_spend_hints_and_additions
 from chia.wallet.util.compute_memos import compute_memos
+from chia.wallet.util.curry_and_treehash import NULL_TREEHASH
 from chia.wallet.util.query_filter import HashFilter, TransactionTypeFilter
 from chia.wallet.util.transaction_type import CLAWBACK_INCOMING_TRANSACTION_TYPES, TransactionType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, CoinSelectionConfig, CoinSelectionConfigLoader, TXConfig
@@ -2332,7 +2333,7 @@ class WalletRpcApi:
             )
             full_puzzle = create_singleton_puzzle(did_puzzle, launcher_id)
             did_puzzle_empty_recovery = DID_INNERPUZ_MOD.curry(
-                our_inner_puzzle, Program.to([]).get_tree_hash(), uint64(0), singleton_struct, metadata
+                our_inner_puzzle, NULL_TREEHASH, uint64(0), singleton_struct, metadata
             )
             # Check if we have the DID wallet
             did_wallet: Optional[DIDWallet] = None
@@ -2422,7 +2423,7 @@ class WalletRpcApi:
                     inner_solution: Program = full_solution.rest().rest().first()
                     recovery_list: List[bytes32] = []
                     backup_required: int = num_verification.as_int()
-                    if recovery_list_hash != Program.to([]).get_tree_hash():
+                    if recovery_list_hash != NULL_TREEHASH:
                         try:
                             for did in inner_solution.rest().rest().rest().rest().rest().as_python():
                                 recovery_list.append(did[0])

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -46,7 +46,7 @@ from chia.wallet.singleton import (
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.compute_memos import compute_memos
-from chia.wallet.util.curry_and_treehash import NULL_TREEHASH
+from chia.wallet.util.curry_and_treehash import NULL_TREEHASH, shatree_int, shatree_pair
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, CoinSelectionConfig, TXConfig
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend, fetch_coin_spend_for_coin_state
@@ -76,7 +76,7 @@ class DIDWallet:
         wallet_state_manager: Any,
         wallet: Wallet,
         amount: uint64,
-        backups_ids: List = [],
+        backups_ids: List[bytes32] = [],
         num_of_backup_ids_needed: uint64 = None,
         metadata: Dict[str, str] = {},
         name: Optional[str] = None,
@@ -231,7 +231,7 @@ class DIDWallet:
         if recovery_list_hash != NULL_TREEHASH:
             try:
                 for did in inner_solution.rest().rest().rest().rest().rest().as_python():
-                    recovery_list.append(did[0])
+                    recovery_list.append(bytes32(did[0]))
             except Exception:
                 self.log.warning(
                     f"DID {launch_coin.name().hex()} has a recovery list hash but missing a reveal,"
@@ -530,7 +530,9 @@ class DIDWallet:
     def puzzle_hash_for_pk(self, pubkey: G1Element) -> bytes32:
         if self.did_info.origin_coin is None:
             # TODO: this seem dumb. Why bother with this case? Is it ever used?
-            return puzzle_for_pk(pubkey).get_tree_hash()
+            # inner puzzle: (8 . 0)
+            innerpuz_hash = shatree_pair(shatree_int(8), NULL_TREEHASH)
+            return create_singleton_puzzle_hash(innerpuz_hash, bytes32([0] * 32))
         origin_coin_name = self.did_info.origin_coin.name()
         innerpuz_hash = did_wallet_puzzles.get_inner_puzhash_by_p2(
             p2_puzhash=puzzle_hash_for_pk(pubkey),

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -46,7 +46,7 @@ from chia.wallet.singleton import (
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.compute_memos import compute_memos
-from chia.wallet.util.curry_and_treehash import NULL_TREEHASH, shatree_int, shatree_pair
+from chia.wallet.util.curry_and_treehash import NIL_TREEHASH, shatree_int, shatree_pair
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, CoinSelectionConfig, TXConfig
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend, fetch_coin_spend_for_coin_state
@@ -228,7 +228,7 @@ class DIDWallet:
         inner_solution: Program = full_solution.rest().rest().first()
         recovery_list: List[bytes32] = []
         backup_required: int = num_verification.as_int()
-        if recovery_list_hash != NULL_TREEHASH:
+        if recovery_list_hash != NIL_TREEHASH:
             try:
                 for did in inner_solution.rest().rest().rest().rest().rest().as_python():
                     recovery_list.append(bytes32(did[0]))
@@ -531,7 +531,7 @@ class DIDWallet:
         if self.did_info.origin_coin is None:
             # TODO: this seem dumb. Why bother with this case? Is it ever used?
             # inner puzzle: (8 . 0)
-            innerpuz_hash = shatree_pair(shatree_int(8), NULL_TREEHASH)
+            innerpuz_hash = shatree_pair(shatree_int(8), NIL_TREEHASH)
             return create_singleton_puzzle_hash(innerpuz_hash, bytes32([0] * 32))
         origin_coin_name = self.did_info.origin_coin.name()
         innerpuz_hash = did_wallet_puzzles.get_inner_puzhash_by_p2(

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -46,6 +46,7 @@ from chia.wallet.singleton import (
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.compute_memos import compute_memos
+from chia.wallet.util.curry_and_treehash import NULL_TREEHASH
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, CoinSelectionConfig, TXConfig
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend, fetch_coin_spend_for_coin_state
@@ -227,7 +228,7 @@ class DIDWallet:
         inner_solution: Program = full_solution.rest().rest().first()
         recovery_list: List[bytes32] = []
         backup_required: int = num_verification.as_int()
-        if recovery_list_hash != Program.to([]).get_tree_hash():
+        if recovery_list_hash != NULL_TREEHASH:
             try:
                 for did in inner_solution.rest().rest().rest().rest().rest().as_python():
                     recovery_list.append(did[0])

--- a/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
+++ b/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
@@ -59,6 +59,7 @@ following mechanism:
 from __future__ import annotations
 
 import hashlib
+from functools import lru_cache
 from typing import Union
 
 from chia_rs import G1Element, PrivateKey
@@ -91,6 +92,7 @@ def calculate_synthetic_offset(public_key: G1Element, hidden_puzzle_hash: bytes3
     return offset
 
 
+@lru_cache(maxsize=1000)
 def calculate_synthetic_public_key(public_key: G1Element, hidden_puzzle_hash: bytes32) -> G1Element:
     synthetic_offset: PrivateKey = PrivateKey.from_bytes(
         calculate_synthetic_offset(public_key, hidden_puzzle_hash).to_bytes(32, "big")
@@ -98,6 +100,7 @@ def calculate_synthetic_public_key(public_key: G1Element, hidden_puzzle_hash: by
     return public_key + synthetic_offset.get_g1()
 
 
+@lru_cache(maxsize=1000)
 def calculate_synthetic_secret_key(secret_key: PrivateKey, hidden_puzzle_hash: bytes32) -> PrivateKey:
     secret_exponent = int.from_bytes(bytes(secret_key), "big")
     public_key = secret_key.get_g1()

--- a/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
+++ b/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
@@ -66,7 +66,7 @@ from clvm.casts import int_from_bytes
 
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.wallet.util.curry_and_treehash import calculate_hash_of_quoted_mod_hash, curry_and_treehash
+from chia.wallet.util.curry_and_treehash import calculate_hash_of_quoted_mod_hash, curry_and_treehash, shatree_atom
 
 from .load_clvm import load_clvm_maybe_recompile
 from .p2_conditions import puzzle_for_conditions
@@ -113,7 +113,7 @@ def puzzle_for_synthetic_public_key(synthetic_public_key: G1Element) -> Program:
 
 
 def puzzle_hash_for_synthetic_public_key(synthetic_public_key: G1Element) -> bytes32:
-    public_key_hash = Program.to(bytes(synthetic_public_key)).get_tree_hash()
+    public_key_hash = shatree_atom(bytes(synthetic_public_key))
     return curry_and_treehash(QUOTED_MOD_HASH, public_key_hash)
 
 

--- a/chia/wallet/util/curry_and_treehash.py
+++ b/chia/wallet/util/curry_and_treehash.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from hashlib import sha256
-from typing import Callable, List
+from typing import Callable, List, Sequence
+
+from clvm.casts import int_to_bytes
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 
@@ -36,6 +38,17 @@ A_KW_TREEHASH = shatree_atom(A_KW)
 C_KW_TREEHASH = shatree_atom(C_KW)
 ONE_TREEHASH = shatree_atom(ONE)
 NULL_TREEHASH = shatree_atom(NULL)
+
+
+def shatree_atom_list(li: Sequence[bytes]) -> bytes32:
+    ret = NULL_TREEHASH
+    for item in reversed(li):
+        ret = shatree_pair(shatree_atom(item), ret)
+    return ret
+
+
+def shatree_int(val: int) -> bytes32:
+    return shatree_atom(int_to_bytes(val))
 
 
 # The environment `E = (F . R)` recursively expands out to

--- a/chia/wallet/util/curry_and_treehash.py
+++ b/chia/wallet/util/curry_and_treehash.py
@@ -37,11 +37,11 @@ Q_KW_TREEHASH = shatree_atom(Q_KW)
 A_KW_TREEHASH = shatree_atom(A_KW)
 C_KW_TREEHASH = shatree_atom(C_KW)
 ONE_TREEHASH = shatree_atom(ONE)
-NULL_TREEHASH = shatree_atom(NULL)
+NIL_TREEHASH = shatree_atom(NULL)
 
 
 def shatree_atom_list(li: Sequence[bytes]) -> bytes32:
-    ret = NULL_TREEHASH
+    ret = NIL_TREEHASH
     for item in reversed(li):
         ret = shatree_pair(shatree_atom(item), ret)
     return ret
@@ -64,7 +64,7 @@ def curried_values_tree_hash(arguments: List[bytes32]) -> bytes32:
         C_KW_TREEHASH,
         shatree_pair(
             shatree_pair(Q_KW_TREEHASH, arguments[0]),
-            shatree_pair(curried_values_tree_hash(arguments[1:]), NULL_TREEHASH),
+            shatree_pair(curried_values_tree_hash(arguments[1:]), NIL_TREEHASH),
         ),
     )
 
@@ -82,7 +82,7 @@ def curry_and_treehash(hash_of_quoted_mod_hash: bytes32, *hashed_arguments: byte
     curried_values = curried_values_tree_hash(list(hashed_arguments))
     return shatree_pair(
         A_KW_TREEHASH,
-        shatree_pair(hash_of_quoted_mod_hash, shatree_pair(curried_values, NULL_TREEHASH)),
+        shatree_pair(hash_of_quoted_mod_hash, shatree_pair(curried_values, NIL_TREEHASH)),
     )
 
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -127,6 +127,7 @@ from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.compute_hints import compute_spend_hints_and_additions
 from chia.wallet.util.compute_memos import compute_memos
+from chia.wallet.util.curry_and_treehash import NULL_TREEHASH
 from chia.wallet.util.puzzle_decorator import PuzzleDecoratorManager
 from chia.wallet.util.query_filter import HashFilter
 from chia.wallet.util.transaction_type import CLAWBACK_INCOMING_TRANSACTION_TYPES, TransactionType
@@ -1254,7 +1255,7 @@ class WalletStateManager:
             full_puzzle = create_singleton_puzzle(did_puzzle, launch_id)
             did_puzzle_empty_recovery = DID_INNERPUZ_MOD.curry(
                 our_inner_puzzle,
-                Program.to([]).get_tree_hash(),
+                NULL_TREEHASH,
                 uint64(0),
                 parent_data.singleton_struct,
                 parent_data.metadata,

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -127,7 +127,7 @@ from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.compute_hints import compute_spend_hints_and_additions
 from chia.wallet.util.compute_memos import compute_memos
-from chia.wallet.util.curry_and_treehash import NULL_TREEHASH
+from chia.wallet.util.curry_and_treehash import NIL_TREEHASH
 from chia.wallet.util.puzzle_decorator import PuzzleDecoratorManager
 from chia.wallet.util.query_filter import HashFilter
 from chia.wallet.util.transaction_type import CLAWBACK_INCOMING_TRANSACTION_TYPES, TransactionType
@@ -1255,7 +1255,7 @@ class WalletStateManager:
             full_puzzle = create_singleton_puzzle(did_puzzle, launch_id)
             did_puzzle_empty_recovery = DID_INNERPUZ_MOD.curry(
                 our_inner_puzzle,
-                NULL_TREEHASH,
+                NIL_TREEHASH,
                 uint64(0),
                 parent_data.singleton_struct,
                 parent_data.metadata,


### PR DESCRIPTION
This PR is best reviewed one commit at a time.

## Purpose:

This PR aims to improve the performance of computing puzzle hashes. This is achieved in 3 commits:

1. rather than computing the hash of `[]` on the fly, use the constant `NULL_TREEHASH`.
2. rather than constructing `Program` objects from values, just to compute the tree hash. Compute the tree hash directly from the values using the existing `shatree_atom()`, `shatree_pair()`, as well as introducing `shatree_int()` and `shatree_byte_list()`
3. Avoid computing the public key given a derived private key (`get_g1()`) multiple times, by wrapping `calculate_synthetic_public_key` and `calculate_synthetic_secret_key` in LRU caches.

## Current Behavior:

We waste time in `get_inner_puzhash_by_p2()`

## New Behavior:

We waste less time in `get_inner_puzhash_by_p2()`

## profile

| function | before | after | after / before |
| --- | --- | --- | --- |
| `get_inner_puzhash_by_p2()` | 25.32% | 5.16% | 0.20 | 
| `puzzle_hash_for_public_key_and_hidden_puzzle_hash` |  17% | 2.12% | 0.12 |

### before

![chia-hotspot-200-204](https://github.com/Chia-Network/chia-blockchain/assets/661450/d5f4faea-1ab2-46f0-acee-75d414593c58)

### after

![chia-hotspot-93](https://github.com/Chia-Network/chia-blockchain/assets/661450/fe46a8c8-5184-4af7-bb8d-ea57fbf04785)
