### PR TITLE
[CHIA-430] Port `chia wallet notifications send` to @tx_out_cmd

### DIFF
--- a/chia/_tests/cmds/wallet/test_notifications.py
+++ b/chia/_tests/cmds/wallet/test_notifications.py
@@ -21,9 +21,9 @@ def test_notifications_send(capsys: object, get_test_cli_clients: Tuple[TestRpcC
     # set RPC Client
     class NotificationsSendRpcClient(TestWalletRpcClient):
         async def send_notification(
-            self, target: bytes32, msg: bytes, amount: uint64, fee: uint64 = uint64(0)
+            self, target: bytes32, msg: bytes, amount: uint64, fee: uint64 = uint64(0), push: bool = True
         ) -> TransactionRecord:
-            self.add_to_log("send_notification", (target, msg, amount, fee))
+            self.add_to_log("send_notification", (target, msg, amount, fee, push))
 
             class FakeTransactionRecord:
                 def __init__(self, name: str) -> None:
@@ -53,7 +53,7 @@ def test_notifications_send(capsys: object, get_test_cli_clients: Tuple[TestRpcC
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     expected_calls: logType = {
-        "send_notification": [(target_ph, bytes(msg, "utf8"), 20000000, 1000000000)],
+        "send_notification": [(target_ph, bytes(msg, "utf8"), 20000000, 1000000000, True)],
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
 

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -1306,6 +1306,7 @@ def notification_cmd() -> None:
 )
 @click.option("-n", "--message", help="The message of the notification", type=str)
 @click.option("-m", "--fee", help="The fee for the transaction, in XCH", type=str)
+@tx_out_cmd
 def send_notification_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -1313,10 +1314,13 @@ def send_notification_cmd(
     amount: str,
     message: str,
     fee: str,
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .wallet_funcs import send_notification
 
-    asyncio.run(send_notification(wallet_rpc_port, fingerprint, Decimal(fee), to_address, message, Decimal(amount)))
+    return asyncio.run(
+        send_notification(wallet_rpc_port, fingerprint, Decimal(fee), to_address, message, Decimal(amount), push=push)
+    )
 
 
 @notification_cmd.command("get", help="Get notification(s) that are in your wallet")

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -1423,17 +1423,20 @@ async def send_notification(
     address_str: str,
     message_hex: str,
     d_amount: Decimal,
-) -> None:
+    push: bool = True,
+) -> List[TransactionRecord]:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
         address: bytes32 = decode_puzzle_hash(address_str)
         amount: uint64 = uint64(d_amount * units["chia"])
         message: bytes = bytes(message_hex, "utf8")
         fee: uint64 = uint64(d_fee * units["chia"])
 
-        tx = await wallet_client.send_notification(address, message, amount, fee)
+        tx = await wallet_client.send_notification(address, message, amount, fee, push=push)
 
-        print("Notification sent successfully.")
-        print(f"To get status, use command: chia wallet get_transaction -f {fingerprint} -tx 0x{tx.name}")
+        if push:
+            print("Notification sent successfully.")
+            print(f"To get status, use command: chia wallet get_transaction -f {fingerprint} -tx 0x{tx.name}")
+        return [tx]
 
 
 async def get_notifications(

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -1284,6 +1284,7 @@ class WalletRpcClient(RpcClient):
         fee: uint64 = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
         timelock_info: ConditionValidTimes = ConditionValidTimes(),
+        push: bool = True,
     ) -> TransactionRecord:
         response = await self.fetch(
             "send_notification",
@@ -1293,6 +1294,7 @@ class WalletRpcClient(RpcClient):
                 "amount": amount,
                 "fee": fee,
                 "extra_conditions": conditions_to_json_dicts(extra_conditions),
+                "push": push,
                 **timelock_info.to_json_dict(),
             },
         )


### PR DESCRIPTION
This brings another set of commands to the @tx_out_cmd decorator which gives it the capability to optionally push a transaction and export the transactions to a local file.