### PR TITLE
[CHIA-602] Add bech32m option for adding public keys

### DIFF
--- a/chia/_tests/core/util/test_keychain.py
+++ b/chia/_tests/core/util/test_keychain.py
@@ -42,7 +42,7 @@ fingerprint = uint32(1310648153)
 public_key = G1Element.from_bytes(
     bytes.fromhex("b5acf3599bc5fa5da1c00f6cc3d5bcf1560def67778b7f50a8c373a83f78761505b6250ab776e38a292e26628009aec4")
 )
-bech32_pubkey = "bls12381g11kkk0xkvmcha9mgwqpakv84du79tqmmm8w79h759gcde6s0mcwc2std39p2mhdcu29yhzvc5qpxhvg2p44f5"
+bech32_pubkey = "bls12381kkk0xkvmcha9mgwqpakv84du79tqmmm8w79h759gcde6s0mcwc2std39p2mhdcu29yhzvc5qpxhvgmknyl7"
 
 
 class TestKeychain:

--- a/chia/_tests/core/util/test_keychain.py
+++ b/chia/_tests/core/util/test_keychain.py
@@ -42,6 +42,7 @@ fingerprint = uint32(1310648153)
 public_key = G1Element.from_bytes(
     bytes.fromhex("b5acf3599bc5fa5da1c00f6cc3d5bcf1560def67778b7f50a8c373a83f78761505b6250ab776e38a292e26628009aec4")
 )
+bech32_pubkey = "bls12381g11kkk0xkvmcha9mgwqpakv84du79tqmmm8w79h759gcde6s0mcwc2std39p2mhdcu29yhzvc5qpxhvg2p44f5"
 
 
 class TestKeychain:
@@ -94,6 +95,12 @@ class TestKeychain:
         kc.delete_all_keys()
         assert kc._get_free_private_key_index() == 0
         assert len(kc.get_all_private_keys()) == 0
+
+        kc.add_key(bech32_pubkey, label=None, private=False)
+        all_pks = kc.get_all_public_keys()
+        assert len(all_pks) == 1
+        assert all_pks[0] == public_key
+        kc.delete_all_keys()
 
         kc.add_key(bytes_to_mnemonic(bytes32.random(seeded_random)))
         kc.add_key(bytes_to_mnemonic(bytes32.random(seeded_random)))

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -374,7 +374,7 @@ class Keychain:
             fingerprint = pk.get_fingerprint()
         else:
             index = self._get_free_private_key_index()
-            if mnemonic_or_pk.startswith("bls12381g1"):
+            if mnemonic_or_pk.startswith("bls1238"):
                 _, data = bech32_decode(mnemonic_or_pk, max_length=94)
                 assert data is not None
                 pk_bytes = bytes(convertbits(data, 5, 8, False))

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -13,6 +13,7 @@ from chia_rs import AugSchemeMPL, G1Element, PrivateKey  # pyright: reportMissin
 from typing_extensions import final
 
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.bech32m import bech32_decode, convertbits
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.errors import (
     KeychainException,
@@ -373,7 +374,12 @@ class Keychain:
             fingerprint = pk.get_fingerprint()
         else:
             index = self._get_free_private_key_index()
-            pk_bytes = hexstr_to_bytes(mnemonic_or_pk)
+            if mnemonic_or_pk.startswith("bls12381g1"):
+                _, data = bech32_decode(mnemonic_or_pk, max_length=94)
+                assert data is not None
+                pk_bytes = bytes(convertbits(data, 5, 8, False))
+            else:
+                pk_bytes = hexstr_to_bytes(mnemonic_or_pk)
             key = G1Element.from_bytes(pk_bytes)
             assert isinstance(key, G1Element)
             key_data = pk_bytes.hex()


### PR DESCRIPTION
Previously you could only add the public key by hex which is a decided ergonomic shortfall of bech32m.  This PR adds the ability to add an observer key as bech32m.