### PR TITLE
Revert `final_pubkey: G1Element` from main

### DIFF
--- a/chia/_tests/wallet/test_signer_protocol.py
+++ b/chia/_tests/wallet/test_signer_protocol.py
@@ -122,7 +122,7 @@ async def test_p2dohp_wallet_signer_protocol(wallet_environments: WalletTestFram
         SumHint(
             [pubkey.get_fingerprint().to_bytes(4, "big")],
             calculate_synthetic_offset(pubkey, DEFAULT_HIDDEN_PUZZLE_HASH).to_bytes(32, "big"),
-            G1Element.from_bytes(wallet_state_manager.main_wallet.puzzle_for_pk(pubkey).uncurry()[1].at("f").as_atom()),
+            wallet_state_manager.main_wallet.puzzle_for_pk(pubkey).uncurry()[1].at("f").as_atom(),
         )
     ]
     assert utx.signing_instructions.key_hints.path_hints == [
@@ -184,7 +184,7 @@ async def test_p2dohp_wallet_signer_protocol(wallet_environments: WalletTestFram
                     not_our_signing_instructions.key_hints,
                     sum_hints=[
                         *not_our_signing_instructions.key_hints.sum_hints,
-                        SumHint([bytes(not_our_pubkey)], std_hash(b"sum hint only"), G1Element()),
+                        SumHint([bytes(not_our_pubkey)], std_hash(b"sum hint only"), bytes(G1Element())),
                     ],
                 ),
             )
@@ -284,7 +284,7 @@ async def test_p2blsdohp_execute_signing_instructions(wallet_environments: Walle
     sum_pk: G1Element = other_sk.get_g1() + root_pk
     signing_instructions: SigningInstructions = SigningInstructions(
         KeyHints(
-            [SumHint([root_fingerprint], test_name, sum_pk)],
+            [SumHint([root_fingerprint], test_name, bytes(sum_pk))],
             [],
         ),
         [SigningTarget(sum_pk.get_fingerprint().to_bytes(4, "big"), test_name, test_name)],
@@ -335,7 +335,7 @@ async def test_p2blsdohp_execute_signing_instructions(wallet_environments: Walle
     sum_pk = child_sk.get_g1() + other_sk.get_g1()
     signing_instructions = SigningInstructions(
         KeyHints(
-            [SumHint([child_sk.get_g1().get_fingerprint().to_bytes(4, "big")], test_name, sum_pk)],
+            [SumHint([child_sk.get_g1().get_fingerprint().to_bytes(4, "big")], test_name, bytes(sum_pk))],
             [PathHint(root_fingerprint, [uint64(1), uint64(2), uint64(3), uint64(4)])],
         ),
         [SigningTarget(sum_pk.get_fingerprint().to_bytes(4, "big"), test_name, test_name)],
@@ -370,8 +370,8 @@ async def test_p2blsdohp_execute_signing_instructions(wallet_environments: Walle
         SigningInstructions(
             KeyHints(
                 [
-                    SumHint([child_sk.get_g1().get_fingerprint().to_bytes(4, "big")], test_name, sum_pk),
-                    SumHint([child_sk_2.get_g1().get_fingerprint().to_bytes(4, "big")], test_name_2, sum_pk_2),
+                    SumHint([child_sk.get_g1().get_fingerprint().to_bytes(4, "big")], test_name, bytes(sum_pk)),
+                    SumHint([child_sk_2.get_g1().get_fingerprint().to_bytes(4, "big")], test_name_2, bytes(sum_pk_2)),
                 ],
                 [
                     PathHint(root_fingerprint, [uint64(1), uint64(2), uint64(3), uint64(4)]),
@@ -412,7 +412,7 @@ async def test_p2blsdohp_execute_signing_instructions(wallet_environments: Walle
     )
     unknown_sum_hint = SigningInstructions(
         KeyHints(
-            [SumHint([b"unknown fingerprint"], b"", G1Element())],
+            [SumHint([b"unknown fingerprint"], b"", bytes(G1Element()))],
             [],
         ),
         [],
@@ -439,7 +439,7 @@ async def test_p2blsdohp_execute_signing_instructions(wallet_environments: Walle
     signing_responses = await wallet.execute_signing_instructions(
         SigningInstructions(
             KeyHints(
-                [SumHint([root_fingerprint], test_name, sum_pk)],
+                [SumHint([root_fingerprint], test_name, bytes(sum_pk))],
                 [],
             ),
             [SigningTarget(sum_pk.get_fingerprint().to_bytes(4, "big"), test_name, test_name)],

--- a/chia/wallet/signer_protocol.py
+++ b/chia/wallet/signer_protocol.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from chia_rs import G1Element
-
 from chia.types.blockchain_format.coin import Coin as _Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
@@ -76,7 +74,7 @@ class SigningTarget(Streamable):
 class SumHint(Streamable):
     fingerprints: List[bytes]
     synthetic_offset: bytes
-    final_pubkey: G1Element
+    final_pubkey: bytes
 
 
 @clvm_streamable

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -513,9 +513,10 @@ class Wallet:
                 return True
         return False
 
-    async def sum_hint_for_pubkey(self, pk: G1Element) -> Optional[SumHint]:
+    async def sum_hint_for_pubkey(self, pk: bytes) -> Optional[SumHint]:
+        pk_parsed: G1Element = G1Element.from_bytes(pk)
         dr: Optional[DerivationRecord] = await self.wallet_state_manager.puzzle_store.record_for_puzzle_hash(
-            puzzle_hash_for_synthetic_public_key(pk)
+            puzzle_hash_for_synthetic_public_key(pk_parsed)
         )
         if dr is None:
             return None
@@ -525,11 +526,12 @@ class Wallet:
             pk,
         )
 
-    async def path_hint_for_pubkey(self, pk: G1Element) -> Optional[PathHint]:
-        index: Optional[uint32] = await self.wallet_state_manager.puzzle_store.index_for_pubkey(pk)
+    async def path_hint_for_pubkey(self, pk: bytes) -> Optional[PathHint]:
+        pk_parsed: G1Element = G1Element.from_bytes(pk)
+        index: Optional[uint32] = await self.wallet_state_manager.puzzle_store.index_for_pubkey(pk_parsed)
         if index is None:
             index = await self.wallet_state_manager.puzzle_store.index_for_puzzle_hash(
-                puzzle_hash_for_synthetic_public_key(pk)
+                puzzle_hash_for_synthetic_public_key(pk_parsed)
             )
         root_pubkey: bytes = self.wallet_state_manager.root_pubkey.get_fingerprint().to_bytes(4, "big")
         if index is None:
@@ -539,7 +541,7 @@ class Wallet:
                     try_owner_sk = master_sk_to_singleton_owner_sk(
                         self.wallet_state_manager.private_key, uint32(pool_wallet_index)
                     )
-                    if try_owner_sk.get_g1() == pk:
+                    if try_owner_sk.get_g1() == pk_parsed:
                         return PathHint(
                             root_pubkey,
                             [uint64(12381), uint64(8444), uint64(5), uint64(pool_wallet_index)],
@@ -609,7 +611,7 @@ class Wallet:
             offset_pk = offset_sk.get_g1()
             pk_lookup[offset_pk.get_fingerprint()] = offset_pk
             sk_lookup[offset_pk.get_fingerprint()] = offset_sk
-            final_pubkey: G1Element = sum_hint.final_pubkey
+            final_pubkey: G1Element = G1Element.from_bytes(sum_hint.final_pubkey)
             final_fingerprint: int = final_pubkey.get_fingerprint()
             pk_lookup[final_fingerprint] = final_pubkey
             sum_hint_lookup[final_fingerprint] = [*fingerprints_we_have, offset_pk.get_fingerprint()]


### PR DESCRIPTION
During a recent PR, an inadvertent change of adding the type constraint `G1Element` was made to the signer protocol which is supposed to be key type agnostic.  This PR reverts the relevant parts of that change.