### PR TITLE
CHIA-437: Add coin id index to coin state batching

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -483,7 +483,7 @@ class CoinStore:
             if include_hinted:
                 cursor = await conn.execute(
                     f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-                    f"coin_parent, amount, timestamp FROM coin_record "
+                    f"coin_parent, amount, timestamp FROM coin_record INDEXED BY sqlite_autoindex_coin_record_1 "
                     f"WHERE coin_name IN (SELECT coin_id FROM hints "
                     f'WHERE hint IN ({"?," * (puzzle_hash_count - 1)}?)) '
                     f"AND (confirmed_index>=? OR spent_index>=?) "


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Improves performance of the query used by `RequestPuzzleState`.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Takes too long since it's not using the proper index.

### New Behavior:

Indexes by coin id, to reduce the number of rows filtered.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:

Tests still pass, and I have tested 100 puzzle hashes in a query with filtering enabled before and after. Used to take a substantial amount of time, now only takes under a second.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
