### PR TITLE
add installed test for `chia init` and fix `importlib_resources` uses

### DIFF
--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -38,7 +38,7 @@ from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, TXConfig
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_coin_store import GetCoinRecords
 
-test_offer_file_path = importlib_resources.files(__name__).joinpath("test_offer.toffer")
+test_offer_file_path = importlib_resources.files(__name__.rpartition(".")[0]).joinpath("test_offer.toffer")
 test_offer_file_bech32 = test_offer_file_path.read_text(encoding="utf-8")
 test_offer_id: str = "0xdfb7e8643376820ec995b0bcdb3fc1f764c16b814df5e074631263fcf1e00839"
 test_offer_id_bytes: bytes32 = bytes32.from_hexstr(test_offer_id)

--- a/chia/_tests/util/benchmarks.py
+++ b/chia/_tests/util/benchmarks.py
@@ -20,7 +20,7 @@ from chia.util.ints import uint8, uint32, uint64, uint128
 # farmer puzzle hash
 ph = bytes32(b"a" * 32)
 
-clvm_generator_bin_path = importlib_resources.files(__name__).joinpath("clvm_generator.bin")
+clvm_generator_bin_path = importlib_resources.files(__name__.rpartition(".")[0]).joinpath("clvm_generator.bin")
 clvm_generator = clvm_generator_bin_path.read_bytes()
 
 

--- a/chia/cmds/installers.py
+++ b/chia/cmds/installers.py
@@ -119,3 +119,11 @@ def test_command(expected_chia_version_str: str, require_madmax: bool) -> None:
     #     expected_output=b"\nBladebit Chia Plotter",
     #     specify_tmp_dir=False,
     # )
+
+    args = [executable_for_service("chia"), "init"]
+    print(f"launching: {args}")
+    subprocess.run(
+        args,
+        check=True,
+        timeout=adjusted_timeout(30),
+    )

--- a/chia/ssl/create_ssl.py
+++ b/chia/ssl/create_ssl.py
@@ -29,7 +29,7 @@ _all_public_node_names: List[str] = ["full_node", "wallet", "farmer", "introduce
 
 
 def get_chia_ca_crt_key() -> Tuple[Any, Any]:
-    here = importlib_resources.files(__name__)
+    here = importlib_resources.files(__name__.rpartition(".")[0])
     crt = here.joinpath("chia_ca.crt").read_bytes()
     key = here.joinpath("chia_ca.key").read_bytes()
     return crt, key

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 
 
 def initial_config_file(filename: Union[str, Path]) -> str:
-    initial_config_path = importlib_resources.files(__name__).joinpath(f"initial-{filename}")
+    initial_config_path = importlib_resources.files(__name__.rpartition(".")[0]).joinpath(f"initial-{filename}")
     contents: str = initial_config_path.read_text(encoding="utf-8")
     return contents
 

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -55,7 +55,7 @@ def set_keys_root_path(keys_root_path: Path) -> None:
 
 
 def bip39_word_list() -> str:
-    word_list_path = importlib_resources.files(__name__).joinpath("english.txt")
+    word_list_path = importlib_resources.files(__name__.rpartition(".")[0]).joinpath("english.txt")
     contents: str = word_list_path.read_text(encoding="utf-8")
     return contents
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

While the old `pkg_resources` uses were content using `__name__` as if it were the parent package of that module, `importlib_resources` does not make that adjustment in the released packages and this results in an extra `config/` in the paths it tries to use.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
