### PR TITLE
CHIA-595: bump chia_rs to 0.8.0 and update G1Element handling

### DIFF
--- a/chia/_tests/clvm/test_puzzles.py
+++ b/chia/_tests/clvm/test_puzzles.py
@@ -233,7 +233,7 @@ def do_test_spend_p2_delegated_puzzle_or_hidden_puzzle_with_delegated_puzzle(hid
 
     assert synthetic_public_key == int_to_public_key(synthetic_offset) + hidden_pub_key_point
 
-    secret_exponent = key_lookup.dict.get(hidden_public_key)
+    secret_exponent = key_lookup.dict[G1Element.from_bytes(hidden_public_key)]
     assert int_to_public_key(secret_exponent) == hidden_pub_key_point
 
     synthetic_secret_exponent = secret_exponent + synthetic_offset

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -2161,7 +2161,7 @@ class TestGeneratorConditions:
         ],
     )
     def test_agg_sig_cost(self, condition, softfork_height):
-        pubkey = "0x" + bytes(G1Element()).hex()
+        pubkey = "0x" + bytes(G1Element.generator()).hex()
 
         if softfork_height >= test_constants.HARD_FORK_FIX_HEIGHT:
             generator_base_cost = 40
@@ -2219,7 +2219,7 @@ class TestGeneratorConditions:
     @pytest.mark.parametrize("extra_arg", [' "baz"', ""])
     @pytest.mark.parametrize("mempool", [True, False])
     def test_agg_sig_extra_arg(self, condition, extra_arg, mempool, softfork_height):
-        pubkey = "0x" + bytes(G1Element()).hex()
+        pubkey = "0x" + bytes(G1Element.generator()).hex()
 
         new_condition = condition in [
             ConditionOpcode.AGG_SIG_PARENT,

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -6,7 +6,7 @@ import random
 from typing import Callable, Dict, List, Optional, Tuple
 
 import pytest
-from chia_rs import G2Element
+from chia_rs import G1Element, G2Element
 from clvm.casts import int_to_bytes
 from clvm_tools import binutils
 
@@ -2161,7 +2161,7 @@ class TestGeneratorConditions:
         ],
     )
     def test_agg_sig_cost(self, condition, softfork_height):
-        pubkey = "abababababababababababababababababababababababab"
+        pubkey = "0x" + bytes(G1Element()).hex()
 
         if softfork_height >= test_constants.HARD_FORK_FIX_HEIGHT:
             generator_base_cost = 40
@@ -2182,7 +2182,7 @@ class TestGeneratorConditions:
 
         # this max cost is exactly enough for the AGG_SIG condition
         npc_result = generator_condition_tester(
-            f'({condition[0]} "{pubkey}" "foobar") ',
+            f'({condition[0]} {pubkey} "foobar") ',
             max_cost=generator_base_cost + 117 * COST_PER_BYTE + expected_cost,
             height=softfork_height,
         )
@@ -2193,7 +2193,7 @@ class TestGeneratorConditions:
 
         # if we subtract one from max cost, this should fail
         npc_result = generator_condition_tester(
-            f'({condition[0]} "{pubkey}" "foobar") ',
+            f'({condition[0]} {pubkey} "foobar") ',
             max_cost=generator_base_cost + 117 * COST_PER_BYTE + expected_cost - 1,
             height=softfork_height,
         )
@@ -2219,7 +2219,7 @@ class TestGeneratorConditions:
     @pytest.mark.parametrize("extra_arg", [' "baz"', ""])
     @pytest.mark.parametrize("mempool", [True, False])
     def test_agg_sig_extra_arg(self, condition, extra_arg, mempool, softfork_height):
-        pubkey = "abababababababababababababababababababababababab"
+        pubkey = "0x" + bytes(G1Element()).hex()
 
         new_condition = condition in [
             ConditionOpcode.AGG_SIG_PARENT,
@@ -2258,7 +2258,7 @@ class TestGeneratorConditions:
 
         # this max cost is exactly enough for the AGG_SIG condition
         npc_result = generator_condition_tester(
-            f'({condition[0]} "{pubkey}" "foobar"{extra_arg}) ',
+            f'({condition[0]} {pubkey} "foobar"{extra_arg}) ',
             max_cost=11000000000,
             height=softfork_height,
             mempool_mode=mempool,

--- a/chia/_tests/core/util/test_cached_bls.py
+++ b/chia/_tests/core/util/test_cached_bls.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from chia_rs import AugSchemeMPL, G1Element
+from chia_rs import AugSchemeMPL
 
 from chia.util import cached_bls
 from chia.util.hash import std_hash
@@ -11,7 +11,7 @@ def test_cached_bls():
     n_keys = 10
     seed = b"a" * 31
     sks = [AugSchemeMPL.key_gen(seed + bytes([i])) for i in range(n_keys)]
-    pks = [bytes(sk.get_g1()) for sk in sks]
+    pks = [sk.get_g1() for sk in sks]
 
     msgs = [("msg-%d" % (i,)).encode() for i in range(n_keys)]
     sigs = [AugSchemeMPL.sign(sk, msg) for sk, msg in zip(sks, msgs)]
@@ -22,7 +22,7 @@ def test_cached_bls():
     sigs_half = sigs[: n_keys // 2]
     agg_sig_half = AugSchemeMPL.aggregate(sigs_half)
 
-    assert AugSchemeMPL.aggregate_verify([G1Element.from_bytes(pk) for pk in pks], msgs, agg_sig)
+    assert AugSchemeMPL.aggregate_verify(pks, msgs, agg_sig)
 
     # Verify with empty cache and populate it
     assert cached_bls.aggregate_verify(pks_half, msgs_half, agg_sig_half, True)
@@ -46,12 +46,12 @@ def test_cached_bls_repeat_pk():
     n_keys = 400
     seed = b"a" * 32
     sks = [AugSchemeMPL.key_gen(seed) for i in range(n_keys)] + [AugSchemeMPL.key_gen(std_hash(seed))]
-    pks = [bytes(sk.get_g1()) for sk in sks]
+    pks = [sk.get_g1() for sk in sks]
 
     msgs = [("msg-%d" % (i,)).encode() for i in range(n_keys + 1)]
     sigs = [AugSchemeMPL.sign(sk, msg) for sk, msg in zip(sks, msgs)]
     agg_sig = AugSchemeMPL.aggregate(sigs)
 
-    assert AugSchemeMPL.aggregate_verify([G1Element.from_bytes(pk) for pk in pks], msgs, agg_sig)
+    assert AugSchemeMPL.aggregate_verify(pks, msgs, agg_sig)
 
     assert cached_bls.aggregate_verify(pks, msgs, agg_sig, force_cache=True)

--- a/chia/_tests/util/key_tool.py
+++ b/chia/_tests/util/key_tool.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List
 
-from chia_rs import AugSchemeMPL, G2Element, PrivateKey
+from chia_rs import AugSchemeMPL, G1Element, G2Element, PrivateKey
 
 from chia._tests.core.make_block_generator import GROUP_ORDER, int_to_public_key
 from chia.simulator.block_tools import test_constants
@@ -13,16 +13,16 @@ from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_fo
 
 @dataclass
 class KeyTool:
-    dict: Dict[bytes, int] = field(default_factory=dict)
+    dict: Dict[G1Element, int] = field(default_factory=dict)
 
     def add_secret_exponents(self, secret_exponents: List[int]) -> None:
         for _ in secret_exponents:
-            self.dict[bytes(int_to_public_key(_))] = _ % GROUP_ORDER
+            self.dict[int_to_public_key(_)] = _ % GROUP_ORDER
 
-    def sign(self, public_key: bytes, message: bytes) -> G2Element:
+    def sign(self, public_key: G1Element, message: bytes) -> G2Element:
         secret_exponent = self.dict.get(public_key)
         if not secret_exponent:
-            raise ValueError("unknown pubkey %s" % public_key.hex())
+            raise ValueError("unknown pubkey %s" % bytes(public_key).hex())
         bls_private_key = PrivateKey.from_bytes(secret_exponent.to_bytes(32, "big"))
         return AugSchemeMPL.sign(bls_private_key, message)
 

--- a/chia/_tests/wallet/clawback/test_clawback_lifecycle.py
+++ b/chia/_tests/wallet/clawback/test_clawback_lifecycle.py
@@ -75,10 +75,9 @@ class TestClawbackLifecycle:
 
         conditions_dict = conditions_dict_for_solution(coin_spend.puzzle_reveal, coin_spend.solution, INFINITE_COST)
         signatures = []
-        for pk_bytes, msg in pkm_pairs_for_conditions_dict(
+        for pk, msg in pkm_pairs_for_conditions_dict(
             conditions_dict, coin_spend.coin, DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA
         ):
-            pk = G1Element.from_bytes(pk_bytes)
             signature = AugSchemeMPL.sign(synthetic_secret_key, msg)
             assert AugSchemeMPL.verify(pk, msg, signature)
             signatures.append(signature)

--- a/chia/_tests/wallet/test_signer_protocol.py
+++ b/chia/_tests/wallet/test_signer_protocol.py
@@ -122,7 +122,7 @@ async def test_p2dohp_wallet_signer_protocol(wallet_environments: WalletTestFram
         SumHint(
             [pubkey.get_fingerprint().to_bytes(4, "big")],
             calculate_synthetic_offset(pubkey, DEFAULT_HIDDEN_PUZZLE_HASH).to_bytes(32, "big"),
-            wallet_state_manager.main_wallet.puzzle_for_pk(pubkey).uncurry()[1].at("f").as_atom(),
+            G1Element.from_bytes(wallet_state_manager.main_wallet.puzzle_for_pk(pubkey).uncurry()[1].at("f").as_atom()),
         )
     ]
     assert utx.signing_instructions.key_hints.path_hints == [
@@ -184,7 +184,7 @@ async def test_p2dohp_wallet_signer_protocol(wallet_environments: WalletTestFram
                     not_our_signing_instructions.key_hints,
                     sum_hints=[
                         *not_our_signing_instructions.key_hints.sum_hints,
-                        SumHint([bytes(not_our_pubkey)], std_hash(b"sum hint only"), bytes(G1Element())),
+                        SumHint([bytes(not_our_pubkey)], std_hash(b"sum hint only"), G1Element()),
                     ],
                 ),
             )
@@ -284,7 +284,7 @@ async def test_p2blsdohp_execute_signing_instructions(wallet_environments: Walle
     sum_pk: G1Element = other_sk.get_g1() + root_pk
     signing_instructions: SigningInstructions = SigningInstructions(
         KeyHints(
-            [SumHint([root_fingerprint], test_name, bytes(sum_pk))],
+            [SumHint([root_fingerprint], test_name, sum_pk)],
             [],
         ),
         [SigningTarget(sum_pk.get_fingerprint().to_bytes(4, "big"), test_name, test_name)],
@@ -335,7 +335,7 @@ async def test_p2blsdohp_execute_signing_instructions(wallet_environments: Walle
     sum_pk = child_sk.get_g1() + other_sk.get_g1()
     signing_instructions = SigningInstructions(
         KeyHints(
-            [SumHint([child_sk.get_g1().get_fingerprint().to_bytes(4, "big")], test_name, bytes(sum_pk))],
+            [SumHint([child_sk.get_g1().get_fingerprint().to_bytes(4, "big")], test_name, sum_pk)],
             [PathHint(root_fingerprint, [uint64(1), uint64(2), uint64(3), uint64(4)])],
         ),
         [SigningTarget(sum_pk.get_fingerprint().to_bytes(4, "big"), test_name, test_name)],
@@ -370,8 +370,8 @@ async def test_p2blsdohp_execute_signing_instructions(wallet_environments: Walle
         SigningInstructions(
             KeyHints(
                 [
-                    SumHint([child_sk.get_g1().get_fingerprint().to_bytes(4, "big")], test_name, bytes(sum_pk)),
-                    SumHint([child_sk_2.get_g1().get_fingerprint().to_bytes(4, "big")], test_name_2, bytes(sum_pk_2)),
+                    SumHint([child_sk.get_g1().get_fingerprint().to_bytes(4, "big")], test_name, sum_pk),
+                    SumHint([child_sk_2.get_g1().get_fingerprint().to_bytes(4, "big")], test_name_2, sum_pk_2),
                 ],
                 [
                     PathHint(root_fingerprint, [uint64(1), uint64(2), uint64(3), uint64(4)]),
@@ -412,7 +412,7 @@ async def test_p2blsdohp_execute_signing_instructions(wallet_environments: Walle
     )
     unknown_sum_hint = SigningInstructions(
         KeyHints(
-            [SumHint([b"unknown fingerprint"], b"", bytes(G1Element()))],
+            [SumHint([b"unknown fingerprint"], b"", G1Element())],
             [],
         ),
         [],
@@ -439,7 +439,7 @@ async def test_p2blsdohp_execute_signing_instructions(wallet_environments: Walle
     signing_responses = await wallet.execute_signing_instructions(
         SigningInstructions(
             KeyHints(
-                [SumHint([root_fingerprint], test_name, bytes(sum_pk))],
+                [SumHint([root_fingerprint], test_name, sum_pk)],
                 [],
             ),
             [SigningTarget(sum_pk.get_fingerprint().to_bytes(4, "big"), test_name, test_name)],

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Dict, List, Optional, Set, Tuple, Union
 
+from chia_rs import G1Element
 from chiabip158 import PyBIP158
 
 from chia.consensus.block_record import BlockRecord
@@ -19,7 +20,7 @@ from chia.full_node.coin_store import CoinStore
 from chia.full_node.mempool_check_conditions import mempool_check_time_locks
 from chia.types.block_protocol import BlockInfo
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.sized_bytes import bytes32, bytes48
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.full_block import FullBlock
 from chia.types.generator_types import BlockGenerator
@@ -512,7 +513,7 @@ async def validate_block_body(
             return error, None
 
     # create hash_key list for aggsig check
-    pairs_pks: List[bytes48] = []
+    pairs_pks: List[G1Element] = []
     pairs_msgs: List[bytes] = []
     if npc_result:
         assert npc_result.conds is not None

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -8,7 +8,7 @@ from concurrent.futures import Executor
 from dataclasses import dataclass
 from typing import Awaitable, Callable, Dict, List, Optional, Sequence, Tuple
 
-from chia_rs import AugSchemeMPL, G1Element
+from chia_rs import AugSchemeMPL
 
 from chia.consensus.block_header_validation import validate_finished_header_block
 from chia.consensus.block_record import BlockRecord
@@ -126,10 +126,8 @@ def batch_pre_validate_blocks(
                     if npc_result is not None and block.transactions_info is not None:
                         assert npc_result.conds
                         pairs_pks, pairs_msgs = pkm_pairs(npc_result.conds, constants.AGG_SIG_ME_ADDITIONAL_DATA)
-                        # Using AugSchemeMPL.aggregate_verify, so it's safe to use from_bytes_unchecked
-                        pks_objects: List[G1Element] = [G1Element.from_bytes_unchecked(pk) for pk in pairs_pks]
                         if not AugSchemeMPL.aggregate_verify(
-                            pks_objects, pairs_msgs, block.transactions_info.aggregated_signature
+                            pairs_pks, pairs_msgs, block.transactions_info.aggregated_signature
                         ):
                             error_int = uint16(Err.BAD_AGGREGATE_SIGNATURE.value)
                         else:

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -11,7 +11,7 @@ from typing import Awaitable, Callable, Collection, Dict, List, Optional, Set, T
 
 from chia_rs import ELIGIBLE_FOR_DEDUP, ELIGIBLE_FOR_FF
 from chia_rs import CoinSpend as RustCoinSpend
-from chia_rs import GTElement
+from chia_rs import G1Element, GTElement
 from chia_rs import Program as RustProgram
 from chia_rs import supports_fast_forward
 from chiabip158 import PyBIP158
@@ -27,7 +27,7 @@ from chia.full_node.mempool import MEMPOOL_ITEM_FEE_LIMIT, Mempool, MempoolRemov
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, mempool_check_time_locks
 from chia.full_node.pending_tx_cache import ConflictTxCache, PendingTxCache
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.sized_bytes import bytes32, bytes48
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.clvm_cost import CLVMCost
 from chia.types.coin_record import CoinRecord
 from chia.types.eligible_coin_spends import EligibilityAndAdditions, UnspentLineageInfo
@@ -78,7 +78,7 @@ def validate_clvm_and_signature(
         if result.error is not None:
             return Err(result.error), b"", {}, time.monotonic() - start_time
 
-        pks: List[bytes48] = []
+        pks: List[G1Element] = []
         msgs: List[bytes] = []
         assert result.conds is not None
         pks, msgs = pkm_pairs(result.conds, additional_data)

--- a/chia/util/cached_bls.py
+++ b/chia/util/cached_bls.py
@@ -1,22 +1,22 @@
 from __future__ import annotations
 
 import functools
-from typing import Dict, List, Optional, Sequence
+from typing import List, Optional, Sequence
 
 from chia_rs import AugSchemeMPL, G1Element, G2Element, GTElement
 
-from chia.types.blockchain_format.sized_bytes import bytes32, bytes48
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.hash import std_hash
 from chia.util.lru_cache import LRUCache
 
 
 def get_pairings(
-    cache: LRUCache[bytes32, GTElement], pks: List[bytes48], msgs: Sequence[bytes], force_cache: bool
+    cache: LRUCache[bytes32, GTElement], pks: List[G1Element], msgs: Sequence[bytes], force_cache: bool
 ) -> List[GTElement]:
     pairings: List[Optional[GTElement]] = []
     missing_count: int = 0
     for pk, msg in zip(pks, msgs):
-        aug_msg: bytes = pk + msg
+        aug_msg: bytes = bytes(pk) + msg
         h: bytes32 = std_hash(aug_msg)
         pairing: Optional[GTElement] = cache.get(h)
         if not force_cache and pairing is None:
@@ -28,23 +28,12 @@ def get_pairings(
                 return []
         pairings.append(pairing)
 
-    # G1Element.from_bytes can be expensive due to subgroup check, so we avoid recomputing it with this cache
-    pk_bytes_to_g1: Dict[bytes48, G1Element] = {}
     ret: List[GTElement] = []
     for i, pairing in enumerate(pairings):
         if pairing is None:
-            aug_msg = pks[i] + msgs[i]
+            aug_msg = bytes(pks[i]) + msgs[i]
             aug_hash: G2Element = AugSchemeMPL.g2_from_message(aug_msg)
-
-            pk_parsed: Optional[G1Element] = pk_bytes_to_g1.get(pks[i])
-            if pk_parsed is None:
-                # In this case, we use from_bytes instead of from_bytes_unchecked, because we will not be using
-                # the bls_signatures aggregate_verify method which performs the subgroup checks
-                pk_parsed = G1Element.from_bytes(pks[i])
-                pk_bytes_to_g1[pks[i]] = pk_parsed
-
-            pairing = aug_hash.pair(pk_parsed)
-
+            pairing = aug_hash.pair(pks[i])
             h = std_hash(aug_msg)
             cache.put(h, pairing)
             ret.append(pairing)
@@ -58,7 +47,7 @@ LOCAL_CACHE: LRUCache[bytes32, GTElement] = LRUCache(50000)
 
 
 def aggregate_verify(
-    pks: List[bytes48],
+    pks: List[G1Element],
     msgs: Sequence[bytes],
     sig: G2Element,
     force_cache: bool = False,
@@ -67,9 +56,7 @@ def aggregate_verify(
     pairings: List[GTElement] = get_pairings(cache, pks, msgs, force_cache)
     if len(pairings) == 0:
         # Using AugSchemeMPL.aggregate_verify, so it's safe to use from_bytes_unchecked
-        pks_objects: List[G1Element] = [G1Element.from_bytes_unchecked(pk) for pk in pks]
-        res: bool = AugSchemeMPL.aggregate_verify(pks_objects, msgs, sig)
-        return res
+        return AugSchemeMPL.aggregate_verify(pks, msgs, sig)
 
     pairings_prod: GTElement = functools.reduce(GTElement.__mul__, pairings)
     res = pairings_prod == sig.pair(G1Element.generator())

--- a/chia/wallet/signer_protocol.py
+++ b/chia/wallet/signer_protocol.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
+from chia_rs import G1Element
+
 from chia.types.blockchain_format.coin import Coin as _Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
@@ -74,7 +76,7 @@ class SigningTarget(Streamable):
 class SumHint(Streamable):
     fingerprints: List[bytes]
     synthetic_offset: bytes
-    final_pubkey: bytes
+    final_pubkey: G1Element
 
 
 @clvm_streamable

--- a/chia/wallet/util/debug_spend_bundle.py
+++ b/chia/wallet/util/debug_spend_bundle.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List
 
-from chia_rs import AugSchemeMPL, G1Element
+from chia_rs import AugSchemeMPL
 from clvm import KEYWORD_FROM_ATOM
 from clvm_tools.binutils import disassemble as bu_disassemble
 
@@ -106,8 +106,8 @@ def debug_spend_bundle(spend_bundle, agg_sig_additional_data=DEFAULT_CONSTANTS.A
             continue
 
         conditions = conditions_dict_for_solution(puzzle_reveal, solution, INFINITE_COST)
-        for pk_bytes, m in pkm_pairs_for_conditions_dict(conditions, coin, agg_sig_additional_data):
-            pks.append(G1Element.from_bytes(pk_bytes))
+        for pk, m in pkm_pairs_for_conditions_dict(conditions, coin, agg_sig_additional_data):
+            pks.append(pk)
             msgs.append(m)
         print()
         cost, r = puzzle_reveal.run_with_cost(INFINITE_COST, solution)

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -2588,20 +2588,20 @@ class WalletStateManager:
 
         return vc_wallet
 
-    async def sum_hint_for_pubkey(self, pk: bytes) -> Optional[SumHint]:
+    async def sum_hint_for_pubkey(self, pk: G1Element) -> Optional[SumHint]:
         return await self.main_wallet.sum_hint_for_pubkey(pk)
 
-    async def path_hint_for_pubkey(self, pk: bytes) -> Optional[PathHint]:
+    async def path_hint_for_pubkey(self, pk: G1Element) -> Optional[PathHint]:
         return await self.main_wallet.path_hint_for_pubkey(pk)
 
-    async def key_hints_for_pubkeys(self, pks: List[bytes]) -> KeyHints:
+    async def key_hints_for_pubkeys(self, pks: List[G1Element]) -> KeyHints:
         return KeyHints(
             [sum_hint for pk in pks for sum_hint in (await self.sum_hint_for_pubkey(pk),) if sum_hint is not None],
             [path_hint for pk in pks for path_hint in (await self.path_hint_for_pubkey(pk),) if path_hint is not None],
         )
 
     async def gather_signing_info(self, coin_spends: List[Spend]) -> SigningInstructions:
-        pks: List[bytes] = []
+        pks: List[G1Element] = []
         signing_targets: List[SigningTarget] = []
         for coin_spend in coin_spends:
             _coin_spend = coin_spend.as_coin_spend()
@@ -2612,12 +2612,12 @@ class WalletStateManager:
                 self.constants.MAX_BLOCK_COST_CLVM,
             )
             # Create signature
-            for pk_bytes, msg in pkm_pairs_for_conditions_dict(
+            for pk, msg in pkm_pairs_for_conditions_dict(
                 conditions_dict, _coin_spend.coin, self.constants.AGG_SIG_ME_ADDITIONAL_DATA
             ):
-                pks.append(pk_bytes)
-                fingerprint: bytes = G1Element.from_bytes(pk_bytes).get_fingerprint().to_bytes(4, "big")
-                signing_targets.append(SigningTarget(fingerprint, msg, std_hash(pk_bytes + msg)))
+                pks.append(pk)
+                fingerprint: bytes = pk.get_fingerprint().to_bytes(4, "big")
+                signing_targets.append(SigningTarget(fingerprint, msg, std_hash(bytes(pk) + msg)))
 
         return SigningInstructions(
             await self.key_hints_for_pubkeys(pks),

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dependencies = [
     "chiapos==2.0.4",  # proof of space
     "clvm==0.9.9",
     "clvm_tools==0.4.9",  # Currying, Program.to, other conveniences
-    "chia_rs==0.7.0",
+    "chia_rs==0.8.0",
     "clvm-tools-rs==0.1.40",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.9.4",  # HTTP server for full node rpc
     "aiosqlite==0.20.0",  # asyncio wrapper for sqlite, to store blocks

--- a/tools/analyze-chain.py
+++ b/tools/analyze-chain.py
@@ -16,7 +16,7 @@ from chia_rs import MEMPOOL_MODE, AugSchemeMPL, G1Element, SpendBundleConditions
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.block_protocol import BlockInfo
 from chia.types.blockchain_format.serialized_program import SerializedProgram
-from chia.types.blockchain_format.sized_bytes import bytes32, bytes48
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.util.condition_tools import pkm_pairs
 from chia.util.full_block_utils import block_info_from_block, generator_from_block
@@ -137,13 +137,12 @@ def default_call(
     if verify_signatures:
         assert isinstance(block, FullBlock)
         # create hash_key list for aggsig check
-        pairs_pks: List[bytes48] = []
+        pairs_pks: List[G1Element] = []
         pairs_msgs: List[bytes] = []
         pairs_pks, pairs_msgs = pkm_pairs(result, DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA)
-        pairs_g1s = [G1Element.from_bytes(x) for x in pairs_pks]
         assert block.transactions_info is not None
         assert block.transactions_info.aggregated_signature is not None
-        assert AugSchemeMPL.aggregate_verify(pairs_g1s, pairs_msgs, block.transactions_info.aggregated_signature)
+        assert AugSchemeMPL.aggregate_verify(pairs_pks, pairs_msgs, block.transactions_info.aggregated_signature)
 
     print(
         f"{hh.hex()}\t{height:7d}\t{cost:11d}\t{run_time:0.3f}\t{num_refs}\t{ref_lookup_time:0.3f}\t{fees:14}\t"


### PR DESCRIPTION
### Purpose:

bump the chia_rs dependency to use the latest version.

The new version returns `G1Element`s in `Spend` and `SpendBundleConditions` as parameters to the `AGG_SIG_*` conditions. This has two consequences in chia-blockchain:

1. We no longer need to convert the `bytes48` objects into `G1Elements` when we get them back from block validation.
2. The public keys are now more strictly validated on the rust side. Converting 48 bytes into a `G1Element` (public key) may fail, if the bytes are not a valid serialization of a valid key.

So, some tests that used garbage bytes in place of a public key had to be updated to use valid keys.

Also, the BLS cache no longer needs to take the keys in byte-form, but can take them as `G1Elements` directly.

### Current Behavior:

The BLS cache takes keys as plain bytes.
The `KeyTool` (test utility) uses serialized public keys as index.
The `pkm_pairs()` function returns public keys as bytes48.

### New Behavior:

The BLS cache takes keys as `G1Element`s
The `KeyTool` uses `G1Element` as index.
The `pkm_pairs()` function returns public keys as `G1Element`.