### PR TITLE
CHIA-685 Remove homebrew rpaths from _ssl.cpython.so on macOS during build

### DIFF
--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -453,7 +453,7 @@ jobs:
       - name: Test for homebrew rpath
         if: matrix.arch.name == 'ARM64'
         run: |
-          otool -l "/Volumes/Chia "*/Chia.app/Contents/Resources/app.asar.unpacked/daemon/_internal/lib-dynload/_ssl.*darwin.so | grep -zv /opt/homebrew/lib
+          otool -l "/Volumes/Chia "*/Chia.app/Contents/Resources/app.asar.unpacked/daemon/_internal/lib-dynload/_ssl.*darwin.so | tr "\n" "0" | grep -v /opt/homebrew/lib
 
       - name: Run chia dev installers test
         run: |

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -453,7 +453,7 @@ jobs:
       - name: Test for homebrew rpath
         if: matrix.arch.name == 'ARM64'
         run: |
-          otool -l "/Volumes/Chia "*/Chia.app/Contents/Resources/app.asar.unpacked/daemon/_internal/lib-dynload/_ssl.*darwin.so | tr "\n" "0" | grep -v /opt/homebrew/lib
+          ! otool -l "/Volumes/Chia "*/Chia.app/Contents/Resources/app.asar.unpacked/daemon/_internal/lib-dynload/_ssl.*darwin.so | grep /opt/homebrew/lib
 
       - name: Run chia dev installers test
         run: |

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -450,6 +450,11 @@ jobs:
         run: |
           find "/Volumes/Chia "*
 
+      - name: Test for homebrew rpath
+        if: matrix.arch.name == 'ARM64'
+        run: |
+          otool -l "/Volumes/Chia "*/Chia.app/Contents/Resources/app.asar.unpacked/daemon/_internal/lib-dynload/_ssl.*darwin.so | grep -zv /opt/homebrew/lib
+
       - name: Run chia dev installers test
         run: |
           "/Volumes/Chia "*"/Chia.app/Contents/Resources/app.asar.unpacked/daemon/chia" dev installers test --expected-chia-version "${{ needs.build.outputs.chia-installer-version }}"

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -37,6 +37,10 @@ echo "Building pip and NPM license directory"
 pwd
 bash ./build_license_directory.sh
 
+# Remove rpaths on some libraries to homebrew directories that 
+# appears sometimes m-series chips (prefer bundled from @loader_path/..)
+bash ./remove_brew_rpaths.sh
+
 cp -r dist/daemon ../chia-blockchain-gui/packages/gui
 # Change to the gui package
 cd ../chia-blockchain-gui/packages/gui || exit 1

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -37,7 +37,7 @@ echo "Building pip and NPM license directory"
 pwd
 bash ./build_license_directory.sh
 
-# Remove rpaths on some libraries to homebrew directories that 
+# Remove rpaths on some libraries to homebrew directories that
 # appears sometimes m-series chips (prefer bundled from @loader_path/..)
 bash ./remove_brew_rpaths.sh
 

--- a/build_scripts/remove_brew_rpaths.sh
+++ b/build_scripts/remove_brew_rpaths.sh
@@ -14,7 +14,7 @@ rpath_name=/opt/homebrew/lib
 
 so_path=$(find "dist/daemon/_internal/lib-dynload" -name "_ssl.cpython-*.so")
 if [[ -z "${so_path}" ]]; then
-    >&2 echo "Failed to find _ssl.cpython-*.so"
+  >&2 echo "Failed to find _ssl.cpython-*.so"
 fi
 
 echo "Found '_ssl.cpython-*.so' at '$so_path':"
@@ -25,16 +25,16 @@ set +e
 nt_output=
 r=0
 while [[ $r -eq 0 ]]; do
-    install_name_tool -delete_rpath $rpath_name "$so_path" 2>&1 | read nt_output
-    r=$?
+  install_name_tool -delete_rpath $rpath_name "$so_path" 2>&1 | read nt_output
+  r=$?
 done
 
 if [[ -n "$nt_output" ]]; then
-    echo "$nt_output" | grep "no LC_RPATH load command with path:" >/dev/null
-    if [[ $? -ne 0 ]]; then
-        >&2 echo "An unexpected error occured when running install_name_tool:"
-        >&2 echo "$nt_output"
-    fi
+  echo "$nt_output" | grep "no LC_RPATH load command with path:" >/dev/null
+  if [[ $? -ne 0 ]]; then
+    >&2 echo "An unexpected error occured when running install_name_tool:"
+    >&2 echo "$nt_output"
+  fi
 fi
 
 echo "Done."

--- a/build_scripts/remove_brew_rpaths.sh
+++ b/build_scripts/remove_brew_rpaths.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Removes rpath loader commands from _ssl.cpython-*.so which are sometimes
+# added on Apple M-series CPUs, prefer bundled dynamic libraries for which
+# there is an rpath added already as "@loader_path/.." -- however, the
+# homebrew rpaths appear with higher precedence, potentially causing issues.
+# See: #18099
+
+echo ""
+echo "Stripping brew rpaths..."
+
+rpath_name=/opt/homebrew/lib
+
+so_path=$(find "dist/daemon/_internal/lib-dynload" -name "_ssl.cpython-*.so")
+if [[ -z "${so_path}" ]]; then
+    >&2 echo "Failed to find _ssl.cpython-*.so"
+fi
+
+echo "Found '_ssl.cpython-*.so' at '$so_path':"
+otool -l "$so_path"
+echo ""
+
+set +e
+nt_output=
+r=0
+while [[ $r -eq 0 ]]; do
+    install_name_tool -delete_rpath $rpath_name "$so_path" 2>&1 | read nt_output
+    r=$?
+done
+
+if [[ -n "$nt_output" ]]; then
+    echo "$nt_output" | grep "no LC_RPATH load command with path:" >/dev/null
+    if [[ $? -ne 0 ]]; then
+        >&2 echo "An unexpected error occured when running install_name_tool:"
+        >&2 echo "$nt_output"
+    fi
+fi
+
+echo "Done."
+echo ""

--- a/build_scripts/remove_brew_rpaths.sh
+++ b/build_scripts/remove_brew_rpaths.sh
@@ -25,12 +25,13 @@ set +e
 nt_output=
 r=0
 while [[ $r -eq 0 ]]; do
-  install_name_tool -delete_rpath $rpath_name "$so_path" 2>&1 | read nt_output
+  install_name_tool -delete_rpath $rpath_name "$so_path" 2>&1 | read -r nt_output
   r=$?
 done
 
 if [[ -n "$nt_output" ]]; then
   echo "$nt_output" | grep "no LC_RPATH load command with path:" >/dev/null
+  # shellcheck disable=SC2181
   if [[ $? -ne 0 ]]; then
     >&2 echo "An unexpected error occured when running install_name_tool:"
     >&2 echo "$nt_output"


### PR DESCRIPTION
Removes rpath load commands from `_ssl.cpython-*.so` which are sometimes added on Apple M-series CPUs, prefer bundled dynamic libraries for which there is an rpath added already as `@loader_path/..` -- however, the homebrew rpaths appear with higher precedence, potentially causing issues.

See: #18099