### PR TITLE
[CHIA-508] Add tx_config and extra_conditions to DID creation endpoint

### DIFF
--- a/chia/_tests/cmds/wallet/test_did.py
+++ b/chia/_tests/cmds/wallet/test_did.py
@@ -22,6 +22,7 @@ def test_did_create(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
         async def create_new_did_wallet(
             self,
             amount: int,
+            tx_config: TXConfig,
             fee: int = 0,
             name: Optional[str] = "DID Wallet",
             backup_ids: Optional[List[str]] = None,
@@ -29,7 +30,7 @@ def test_did_create(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
         ) -> Dict[str, Union[str, int]]:
             if backup_ids is None:
                 backup_ids = []
-            self.add_to_log("create_new_did_wallet", (amount, fee, name, backup_ids, required_num))
+            self.add_to_log("create_new_did_wallet", (amount, tx_config, fee, name, backup_ids, required_num))
             return {"wallet_id": 3, "my_did": "did:chia:testdid123456"}
 
     inst_rpc_client = DidCreateRpcClient()  # pylint: disable=no-value-for-parameter
@@ -42,7 +43,7 @@ def test_did_create(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     expected_calls: logType = {
-        "create_new_did_wallet": [(3, 100000000000, "test", [], 0)],
+        "create_new_did_wallet": [(3, DEFAULT_TX_CONFIG, 100000000000, "test", [], 0)],
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
 

--- a/chia/_tests/wallet/cat_wallet/test_trades.py
+++ b/chia/_tests/wallet/cat_wallet/test_trades.py
@@ -134,10 +134,10 @@ async def test_cat_trades(
 
         # Mint some DIDs
         did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1)
+            wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1), wallet_environments.tx_config
         )
         did_wallet_taker: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node_taker.wallet_state_manager, wallet_taker, uint64(1)
+            wallet_node_taker.wallet_state_manager, wallet_taker, uint64(1), wallet_environments.tx_config
         )
         did_id_maker = bytes32.from_hexstr(did_wallet_maker.get_my_DID())
         did_id_taker = bytes32.from_hexstr(did_wallet_taker.get_my_DID())

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -85,7 +85,7 @@ class TestDIDWallet:
         # Wallet1 sets up DIDWallet1 without any backup set
         async with wallet_node_0.wallet_state_manager.lock:
             did_wallet_0: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node_0.wallet_state_manager, wallet_0, uint64(101)
+                wallet_node_0.wallet_state_manager, wallet_0, uint64(101), DEFAULT_TX_CONFIG
             )
 
         with pytest.raises(RuntimeError):
@@ -157,7 +157,7 @@ class TestDIDWallet:
         # Wallet1 sets up DIDWallet1 without any backup set
         async with wallet_node_0.wallet_state_manager.lock:
             did_wallet_0: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node_0.wallet_state_manager, wallet_0, uint64(101)
+                wallet_node_0.wallet_state_manager, wallet_0, uint64(101), DEFAULT_TX_CONFIG
             )
 
         spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
@@ -177,7 +177,7 @@ class TestDIDWallet:
 
         async with wallet_node_1.wallet_state_manager.lock:
             did_wallet_1: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node_1.wallet_state_manager, wallet_1, uint64(201), backup_ids
+                wallet_node_1.wallet_state_manager, wallet_1, uint64(201), DEFAULT_TX_CONFIG, backup_ids
             )
 
         spend_bundle_list = await wallet_node_1.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
@@ -198,7 +198,7 @@ class TestDIDWallet:
         # Wallet2 recovers DIDWallet2 to a new set of keys
         async with wallet_node_2.wallet_state_manager.lock:
             did_wallet_2 = await DIDWallet.create_new_did_wallet_from_recovery(
-                wallet_node_2.wallet_state_manager, wallet_2, backup_data
+                wallet_node_2.wallet_state_manager, wallet_2, DEFAULT_TX_CONFIG, backup_data
             )
         coin = await did_wallet_1.get_coin()
         assert did_wallet_2.did_info.temp_coin == coin
@@ -303,7 +303,7 @@ class TestDIDWallet:
 
         async with wallet_node.wallet_state_manager.lock:
             did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node.wallet_state_manager, wallet, uint64(101)
+                wallet_node.wallet_state_manager, wallet, uint64(101), DEFAULT_TX_CONFIG
             )
         assert did_wallet.get_name() == "Profile 1"
         spend_bundle_list = await wallet_node.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
@@ -320,7 +320,7 @@ class TestDIDWallet:
 
         async with wallet_node_2.wallet_state_manager.lock:
             did_wallet_2: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node_2.wallet_state_manager, wallet2, uint64(101), recovery_list
+                wallet_node_2.wallet_state_manager, wallet2, uint64(101), DEFAULT_TX_CONFIG, recovery_list
             )
 
         spend_bundle_list = await wallet_node_2.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
@@ -341,7 +341,7 @@ class TestDIDWallet:
 
         async with wallet_node_2.wallet_state_manager.lock:
             did_wallet_3: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node_2.wallet_state_manager, wallet2, uint64(201), recovery_list
+                wallet_node_2.wallet_state_manager, wallet2, uint64(201), DEFAULT_TX_CONFIG, recovery_list
             )
 
         spend_bundle_list = await wallet_node_2.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
@@ -453,7 +453,7 @@ class TestDIDWallet:
 
         async with wallet_node.wallet_state_manager.lock:
             did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node.wallet_state_manager, wallet, uint64(101)
+                wallet_node.wallet_state_manager, wallet, uint64(101), DEFAULT_TX_CONFIG
             )
 
         spend_bundle_list = await wallet_node.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
@@ -501,7 +501,7 @@ class TestDIDWallet:
 
         async with wallet_node.wallet_state_manager.lock:
             did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node.wallet_state_manager, wallet, uint64(101)
+                wallet_node.wallet_state_manager, wallet, uint64(101), DEFAULT_TX_CONFIG
             )
         spend_bundle_list = await wallet_node.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
 
@@ -585,7 +585,7 @@ class TestDIDWallet:
 
         async with wallet_node.wallet_state_manager.lock:
             did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node.wallet_state_manager, wallet, uint64(101)
+                wallet_node.wallet_state_manager, wallet, uint64(101), DEFAULT_TX_CONFIG
             )
         spend_bundle_list = await wallet_node.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
 
@@ -599,7 +599,7 @@ class TestDIDWallet:
 
         async with wallet_node_2.wallet_state_manager.lock:
             did_wallet_2: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node_2.wallet_state_manager, wallet2, uint64(101), recovery_list
+                wallet_node_2.wallet_state_manager, wallet2, uint64(101), DEFAULT_TX_CONFIG, recovery_list
             )
         spend_bundle_list = await wallet_node_2.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
             did_wallet_2.id()
@@ -764,6 +764,7 @@ class TestDIDWallet:
                 wallet_node.wallet_state_manager,
                 wallet,
                 uint64(101),
+                DEFAULT_TX_CONFIG,
                 [bytes(ph)],
                 uint64(1),
                 {"Twitter": "Test", "GitHub": "测试"},
@@ -846,7 +847,7 @@ class TestDIDWallet:
 
         async with wallet_node.wallet_state_manager.lock:
             did_wallet_1: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node.wallet_state_manager, wallet, uint64(101), []
+                wallet_node.wallet_state_manager, wallet, uint64(101), DEFAULT_TX_CONFIG, []
             )
         spend_bundle_list = await wallet_node.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
             did_wallet_1.id()
@@ -899,7 +900,13 @@ class TestDIDWallet:
 
         async with wallet_node.wallet_state_manager.lock:
             did_wallet_1: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node.wallet_state_manager, wallet, did_amount, [], metadata={"twitter": "twitter"}, fee=fee
+                wallet_node.wallet_state_manager,
+                wallet,
+                did_amount,
+                DEFAULT_TX_CONFIG,
+                [],
+                metadata={"twitter": "twitter"},
+                fee=fee,
             )
         transaction_records = await wallet_node.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
             did_wallet_1.id()
@@ -1033,7 +1040,7 @@ class TestDIDWallet:
 
         async with wallet_node.wallet_state_manager.lock:
             did_wallet_1: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node.wallet_state_manager, wallet, did_amount, [], fee=fee
+                wallet_node.wallet_state_manager, wallet, did_amount, DEFAULT_TX_CONFIG, [], fee=fee
             )
         transaction_records = await wallet_node.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
             did_wallet_1.id()
@@ -1115,6 +1122,7 @@ class TestDIDWallet:
                 wallet_node.wallet_state_manager,
                 wallet,
                 uint64(101),
+                DEFAULT_TX_CONFIG,
                 [bytes(ph)],
                 uint64(1),
                 {"Twitter": "Test", "GitHub": "测试"},
@@ -1247,6 +1255,7 @@ class TestDIDWallet:
                 wallet_node_0.wallet_state_manager,
                 wallet_0,
                 uint64(101),
+                DEFAULT_TX_CONFIG,
                 backups_ids=recovery_list,
                 num_of_backup_ids_needed=0,
             )
@@ -1313,6 +1322,7 @@ class TestDIDWallet:
                 wallet_node_1.wallet_state_manager,
                 wallet,
                 uint64(101),
+                DEFAULT_TX_CONFIG,
                 [bytes32(ph)],
                 uint64(1),
                 {"Twitter": "Test", "GitHub": "测试"},
@@ -1389,7 +1399,9 @@ async def test_did_coin_records(wallet_environments: WalletTestFramework, monkey
     client = wallet_environments.environments[0].rpc_client
 
     # Generate DID wallet
-    did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(wallet_node.wallet_state_manager, wallet, uint64(1))
+    did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
+        wallet_node.wallet_state_manager, wallet, uint64(1), DEFAULT_TX_CONFIG
+    )
 
     await wallet_environments.process_pending_states(
         [

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -198,7 +198,7 @@ class TestDIDWallet:
         # Wallet2 recovers DIDWallet2 to a new set of keys
         async with wallet_node_2.wallet_state_manager.lock:
             did_wallet_2 = await DIDWallet.create_new_did_wallet_from_recovery(
-                wallet_node_2.wallet_state_manager, wallet_2, DEFAULT_TX_CONFIG, backup_data
+                wallet_node_2.wallet_state_manager, wallet_2, backup_data
             )
         coin = await did_wallet_1.get_coin()
         assert did_wallet_2.did_info.temp_coin == coin
@@ -985,7 +985,7 @@ class TestDIDWallet:
 
         async with wallet_node.wallet_state_manager.lock:
             did_wallet_1: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node.wallet_state_manager, wallet, uint64(101), [], fee=fee
+                wallet_node.wallet_state_manager, wallet, uint64(101), DEFAULT_TX_CONFIG, [], fee=fee
             )
         spend_bundle_list = await wallet_node.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
             did_wallet_1.id()

--- a/chia/_tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -93,7 +93,7 @@ async def test_nft_offer_sell_nft(
     await full_node_api.farm_rewards_to_wallet(funds, wallet_taker, timeout=30)
 
     did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1)
+        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_maker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
         did_wallet_maker.id()
@@ -237,7 +237,7 @@ async def test_nft_offer_request_nft(
     await full_node_api.farm_rewards_to_wallet(funds, wallet_taker, timeout=30)
 
     did_wallet_taker: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_taker.wallet_state_manager, wallet_taker, uint64(1)
+        wallet_node_taker.wallet_state_manager, wallet_taker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_taker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
         did_wallet_taker.id()
@@ -379,7 +379,7 @@ async def test_nft_offer_sell_did_to_did(
     await full_node_api.farm_rewards_to_wallet(funds, wallet_taker, timeout=30)
 
     did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1)
+        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_maker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
         did_wallet_maker.id()
@@ -435,7 +435,7 @@ async def test_nft_offer_sell_did_to_did(
 
     # TAKER SETUP -  WITH DID
     did_wallet_taker: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_taker.wallet_state_manager, wallet_taker, uint64(1)
+        wallet_node_taker.wallet_state_manager, wallet_taker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list_taker = await wallet_node_taker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
         did_wallet_taker.id()
@@ -544,7 +544,7 @@ async def test_nft_offer_sell_nft_for_cat(
     await full_node_api.farm_rewards_to_wallet(funds, wallet_taker, timeout=30)
 
     did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1)
+        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_maker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
         did_wallet_maker.id()
@@ -730,7 +730,7 @@ async def test_nft_offer_request_nft_for_cat(
     await full_node_api.farm_rewards_to_wallet(funds, wallet_taker, timeout=30)
 
     did_wallet_taker: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_taker.wallet_state_manager, wallet_taker, uint64(1)
+        wallet_node_taker.wallet_state_manager, wallet_taker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_taker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
         did_wallet_taker.id()
@@ -929,7 +929,7 @@ async def test_nft_offer_sell_cancel(
     await full_node_api.farm_rewards_to_wallet(funds, wallet_maker, timeout=30)
 
     did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1)
+        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_maker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
         did_wallet_maker.id()
@@ -1049,7 +1049,7 @@ async def test_nft_offer_sell_cancel_in_batch(
     await full_node_api.farm_rewards_to_wallet(funds, wallet_maker, timeout=30)
 
     did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1)
+        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_maker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
         did_wallet_maker.id()
@@ -1215,8 +1215,12 @@ async def test_complex_nft_offer(
     basic_nft_wallet_maker = await NFTWallet.create_new_nft_wallet(wsm_maker, wallet_maker, name="NFT WALLET MAKER")
     basic_nft_wallet_taker = await NFTWallet.create_new_nft_wallet(wsm_taker, wallet_taker, name="NFT WALLET TAKER")
 
-    did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(wsm_maker, wallet_maker, uint64(1))
-    did_wallet_taker: DIDWallet = await DIDWallet.create_new_did_wallet(wsm_taker, wallet_taker, uint64(1))
+    did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
+        wsm_maker, wallet_maker, uint64(1), DEFAULT_TX_CONFIG
+    )
+    did_wallet_taker: DIDWallet = await DIDWallet.create_new_did_wallet(
+        wsm_taker, wallet_taker, uint64(1), DEFAULT_TX_CONFIG
+    )
     did_spend_bundle_maker = (
         await wallet_node_maker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet_maker.id())
     )[0].spend_bundle

--- a/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -72,7 +72,7 @@ async def test_nft_mint_from_did(
     await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
 
     did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_0.wallet_state_manager, wallet_0, uint64(1)
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
     spend_bundle = spend_bundle_list[0].spend_bundle
@@ -215,7 +215,7 @@ async def test_nft_mint_from_did_rpc(
     )
 
     did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1)
+        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_maker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
         did_wallet_maker.id()
@@ -411,7 +411,7 @@ async def test_nft_mint_from_did_rpc_no_royalties(
     )
 
     did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1)
+        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_maker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
         did_wallet_maker.id()
@@ -562,7 +562,7 @@ async def test_nft_mint_from_did_multiple_xch(
     await time_out_assert(30, wallet_maker.get_confirmed_balance, funds)
 
     did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_0.wallet_state_manager, wallet_maker, uint64(1)
+        wallet_node_0.wallet_state_manager, wallet_maker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
     spend_bundle = spend_bundle_list[0].spend_bundle
@@ -678,7 +678,7 @@ async def test_nft_mint_from_xch(
     await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
 
     did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_0.wallet_state_manager, wallet_0, uint64(1)
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
     spend_bundle = spend_bundle_list[0].spend_bundle
@@ -820,7 +820,7 @@ async def test_nft_mint_from_xch_rpc(
     )
 
     did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1)
+        wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_maker.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(
         did_wallet_maker.id()
@@ -982,7 +982,7 @@ async def test_nft_mint_from_xch_multiple_xch(
     await time_out_assert(30, wallet_maker.get_confirmed_balance, funds)
 
     did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_0.wallet_state_manager, wallet_maker, uint64(1)
+        wallet_node_0.wallet_state_manager, wallet_maker, uint64(1), DEFAULT_TX_CONFIG
     )
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
     spend_bundle = spend_bundle_list[0].spend_bundle

--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -783,7 +783,9 @@ async def test_nft_with_did_wallet_creation(
 
     await time_out_assert(30, wallet_0.get_unconfirmed_balance, funds)
     await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
-    did_wallet = await DIDWallet.create_new_did_wallet(wallet_node_0.wallet_state_manager, wallet_0, uint64(1))
+    did_wallet = await DIDWallet.create_new_did_wallet(
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1), DEFAULT_TX_CONFIG
+    )
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
     spend_bundle = spend_bundle_list[0].spend_bundle
     assert spend_bundle is not None
@@ -947,7 +949,9 @@ async def test_nft_rpc_mint(self_hostname: str, two_wallet_nodes: OldSimulatorsA
 
     await time_out_assert(30, wallet_0.get_unconfirmed_balance, funds)
     await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
-    did_wallet = await DIDWallet.create_new_did_wallet(wallet_node_0.wallet_state_manager, wallet_0, uint64(1))
+    did_wallet = await DIDWallet.create_new_did_wallet(
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1), DEFAULT_TX_CONFIG
+    )
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
     spend_bundle = spend_bundle_list[0].spend_bundle
     assert spend_bundle is not None
@@ -1067,7 +1071,9 @@ async def test_nft_transfer_nft_with_did(
     await time_out_assert(30, wallet_0.get_unconfirmed_balance, funds)
     await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
     # Create DID
-    did_wallet = await DIDWallet.create_new_did_wallet(wallet_node_0.wallet_state_manager, wallet_0, uint64(1))
+    did_wallet = await DIDWallet.create_new_did_wallet(
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1), DEFAULT_TX_CONFIG
+    )
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
     spend_bundle = spend_bundle_list[0].spend_bundle
     assert spend_bundle is not None
@@ -1233,7 +1239,9 @@ async def test_update_metadata_for_nft_did(
 
     await time_out_assert(30, wallet_0.get_unconfirmed_balance, funds)
     await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
-    did_wallet = await DIDWallet.create_new_did_wallet(wallet_node_0.wallet_state_manager, wallet_0, uint64(1))
+    did_wallet = await DIDWallet.create_new_did_wallet(
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1), DEFAULT_TX_CONFIG
+    )
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
 
     spend_bundle = spend_bundle_list[0].spend_bundle
@@ -1362,7 +1370,9 @@ async def test_nft_bulk_set_did(self_hostname: str, two_wallet_nodes: OldSimulat
 
     await time_out_assert(30, wallet_0.get_unconfirmed_balance, funds)
     await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
-    did_wallet = await DIDWallet.create_new_did_wallet(wallet_node_0.wallet_state_manager, wallet_0, uint64(1))
+    did_wallet = await DIDWallet.create_new_did_wallet(
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1), DEFAULT_TX_CONFIG
+    )
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
     spend_bundle = spend_bundle_list[0].spend_bundle
     assert spend_bundle is not None
@@ -1535,7 +1545,9 @@ async def test_nft_bulk_transfer(self_hostname: str, two_wallet_nodes: OldSimula
 
     await time_out_assert(30, wallet_0.get_unconfirmed_balance, funds)
     await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
-    did_wallet = await DIDWallet.create_new_did_wallet(wallet_node_0.wallet_state_manager, wallet_0, uint64(1))
+    did_wallet = await DIDWallet.create_new_did_wallet(
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1), DEFAULT_TX_CONFIG
+    )
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
     spend_bundle = spend_bundle_list[0].spend_bundle
     assert spend_bundle is not None
@@ -1685,7 +1697,9 @@ async def test_nft_set_did(self_hostname: str, two_wallet_nodes: OldSimulatorsAn
 
     await time_out_assert(30, wallet_0.get_unconfirmed_balance, funds)
     await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
-    did_wallet = await DIDWallet.create_new_did_wallet(wallet_node_0.wallet_state_manager, wallet_0, uint64(1))
+    did_wallet = await DIDWallet.create_new_did_wallet(
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1), DEFAULT_TX_CONFIG
+    )
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet.id())
     spend_bundle = spend_bundle_list[0].spend_bundle
     assert spend_bundle is not None
@@ -1730,7 +1744,9 @@ async def test_nft_set_did(self_hostname: str, two_wallet_nodes: OldSimulatorsAn
     nft_coin_id = coins[0].nft_coin_id
 
     # Test set None -> DID1
-    did_wallet1 = await DIDWallet.create_new_did_wallet(wallet_node_0.wallet_state_manager, wallet_0, uint64(1))
+    did_wallet1 = await DIDWallet.create_new_did_wallet(
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1), DEFAULT_TX_CONFIG
+    )
     spend_bundle_list = await wallet_node_0.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(did_wallet1.id())
 
     spend_bundle = spend_bundle_list[0].spend_bundle

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -1421,7 +1421,7 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     await generate_funds(env.full_node.api, env.wallet_1, 5)
 
     # Create a DID wallet
-    res = await wallet_1_rpc.create_new_did_wallet(amount=1, name="Profile 1")
+    res = await wallet_1_rpc.create_new_did_wallet(amount=1, tx_config=DEFAULT_TX_CONFIG, name="Profile 1")
     assert res["success"]
     did_wallet_id_0 = res["wallet_id"]
     did_id_0 = res["my_did"]
@@ -2312,7 +2312,7 @@ async def test_set_wallet_resync_on_startup(wallet_rpc_environment: WalletRpcTes
     client: WalletRpcClient = env.wallet_1.rpc_client
     await generate_funds(full_node_api, env.wallet_1)
     wc = env.wallet_1.rpc_client
-    await wc.create_new_did_wallet(1, 0)
+    await wc.create_new_did_wallet(1, DEFAULT_TX_CONFIG, 0)
     await time_out_assert(5, check_mempool_spend_count, True, full_node_api, 1)
     await farm_transaction_block(full_node_api, env.wallet_1.node)
     await time_out_assert(20, wc.get_synced)

--- a/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
@@ -148,7 +148,11 @@ async def test_vc_lifecycle(wallet_environments: WalletTestFramework) -> None:
 
     # Generate DID as an "authorized provider"
     did_id: bytes32 = bytes32.from_hexstr(
-        (await DIDWallet.create_new_did_wallet(wallet_node_0.wallet_state_manager, wallet_0, uint64(1))).get_my_DID()
+        (
+            await DIDWallet.create_new_did_wallet(
+                wallet_node_0.wallet_state_manager, wallet_0, uint64(1), DEFAULT_TX_CONFIG
+            )
+        ).get_my_DID()
     )
 
     # Mint a VC
@@ -633,7 +637,7 @@ async def test_self_revoke(wallet_environments: WalletTestFramework) -> None:
 
     # Generate DID as an "authorized provider"
     did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-        wallet_node_0.wallet_state_manager, wallet_0, uint64(1)
+        wallet_node_0.wallet_state_manager, wallet_0, uint64(1), DEFAULT_TX_CONFIG
     )
     did_id: bytes32 = bytes32.from_hexstr(did_wallet.get_my_DID())
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -904,7 +904,9 @@ async def create_did_wallet(
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
         fee: int = int(d_fee * units["chia"])
         try:
-            response = await wallet_client.create_new_did_wallet(amount, fee, name)
+            response = await wallet_client.create_new_did_wallet(
+                amount, CMDTXConfigLoader().to_tx_config(units["chia"], config, fingerprint), fee, name
+            )
             wallet_id = response["wallet_id"]
             my_did = response["my_did"]
             print(f"Successfully created a DID wallet with name {name} and id {wallet_id} on key {fingerprint}")

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -767,11 +767,13 @@ class WalletRpcApi:
                         wallet_state_manager,
                         main_wallet,
                         uint64(request["amount"]),
+                        tx_config,
                         backup_dids,
                         uint64(num_needed),
                         metadata,
                         did_wallet_name,
                         uint64(request.get("fee", 0)),
+                        extra_conditions=extra_conditions,
                     )
 
                     my_did_id = encode_puzzle_hash(

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -405,10 +405,13 @@ class WalletRpcClient(RpcClient):
     async def create_new_did_wallet(
         self,
         amount: int,
+        tx_config: TXConfig,
         fee: int = 0,
         name: Optional[str] = "DID Wallet",
         backup_ids: List[str] = [],
         required_num: int = 0,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+        timelock_info: ConditionValidTimes = ConditionValidTimes(),
     ) -> Dict[str, Any]:
         request = {
             "wallet_type": "did_wallet",
@@ -418,6 +421,9 @@ class WalletRpcClient(RpcClient):
             "amount": amount,
             "fee": fee,
             "wallet_name": name,
+            "extra_conditions": conditions_to_json_dicts(extra_conditions),
+            **tx_config.to_json_dict(),
+            **timelock_info.to_json_dict(),
         }
         response = await self.fetch("create_new_wallet", request)
         return response


### PR DESCRIPTION
Missed in the initial refactors due to its unique position as a wallet creator, this PR adds the standard transaction parameters of `tx_config` and `extra_conditions` to the endpoint for creating DIDs.

Addresses https://github.com/Chia-Network/chia-blockchain/issues/17997