### PR TITLE
simplify mempool coin spends

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -9,11 +9,7 @@ from dataclasses import dataclass
 from multiprocessing.context import BaseContext
 from typing import Awaitable, Callable, Collection, Dict, List, Optional, Set, Tuple, TypeVar
 
-from chia_rs import ELIGIBLE_FOR_DEDUP, ELIGIBLE_FOR_FF
-from chia_rs import CoinSpend as RustCoinSpend
-from chia_rs import G1Element, GTElement
-from chia_rs import Program as RustProgram
-from chia_rs import supports_fast_forward
+from chia_rs import ELIGIBLE_FOR_DEDUP, ELIGIBLE_FOR_FF, G1Element, GTElement, supports_fast_forward
 from chiabip158 import PyBIP158
 
 from chia.consensus.block_record import BlockRecordProtocol
@@ -461,13 +457,7 @@ class MempoolManager:
                 coin_id,
                 EligibilityAndAdditions(is_eligible_for_dedup=False, spend_additions=[], is_eligible_for_ff=False),
             )
-            # We can't just go with the eligible for fast forward flag, we need to validate
-            rust_coin_spend = RustCoinSpend(
-                coin=coin_spend.coin,
-                puzzle_reveal=RustProgram.from_bytes(bytes(coin_spend.puzzle_reveal)),
-                solution=RustProgram.from_bytes(bytes(coin_spend.solution)),
-            )
-            mark_as_fast_forward = eligibility_info.is_eligible_for_ff and supports_fast_forward(rust_coin_spend)
+            mark_as_fast_forward = eligibility_info.is_eligible_for_ff and supports_fast_forward(coin_spend)
             # We are now able to check eligibility of both dedup and fast forward
             if not (eligibility_info.is_eligible_for_dedup or mark_as_fast_forward):
                 non_eligible_coin_ids.append(coin_id)

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import dataclasses
 from typing import Awaitable, Callable, Dict, List, Optional, Tuple
 
-from chia_rs import CoinSpend as RustCoinSpend
-from chia_rs import Program as RustProgram
 from chia_rs import fast_forward_singleton
 
 from chia.consensus.condition_costs import ConditionCost
@@ -117,13 +115,8 @@ def perform_the_fast_forward(
     # These hold because puzzle hash is not expected to change
     assert new_coin.name() == unspent_lineage_info.coin_id
     assert new_parent.name() == unspent_lineage_info.parent_id
-    rust_coin_spend = RustCoinSpend(
-        coin=spend_data.coin_spend.coin,
-        puzzle_reveal=RustProgram.from_bytes(bytes(spend_data.coin_spend.puzzle_reveal)),
-        solution=RustProgram.from_bytes(bytes(spend_data.coin_spend.solution)),
-    )
     new_solution = SerializedProgram.from_bytes(
-        fast_forward_singleton(spend=rust_coin_spend, new_coin=new_coin, new_parent=new_parent)
+        fast_forward_singleton(spend=spend_data.coin_spend, new_coin=new_coin, new_parent=new_parent)
     )
     singleton_child = None
     patched_additions = []


### PR DESCRIPTION
### Purpose:

the `CoinSpend` is the same in `chia_rs` and `chia.types.coin_spend`.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:

There's a redundant copy of the `CoinSpend` (supposed conversion).

### New Behavior:

There's no redundant copy of the `CoinSpend`