### PR TITLE
[CHIA-429] Port `chia wallet nft ...` to @tx_out_cmd

### DIFF
--- a/chia/_tests/cmds/wallet/test_nft.py
+++ b/chia/_tests/cmds/wallet/test_nft.py
@@ -96,6 +96,7 @@ def test_nft_mint(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Pa
             royalty_percentage: int = 0,
             did_id: Optional[str] = None,
             reuse_puzhash: Optional[bool] = None,
+            push: bool = True,
         ) -> NFTMintNFTResponse:
             self.add_to_log(
                 "mint_nft",
@@ -115,6 +116,7 @@ def test_nft_mint(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Pa
                     royalty_percentage,
                     did_id,
                     reuse_puzhash,
+                    push,
                 ),
             )
             return NFTMintNFTResponse(
@@ -171,6 +173,7 @@ def test_nft_mint(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Pa
                 500000000000,
                 0,
                 "0xcee228b8638c67cb66a55085be99fa3b457ae5b56915896f581990f600b2c652",
+                True,
             )
         ],
     }
@@ -190,8 +193,9 @@ def test_nft_add_uri(capsys: object, get_test_cli_clients: Tuple[TestRpcClients,
             uri: str,
             fee: int,
             tx_config: TXConfig,
+            push: bool,
         ) -> NFTAddURIResponse:
-            self.add_to_log("add_uri_to_nft", (wallet_id, nft_coin_id, key, uri, fee, tx_config))
+            self.add_to_log("add_uri_to_nft", (wallet_id, nft_coin_id, key, uri, fee, tx_config, push))
             return NFTAddURIResponse([STD_UTX], [STD_TX], uint32(wallet_id), SpendBundle([], G2Element()))
 
     inst_rpc_client = NFTAddUriRpcClient()  # pylint: disable=no-value-for-parameter
@@ -223,6 +227,7 @@ def test_nft_add_uri(capsys: object, get_test_cli_clients: Tuple[TestRpcClients,
                 "https://example.com/nft",
                 500000000000,
                 DEFAULT_TX_CONFIG.override(reuse_puzhash=True),
+                True,
             )
         ],
     }
@@ -241,8 +246,9 @@ def test_nft_transfer(capsys: object, get_test_cli_clients: Tuple[TestRpcClients
             target_address: str,
             fee: int,
             tx_config: TXConfig,
+            push: bool,
         ) -> NFTTransferNFTResponse:
-            self.add_to_log("transfer_nft", (wallet_id, nft_coin_id, target_address, fee, tx_config))
+            self.add_to_log("transfer_nft", (wallet_id, nft_coin_id, target_address, fee, tx_config, push))
             return NFTTransferNFTResponse(
                 [STD_UTX],
                 [STD_TX],
@@ -269,11 +275,11 @@ def test_nft_transfer(capsys: object, get_test_cli_clients: Tuple[TestRpcClients
     ]
     # these are various things that should be in the output
     assert STD_TX.spend_bundle is not None
-    assert_list = [f"NFT transferred successfully with spend bundle: {STD_TX.spend_bundle.to_json_dict()}"]
+    assert_list = ["NFT transferred successfully", f"spend bundle: {STD_TX.spend_bundle.to_json_dict()}"]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     expected_calls: logType = {
         "transfer_nft": [
-            (4, nft_coin_id, target_address, 500000000000, DEFAULT_TX_CONFIG.override(reuse_puzhash=True))
+            (4, nft_coin_id, target_address, 500000000000, DEFAULT_TX_CONFIG.override(reuse_puzhash=True), True)
         ],
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -1016,6 +1016,7 @@ def nft_sign_message(wallet_rpc_port: Optional[int], fingerprint: int, nft_id: s
     is_flag=True,
     default=False,
 )
+@tx_out_cmd
 def nft_mint_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -1034,7 +1035,8 @@ def nft_mint_cmd(
     fee: str,
     royalty_percentage_fraction: int,
     reuse: bool,
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .wallet_funcs import mint_nft
 
     if metadata_uris is None:
@@ -1047,7 +1049,7 @@ def nft_mint_cmd(
     else:
         license_uris_list = [lu.strip() for lu in license_uris.split(",")]
 
-    asyncio.run(
+    return asyncio.run(
         mint_nft(
             wallet_rpc_port=wallet_rpc_port,
             fp=fingerprint,
@@ -1066,6 +1068,7 @@ def nft_mint_cmd(
             d_fee=Decimal(fee),
             royalty_percentage=royalty_percentage_fraction,
             reuse_puzhash=True if reuse else None,
+            push=push,
         )
     )
 
@@ -1099,6 +1102,7 @@ def nft_mint_cmd(
     is_flag=True,
     default=False,
 )
+@tx_out_cmd
 def nft_add_uri_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -1109,10 +1113,11 @@ def nft_add_uri_cmd(
     license_uri: str,
     fee: str,
     reuse: bool,
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .wallet_funcs import add_uri_to_nft
 
-    asyncio.run(
+    return asyncio.run(
         add_uri_to_nft(
             wallet_rpc_port=wallet_rpc_port,
             fp=fingerprint,
@@ -1123,6 +1128,7 @@ def nft_add_uri_cmd(
             metadata_uri=metadata_uri,
             license_uri=license_uri,
             reuse_puzhash=True if reuse else None,
+            push=push,
         )
     )
 
@@ -1154,6 +1160,7 @@ def nft_add_uri_cmd(
     is_flag=True,
     default=False,
 )
+@tx_out_cmd
 def nft_transfer_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -1162,10 +1169,11 @@ def nft_transfer_cmd(
     target_address: str,
     fee: str,
     reuse: bool,
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .wallet_funcs import transfer_nft
 
-    asyncio.run(
+    return asyncio.run(
         transfer_nft(
             wallet_rpc_port=wallet_rpc_port,
             fp=fingerprint,
@@ -1174,6 +1182,7 @@ def nft_transfer_cmd(
             nft_coin_id=nft_coin_id,
             target_address=target_address,
             reuse_puzhash=True if reuse else None,
+            push=push,
         )
     )
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -1125,7 +1125,8 @@ async def mint_nft(
     d_fee: Decimal,
     royalty_percentage: int,
     reuse_puzhash: Optional[bool],
-) -> None:
+    push: bool = True,
+) -> List[TransactionRecord]:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
         royalty_address = (
             None
@@ -1171,11 +1172,15 @@ async def mint_nft(
                 fee,
                 royalty_percentage,
                 did_id,
+                push=push,
             )
             spend_bundle = mint_response.spend_bundle
-            print(f"NFT minted Successfully with spend bundle: {spend_bundle}")
+            if push:
+                print(f"NFT minted Successfully with spend bundle: {spend_bundle}")
+            return mint_response.transactions
         except Exception as e:
             print(f"Failed to mint NFT: {e}")
+            return []
 
 
 async def add_uri_to_nft(
@@ -1189,7 +1194,8 @@ async def add_uri_to_nft(
     metadata_uri: Optional[str],
     license_uri: Optional[str],
     reuse_puzhash: Optional[bool],
-) -> None:
+    push: bool = True,
+) -> List[TransactionRecord]:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
         try:
             if len([x for x in (uri, metadata_uri, license_uri) if x is not None]) > 1:
@@ -1215,11 +1221,15 @@ async def add_uri_to_nft(
                 tx_config=CMDTXConfigLoader(
                     reuse_puzhash=reuse_puzhash,
                 ).to_tx_config(units["chia"], config, fingerprint),
+                push=push,
             )
             spend_bundle = response.spend_bundle.to_json_dict()
-            print(f"URI added successfully with spend bundle: {spend_bundle}")
+            if push:
+                print(f"URI added successfully with spend bundle: {spend_bundle}")
+            return response.transactions
         except Exception as e:
             print(f"Failed to add URI to NFT: {e}")
+            return []
 
 
 async def transfer_nft(
@@ -1231,7 +1241,8 @@ async def transfer_nft(
     nft_coin_id: str,
     target_address: str,
     reuse_puzhash: Optional[bool],
-) -> None:
+    push: bool = True,
+) -> List[TransactionRecord]:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
         try:
             target_address = ensure_valid_address(target_address, allowed_types={AddressType.XCH}, config=config)
@@ -1244,11 +1255,16 @@ async def transfer_nft(
                 tx_config=CMDTXConfigLoader(
                     reuse_puzhash=reuse_puzhash,
                 ).to_tx_config(units["chia"], config, fingerprint),
+                push=push,
             )
             spend_bundle = response.spend_bundle.to_json_dict()
-            print(f"NFT transferred successfully with spend bundle: {spend_bundle}")
+            if push:
+                print("NFT transferred successfully")
+            print(f"spend bundle: {spend_bundle}")
+            return response.transactions
         except Exception as e:
             print(f"Failed to transfer NFT: {e}")
+            return []
 
 
 def print_nft_info(nft: NFTInfo, *, config: Dict[str, Any]) -> None:


### PR DESCRIPTION
This brings another set of commands to the @tx_out_cmd decorator which gives it the capability to optionally push a transaction and export the transactions to a local file.