### PR TITLE
[CHIA-431] Port `chia wallet vcs ...` to @tx_out_cmd

### DIFF
--- a/chia/_tests/cmds/wallet/test_vcs.py
+++ b/chia/_tests/cmds/wallet/test_vcs.py
@@ -31,8 +31,9 @@ def test_vcs_mint(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Pa
             tx_config: TXConfig,
             target_address: Optional[bytes32] = None,
             fee: uint64 = uint64(0),
+            push: bool = True,
         ) -> VCMintResponse:
-            self.add_to_log("vc_mint", (did_id, tx_config, target_address, fee))
+            self.add_to_log("vc_mint", (did_id, tx_config, target_address, fee, push))
 
             return VCMintResponse(
                 [STD_UTX],
@@ -64,7 +65,7 @@ def test_vcs_mint(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Pa
         f"Transaction {get_bytes32(2).hex()}",
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
-    expected_calls: logType = {"vc_mint": [(did_bytes, DEFAULT_TX_CONFIG, target_bytes, 500000000000)]}
+    expected_calls: logType = {"vc_mint": [(did_bytes, DEFAULT_TX_CONFIG, target_bytes, 500000000000, True)]}
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
 
 
@@ -117,8 +118,11 @@ def test_vcs_update_proofs(capsys: object, get_test_cli_clients: Tuple[TestRpcCl
             new_proof_hash: Optional[bytes32] = None,
             provider_inner_puzhash: Optional[bytes32] = None,
             fee: uint64 = uint64(0),
+            push: bool = True,
         ) -> VCSpendResponse:
-            self.add_to_log("vc_spend", (vc_id, tx_config, new_puzhash, new_proof_hash, provider_inner_puzhash, fee))
+            self.add_to_log(
+                "vc_spend", (vc_id, tx_config, new_puzhash, new_proof_hash, provider_inner_puzhash, fee, push)
+            )
             return VCSpendResponse([STD_UTX], [STD_TX])
 
     inst_rpc_client = VcsUpdateProofsRpcClient()  # pylint: disable=no-value-for-parameter
@@ -145,7 +149,15 @@ def test_vcs_update_proofs(capsys: object, get_test_cli_clients: Tuple[TestRpcCl
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     expected_calls: logType = {
         "vc_spend": [
-            (vc_bytes, DEFAULT_TX_CONFIG.override(reuse_puzhash=True), target_ph, new_proof, None, uint64(500000000000))
+            (
+                vc_bytes,
+                DEFAULT_TX_CONFIG.override(reuse_puzhash=True),
+                target_ph,
+                new_proof,
+                None,
+                uint64(500000000000),
+                True,
+            )
         ]
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
@@ -219,8 +231,9 @@ def test_vcs_revoke(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
             vc_parent_id: bytes32,
             tx_config: TXConfig,
             fee: uint64 = uint64(0),
+            push: bool = True,
         ) -> VCRevokeResponse:
-            self.add_to_log("vc_revoke", (vc_parent_id, tx_config, fee))
+            self.add_to_log("vc_revoke", (vc_parent_id, tx_config, fee, push))
             return VCRevokeResponse([STD_UTX], [STD_TX])
 
     inst_rpc_client = VcsRevokeRpcClient()  # pylint: disable=no-value-for-parameter
@@ -242,8 +255,8 @@ def test_vcs_revoke(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
     expected_calls: logType = {
         "vc_get": [(vc_id,)],
         "vc_revoke": [
-            (parent_id, DEFAULT_TX_CONFIG.override(reuse_puzhash=True), uint64(500000000000)),
-            (parent_id, DEFAULT_TX_CONFIG.override(reuse_puzhash=True), uint64(500000000000)),
+            (parent_id, DEFAULT_TX_CONFIG.override(reuse_puzhash=True), uint64(500000000000), True),
+            (parent_id, DEFAULT_TX_CONFIG.override(reuse_puzhash=True), uint64(500000000000), True),
         ],
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
@@ -260,6 +273,7 @@ def test_vcs_approve_r_cats(capsys: object, get_test_cli_clients: Tuple[TestRpcC
             min_amount_to_claim: uint64,
             tx_config: TXConfig,
             fee: uint64 = uint64(0),
+            push: bool = True,
         ) -> List[TransactionRecord]:
             self.add_to_log(
                 "crcat_approve_pending",
@@ -268,6 +282,7 @@ def test_vcs_approve_r_cats(capsys: object, get_test_cli_clients: Tuple[TestRpcC
                     min_amount_to_claim,
                     tx_config,
                     fee,
+                    push,
                 ),
             )
             return [STD_TX]
@@ -305,6 +320,7 @@ def test_vcs_approve_r_cats(capsys: object, get_test_cli_clients: Tuple[TestRpcC
                     reuse_puzhash=True,
                 ),
                 uint64(500000000000),
+                True,
             )
         ],
         "get_wallets": [(None,)],

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -1386,16 +1386,18 @@ def vcs_cmd() -> None:  # pragma: no cover
 @click.option("-d", "--did", help="The DID of the VC's proof provider", type=str, required=True)
 @click.option("-t", "--target-address", help="The address to send the VC to once it's minted", type=str, required=False)
 @click.option("-m", "--fee", help="Blockchain fee for mint transaction, in XCH", type=str, required=False, default="0")
+@tx_out_cmd
 def mint_vc_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
     did: str,
     target_address: Optional[str],
     fee: str,
-) -> None:  # pragma: no cover
+    push: bool,
+) -> List[TransactionRecord]:
     from .wallet_funcs import mint_vc
 
-    asyncio.run(mint_vc(wallet_rpc_port, fingerprint, did, Decimal(fee), target_address))
+    return asyncio.run(mint_vc(wallet_rpc_port, fingerprint, did, Decimal(fee), target_address, push=push))
 
 
 @vcs_cmd.command("get", short_help="Get a list of existing VCs")
@@ -1451,6 +1453,7 @@ def get_vcs_cmd(
     default=False,
     show_default=True,
 )
+@tx_out_cmd
 def spend_vc_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -1459,10 +1462,11 @@ def spend_vc_cmd(
     new_proof_hash: str,
     fee: str,
     reuse_puzhash: bool,
-) -> None:  # pragma: no cover
+    push: bool,
+) -> List[TransactionRecord]:
     from .wallet_funcs import spend_vc
 
-    asyncio.run(
+    return asyncio.run(
         spend_vc(
             wallet_rpc_port=wallet_rpc_port,
             fp=fingerprint,
@@ -1471,6 +1475,7 @@ def spend_vc_cmd(
             new_puzhash=new_puzhash,
             new_proof_hash=new_proof_hash,
             reuse_puzhash=reuse_puzhash,
+            push=push,
         )
     )
 
@@ -1549,6 +1554,7 @@ def get_proofs_for_root_cmd(
     default=False,
     show_default=True,
 )
+@tx_out_cmd
 def revoke_vc_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -1556,10 +1562,13 @@ def revoke_vc_cmd(
     vc_id: Optional[str],
     fee: str,
     reuse_puzhash: bool,
-) -> None:  # pragma: no cover
+    push: bool,
+) -> List[TransactionRecord]:
     from .wallet_funcs import revoke_vc
 
-    asyncio.run(revoke_vc(wallet_rpc_port, fingerprint, parent_coin_id, vc_id, Decimal(fee), reuse_puzhash))
+    return asyncio.run(
+        revoke_vc(wallet_rpc_port, fingerprint, parent_coin_id, vc_id, Decimal(fee), reuse_puzhash, push=push)
+    )
 
 
 @vcs_cmd.command("approve_r_cats", help="Claim any R-CATs that are currently pending VC approval")
@@ -1586,6 +1595,7 @@ def revoke_vc_cmd(
     is_flag=True,
     default=False,
 )
+@tx_out_cmd
 def approve_r_cats_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -1595,11 +1605,20 @@ def approve_r_cats_cmd(
     min_coin_amount: Optional[Decimal],
     max_coin_amount: Optional[Decimal],
     reuse: bool,
-) -> None:  # pragma: no cover
+    push: bool,
+) -> List[TransactionRecord]:
     from .wallet_funcs import approve_r_cats
 
-    asyncio.run(
+    return asyncio.run(
         approve_r_cats(
-            wallet_rpc_port, fingerprint, id, min_amount_to_claim, Decimal(fee), min_coin_amount, max_coin_amount, reuse
+            wallet_rpc_port,
+            fingerprint,
+            id,
+            min_amount_to_claim,
+            Decimal(fee),
+            min_coin_amount,
+            max_coin_amount,
+            reuse,
+            push,
         )
     )


### PR DESCRIPTION
This brings another set of commands to the @tx_out_cmd decorator which gives it the capability to optionally push a transaction and export the transactions to a local file.