### PR TITLE
[CHIA-432] Port `chia dao ...` to @tx_out_cmd (and exclude DL and pooling)

### DIFF
--- a/chia/_tests/cmds/wallet/test_dao.py
+++ b/chia/_tests/cmds/wallet/test_dao.py
@@ -48,6 +48,7 @@ def test_dao_create(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
             name: Optional[str] = None,
             fee: uint64 = uint64(0),
             fee_for_cat: uint64 = uint64(0),
+            push: bool = True,
         ) -> CreateNewDAOWalletResponse:
             if not treasury_id:
                 treasury_id = bytes32(token_bytes(32))
@@ -140,6 +141,7 @@ def test_dao_treasury(capsys: object, get_test_cli_clients: Tuple[TestRpcClients
             tx_config: TXConfig,
             fee: uint64 = uint64(0),
             reuse_puzhash: Optional[bool] = None,
+            push: bool = True,
         ) -> DAOAddFundsToTreasuryResponse:
             return DAOAddFundsToTreasuryResponse([STD_UTX], [STD_TX], STD_TX.name, STD_TX)
 
@@ -278,6 +280,7 @@ def test_dao_proposals(capsys: object, get_test_cli_clients: Tuple[TestRpcClient
             tx_config: TXConfig,
             is_yes_vote: bool,
             fee: uint64 = uint64(0),
+            push: bool = True,
         ) -> DAOVoteOnProposalResponse:
             return DAOVoteOnProposalResponse([STD_UTX], [STD_TX], STD_TX.name, STD_TX)
 
@@ -289,6 +292,7 @@ def test_dao_proposals(capsys: object, get_test_cli_clients: Tuple[TestRpcClient
             fee: uint64 = uint64(0),
             self_destruct: bool = False,
             reuse_puzhash: Optional[bool] = None,
+            push: bool = True,
         ) -> DAOCloseProposalResponse:
             return DAOCloseProposalResponse([STD_UTX], [STD_TX], STD_TX.name, STD_TX)
 
@@ -306,6 +310,7 @@ def test_dao_proposals(capsys: object, get_test_cli_clients: Tuple[TestRpcClient
             new_dao_rules: Optional[Dict[str, uint64]] = None,
             fee: uint64 = uint64(0),
             reuse_puzhash: Optional[bool] = None,
+            push: bool = True,
         ) -> DAOCreateProposalResponse:
             return DAOCreateProposalResponse([STD_UTX], [STD_TX], bytes32([0] * 32), STD_TX.name, STD_TX)
 
@@ -489,6 +494,7 @@ def test_dao_cats(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Pa
             tx_config: TXConfig,
             fee: uint64 = uint64(0),
             reuse_puzhash: Optional[bool] = None,
+            push: bool = True,
         ) -> DAOSendToLockupResponse:
             return DAOSendToLockupResponse([STD_UTX], [STD_TX], STD_TX.name, [STD_TX])
 
@@ -498,6 +504,7 @@ def test_dao_cats(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Pa
             tx_config: TXConfig,
             fee: uint64 = uint64(0),
             reuse_puzhash: Optional[bool] = None,
+            push: bool = True,
         ) -> DAOFreeCoinsFromFinishedProposalsResponse:
             return DAOFreeCoinsFromFinishedProposalsResponse([STD_UTX], [STD_TX], STD_TX.name, STD_TX)
 
@@ -508,6 +515,7 @@ def test_dao_cats(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Pa
             coins: Optional[List[Dict[str, Union[str, int]]]] = None,
             fee: uint64 = uint64(0),
             reuse_puzhash: Optional[bool] = None,
+            push: bool = True,
         ) -> DAOExitLockupResponse:
             return DAOExitLockupResponse([STD_UTX], [STD_TX], STD_TX.name, STD_TX)
 

--- a/chia/cmds/dao.py
+++ b/chia/cmds/dao.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence
 
 import click
 
-from chia.cmds.cmds_util import tx_config_args
+from chia.cmds.cmds_util import tx_config_args, tx_out_cmd
 from chia.cmds.plotnft import validate_fee
+from chia.wallet.transaction_record import TransactionRecord
 
 
 @click.group("dao", short_help="Create, manage or show state of DAOs", no_args_is_help=True)
@@ -155,6 +156,7 @@ def dao_add_cmd(
     callback=validate_fee,
 )
 @tx_config_args
+@tx_out_cmd
 def dao_create_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -175,7 +177,8 @@ def dao_create_cmd(
     coins_to_exclude: Sequence[str],
     amounts_to_exclude: Sequence[str],
     reuse: Optional[bool],
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .dao_funcs import create_dao_wallet
 
     if self_destruct == proposal_timelock:
@@ -201,8 +204,9 @@ def dao_create_cmd(
         "coins_to_exclude": coins_to_exclude,
         "amounts_to_exclude": amounts_to_exclude,
         "reuse_puzhash": reuse,
+        "push": push,
     }
-    asyncio.run(create_dao_wallet(extra_params, wallet_rpc_port, fingerprint))
+    return asyncio.run(create_dao_wallet(extra_params, wallet_rpc_port, fingerprint))
 
 
 # ----------------------------------------------------------------------------------------
@@ -266,6 +270,7 @@ def dao_get_id_cmd(
     callback=validate_fee,
 )
 @tx_config_args
+@tx_out_cmd
 def dao_add_funds_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -278,7 +283,8 @@ def dao_add_funds_cmd(
     coins_to_exclude: Sequence[str],
     amounts_to_exclude: Sequence[str],
     reuse: Optional[bool],
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .dao_funcs import add_funds_to_treasury
 
     extra_params = {
@@ -291,8 +297,9 @@ def dao_add_funds_cmd(
         "coins_to_exclude": coins_to_exclude,
         "amounts_to_exclude": amounts_to_exclude,
         "reuse_puzhash": reuse,
+        "push": push,
     }
-    asyncio.run(add_funds_to_treasury(extra_params, wallet_rpc_port, fingerprint))
+    return asyncio.run(add_funds_to_treasury(extra_params, wallet_rpc_port, fingerprint))
 
 
 @dao_cmd.command("balance", short_help="Get the asset balances for a DAO treasury", no_args_is_help=True)
@@ -455,6 +462,7 @@ def dao_show_proposal_cmd(
     callback=validate_fee,
 )
 @tx_config_args
+@tx_out_cmd
 def dao_vote_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -468,7 +476,8 @@ def dao_vote_cmd(
     coins_to_exclude: Sequence[str],
     amounts_to_exclude: Sequence[str],
     reuse: Optional[bool],
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .dao_funcs import vote_on_proposal
 
     is_yes_vote = False if vote_no else True
@@ -484,8 +493,9 @@ def dao_vote_cmd(
         "coins_to_exclude": coins_to_exclude,
         "amounts_to_exclude": amounts_to_exclude,
         "reuse_puzhash": reuse,
+        "push": push,
     }
-    asyncio.run(vote_on_proposal(extra_params, wallet_rpc_port, fingerprint))
+    return asyncio.run(vote_on_proposal(extra_params, wallet_rpc_port, fingerprint))
 
 
 # ----------------------------------------------------------------------------------------
@@ -526,6 +536,7 @@ def dao_vote_cmd(
     callback=validate_fee,
 )
 @tx_config_args
+@tx_out_cmd
 def dao_close_proposal_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -538,7 +549,8 @@ def dao_close_proposal_cmd(
     coins_to_exclude: Sequence[str],
     amounts_to_exclude: Sequence[str],
     reuse: Optional[bool],
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .dao_funcs import close_proposal
 
     extra_params = {
@@ -551,8 +563,9 @@ def dao_close_proposal_cmd(
         "coins_to_exclude": coins_to_exclude,
         "amounts_to_exclude": amounts_to_exclude,
         "reuse_puzhash": reuse,
+        "push": push,
     }
-    asyncio.run(close_proposal(extra_params, wallet_rpc_port, fingerprint))
+    return asyncio.run(close_proposal(extra_params, wallet_rpc_port, fingerprint))
 
 
 # ----------------------------------------------------------------------------------------
@@ -586,6 +599,7 @@ def dao_close_proposal_cmd(
     callback=validate_fee,
 )
 @tx_config_args
+@tx_out_cmd
 def dao_lockup_coins_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -597,7 +611,8 @@ def dao_lockup_coins_cmd(
     coins_to_exclude: Sequence[str],
     amounts_to_exclude: Sequence[str],
     reuse: Optional[bool],
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .dao_funcs import lockup_coins
 
     extra_params = {
@@ -609,8 +624,9 @@ def dao_lockup_coins_cmd(
         "coins_to_exclude": coins_to_exclude,
         "amounts_to_exclude": amounts_to_exclude,
         "reuse_puzhash": reuse,
+        "push": push,
     }
-    asyncio.run(lockup_coins(extra_params, wallet_rpc_port, fingerprint))
+    return asyncio.run(lockup_coins(extra_params, wallet_rpc_port, fingerprint))
 
 
 @dao_cmd.command("release_coins", short_help="Release closed proposals from DAO CATs", no_args_is_help=True)
@@ -633,6 +649,7 @@ def dao_lockup_coins_cmd(
     callback=validate_fee,
 )
 @tx_config_args
+@tx_out_cmd
 def dao_release_coins_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -643,7 +660,8 @@ def dao_release_coins_cmd(
     coins_to_exclude: Sequence[str],
     amounts_to_exclude: Sequence[str],
     reuse: Optional[bool],
-) -> None:
+    push: bool = True,
+) -> List[TransactionRecord]:
     from .dao_funcs import release_coins
 
     extra_params = {
@@ -654,8 +672,9 @@ def dao_release_coins_cmd(
         "coins_to_exclude": coins_to_exclude,
         "amounts_to_exclude": amounts_to_exclude,
         "reuse_puzhash": reuse,
+        "push": push,
     }
-    asyncio.run(release_coins(extra_params, wallet_rpc_port, fingerprint))
+    return asyncio.run(release_coins(extra_params, wallet_rpc_port, fingerprint))
 
 
 @dao_cmd.command("exit_lockup", short_help="Release DAO CATs from voting mode", no_args_is_help=True)
@@ -678,6 +697,7 @@ def dao_release_coins_cmd(
     callback=validate_fee,
 )
 @tx_config_args
+@tx_out_cmd
 def dao_exit_lockup_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -688,7 +708,8 @@ def dao_exit_lockup_cmd(
     coins_to_exclude: Sequence[str],
     amounts_to_exclude: Sequence[str],
     reuse: Optional[bool],
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .dao_funcs import exit_lockup
 
     extra_params = {
@@ -699,8 +720,9 @@ def dao_exit_lockup_cmd(
         "coins_to_exclude": coins_to_exclude,
         "amounts_to_exclude": amounts_to_exclude,
         "reuse_puzhash": reuse,
+        "push": push,
     }
-    asyncio.run(exit_lockup(extra_params, wallet_rpc_port, fingerprint))
+    return asyncio.run(exit_lockup(extra_params, wallet_rpc_port, fingerprint))
 
 
 # ----------------------------------------------------------------------------------------
@@ -772,6 +794,7 @@ def dao_proposal(ctx: click.Context) -> None:
     callback=validate_fee,
 )
 @tx_config_args
+@tx_out_cmd
 def dao_create_spend_proposal_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -787,7 +810,8 @@ def dao_create_spend_proposal_cmd(
     coins_to_exclude: Sequence[str],
     amounts_to_exclude: Sequence[str],
     reuse: Optional[bool],
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .dao_funcs import create_spend_proposal
 
     extra_params = {
@@ -803,8 +827,9 @@ def dao_create_spend_proposal_cmd(
         "coins_to_exclude": coins_to_exclude,
         "amounts_to_exclude": amounts_to_exclude,
         "reuse_puzhash": reuse,
+        "push": push,
     }
-    asyncio.run(create_spend_proposal(extra_params, wallet_rpc_port, fingerprint))
+    return asyncio.run(create_spend_proposal(extra_params, wallet_rpc_port, fingerprint))
 
 
 @dao_proposal.command("update", short_help="Create a proposal to change the DAO rules", no_args_is_help=True)
@@ -877,6 +902,7 @@ def dao_create_spend_proposal_cmd(
     callback=validate_fee,
 )
 @tx_config_args
+@tx_out_cmd
 def dao_create_update_proposal_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -894,7 +920,8 @@ def dao_create_update_proposal_cmd(
     coins_to_exclude: Sequence[str],
     amounts_to_exclude: Sequence[str],
     reuse: Optional[bool],
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .dao_funcs import create_update_proposal
 
     extra_params = {
@@ -912,8 +939,9 @@ def dao_create_update_proposal_cmd(
         "coins_to_exclude": coins_to_exclude,
         "amounts_to_exclude": amounts_to_exclude,
         "reuse_puzhash": reuse,
+        "push": push,
     }
-    asyncio.run(create_update_proposal(extra_params, wallet_rpc_port, fingerprint))
+    return asyncio.run(create_update_proposal(extra_params, wallet_rpc_port, fingerprint))
 
 
 @dao_proposal.command("mint", short_help="Create a proposal to mint new DAO CATs", no_args_is_help=True)
@@ -959,6 +987,7 @@ def dao_create_update_proposal_cmd(
     callback=validate_fee,
 )
 @tx_config_args
+@tx_out_cmd
 def dao_create_mint_proposal_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -972,7 +1001,8 @@ def dao_create_mint_proposal_cmd(
     coins_to_exclude: Sequence[str],
     amounts_to_exclude: Sequence[str],
     reuse: Optional[bool],
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .dao_funcs import create_mint_proposal
 
     extra_params = {
@@ -986,8 +1016,9 @@ def dao_create_mint_proposal_cmd(
         "coins_to_exclude": coins_to_exclude,
         "amounts_to_exclude": amounts_to_exclude,
         "reuse_puzhash": reuse,
+        "push": push,
     }
-    asyncio.run(create_mint_proposal(extra_params, wallet_rpc_port, fingerprint))
+    return asyncio.run(create_mint_proposal(extra_params, wallet_rpc_port, fingerprint))
 
 
 # ----------------------------------------------------------------------------------------

--- a/chia/cmds/dao_funcs.py
+++ b/chia/cmds/dao_funcs.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import time
 from decimal import Decimal
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from chia.cmds.cmds_util import CMDTXConfigLoader, get_wallet_client, transaction_status_msg, transaction_submitted_msg
 from chia.cmds.units import units
@@ -13,6 +13,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.config import selected_network_address_prefix
 from chia.util.ints import uint64
+from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.tx_config import DEFAULT_COIN_SELECTION_CONFIG
 from chia.wallet.util.wallet_types import WalletType
 
@@ -45,7 +46,7 @@ async def add_dao_wallet(args: Dict[str, Any], wallet_rpc_port: Optional[int], f
         print(f"DAOCAT Wallet ID: {res.dao_cat_wallet_id}")
 
 
-async def create_dao_wallet(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
+async def create_dao_wallet(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> List[TransactionRecord]:
     proposal_minimum = uint64(int(Decimal(args["proposal_minimum_amount"]) * units["chia"]))
 
     if proposal_minimum % 2 == 0:
@@ -95,13 +96,16 @@ async def create_dao_wallet(args: Dict[str, Any], wallet_rpc_port: Optional[int]
                     "reuse_puzhash": args["reuse_puzhash"],
                 }
             ).to_tx_config(units["chia"], config, fingerprint),
+            push=args["push"],
         )
 
-        print("Successfully created DAO Wallet")
+        if args["push"]:
+            print("Successfully created DAO Wallet")
         print(f"DAO Treasury ID: {res.treasury_id.hex()}")
         print(f"DAO Wallet ID: {res.wallet_id}")
         print(f"CAT Wallet ID: {res.cat_wallet_id}")
         print(f"DAOCAT Wallet ID: {res.dao_cat_wallet_id}")
+        return res.transactions
 
 
 async def get_treasury_id(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
@@ -123,7 +127,9 @@ async def get_rules(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: in
             print(f"{rule}: {val}")
 
 
-async def add_funds_to_treasury(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
+async def add_funds_to_treasury(
+    args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int
+) -> List[TransactionRecord]:
     wallet_id = args["wallet_id"]
     funding_wallet_id = args["funding_wallet_id"]
     amount = Decimal(args["amount"])
@@ -134,7 +140,7 @@ async def add_funds_to_treasury(args: Dict[str, Any], wallet_rpc_port: Optional[
             mojo_per_unit = get_mojo_per_unit(typ)
         except LookupError:  # pragma: no cover
             print(f"Wallet id: {wallet_id} not found.")
-            return
+            return []
 
         fee = Decimal(args["fee"])
         final_fee: uint64 = uint64(int(fee * units["chia"]))
@@ -154,18 +160,22 @@ async def add_funds_to_treasury(args: Dict[str, Any], wallet_rpc_port: Optional[
                     "reuse_puzhash": args["reuse_puzhash"],
                 }
             ).to_tx_config(units["chia"], config, fingerprint),
+            push=args["push"],
         )
 
-        start = time.time()
-        while time.time() - start < 10:
-            await asyncio.sleep(0.1)
-            tx = await wallet_client.get_transaction(res.tx_id)
-            if len(tx.sent_to) > 0:
-                print(transaction_submitted_msg(tx))
-                print(transaction_status_msg(fingerprint, res.tx_id))
-                return None
+        if args["push"]:
+            start = time.time()
+            while time.time() - start < 10:
+                await asyncio.sleep(0.1)
+                tx = await wallet_client.get_transaction(res.tx_id)
+                if len(tx.sent_to) > 0:
+                    print(transaction_submitted_msg(tx))
+                    print(transaction_status_msg(fingerprint, res.tx_id))
+                    return res.transactions
 
-        print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")  # pragma: no cover
+        if args["push"]:  # pragma: no cover
+            print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")
+        return res.transactions  # pragma: no cover
 
 
 async def get_treasury_balance(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
@@ -283,7 +293,7 @@ async def show_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp
             print(f"Address: {address}")
 
 
-async def vote_on_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
+async def vote_on_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> List[TransactionRecord]:
     wallet_id = args["wallet_id"]
     vote_amount = args["vote_amount"]
     fee = args["fee"]
@@ -307,20 +317,24 @@ async def vote_on_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int],
                     "reuse_puzhash": args["reuse_puzhash"],
                 }
             ).to_tx_config(units["chia"], config, fingerprint),
+            push=args["push"],
         )
-        start = time.time()
-        while time.time() - start < 10:
-            await asyncio.sleep(0.1)
-            tx = await wallet_client.get_transaction(res.tx_id)
-            if len(tx.sent_to) > 0:
-                print(transaction_submitted_msg(tx))
-                print(transaction_status_msg(fingerprint, res.tx_id))
-                return None
+        if args["push"]:
+            start = time.time()
+            while time.time() - start < 10:
+                await asyncio.sleep(0.1)
+                tx = await wallet_client.get_transaction(res.tx_id)
+                if len(tx.sent_to) > 0:
+                    print(transaction_submitted_msg(tx))
+                    print(transaction_status_msg(fingerprint, res.tx_id))
+                    return res.transactions
 
-        print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")  # pragma: no cover
+        if args["push"]:  # pragma: no cover
+            print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")
+        return res.transactions  # pragma: no cover
 
 
-async def close_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
+async def close_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> List[TransactionRecord]:
     wallet_id = args["wallet_id"]
     fee = args["fee"]
     final_fee: uint64 = uint64(int(Decimal(fee) * units["chia"]))
@@ -341,20 +355,25 @@ async def close_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int], f
                     "reuse_puzhash": args["reuse_puzhash"],
                 }
             ).to_tx_config(units["chia"], config, fingerprint),
+            push=args["push"],
         )
-        start = time.time()
-        while time.time() - start < 10:
-            await asyncio.sleep(0.1)
-            tx = await wallet_client.get_transaction(res.tx_id)
-            if len(tx.sent_to) > 0:
-                print(transaction_submitted_msg(tx))
-                print(transaction_status_msg(fingerprint, res.tx_id))
-                return None
 
-        print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")  # pragma: no cover
+        if args["push"]:
+            start = time.time()
+            while time.time() - start < 10:
+                await asyncio.sleep(0.1)
+                tx = await wallet_client.get_transaction(res.tx_id)
+                if len(tx.sent_to) > 0:
+                    print(transaction_submitted_msg(tx))
+                    print(transaction_status_msg(fingerprint, res.tx_id))
+                    return res.transactions
+
+        if args["push"]:  # pragma: no cover
+            print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")
+        return res.transactions  # pragma: no cover
 
 
-async def lockup_coins(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
+async def lockup_coins(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> List[TransactionRecord]:
     wallet_id = args["wallet_id"]
     amount = args["amount"]
     final_amount: uint64 = uint64(int(Decimal(amount) * units["cat"]))
@@ -374,20 +393,25 @@ async def lockup_coins(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp:
                     "reuse_puzhash": args["reuse_puzhash"],
                 }
             ).to_tx_config(units["chia"], config, fingerprint),
+            push=args["push"],
         )
-        start = time.time()
-        while time.time() - start < 10:
-            await asyncio.sleep(0.1)
-            tx = await wallet_client.get_transaction(res.tx_id)
-            if len(tx.sent_to) > 0:
-                print(transaction_submitted_msg(tx))
-                print(transaction_status_msg(fingerprint, res.tx_id))
-                return None
+        if args["push"]:
+            start = time.time()
+            while time.time() - start < 10:
+                await asyncio.sleep(0.1)
+                tx = await wallet_client.get_transaction(res.tx_id)
+                if len(tx.sent_to) > 0:
+                    print(transaction_submitted_msg(tx))
+                    print(transaction_status_msg(fingerprint, res.tx_id))
+                    return res.transactions
 
-        print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")  # pragma: no cover
+        if args["push"]:  # pragma: no cover
+            print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")
+
+        return res.transactions  # pragma: no cover
 
 
-async def release_coins(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
+async def release_coins(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> List[TransactionRecord]:
     wallet_id = args["wallet_id"]
     fee = args["fee"]
     final_fee: uint64 = uint64(int(Decimal(fee) * units["chia"]))
@@ -404,19 +428,24 @@ async def release_coins(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp
                     "reuse_puzhash": args["reuse_puzhash"],
                 }
             ).to_tx_config(units["chia"], config, fingerprint),
+            push=args["push"],
         )
-        start = time.time()
-        while time.time() - start < 10:
-            await asyncio.sleep(0.1)
-            tx = await wallet_client.get_transaction(res.tx_id)
-            if len(tx.sent_to) > 0:
-                print(transaction_submitted_msg(tx))
-                print(transaction_status_msg(fingerprint, res.tx_id))
-                return None
-        print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")  # pragma: no cover
+        if args["push"]:
+            start = time.time()
+            while time.time() - start < 10:
+                await asyncio.sleep(0.1)
+                tx = await wallet_client.get_transaction(res.tx_id)
+                if len(tx.sent_to) > 0:
+                    print(transaction_submitted_msg(tx))
+                    print(transaction_status_msg(fingerprint, res.tx_id))
+                    return res.transactions
+
+        if args["push"]:  # pragma: no cover
+            print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")
+        return res.transactions  # pragma: no cover
 
 
-async def exit_lockup(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
+async def exit_lockup(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> List[TransactionRecord]:
     wallet_id = args["wallet_id"]
     fee = args["fee"]
     final_fee: uint64 = uint64(int(Decimal(fee) * units["chia"]))
@@ -434,19 +463,27 @@ async def exit_lockup(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: 
                     "reuse_puzhash": args["reuse_puzhash"],
                 }
             ).to_tx_config(units["chia"], config, fingerprint),
+            push=args["push"],
         )
-        start = time.time()
-        while time.time() - start < 10:
-            await asyncio.sleep(0.1)
-            tx = await wallet_client.get_transaction(res.tx_id)
-            if len(tx.sent_to) > 0:
-                print(transaction_submitted_msg(tx))
-                print(transaction_status_msg(fingerprint, res.tx_id))
-                return None
-        print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")  # pragma: no cover
+
+        if args["push"]:
+            start = time.time()
+            while time.time() - start < 10:
+                await asyncio.sleep(0.1)
+                tx = await wallet_client.get_transaction(res.tx_id)
+                if len(tx.sent_to) > 0:
+                    print(transaction_submitted_msg(tx))
+                    print(transaction_status_msg(fingerprint, res.tx_id))
+                    return res.transactions
+
+        if args["push"]:  # pragma: no cover
+            print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")
+        return res.transactions  # pragma: no cover
 
 
-async def create_spend_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
+async def create_spend_proposal(
+    args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int
+) -> List[TransactionRecord]:
     wallet_id = args["wallet_id"]
     fee = args["fee"]
     final_fee: uint64 = uint64(int(Decimal(fee) * units["chia"]))
@@ -489,15 +526,20 @@ async def create_spend_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[
                     "reuse_puzhash": args["reuse_puzhash"],
                 }
             ).to_tx_config(units["chia"], config, fingerprint),
+            push=args["push"],
         )
 
         asset_id_name = asset_id if asset_id else "XCH"
         print(f"Created spend proposal for asset: {asset_id_name}")
-        print("Successfully created proposal.")
+        if args["push"]:
+            print("Successfully created proposal.")
         print(f"Proposal ID: {res.proposal_id.hex()}")
+        return res.transactions
 
 
-async def create_update_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
+async def create_update_proposal(
+    args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int
+) -> List[TransactionRecord]:
     wallet_id = args["wallet_id"]
     fee = Decimal(args["fee"])
     final_fee: uint64 = uint64(int(fee * units["chia"]))
@@ -532,13 +574,18 @@ async def create_update_proposal(args: Dict[str, Any], wallet_rpc_port: Optional
                     "reuse_puzhash": args["reuse_puzhash"],
                 }
             ).to_tx_config(units["chia"], config, fingerprint),
+            push=args["push"],
         )
 
-        print("Successfully created proposal.")
+        if args["push"]:
+            print("Successfully created proposal.")
         print(f"Proposal ID: {res.proposal_id.hex()}")
+        return res.transactions
 
 
-async def create_mint_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
+async def create_mint_proposal(
+    args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int
+) -> List[TransactionRecord]:
     wallet_id = args["wallet_id"]
     fee = args["fee"]
     final_fee: uint64 = uint64(int(Decimal(fee) * units["chia"]))
@@ -562,7 +609,10 @@ async def create_mint_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[i
                     "reuse_puzhash": args["reuse_puzhash"],
                 }
             ).to_tx_config(units["chia"], config, fingerprint),
+            push=args["push"],
         )
 
-        print("Successfully created proposal.")
+        if args["push"]:
+            print("Successfully created proposal.")
         print(f"Proposal ID: {res.proposal_id.hex()}")
+        return res.transactions

--- a/chia/cmds/dao_funcs.py
+++ b/chia/cmds/dao_funcs.py
@@ -173,9 +173,9 @@ async def add_funds_to_treasury(
                     print(transaction_status_msg(fingerprint, res.tx_id))
                     return res.transactions
 
-        if args["push"]:  # pragma: no cover
+        if args["push"]:
             print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")
-        return res.transactions  # pragma: no cover
+        return res.transactions
 
 
 async def get_treasury_balance(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> None:
@@ -329,9 +329,9 @@ async def vote_on_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int],
                     print(transaction_status_msg(fingerprint, res.tx_id))
                     return res.transactions
 
-        if args["push"]:  # pragma: no cover
+        if args["push"]:
             print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")
-        return res.transactions  # pragma: no cover
+        return res.transactions
 
 
 async def close_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> List[TransactionRecord]:
@@ -368,9 +368,9 @@ async def close_proposal(args: Dict[str, Any], wallet_rpc_port: Optional[int], f
                     print(transaction_status_msg(fingerprint, res.tx_id))
                     return res.transactions
 
-        if args["push"]:  # pragma: no cover
+        if args["push"]:
             print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")
-        return res.transactions  # pragma: no cover
+        return res.transactions
 
 
 async def lockup_coins(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> List[TransactionRecord]:
@@ -405,10 +405,10 @@ async def lockup_coins(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp:
                     print(transaction_status_msg(fingerprint, res.tx_id))
                     return res.transactions
 
-        if args["push"]:  # pragma: no cover
+        if args["push"]:
             print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")
 
-        return res.transactions  # pragma: no cover
+        return res.transactions
 
 
 async def release_coins(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> List[TransactionRecord]:
@@ -440,9 +440,9 @@ async def release_coins(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp
                     print(transaction_status_msg(fingerprint, res.tx_id))
                     return res.transactions
 
-        if args["push"]:  # pragma: no cover
+        if args["push"]:
             print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")
-        return res.transactions  # pragma: no cover
+        return res.transactions
 
 
 async def exit_lockup(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: int) -> List[TransactionRecord]:
@@ -476,9 +476,9 @@ async def exit_lockup(args: Dict[str, Any], wallet_rpc_port: Optional[int], fp: 
                     print(transaction_status_msg(fingerprint, res.tx_id))
                     return res.transactions
 
-        if args["push"]:  # pragma: no cover
+        if args["push"]:
             print(f"Transaction not yet submitted to nodes. TX ID: {res.tx_id.hex()}")
-        return res.transactions  # pragma: no cover
+        return res.transactions
 
 
 async def create_spend_proposal(

--- a/chia/cmds/data.py
+++ b/chia/cmds/data.py
@@ -139,7 +139,7 @@ def create_max_page_size_option() -> Callable[[FC], FC]:
 
 # Functions with this mark in this file are not being ported to @tx_out_cmd due to API peculiarities
 # They will therefore not work with observer-only functionality
-# MARK: tx_endpoint  (This creates wallet transactions and should be parametrized by relevant options)
+# NOTE: tx_endpoint  (This creates wallet transactions and should be parametrized by relevant options)
 @data_cmd.command("create_data_store", help="Create a new data store")
 @create_rpc_port_option()
 @create_fee_option()
@@ -174,7 +174,7 @@ def get_value(
     run(get_value_cmd(data_rpc_port, id, key_string, root_hash, fingerprint=fingerprint))
 
 
-# MARK: tx_endpoint
+# NOTE: tx_endpoint
 @data_cmd.command("update_data_store", help="Update a store by providing the changelist operations")
 @create_data_store_id_option()
 @create_changelist_option()
@@ -473,7 +473,7 @@ def add_missing_files(
     )
 
 
-# MARK: tx_endpoint
+# NOTE: tx_endpoint
 @data_cmd.command("add_mirror", help="Publish mirror urls on chain")
 @click.option("-i", "--id", help="Store id", type=str, required=True)
 @click.option(
@@ -512,7 +512,7 @@ def add_mirror(
     )
 
 
-# MARK: tx_endpoint
+# NOTE: tx_endpoint
 @data_cmd.command("delete_mirror", help="Delete an owned mirror by its coin id")
 @click.option("-c", "--coin_id", help="Coin id", type=str, required=True)
 @create_fee_option()

--- a/chia/cmds/data.py
+++ b/chia/cmds/data.py
@@ -137,6 +137,9 @@ def create_max_page_size_option() -> Callable[[FC], FC]:
     )
 
 
+# Functions with this mark in this file are not being ported to @tx_out_cmd due to API peculiarities
+# They will therefore not work with observer-only functionality
+# MARK: tx_endpoint  (This creates wallet transactions and should be parametrized by relevant options)
 @data_cmd.command("create_data_store", help="Create a new data store")
 @create_rpc_port_option()
 @create_fee_option()
@@ -171,6 +174,7 @@ def get_value(
     run(get_value_cmd(data_rpc_port, id, key_string, root_hash, fingerprint=fingerprint))
 
 
+# MARK: tx_endpoint
 @data_cmd.command("update_data_store", help="Update a store by providing the changelist operations")
 @create_data_store_id_option()
 @create_changelist_option()
@@ -469,6 +473,7 @@ def add_missing_files(
     )
 
 
+# MARK: tx_endpoint
 @data_cmd.command("add_mirror", help="Publish mirror urls on chain")
 @click.option("-i", "--id", help="Store id", type=str, required=True)
 @click.option(
@@ -507,6 +512,7 @@ def add_mirror(
     )
 
 
+# MARK: tx_endpoint
 @data_cmd.command("delete_mirror", help="Delete an owned mirror by its coin id")
 @click.option("-c", "--coin_id", help="Coin id", type=str, required=True)
 @create_fee_option()

--- a/chia/cmds/plotnft.py
+++ b/chia/cmds/plotnft.py
@@ -55,7 +55,7 @@ def get_login_link_cmd(launcher_id: str) -> None:
 
 # Functions with this mark in this file are not being ported to @tx_out_cmd due to lack of observer key support
 # They will therefore not work with observer-only functionality
-# MARK: tx_endpoint  (This creates wallet transactions and should be parametrized by relevant options)
+# NOTE: tx_endpoint  (This creates wallet transactions and should be parametrized by relevant options)
 @plotnft_cmd.command("create", help="Create a plot NFT")
 @click.option("-y", "--yes", "dont_prompt", help="No prompts", is_flag=True)
 @options.create_fingerprint()
@@ -104,7 +104,7 @@ def create_cmd(
     )
 
 
-# MARK: tx_endpoint
+# NOTE: tx_endpoint
 @plotnft_cmd.command("join", help="Join a plot NFT to a Pool")
 @click.option("-y", "--yes", "dont_prompt", help="No prompts", is_flag=True)
 @click.option("-i", "--id", help="ID of the wallet to use", type=int, default=None, show_default=True, required=True)
@@ -146,7 +146,7 @@ def join_cmd(
     )
 
 
-# MARK: tx_endpoint
+# NOTE: tx_endpoint
 @plotnft_cmd.command("leave", help="Leave a pool and return to self-farming")
 @click.option("-y", "--yes", "dont_prompt", help="No prompts", is_flag=True)
 @click.option("-i", "--id", help="ID of the wallet to use", type=int, default=None, show_default=True, required=True)
@@ -202,7 +202,7 @@ def inspect(wallet_rpc_port: Optional[int], fingerprint: int, id: int) -> None:
     asyncio.run(inspect_cmd(wallet_rpc_port, fingerprint, id))
 
 
-# MARK: tx_endpoint
+# NOTE: tx_endpoint
 @plotnft_cmd.command("claim", help="Claim rewards from a plot NFT")
 @click.option("-i", "--id", help="ID of the wallet to use", type=int, default=None, show_default=True, required=True)
 @options.create_fingerprint()

--- a/chia/cmds/plotnft.py
+++ b/chia/cmds/plotnft.py
@@ -53,6 +53,9 @@ def get_login_link_cmd(launcher_id: str) -> None:
     asyncio.run(get_login_link(launcher_id))
 
 
+# Functions with this mark in this file are not being ported to @tx_out_cmd due to lack of observer key support
+# They will therefore not work with observer-only functionality
+# MARK: tx_endpoint  (This creates wallet transactions and should be parametrized by relevant options)
 @plotnft_cmd.command("create", help="Create a plot NFT")
 @click.option("-y", "--yes", "dont_prompt", help="No prompts", is_flag=True)
 @options.create_fingerprint()
@@ -101,6 +104,7 @@ def create_cmd(
     )
 
 
+# MARK: tx_endpoint
 @plotnft_cmd.command("join", help="Join a plot NFT to a Pool")
 @click.option("-y", "--yes", "dont_prompt", help="No prompts", is_flag=True)
 @click.option("-i", "--id", help="ID of the wallet to use", type=int, default=None, show_default=True, required=True)
@@ -142,6 +146,7 @@ def join_cmd(
     )
 
 
+# MARK: tx_endpoint
 @plotnft_cmd.command("leave", help="Leave a pool and return to self-farming")
 @click.option("-y", "--yes", "dont_prompt", help="No prompts", is_flag=True)
 @click.option("-i", "--id", help="ID of the wallet to use", type=int, default=None, show_default=True, required=True)
@@ -197,6 +202,7 @@ def inspect(wallet_rpc_port: Optional[int], fingerprint: int, id: int) -> None:
     asyncio.run(inspect_cmd(wallet_rpc_port, fingerprint, id))
 
 
+# MARK: tx_endpoint
 @plotnft_cmd.command("claim", help="Claim rewards from a plot NFT")
 @click.option("-i", "--id", help="ID of the wallet to use", type=int, default=None, show_default=True, required=True)
 @options.create_fingerprint()

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -1321,6 +1321,7 @@ class WalletRpcClient(RpcClient):
         fee: uint64 = uint64(0),
         fee_for_cat: uint64 = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
+        push: bool = True,
     ) -> CreateNewDAOWalletResponse:
         request: Dict[str, Any] = {
             "wallet_type": "dao_wallet",
@@ -1333,6 +1334,7 @@ class WalletRpcClient(RpcClient):
             "fee": fee,
             "fee_for_cat": fee_for_cat,
             "extra_conditions": list(extra_conditions),
+            "push": push,
             **tx_config.to_json_dict(),
         }
         response = await self.fetch("create_new_wallet", request)
@@ -1362,6 +1364,7 @@ class WalletRpcClient(RpcClient):
         new_dao_rules: Optional[Dict[str, Optional[uint64]]] = None,
         fee: uint64 = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
+        push: bool = True,
     ) -> DAOCreateProposalResponse:
         request: Dict[str, Any] = {
             "wallet_id": wallet_id,
@@ -1400,6 +1403,7 @@ class WalletRpcClient(RpcClient):
         is_yes_vote: bool = True,
         fee: uint64 = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
+        push: bool = True,
     ) -> DAOVoteOnProposalResponse:
         request: Dict[str, Any] = {
             "wallet_id": wallet_id,
@@ -1408,6 +1412,7 @@ class WalletRpcClient(RpcClient):
             "is_yes_vote": is_yes_vote,
             "fee": fee,
             "extra_conditions": list(extra_conditions),
+            "push": push,
             **tx_config.to_json_dict(),
         }
         response = await self.fetch("dao_vote_on_proposal", request)
@@ -1426,6 +1431,7 @@ class WalletRpcClient(RpcClient):
         self_destruct: Optional[bool] = None,
         fee: uint64 = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
+        push: bool = True,
     ) -> DAOCloseProposalResponse:
         request: Dict[str, Any] = {
             "wallet_id": wallet_id,
@@ -1433,6 +1439,7 @@ class WalletRpcClient(RpcClient):
             "self_destruct": self_destruct,
             "fee": fee,
             "extra_conditions": list(extra_conditions),
+            "push": push,
             **tx_config.to_json_dict(),
         }
         response = await self.fetch("dao_close_proposal", request)
@@ -1444,6 +1451,7 @@ class WalletRpcClient(RpcClient):
         tx_config: TXConfig,
         fee: uint64 = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
+        push: bool = True,
     ) -> DAOFreeCoinsFromFinishedProposalsResponse:
         request: Dict[str, Any] = {
             "wallet_id": wallet_id,
@@ -1467,6 +1475,7 @@ class WalletRpcClient(RpcClient):
         tx_config: TXConfig,
         fee: uint64 = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
+        push: bool = True,
     ) -> DAOAddFundsToTreasuryResponse:
         request: Dict[str, Any] = {
             "wallet_id": wallet_id,
@@ -1474,6 +1483,7 @@ class WalletRpcClient(RpcClient):
             "amount": amount,
             "fee": fee,
             "extra_conditions": list(extra_conditions),
+            "push": push,
             **tx_config.to_json_dict(),
         }
         response = await self.fetch("dao_add_funds_to_treasury", request)
@@ -1486,12 +1496,14 @@ class WalletRpcClient(RpcClient):
         tx_config: TXConfig,
         fee: uint64 = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
+        push: bool = True,
     ) -> DAOSendToLockupResponse:
         request: Dict[str, Any] = {
             "wallet_id": wallet_id,
             "amount": amount,
             "fee": fee,
             "extra_conditions": list(extra_conditions),
+            "push": push,
             **tx_config.to_json_dict(),
         }
         response = await self.fetch("dao_send_to_lockup", request)
@@ -1504,12 +1516,14 @@ class WalletRpcClient(RpcClient):
         coins: Optional[List[Dict[str, Any]]] = None,
         fee: uint64 = uint64(0),
         extra_conditions: Tuple[Condition, ...] = tuple(),
+        push: bool = True,
     ) -> DAOExitLockupResponse:
         request: Dict[str, Any] = {
             "wallet_id": wallet_id,
             "coins": coins,
             "fee": fee,
             "extra_conditions": list(extra_conditions),
+            "push": push,
             **tx_config.to_json_dict(),
         }
         response = await self.fetch("dao_exit_lockup", request)


### PR DESCRIPTION
This brings another set of commands to the @tx_out_cmd decorator which gives it the capability to optionally push a transaction and export the transactions to a local file.

This PR being the last in a chain of similar PRs, I have included some comments explaining that DL and pooling endpoints will not be ported to the decorator at this time.  Didn't think that necessitated its own PR and CI run :)