### PR TITLE
CHIA-595: update test fixture ConsensusMode to be ordered

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -1992,14 +1992,14 @@ class TestBodyValidation:
         # in the 2.0 hard fork, we relax the strict 2-parameters rule of
         # AGG_SIG_* conditions, in consensus mode. In mempool mode we always
         # apply strict rules.
-        if consensus_mode == ConsensusMode.HARD_FORK_2_0 and with_garbage:
+        if consensus_mode >= ConsensusMode.HARD_FORK_2_0 and with_garbage:
             expected = (AddBlockResult.NEW_PEAK, None, 2)
 
         # before the 2.0 hard fork, these conditions do not exist
         # but WalletTool still lets us create them, and aggregate them into the
         # block signature. When the pre-hard fork node sees them, the conditions
         # are ignored, but the aggregate signature is corrupt.
-        if consensus_mode != ConsensusMode.HARD_FORK_2_0 and opcode in [
+        if consensus_mode < ConsensusMode.HARD_FORK_2_0 and opcode in [
             ConditionOpcode.AGG_SIG_PARENT,
             ConditionOpcode.AGG_SIG_PUZZLE,
             ConditionOpcode.AGG_SIG_AMOUNT,
@@ -2443,7 +2443,7 @@ class TestBodyValidation:
         )
         await _validate_and_add_block(b, blocks[-1])
         generator_arg = detect_potential_template_generator(blocks[-1].height, blocks[-1].transactions_generator)
-        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+        if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
             # once the hard for activates, we don't use this form of block
             # compression anymore
             assert generator_arg is None
@@ -2458,7 +2458,7 @@ class TestBodyValidation:
             previous_generator=generator_arg,
         )
         block = blocks[-1]
-        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+        if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
             # once the hard for activates, we don't use this form of block
             # compression anymore
             assert len(block.transactions_generator_ref_list) == 0
@@ -3128,7 +3128,7 @@ class TestReorgs:
     async def test_get_tx_peak_reorg(self, empty_blockchain, bt, consensus_mode: ConsensusMode):
         b = empty_blockchain
 
-        if consensus_mode == ConsensusMode.PLAIN:
+        if consensus_mode < ConsensusMode.SOFT_FORK_4:
             reorg_point = 13
         else:
             reorg_point = 12

--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -14,7 +14,7 @@ import random
 import sysconfig
 import tempfile
 from contextlib import AsyncExitStack
-from enum import Enum
+from enum import IntEnum
 from typing import Any, AsyncIterator, Callable, Dict, Iterator, List, Tuple, Union
 
 import aiohttp
@@ -187,10 +187,10 @@ def get_keychain():
         KeyringWrapper.cleanup_shared_instance()
 
 
-class ConsensusMode(Enum):
+class ConsensusMode(IntEnum):
     PLAIN = 0
-    HARD_FORK_2_0 = 1
-    SOFT_FORK_4 = 2
+    SOFT_FORK_4 = 1
+    HARD_FORK_2_0 = 2
 
 
 @pytest.fixture(
@@ -202,22 +202,21 @@ def consensus_mode(request):
 
 
 @pytest.fixture(scope="session")
-def blockchain_constants(consensus_mode) -> ConsensusConstants:
-    if consensus_mode == ConsensusMode.PLAIN:
-        return test_constants
-    if consensus_mode == ConsensusMode.SOFT_FORK_4:
-        return test_constants.replace(
+def blockchain_constants(consensus_mode: ConsensusMode) -> ConsensusConstants:
+    ret: ConsensusConstants = test_constants
+    if consensus_mode >= ConsensusMode.SOFT_FORK_4:
+        ret = ret.replace(
             SOFT_FORK4_HEIGHT=uint32(2),
         )
-    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
-        return test_constants.replace(
+    if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
+        ret = ret.replace(
             HARD_FORK_HEIGHT=uint32(2),
             HARD_FORK_FIX_HEIGHT=uint32(2),
             PLOT_FILTER_128_HEIGHT=uint32(10),
             PLOT_FILTER_64_HEIGHT=uint32(15),
             PLOT_FILTER_32_HEIGHT=uint32(20),
         )
-    raise AssertionError("Invalid Blockchain mode in simulation")
+    return ret
 
 
 @pytest.fixture(scope="session", name="bt")
@@ -264,7 +263,7 @@ def db_version(request) -> int:
     return request.param
 
 
-SOFTFORK_HEIGHTS = [1000000, 5496000, 5496100, 5716000]
+SOFTFORK_HEIGHTS = [1000000, 5496000, 5496100, 5716000, 5940000]
 
 
 @pytest.fixture(scope="function", params=SOFTFORK_HEIGHTS)
@@ -278,7 +277,7 @@ saved_blocks_version = "2.0"
 @pytest.fixture(scope="session")
 def default_400_blocks(bt, consensus_mode):
     version = ""
-    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+    if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
     from chia._tests.util.blockchain import persistent_blocks
@@ -289,7 +288,7 @@ def default_400_blocks(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def default_1000_blocks(bt, consensus_mode):
     version = ""
-    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+    if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
     from chia._tests.util.blockchain import persistent_blocks
@@ -300,7 +299,7 @@ def default_1000_blocks(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def pre_genesis_empty_slots_1000_blocks(bt, consensus_mode):
     version = ""
-    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+    if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
     from chia._tests.util.blockchain import persistent_blocks
@@ -317,7 +316,7 @@ def pre_genesis_empty_slots_1000_blocks(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def default_1500_blocks(bt, consensus_mode):
     version = ""
-    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+    if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
     from chia._tests.util.blockchain import persistent_blocks
@@ -330,7 +329,7 @@ def default_10000_blocks(bt, consensus_mode):
     from chia._tests.util.blockchain import persistent_blocks
 
     version = ""
-    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+    if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
     return persistent_blocks(
@@ -347,7 +346,7 @@ def default_10000_blocks(bt, consensus_mode):
 @pytest.fixture(scope="session")
 def test_long_reorg_blocks(bt, consensus_mode, default_10000_blocks):
     version = ""
-    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+    if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
     from chia._tests.util.blockchain import persistent_blocks
@@ -369,7 +368,7 @@ def test_long_reorg_blocks(bt, consensus_mode, default_10000_blocks):
 @pytest.fixture(scope="session")
 def test_long_reorg_blocks_light(bt, consensus_mode, default_10000_blocks):
     version = ""
-    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+    if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
     from chia._tests.util.blockchain import persistent_blocks
@@ -388,7 +387,7 @@ def test_long_reorg_blocks_light(bt, consensus_mode, default_10000_blocks):
 @pytest.fixture(scope="session")
 def default_2000_blocks_compact(bt, consensus_mode):
     version = ""
-    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+    if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
     from chia._tests.util.blockchain import persistent_blocks
@@ -410,7 +409,7 @@ def default_10000_blocks_compact(bt, consensus_mode):
     from chia._tests.util.blockchain import persistent_blocks
 
     version = ""
-    if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+    if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
         version = "_hardfork"
 
     return persistent_blocks(

--- a/chia/_tests/core/full_node/test_conditions.py
+++ b/chia/_tests/core/full_node/test_conditions.py
@@ -140,13 +140,13 @@ class TestConditions:
         conditions = Program.to(assemble(f"(({opcode} 1337))"))
         additions, removals, new_block = await check_conditions(bt, conditions)
 
-        if consensus_mode != ConsensusMode.HARD_FORK_2_0:
+        if consensus_mode < ConsensusMode.HARD_FORK_2_0:
             # before the hard fork, all unknown conditions have 0 cost
             expected_cost = 0
 
         # once the hard fork activates, blocks no longer pay the cost of the ROM
         # generator (which includes hashing all puzzles).
-        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+        if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
             block_base_cost = 756064
         else:
             block_base_cost = 761056
@@ -167,7 +167,7 @@ class TestConditions:
         conditions = Program.to(assemble(condition))
         additions, removals, new_block = await check_conditions(bt, conditions)
 
-        if consensus_mode != ConsensusMode.HARD_FORK_2_0:
+        if consensus_mode < ConsensusMode.HARD_FORK_2_0:
             # the SOFTFORK condition is not recognized before the hard fork
             expected_cost = 0
             block_base_cost = 737056
@@ -376,7 +376,7 @@ class TestConditions:
         pre-v2-softfork, and rejects more than the announcement limit afterward.
         """
 
-        if condition1.startswith("(66") and consensus_mode != ConsensusMode.SOFT_FORK_4:
+        if condition1.startswith("(66") and consensus_mode < ConsensusMode.SOFT_FORK_4:
             # The message conditions aren't enabled until Soft-fork 3, so there
             # won't be any errors unless it's activated
             expect_err = None
@@ -459,7 +459,7 @@ class TestConditions:
         coin = blocks[-2].get_included_reward_coins()[0]
         conditions = Program.to(assemble("(" + conds.format(coin="0x" + coin.name().hex()) + ")"))
         # before the softfork has activated, it's all allowed
-        if consensus_mode.value < ConsensusMode.SOFT_FORK_4.value:
+        if consensus_mode < ConsensusMode.SOFT_FORK_4:
             expected = None
 
         await check_conditions(bt, conditions, expected_err=expected)

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -210,7 +210,7 @@ class TestFullNodeBlockCompression:
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
         assert program is not None
         template = detect_potential_template_generator(uint32(5), program)
-        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+        if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
             # after the hard fork we don't use this compression mechanism
             # anymore, we use CLVM backrefs in the encoding instead
             assert template is None
@@ -246,7 +246,7 @@ class TestFullNodeBlockCompression:
         assert program is not None
         assert detect_potential_template_generator(uint32(6), program) is None
         num_blocks = len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list)
-        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+        if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
             # after the hard fork we don't use this compression mechanism
             # anymore, we use CLVM backrefs in the encoding instead
             assert num_blocks == 0
@@ -327,7 +327,7 @@ class TestFullNodeBlockCompression:
         assert program is not None
         assert detect_potential_template_generator(uint32(9), program) is None
         num_blocks = len((await full_node_1.get_all_full_blocks())[-1].transactions_generator_ref_list)
-        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+        if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
             # after the hard fork we don't use this compression mechanism
             # anymore, we use CLVM backrefs in the encoding instead
             assert num_blocks == 0
@@ -422,7 +422,7 @@ class TestFullNodeBlockCompression:
         program: Optional[SerializedProgram] = (await full_node_1.get_all_full_blocks())[-1].transactions_generator
         assert program is not None
         template = detect_potential_template_generator(uint32(11), program)
-        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+        if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
             # after the hard fork we don't use this compression mechanism
             # anymore, we use CLVM backrefs in the encoding instead
             assert template is None
@@ -437,7 +437,7 @@ class TestFullNodeBlockCompression:
         assert height == len(all_blocks) - 1
 
         template = full_node_1.full_node.full_node_store.previous_generator
-        if consensus_mode == ConsensusMode.HARD_FORK_2_0:
+        if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
             # after the hard fork we don't use this compression mechanism
             # anymore, we use CLVM backrefs in the encoding instead
             assert template is None

--- a/chia/_tests/core/test_full_node_rpc.py
+++ b/chia/_tests/core/test_full_node_rpc.py
@@ -221,7 +221,7 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
         await full_node_api_1.farm_new_transaction_block(FarmNewBlockProtocol(ph_2))
         block: FullBlock = (await full_node_api_1.get_all_full_blocks())[-1]
 
-        if consensus_mode != ConsensusMode.HARD_FORK_2_0:
+        if consensus_mode < ConsensusMode.HARD_FORK_2_0:
             # after the hard fork, we don't compress blocks using
             # block references anymore
             assert len(block.transactions_generator_ref_list) > 0  # compression has occurred


### PR DESCRIPTION
### Purpose:

Make it simpler to introduce new soft-forks in our tests, that activate after the hard fork. In this case both the hard fork features *and* a new soft-fork will have activated, and should be active in the tests.

### Current Behavior:

The `ConsensusMode` fixture is an *unordered* enum, with `PLAIN`, `SOFT_FORK_4` and `HARD_FORK_2_0`.
Tests that depend on whether the hard fork has activated or not check for `consensus_mode == ConsensusMode.HARD_FORK_2_0`.

### New Behavior:

The `ConsensusMode` fixture is an *ordered* `IntEnum`. Ordered by the activation order of the forks.
The test constants are updated based on the current test case consensus mode by iterating, in chronological order, the forks.

Tests that depend on whether the hard fork has activated or not check for `consensus_mode >= ConsensusMode.HARD_FORK_2_0`, allowing for other constants to represent forks activating after the hard fork.