### PR TITLE
Remove ALERTS_URL and CHIA_ALERTS_PUBKEY

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -131,8 +131,6 @@ network_overrides: &network_overrides
       default_full_node_port: 58444
 
 selected_network: &selected_network "mainnet"
-ALERTS_URL: https://download.chia.net/notify/mainnet_alert.txt
-CHIA_ALERTS_PUBKEY: 89b7fd87cb56e926ecefb879a29aae308be01f31980569f6a75a69d2a9a69daefd71fb778d865f7c50d6c967e3025937
 
 # public ssl ca is included in source code
 # Private ssl ca is used for trusted connections between machines user owns


### PR DESCRIPTION
These config items are confusing and also not used anywhere in either `chia-blockchain` or `chia-blockchain-gui`, and the only reference within the org are other config files including them.

It seems after looking at the source code of `chia-blockchain==1.0.0`, we used to make an API call to this endpoint, parse the JSON, and use this as a source of truth for the `GENESIS_CHALLENGE`.

However, this is now `ConsensusConstants.GENESIS_CHALLENGE`, and an API call is no longer used anywhere for this.
