### PR TITLE
[CHIA-428] Port `chia wallet did ...` to @tx_out_cmd

### DIFF
--- a/chia/_tests/cmds/wallet/test_did.py
+++ b/chia/_tests/cmds/wallet/test_did.py
@@ -32,10 +32,11 @@ def test_did_create(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
             name: Optional[str] = "DID Wallet",
             backup_ids: Optional[List[str]] = None,
             required_num: int = 0,
+            push: bool = True,
         ) -> Dict[str, Union[str, int]]:
             if backup_ids is None:
                 backup_ids = []
-            self.add_to_log("create_new_did_wallet", (amount, fee, name, backup_ids, required_num))
+            self.add_to_log("create_new_did_wallet", (amount, fee, name, backup_ids, required_num, push))
             return {"wallet_id": 3, "my_did": "did:chia:testdid123456"}
 
     inst_rpc_client = DidCreateRpcClient()  # pylint: disable=no-value-for-parameter
@@ -48,7 +49,7 @@ def test_did_create(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     expected_calls: logType = {
-        "create_new_did_wallet": [(3, 100000000000, "test", [], 0)],
+        "create_new_did_wallet": [(3, 100000000000, "test", [], 0, True)],
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
 
@@ -180,8 +181,9 @@ def test_did_update_metadata(capsys: object, get_test_cli_clients: Tuple[TestRpc
             wallet_id: int,
             metadata: Dict[str, object],
             tx_config: TXConfig,
+            push: bool = True,
         ) -> DIDUpdateMetadataResponse:
-            self.add_to_log("update_did_metadata", (wallet_id, metadata, tx_config))
+            self.add_to_log("update_did_metadata", (wallet_id, metadata, tx_config, push))
             return DIDUpdateMetadataResponse([STD_UTX], [STD_TX], SpendBundle([], G2Element()), uint32(wallet_id))
 
     inst_rpc_client = DidUpdateMetadataRpcClient()  # pylint: disable=no-value-for-parameter
@@ -203,7 +205,7 @@ def test_did_update_metadata(capsys: object, get_test_cli_clients: Tuple[TestRpc
     assert_list = [f"Successfully updated DID wallet ID: {w_id}, Spend Bundle: {STD_TX.spend_bundle.to_json_dict()}"]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     expected_calls: logType = {
-        "update_did_metadata": [(w_id, {"test": True}, DEFAULT_TX_CONFIG.override(reuse_puzhash=True))],
+        "update_did_metadata": [(w_id, {"test": True}, DEFAULT_TX_CONFIG.override(reuse_puzhash=True), True)],
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
 
@@ -252,9 +254,9 @@ def test_did_message_spend(capsys: object, get_test_cli_clients: Tuple[TestRpcCl
     # set RPC Client
     class DidMessageSpendRpcClient(TestWalletRpcClient):
         async def did_message_spend(
-            self, wallet_id: int, tx_config: TXConfig, extra_conditions: Tuple[Condition, ...]
+            self, wallet_id: int, tx_config: TXConfig, extra_conditions: Tuple[Condition, ...], push: bool
         ) -> DIDMessageSpendResponse:
-            self.add_to_log("did_message_spend", (wallet_id, tx_config, extra_conditions))
+            self.add_to_log("did_message_spend", (wallet_id, tx_config, extra_conditions, True))
             return DIDMessageSpendResponse([STD_UTX], [STD_TX], SpendBundle([], G2Element()))
 
     inst_rpc_client = DidMessageSpendRpcClient()  # pylint: disable=no-value-for-parameter
@@ -286,6 +288,7 @@ def test_did_message_spend(capsys: object, get_test_cli_clients: Tuple[TestRpcCl
                     *(CreateCoinAnnouncement(ann) for ann in c_announcements),
                     *(CreatePuzzleAnnouncement(ann) for ann in puz_announcements),
                 ),
+                True,
             )
         ],
     }
@@ -304,8 +307,9 @@ def test_did_transfer(capsys: object, get_test_cli_clients: Tuple[TestRpcClients
             fee: int,
             with_recovery: bool,
             tx_config: TXConfig,
+            push: bool,
         ) -> DIDTransferDIDResponse:
-            self.add_to_log("did_transfer_did", (wallet_id, address, fee, with_recovery, tx_config))
+            self.add_to_log("did_transfer_did", (wallet_id, address, fee, with_recovery, tx_config, push))
             return DIDTransferDIDResponse(
                 [STD_UTX],
                 [STD_TX],
@@ -340,6 +344,8 @@ def test_did_transfer(capsys: object, get_test_cli_clients: Tuple[TestRpcClients
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     expected_calls: logType = {
-        "did_transfer_did": [(w_id, t_address, 500000000000, True, DEFAULT_TX_CONFIG.override(reuse_puzhash=True))],
+        "did_transfer_did": [
+            (w_id, t_address, 500000000000, True, DEFAULT_TX_CONFIG.override(reuse_puzhash=True), True)
+        ],
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -650,12 +650,13 @@ def did_cmd() -> None:
     show_default=True,
     callback=validate_fee,
 )
+@tx_out_cmd
 def did_create_wallet_cmd(
-    wallet_rpc_port: Optional[int], fingerprint: int, name: Optional[str], amount: int, fee: str
-) -> None:
+    wallet_rpc_port: Optional[int], fingerprint: int, name: Optional[str], amount: int, fee: str, push: bool
+) -> List[TransactionRecord]:
     from .wallet_funcs import create_did_wallet
 
-    asyncio.run(create_did_wallet(wallet_rpc_port, fingerprint, Decimal(fee), name, amount))
+    return asyncio.run(create_did_wallet(wallet_rpc_port, fingerprint, Decimal(fee), name, amount, push=push))
 
 
 @did_cmd.command("sign_message", help="Sign a message by a DID")
@@ -750,12 +751,13 @@ def did_get_details_cmd(wallet_rpc_port: Optional[int], fingerprint: int, coin_i
     is_flag=True,
     default=False,
 )
+@tx_out_cmd
 def did_update_metadata_cmd(
-    wallet_rpc_port: Optional[int], fingerprint: int, id: int, metadata: str, reuse: bool
-) -> None:
+    wallet_rpc_port: Optional[int], fingerprint: int, id: int, metadata: str, reuse: bool, push: bool
+) -> List[TransactionRecord]:
     from .wallet_funcs import update_did_metadata
 
-    asyncio.run(update_did_metadata(wallet_rpc_port, fingerprint, id, metadata, reuse))
+    return asyncio.run(update_did_metadata(wallet_rpc_port, fingerprint, id, metadata, reuse, push=push))
 
 
 @did_cmd.command("find_lost", help="Find the did you should own and recovery the DID wallet")
@@ -830,13 +832,15 @@ def did_find_lost_cmd(
     type=str,
     required=False,
 )
+@tx_out_cmd
 def did_message_spend_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
     id: int,
     puzzle_announcements: Optional[str],
     coin_announcements: Optional[str],
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .wallet_funcs import did_message_spend
 
     puzzle_list: List[str] = []
@@ -849,7 +853,7 @@ def did_message_spend_cmd(
                 bytes.fromhex(announcement)
         except ValueError:
             print("Invalid puzzle announcement format, should be a list of hex strings.")
-            return
+            return []
     if coin_announcements is not None:
         try:
             coin_list = coin_announcements.split(",")
@@ -858,9 +862,9 @@ def did_message_spend_cmd(
                 bytes.fromhex(announcement)
         except ValueError:
             print("Invalid coin announcement format, should be a list of hex strings.")
-            return
+            return []
 
-    asyncio.run(did_message_spend(wallet_rpc_port, fingerprint, id, puzzle_list, coin_list))
+    return asyncio.run(did_message_spend(wallet_rpc_port, fingerprint, id, puzzle_list, coin_list, push=push))
 
 
 @did_cmd.command("transfer", help="Transfer a DID")
@@ -892,6 +896,7 @@ def did_message_spend_cmd(
     is_flag=True,
     default=False,
 )
+@tx_out_cmd
 def did_transfer_did(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -900,10 +905,11 @@ def did_transfer_did(
     reset_recovery: bool,
     fee: str,
     reuse: bool,
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .wallet_funcs import transfer_did
 
-    asyncio.run(
+    return asyncio.run(
         transfer_did(
             wallet_rpc_port,
             fingerprint,
@@ -912,6 +918,7 @@ def did_transfer_did(
             target_address,
             reset_recovery is False,
             True if reuse else None,
+            push=push,
         )
     )
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -763,6 +763,9 @@ class WalletRpcApi:
                     if type(request["metadata"]) is dict:
                         metadata = request["metadata"]
 
+                if not push:
+                    raise ValueError("Creation of DID wallet must be automatically pushed for now.")
+
                 async with self.service.wallet_state_manager.lock:
                     did_wallet_name: str = request.get("wallet_name", None)
                     if did_wallet_name is not None:

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -413,6 +413,7 @@ class WalletRpcClient(RpcClient):
         name: Optional[str] = "DID Wallet",
         backup_ids: List[str] = [],
         required_num: int = 0,
+        push: bool = True,
     ) -> Dict[str, Any]:
         request = {
             "wallet_type": "did_wallet",
@@ -422,6 +423,7 @@ class WalletRpcClient(RpcClient):
             "amount": amount,
             "fee": fee,
             "wallet_name": name,
+            "push": push,
         }
         response = await self.fetch("create_new_wallet", request)
         return response


### PR DESCRIPTION

This brings another set of commands to the @tx_out_cmd decorator which gives it the capability to optionally push a transaction and export the transactions to a local file.