### PR TITLE
temporarily exclude focal and jammy installer script testing on arm

### DIFF
--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -142,6 +142,14 @@ jobs:
               type: arch
             arch:
               matrix: arm
+          - distribution:
+              url: "docker://ubuntu:focal"
+            arch:
+              matrix: arm
+          - distribution:
+              url: "docker://ubuntu:jammy"
+            arch:
+              matrix: arm
 
     steps:
       - name: Prepare Amazon Linux


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

noble was already fixed upstream

skip until upstream fixes jammy and focal

https://github.com/Chia-Network/chia-blockchain/actions/runs/9097925443/job/25052367324
```
The following packages have unmet dependencies:
 git : Depends: git-man (< 1:2.43.2-.) but 1:2.45.1-0ppa1~ubuntu22.04.1 is to be installed
       Recommends: patch but it is not going to be installed
       Recommends: less but it is not going to be installed
       Recommends: ssh-client
E: Unable to correct problems, you have held broken packages.
```

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
