### PR TITLE
[CHIA-365] Return exception and error from get_kv_diff when either of the hashes has no data

### DIFF
--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -2864,32 +2864,28 @@ async def test_pagination_rpcs(
         )
         assert diff_res == diff_reference
 
-        diff_res = await data_rpc_api.get_kv_diff(
-            {
-                "id": store_id.hex(),
-                "hash_1": hash1.hex(),
-                "hash_2": bytes32([0] * 31 + [1]).hex(),
-                "page": 0,
-                "max_page_size": 10,
-            }
-        )
-        empty_diff_reference = {
-            "total_pages": 1,
-            "total_bytes": 0,
-            "diff": [],
-        }
-        assert diff_res == empty_diff_reference
+        invalid_hash = bytes32([0] * 31 + [1])
+        with pytest.raises(Exception, match=f"Unable to diff: Can't find keys and values for {invalid_hash.hex()}"):
+            await data_rpc_api.get_kv_diff(
+                {
+                    "id": store_id.hex(),
+                    "hash_1": hash1.hex(),
+                    "hash_2": invalid_hash.hex(),
+                    "page": 0,
+                    "max_page_size": 10,
+                }
+            )
 
-        diff_res = await data_rpc_api.get_kv_diff(
-            {
-                "id": store_id.hex(),
-                "hash_1": bytes32([0] * 31 + [1]).hex(),
-                "hash_2": hash2.hex(),
-                "page": 0,
-                "max_page_size": 10,
-            }
-        )
-        assert diff_res == empty_diff_reference
+        with pytest.raises(Exception, match=f"Unable to diff: Can't find keys and values for {invalid_hash.hex()}"):
+            diff_res = await data_rpc_api.get_kv_diff(
+                {
+                    "id": store_id.hex(),
+                    "hash_1": invalid_hash.hex(),
+                    "hash_2": hash2.hex(),
+                    "page": 0,
+                    "max_page_size": 10,
+                }
+            )
 
         new_value = b"\x02\x02"
         changelist = [{"action": "upsert", "key": key6.hex(), "value": new_value.hex()}]

--- a/chia/_tests/core/data_layer/test_data_store.py
+++ b/chia/_tests/core/data_layer/test_data_store.py
@@ -1187,8 +1187,10 @@ async def test_kv_diff_2(data_store: DataStore, store_id: bytes32) -> None:
     assert diff_1 == {DiffData(OperationType.INSERT, b"000", b"000")}
     diff_2 = await data_store.get_kv_diff(store_id, insert_result.node_hash, empty_hash)
     assert diff_2 == {DiffData(OperationType.DELETE, b"000", b"000")}
-    diff_3 = await data_store.get_kv_diff(store_id, invalid_hash, insert_result.node_hash)
-    assert diff_3 == set()
+    with pytest.raises(Exception, match=f"Unable to diff: Can't find keys and values for {invalid_hash.hex()}"):
+        await data_store.get_kv_diff(store_id, invalid_hash, insert_result.node_hash)
+    with pytest.raises(Exception, match=f"Unable to diff: Can't find keys and values for {invalid_hash.hex()}"):
+        await data_store.get_kv_diff(store_id, insert_result.node_hash, invalid_hash)
 
 
 @pytest.mark.anyio

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -872,11 +872,12 @@ class DataStore:
         self, store_id: bytes32, page: int, max_page_size: int, hash1: bytes32, hash2: bytes32
     ) -> KVDiffPaginationData:
         old_pairs = await self.get_keys_values_compressed(store_id, hash1)
-        new_pairs = await self.get_keys_values_compressed(store_id, hash2)
         if len(old_pairs.keys_values_hashed) == 0 and hash1 != bytes32([0] * 32):
-            return KVDiffPaginationData(1, 0, [])
+            raise Exception(f"Unable to diff: Can't find keys and values for {hash1}")
+
+        new_pairs = await self.get_keys_values_compressed(store_id, hash2)
         if len(new_pairs.keys_values_hashed) == 0 and hash2 != bytes32([0] * 32):
-            return KVDiffPaginationData(1, 0, [])
+            raise Exception(f"Unable to diff: Can't find keys and values for {hash2}")
 
         old_pairs_leaf_hashes = {v for v in old_pairs.keys_values_hashed.values()}
         new_pairs_leaf_hashes = {v for v in new_pairs.keys_values_hashed.values()}
@@ -2129,11 +2130,13 @@ class DataStore:
     ) -> Set[DiffData]:
         async with self.db_wrapper.reader():
             old_pairs = set(await self.get_keys_values(store_id, hash_1))
-            new_pairs = set(await self.get_keys_values(store_id, hash_2))
             if len(old_pairs) == 0 and hash_1 != bytes32([0] * 32):
-                return set()
+                raise Exception(f"Unable to diff: Can't find keys and values for {hash_1}")
+
+            new_pairs = set(await self.get_keys_values(store_id, hash_2))
             if len(new_pairs) == 0 and hash_2 != bytes32([0] * 32):
-                return set()
+                raise Exception(f"Unable to diff: Can't find keys and values for {hash_2}")
+
             insertions = {
                 DiffData(type=OperationType.INSERT, key=node.key, value=node.value)
                 for node in new_pairs


### PR DESCRIPTION
Fix issue where `get_kv_diff` returns an empty diff even though one of the provided hashes has no data. Instead this will return an error code about unable to perform the diff because there wasn't any data to diff.

