### PR TITLE
[CHIA-426] Port `chia wallet clawback` to @tx_out_cmd

### DIFF
--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -507,10 +507,21 @@ def test_clawback(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Pa
             coin_ids: List[bytes32],
             fee: int = 0,
             force: bool = False,
+            push: bool = True,
         ) -> Dict[str, Any]:
-            self.add_to_log("spend_clawback_coins", (coin_ids, fee, force))
+            self.add_to_log("spend_clawback_coins", (coin_ids, fee, force, push))
             tx_hex_list = [get_bytes32(6).hex(), get_bytes32(7).hex(), get_bytes32(8).hex()]
-            return {"transaction_ids": tx_hex_list}
+            return {
+                "transaction_ids": tx_hex_list,
+                "transactions": [
+                    STD_TX.to_json_dict_convenience(
+                        {
+                            "selected_network": "mainnet",
+                            "network_overrides": {"config": {"mainnet": {"address_prefix": "xch"}}},
+                        }
+                    )
+                ],
+            }
 
     inst_rpc_client = ClawbackWalletRpcClient()  # pylint: disable=no-value-for-parameter
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
@@ -528,7 +539,7 @@ def test_clawback(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Pa
     run_cli_command_and_assert(capsys, root_dir, command_args, ["transaction_ids", str(r_tx_ids_hex)])
     # these are various things that should be in the output
     expected_calls: logType = {
-        "spend_clawback_coins": [(tx_ids, 1000000000000, False)],
+        "spend_clawback_coins": [(tx_ids, 1000000000000, False, True)],
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
 

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -313,14 +313,15 @@ def get_address_cmd(wallet_rpc_port: Optional[int], id: int, fingerprint: int, n
     is_flag=True,
     default=False,
 )
+@tx_out_cmd
 def clawback(
-    wallet_rpc_port: Optional[int], id: int, fingerprint: int, tx_ids: str, fee: str, force: bool
-) -> None:  # pragma: no cover
+    wallet_rpc_port: Optional[int], id: int, fingerprint: int, tx_ids: str, fee: str, force: bool, push: bool
+) -> List[TransactionRecord]:
     from .wallet_funcs import spend_clawback
 
-    asyncio.run(
+    return asyncio.run(
         spend_clawback(
-            wallet_rpc_port=wallet_rpc_port, fp=fingerprint, fee=Decimal(fee), tx_ids_str=tx_ids, force=force
+            wallet_rpc_port=wallet_rpc_port, fp=fingerprint, fee=Decimal(fee), tx_ids_str=tx_ids, force=force, push=push
         )
     )
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -1457,20 +1457,27 @@ async def sign_message(
 
 
 async def spend_clawback(
-    *, wallet_rpc_port: Optional[int], fp: Optional[int], fee: Decimal, tx_ids_str: str, force: bool = False
-) -> None:  # pragma: no cover
+    *,
+    wallet_rpc_port: Optional[int],
+    fp: Optional[int],
+    fee: Decimal,
+    tx_ids_str: str,
+    force: bool = False,
+    push: bool = True,
+) -> List[TransactionRecord]:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, _, _):
         tx_ids = []
         for tid in tx_ids_str.split(","):
             tx_ids.append(bytes32.from_hexstr(tid))
         if len(tx_ids) == 0:
             print("Transaction ID is required.")
-            return
+            return []
         if fee < 0:
             print("Batch fee cannot be negative.")
-            return
-        response = await wallet_client.spend_clawback_coins(tx_ids, int(fee * units["chia"]), force)
+            return []
+        response = await wallet_client.spend_clawback_coins(tx_ids, int(fee * units["chia"]), force, push=push)
         print(str(response))
+        return [TransactionRecord.from_json_dict_convenience(tx) for tx in response["transactions"]]
 
 
 async def mint_vc(

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -299,6 +299,7 @@ class WalletRpcClient(RpcClient):
         coin_ids: List[bytes32],
         fee: int = 0,
         force: bool = False,
+        push: bool = True,
         extra_conditions: Tuple[Condition, ...] = tuple(),
         timelock_info: ConditionValidTimes = ConditionValidTimes(),
     ) -> Dict[str, Any]:
@@ -307,6 +308,7 @@ class WalletRpcClient(RpcClient):
             "fee": fee,
             "force": force,
             "extra_conditions": conditions_to_json_dicts(extra_conditions),
+            "push": push,
             **timelock_info.to_json_dict(),
         }
         response = await self.fetch("spend_clawback_coins", request)


### PR DESCRIPTION
This brings another set of commands to the @tx_out_cmd decorator which gives it the capability to optionally push a transaction and export the transactions to a local file.