### PR TITLE
fix macos installer test matrix

### DIFF
--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -423,6 +423,10 @@ jobs:
               matrix: 13
             arch:
               matrix: arm
+          - os:
+              matrix: 14
+            arch:
+              matrix: intel
 
     steps:
       - uses: Chia-Network/actions/clean-workspace@main


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

https://github.com/Chia-Network/chia-blockchain/pull/17937 quietly broke the macOS installer test matrix.  You can see the error at https://github.com/Chia-Network/chia-blockchain/actions/runs/8996036271.

> `Error when evaluating 'runs-on' for job 'test'. .github/workflows/build-macos-installers.yml (Line: 386, Col: 14): Unexpected value ''`

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
