### PR TITLE
Add optional trusted CIDR list

### DIFF
--- a/chia/_tests/util/test_trusted_peer.py
+++ b/chia/_tests/util/test_trusted_peer.py
@@ -43,4 +43,9 @@ from chia.util.network import is_trusted_peer
 def test_is_trusted_peer(
     host: str, node_id: bytes32, trusted_peers: Dict[str, Any], trusted_cidrs: List[str], testing: bool, result: bool
 ) -> None:
-    assert is_trusted_peer(host=host, node_id=node_id, trusted_peers=trusted_peers, testing=testing, trusted_cidrs=trusted_cidrs) == result
+    assert (
+        is_trusted_peer(
+            host=host, node_id=node_id, trusted_peers=trusted_peers, testing=testing, trusted_cidrs=trusted_cidrs
+        )
+        == result
+    )

--- a/chia/_tests/util/test_trusted_peer.py
+++ b/chia/_tests/util/test_trusted_peer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import pytest
 
@@ -9,33 +9,38 @@ from chia.util.network import is_trusted_peer
 
 
 @pytest.mark.parametrize(
-    "host,node_id,trusted_peers,testing,result",
+    "host,node_id,trusted_peers,trusted_cidrs,testing,result",
     [
         # IPv6 localhost testing
-        ("::1", bytes32(b"0" * 32), {}, False, True),
+        ("::1", bytes32(b"0" * 32), {}, [], False, True),
         # IPv6 localhost testing with mismatched node_id (still True)
-        ("::1", bytes32(b"d" * 32), {bytes32(b"a" * 32).hex(): "0"}, False, True),
+        ("::1", bytes32(b"d" * 32), {bytes32(b"a" * 32).hex(): "0"}, [], False, True),
         # IPv6 localhost testing with testing flag True
-        ("::1", bytes32(b"0" * 32), {}, True, False),
-        ("::1", bytes32(b"d" * 32), {bytes32(b"a" * 32).hex(): "0"}, True, False),
+        ("::1", bytes32(b"0" * 32), {}, [], True, False),
+        ("::1", bytes32(b"d" * 32), {bytes32(b"a" * 32).hex(): "0"}, [], True, False),
         # IPv6 localhost long form
-        ("0:0:0:0:0:0:0:1", bytes32(b"0" * 32), {}, False, True),
-        ("0:0:0:0:0:0:0:1", bytes32(b"0" * 32), {}, True, False),
+        ("0:0:0:0:0:0:0:1", bytes32(b"0" * 32), {}, [], False, True),
+        ("0:0:0:0:0:0:0:1", bytes32(b"0" * 32), {}, [], True, False),
         # IPv4 localhost testing
-        ("127.0.0.1", bytes32(b"0" * 32), {}, False, True),
-        ("localhost", bytes32(b"0" * 32), {}, False, True),
-        ("127.0.0.1", bytes32(b"0" * 32), {}, True, False),
-        ("localhost", bytes32(b"0" * 32), {}, True, False),
+        ("127.0.0.1", bytes32(b"0" * 32), {}, [], False, True),
+        ("localhost", bytes32(b"0" * 32), {}, [], False, True),
+        ("127.0.0.1", bytes32(b"0" * 32), {}, [], True, False),
+        ("localhost", bytes32(b"0" * 32), {}, [], True, False),
         # localhost testing with testing True but with matching node_id
-        ("127.0.0.1", bytes32(b"0" * 32), {bytes32(b"0" * 32).hex(): "0"}, True, True),
+        ("127.0.0.1", bytes32(b"0" * 32), {bytes32(b"0" * 32).hex(): "0"}, [], True, True),
         # misc
-        ("2000:1000::1234:abcd", bytes32(b"0" * 32), {}, True, False),
-        ("10.11.12.13", bytes32(b"d" * 32), {bytes32(b"a" * 32).hex(): "0"}, False, False),
-        ("10.11.12.13", bytes32(b"d" * 32), {bytes32(b"d" * 32).hex(): "0"}, False, True),
-        ("10.11.12.13", bytes32(b"d" * 32), {}, False, False),
+        ("2000:1000::1234:abcd", bytes32(b"0" * 32), {}, [], True, False),
+        ("10.11.12.13", bytes32(b"d" * 32), {bytes32(b"a" * 32).hex(): "0"}, [], False, False),
+        ("10.11.12.13", bytes32(b"d" * 32), {bytes32(b"d" * 32).hex(): "0"}, [], False, True),
+        ("10.11.12.13", bytes32(b"d" * 32), {}, [], False, False),
+        # CIDR Allowlist
+        ("2000:1000::1234:abcd", bytes32(b"0" * 32), {}, ["2000:1000::/64"], False, True),
+        ("2000:1000::1234:abcd", bytes32(b"0" * 32), {}, [], False, False),
+        ("10.11.12.13", bytes32(b"d" * 32), {bytes32(b"a" * 32).hex(): "0"}, ["10.0.0.0/8"], False, True),
+        ("10.11.12.13", bytes32(b"d" * 32), {bytes32(b"a" * 32).hex(): "0"}, [], False, False),
     ],
 )
 def test_is_trusted_peer(
-    host: str, node_id: bytes32, trusted_peers: Dict[str, Any], testing: bool, result: bool
+    host: str, node_id: bytes32, trusted_peers: Dict[str, Any], trusted_cidrs: List[str], testing: bool, result: bool
 ) -> None:
-    assert is_trusted_peer(host=host, node_id=node_id, trusted_peers=trusted_peers, testing=testing) == result
+    assert is_trusted_peer(host=host, node_id=node_id, trusted_peers=trusted_peers, testing=testing, trusted_cidrs=trusted_cidrs) == result

--- a/chia/cmds/peer_funcs.py
+++ b/chia/cmds/peer_funcs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from chia.cmds.cmds_util import NODE_TYPES, get_any_service_client
 from chia.rpc.rpc_client import RpcClient
@@ -49,7 +49,7 @@ async def remove_node_connection(rpc_client: RpcClient, remove_connection: str) 
     print(result_txt)
 
 
-async def print_connections(rpc_client: RpcClient, trusted_peers: Dict[str, Any]) -> None:
+async def print_connections(rpc_client: RpcClient, trusted_peers: Dict[str, Any], trusted_cidrs: List[str]) -> None:
     import time
 
     from chia.server.outbound_message import NodeType
@@ -68,7 +68,7 @@ async def print_connections(rpc_client: RpcClient, trusted_peers: Dict[str, Any]
         # Strip IPv6 brackets
         host = host.strip("[]")
 
-        trusted: bool = is_trusted_peer(host, con["node_id"], trusted_peers, False)
+        trusted: bool = is_trusted_peer(host, con["node_id"], trusted_peers, trusted_cidrs, False)
         # Nodetype length is 9 because INTRODUCER will be deprecated
         if NodeType(con["type"]) is NodeType.FULL_NODE:
             peak_height = con.get("peak_height", None)
@@ -117,8 +117,9 @@ async def peer_async(
     async with get_any_service_client(client_type, rpc_port, root_path) as (rpc_client, config):
         # Check or edit node connections
         if show_connections:
-            trusted_peers: Dict[str, Any] = config["full_node"].get("trusted_peers", {})
-            await print_connections(rpc_client, trusted_peers)
+            trusted_peers: Dict[str, Any] = config[node_type].get("trusted_peers", {})
+            trusted_cidrs: List[str] = config[node_type].get("trusted_cidrs", [])
+            await print_connections(rpc_client, trusted_peers, trusted_cidrs)
             # if called together with state, leave a blank line
         if add_connection:
             await add_node_connection(rpc_client, add_connection)

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -895,7 +895,8 @@ async def print_balances(
 
         print(" ")
         trusted_peers: dict[str, str] = config["wallet"].get("trusted_peers", {})
-        await print_connections(wallet_client, trusted_peers)
+        trusted_cidrs: List[str] = config["wallet"].get("trusted_cidrs", [])
+        await print_connections(wallet_client, trusted_peers, trusted_cidrs)
 
 
 async def create_did_wallet(

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -712,6 +712,7 @@ class ChiaServer:
             host=peer.peer_info.host,
             node_id=peer.peer_node_id,
             trusted_peers=trusted_peers,
+            trusted_cidrs=self.config.get("trusted_cidrs", []),
             testing=self.config.get("testing", False),
         )
 

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -147,7 +147,10 @@ def is_in_network(peer_host: str, networks: Iterable[Union[IPv4Network, IPv6Netw
 
 
 def is_trusted_cidr(peer_host: str, trusted_cidrs: List[str]) -> bool:
-    ip_obj = ipaddress.ip_address(peer_host)
+    try:
+        ip_obj = ipaddress.ip_address(peer_host)
+    except ValueError:
+        return False
 
     for cidr in trusted_cidrs:
         network = ipaddress.ip_network(cidr)

--- a/chia/util/network.py
+++ b/chia/util/network.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import socket
 import ssl
@@ -145,12 +146,25 @@ def is_in_network(peer_host: str, networks: Iterable[Union[IPv4Network, IPv6Netw
         return False
 
 
+def is_trusted_cidr(peer_host: str, trusted_cidrs: List[str]) -> bool:
+    ip_obj = ipaddress.ip_address(peer_host)
+
+    for cidr in trusted_cidrs:
+        network = ipaddress.ip_network(cidr)
+        if ip_obj in network:
+            return True
+
+    return False
+
+
 def is_localhost(peer_host: str) -> bool:
     return peer_host in ["127.0.0.1", "localhost", "::1", "0:0:0:0:0:0:0:1"]
 
 
-def is_trusted_peer(host: str, node_id: bytes32, trusted_peers: Dict[str, Any], testing: bool = False) -> bool:
-    return not testing and is_localhost(host) or node_id.hex() in trusted_peers
+def is_trusted_peer(
+    host: str, node_id: bytes32, trusted_peers: Dict[str, Any], trusted_cidrs: List[str], testing: bool = False
+) -> bool:
+    return not testing and is_localhost(host) or node_id.hex() in trusted_peers or is_trusted_cidr(host, trusted_cidrs)
 
 
 def class_for_type(type: NodeType) -> Any:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

Allows a node to be considered trusted if its within a given CIDR block

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

Nodes can be trusted if:
* localhost
* Node ID in config (`trusted_peers`)

### New Behavior:

Nodes can be trusted if:
* localhost
* Node ID in config (`trusted_peers`)
* Peer IP is within a CIDR in config (`trusted_cidrs`)
