### PR TITLE
CHIA-623: Split capabilities for each service

### DIFF
--- a/chia/_tests/connection_utils.py
+++ b/chia/_tests/connection_utils.py
@@ -11,7 +11,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 
 from chia._tests.util.time_out_assert import time_out_assert
-from chia.protocols.shared_protocol import capabilities
+from chia.protocols.shared_protocol import default_capabilities
 from chia.server.outbound_message import NodeType
 from chia.server.server import ChiaServer, ssl_context_for_client
 from chia.server.ssl_context import chia_ssl_ca_paths, private_ssl_ca_paths
@@ -86,7 +86,7 @@ async def add_dummy_connection_wsc(
         peer_id,
         100,
         30,
-        local_capabilities_for_handshake=capabilities,
+        local_capabilities_for_handshake=default_capabilities[type],
     )
     await wsc.perform_handshake(server._network_id, dummy_port, type)
     if wsc.incoming_message_task is not None:

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -34,7 +34,7 @@ from chia.protocols import full_node_protocol as fnp
 from chia.protocols import timelord_protocol, wallet_protocol
 from chia.protocols.full_node_protocol import RespondTransaction
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
-from chia.protocols.shared_protocol import Capability, capabilities
+from chia.protocols.shared_protocol import Capability, default_capabilities
 from chia.protocols.wallet_protocol import SendTransaction, TransactionAck
 from chia.server.address_manager import AddressManager
 from chia.server.outbound_message import Message, NodeType
@@ -2178,9 +2178,9 @@ class TestFullNodeProtocol:
         argnames=["custom_capabilities", "expect_success"],
         argvalues=[
             # standard
-            [capabilities, True],
+            [default_capabilities[NodeType.FULL_NODE], True],
             # an additional enabled but unknown capability
-            [[*capabilities, (uint16(max(Capability) + 1), "1")], True],
+            [[*default_capabilities[NodeType.FULL_NODE], (uint16(max(Capability) + 1), "1")], True],
             # no capability, not even Chia mainnet
             # TODO: shouldn't we fail without Capability.BASE?
             [[], True],

--- a/chia/_tests/core/ssl/test_ssl.py
+++ b/chia/_tests/core/ssl/test_ssl.py
@@ -8,7 +8,7 @@ import ssl
 import aiohttp
 import pytest
 
-from chia.protocols.shared_protocol import capabilities
+from chia.protocols.shared_protocol import default_capabilities
 from chia.server.outbound_message import NodeType
 from chia.server.server import ChiaServer, ssl_context_for_client
 from chia.server.ssl_context import chia_ssl_ca_paths, private_ssl_ca_paths
@@ -36,7 +36,7 @@ async def establish_connection(server: ChiaServer, self_hostname: str, ssl_conte
             bytes32(b"\x00" * 32),
             100,
             30,
-            local_capabilities_for_handshake=capabilities,
+            local_capabilities_for_handshake=default_capabilities[NodeType.FULL_NODE],
         )
         await wsc.perform_handshake(server._network_id, dummy_port, NodeType.FULL_NODE)
         await wsc.close()

--- a/chia/protocols/shared_protocol.py
+++ b/chia/protocols/shared_protocol.py
@@ -40,6 +40,15 @@ class Capability(IntEnum):
     NONE_RESPONSE = 4
 
 
+# "1" means capability is enabled
+capabilities = [
+    (uint16(Capability.BASE.value), "1"),
+    (uint16(Capability.BLOCK_HEADERS.value), "1"),
+    (uint16(Capability.RATE_LIMITS_V2.value), "1"),
+    # (uint16(Capability.NONE_RESPONSE.value), "1"), # capability removed but functionality is still supported
+]
+
+
 @streamable
 @dataclass(frozen=True)
 class Handshake(Streamable):
@@ -49,15 +58,6 @@ class Handshake(Streamable):
     server_port: uint16
     node_type: uint8
     capabilities: List[Tuple[uint16, str]]
-
-
-# "1" means capability is enabled
-capabilities = [
-    (uint16(Capability.BASE.value), "1"),
-    (uint16(Capability.BLOCK_HEADERS.value), "1"),
-    (uint16(Capability.RATE_LIMITS_V2.value), "1"),
-    # (uint16(Capability.NONE_RESPONSE.value), "1"), # capability removed but functionality is still supported
-]
 
 
 @streamable

--- a/chia/protocols/shared_protocol.py
+++ b/chia/protocols/shared_protocol.py
@@ -37,16 +37,27 @@ class Capability(IntEnum):
     RATE_LIMITS_V2 = 3
 
     # a node can handle a None response and not wait the full timeout
+    # capability removed but functionality is still supported
     NONE_RESPONSE = 4
 
 
-# "1" means capability is enabled
-capabilities = [
+# These are the default capabilities used in all outgoing handshakes.
+# "1" means the capability is supported and enabled.
+_capabilities: List[Tuple[uint16, str]] = [
     (uint16(Capability.BASE.value), "1"),
     (uint16(Capability.BLOCK_HEADERS.value), "1"),
     (uint16(Capability.RATE_LIMITS_V2.value), "1"),
-    # (uint16(Capability.NONE_RESPONSE.value), "1"), # capability removed but functionality is still supported
 ]
+
+default_capabilities = {
+    NodeType.FULL_NODE: _capabilities,
+    NodeType.HARVESTER: _capabilities,
+    NodeType.FARMER: _capabilities,
+    NodeType.TIMELORD: _capabilities,
+    NodeType.INTRODUCER: _capabilities,
+    NodeType.WALLET: _capabilities,
+    NodeType.DATA_LAYER: _capabilities,
+}
 
 
 @streamable

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -42,7 +42,7 @@ from chia.util.misc import SignalHandlers
 from chia.util.network import resolve
 from chia.util.setproctitle import setproctitle
 
-from ..protocols.shared_protocol import capabilities
+from ..protocols.shared_protocol import default_capabilities
 from ..util.chia_version import chia_short_version
 
 # this is used to detect whether we are running in the main process or not, in
@@ -117,7 +117,7 @@ class Service(Generic[_T_RpcServiceProtocol, _T_ApiProtocol, _T_RpcApiProtocol])
         if node_type == NodeType.WALLET:
             inbound_rlp = self.service_config.get("inbound_rate_limit_percent", inbound_rlp)
             outbound_rlp = 60
-        capabilities_to_use: List[Tuple[uint16, str]] = capabilities
+        capabilities_to_use: List[Tuple[uint16, str]] = default_capabilities[node_type]
         if override_capabilities is not None:
             capabilities_to_use = override_capabilities
 

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -63,7 +63,9 @@ def create_lock_and_load_config(certs_path: Path, root_path: Path) -> Iterator[D
         yield config
 
 
-def get_capabilities(disable_capabilities_values: Optional[List[Capability]]) -> List[Tuple[uint16, str]]:
+def get_capabilities(
+    node_type: NodeType, disable_capabilities_values: Optional[List[Capability]]
+) -> List[Tuple[uint16, str]]:
     if disable_capabilities_values is not None:
         try:
             if Capability.BASE in disable_capabilities_values:
@@ -71,7 +73,7 @@ def get_capabilities(disable_capabilities_values: Optional[List[Capability]]) ->
                 disable_capabilities_values.remove(Capability.BASE)
 
             updated_capabilities = []
-            for capability in default_capabilities[NodeType.FULL_NODE]:
+            for capability in default_capabilities[node_type]:
                 if Capability(int(capability[0])) in disable_capabilities_values:
                     # "0" means capability is disabled
                     updated_capabilities.append((capability[0], "0"))
@@ -80,7 +82,7 @@ def get_capabilities(disable_capabilities_values: Optional[List[Capability]]) ->
             return updated_capabilities
         except Exception:
             logging.getLogger(__name__).exception("Error disabling capabilities, defaulting to all capabilities")
-    return default_capabilities[NodeType.FULL_NODE].copy()
+    return default_capabilities[node_type].copy()
 
 
 @asynccontextmanager
@@ -150,7 +152,9 @@ async def setup_full_node(
     overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = replace_str_to_bytes(consensus_constants, **overrides)
     local_bt.change_config(config)
-    override_capabilities = None if disable_capabilities is None else get_capabilities(disable_capabilities)
+    override_capabilities = (
+        None if disable_capabilities is None else get_capabilities(NodeType.FULL_NODE, disable_capabilities)
+    )
     service: Union[FullNodeService, SimulatorFullNodeService]
     if simulator:
         service = await create_full_node_simulator_service(

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -63,9 +63,7 @@ def create_lock_and_load_config(certs_path: Path, root_path: Path) -> Iterator[D
         yield config
 
 
-def get_capabilities(
-    node_type: NodeType, disable_capabilities_values: Optional[List[Capability]]
-) -> List[Tuple[uint16, str]]:
+def get_capabilities(node_type: NodeType, disable_capabilities_values: List[Capability]) -> List[Tuple[uint16, str]]:
     if disable_capabilities_values is not None:
         try:
             if Capability.BASE in disable_capabilities_values:

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -14,7 +14,7 @@ from typing import Any, AsyncGenerator, AsyncIterator, Dict, Iterator, List, Opt
 from chia.cmds.init_funcs import init
 from chia.consensus.constants import ConsensusConstants, replace_str_to_bytes
 from chia.daemon.server import WebSocketServer, daemon_launch_lock_path
-from chia.protocols.shared_protocol import Capability, capabilities
+from chia.protocols.shared_protocol import Capability, default_capabilities
 from chia.seeder.dns_server import DNSServer, create_dns_server_service
 from chia.seeder.start_crawler import create_full_node_crawler_service
 from chia.server.outbound_message import NodeType
@@ -71,7 +71,7 @@ def get_capabilities(disable_capabilities_values: Optional[List[Capability]]) ->
                 disable_capabilities_values.remove(Capability.BASE)
 
             updated_capabilities = []
-            for capability in capabilities:
+            for capability in default_capabilities[NodeType.FULL_NODE]:
                 if Capability(int(capability[0])) in disable_capabilities_values:
                     # "0" means capability is disabled
                     updated_capabilities.append((capability[0], "0"))
@@ -80,7 +80,7 @@ def get_capabilities(disable_capabilities_values: Optional[List[Capability]]) ->
             return updated_capabilities
         except Exception:
             logging.getLogger(__name__).exception("Error disabling capabilities, defaulting to all capabilities")
-    return capabilities.copy()
+    return default_capabilities[NodeType.FULL_NODE].copy()
 
 
 @asynccontextmanager


### PR DESCRIPTION
### Purpose:

Splits the default capabilities for each `NodeType`. This allows adding capabilities which are only supported for certain services, for example a wallet protocol capability which may be supported by the node but the reference wallet doesn't yet use (ie `MEMPOOL_UPDATES`).

### Current Behavior:

All services use the same `capabilities`.

### New Behavior:

Every service has their own `default_capabilities`.