### PR TITLE
[CHIA-710] Add the concept of 'action scopes'

### DIFF
--- a/chia/_tests/util/test_action_scope.py
+++ b/chia/_tests/util/test_action_scope.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import AsyncIterator
+
+import pytest
+
+from chia.util.action_scope import ActionScope, StateInterface
+
+
+@dataclass
+class TestSideEffects:
+    buf: bytes = b""
+
+    def __bytes__(self) -> bytes:
+        return self.buf
+
+    @classmethod
+    def from_bytes(cls, blob: bytes) -> TestSideEffects:
+        return cls(blob)
+
+
+async def default_async_callback(interface: StateInterface[TestSideEffects]) -> None:
+    return None
+
+
+async def default_async_commit(interface: TestSideEffects) -> None:
+    return None
+
+
+# Test adding a callback
+def test_add_callback() -> None:
+    state_interface = StateInterface({}, TestSideEffects(), True)
+    initial_count = len(state_interface._new_callbacks)
+    state_interface.add_callback(default_async_callback)
+    assert len(state_interface._new_callbacks) == initial_count + 1
+
+
+# Fixture to create an ActionScope with a mocked DBWrapper2
+@pytest.fixture
+async def action_scope() -> AsyncIterator[ActionScope[TestSideEffects]]:
+    async with ActionScope.new_scope(TestSideEffects) as scope:
+        yield scope
+
+
+# Test creating a new ActionScope and ensuring tables are created
+@pytest.mark.anyio
+async def test_new_action_scope(action_scope: ActionScope[TestSideEffects]) -> None:
+    async with action_scope.use() as interface:
+        assert interface == StateInterface({}, TestSideEffects(), True)
+
+
+@pytest.mark.anyio
+async def test_scope_persistence(action_scope: ActionScope[TestSideEffects]) -> None:
+    async with action_scope.use() as interface:
+        interface.memos[b"foo"] = b"bar"
+        interface.side_effects.buf = b"bar"
+
+    async with action_scope.use() as interface:
+        assert interface.memos[b"foo"] == b"bar"
+        assert interface.side_effects.buf == b"bar"
+
+
+@pytest.mark.anyio
+async def test_transactionality(action_scope: ActionScope[TestSideEffects]) -> None:
+    async with action_scope.use() as interface:
+        interface.memos[b"foo"] = b"bar"
+        interface.side_effects.buf = b"bar"
+
+    try:
+        async with action_scope.use() as interface:
+            interface.memos[b"foo"] = b"qux"
+            interface.side_effects.buf = b"qat"
+            raise RuntimeError("Going to be caught")
+    except RuntimeError:
+        pass
+
+    async with action_scope.use() as interface:
+        assert interface.memos[b"foo"] == b"bar"
+        assert interface.side_effects.buf == b"bar"
+
+
+@pytest.mark.anyio
+async def test_callbacks() -> None:
+    async with ActionScope.new_scope(TestSideEffects) as action_scope:
+        async with action_scope.use() as interface:
+
+            async def callback(interface: StateInterface[TestSideEffects]) -> None:
+                interface.side_effects.buf = b"bar"
+
+            interface.add_callback(callback)
+
+    assert action_scope.side_effects.buf == b"bar"
+
+
+@pytest.mark.anyio
+async def test_callback_in_callback_error() -> None:
+    with pytest.raises(ValueError, match="callback"):
+        async with ActionScope.new_scope(TestSideEffects) as action_scope:
+            async with action_scope.use() as interface:
+
+                async def callback(interface: StateInterface[TestSideEffects]) -> None:
+                    interface.add_callback(default_async_callback)
+
+                interface.add_callback(callback)
+
+
+@pytest.mark.anyio
+async def test_no_callbacks_if_error() -> None:
+    try:
+        async with ActionScope.new_scope(TestSideEffects) as action_scope:
+            async with action_scope.use() as interface:
+
+                async def callback(interface: StateInterface[TestSideEffects]) -> None:
+                    raise NotImplementedError("Should not get here")  # pragma: no cover
+
+                interface.add_callback(callback)
+
+            async with action_scope.use() as interface:
+                raise RuntimeError("This should prevent the callbacks from being called")
+    except RuntimeError:
+        pass

--- a/chia/_tests/util/test_action_scope.py
+++ b/chia/_tests/util/test_action_scope.py
@@ -122,3 +122,12 @@ async def test_no_callbacks_if_error() -> None:
                 interface.set_callback(callback2)
 
             raise RuntimeError("This should prevent the callbacks from being called")
+
+
+# TODO: add suport, change this test to test it and add a test for nested transactionality
+@pytest.mark.anyio
+async def test_nested_use_banned(action_scope: ActionScope[TestSideEffects]) -> None:
+    async with action_scope.use() as _:
+        with pytest.raises(RuntimeError, match="cannot currently support nested transactions"):
+            async with action_scope.use() as _:
+                pass

--- a/chia/_tests/util/test_action_scope.py
+++ b/chia/_tests/util/test_action_scope.py
@@ -127,7 +127,7 @@ async def test_no_callbacks_if_error() -> None:
 # TODO: add suport, change this test to test it and add a test for nested transactionality
 @pytest.mark.anyio
 async def test_nested_use_banned(action_scope: ActionScope[TestSideEffects]) -> None:
-    async with action_scope.use() as _:
+    async with action_scope.use():
         with pytest.raises(RuntimeError, match="cannot currently support nested transactions"):
-            async with action_scope.use() as _:
+            async with action_scope.use():
                 pass

--- a/chia/_tests/util/test_action_scope.py
+++ b/chia/_tests/util/test_action_scope.py
@@ -52,7 +52,6 @@ async def test_new_action_scope(action_scope: ActionScope[TestSideEffects]) -> N
 
 @pytest.mark.anyio
 async def test_scope_persistence(action_scope: ActionScope[TestSideEffects]) -> None:
-    """ """
     async with action_scope.use() as interface:
         interface.side_effects.buf = b"baz"
 
@@ -117,9 +116,9 @@ async def test_no_callbacks_if_error() -> None:
         async with ActionScope.new_scope(TestSideEffects) as action_scope:
             async with action_scope.use() as interface:
 
-                async def callback(interface: StateInterface[TestSideEffects]) -> None:
+                async def callback2(interface: StateInterface[TestSideEffects]) -> None:
                     raise NotImplementedError("Should not get here")  # pragma: no cover
 
-                interface.set_callback(callback)
+                interface.set_callback(callback2)
 
             raise RuntimeError("This should prevent the callbacks from being called")

--- a/chia/_tests/util/test_action_scope.py
+++ b/chia/_tests/util/test_action_scope.py
@@ -21,11 +21,7 @@ class TestSideEffects:
 
 
 async def default_async_callback(interface: StateInterface[TestSideEffects]) -> None:
-    return None
-
-
-async def default_async_commit(interface: TestSideEffects) -> None:
-    return None
+    return None  # pragma: no cover
 
 
 # Test adding a callback

--- a/chia/_tests/util/test_action_scope.py
+++ b/chia/_tests/util/test_action_scope.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import AsyncIterator
+from typing import AsyncIterator, final
 
 import pytest
 
 from chia.util.action_scope import ActionScope, StateInterface
 
 
+@final
 @dataclass
 class TestSideEffects:
     buf: bytes = b""
@@ -27,53 +28,56 @@ async def default_async_callback(interface: StateInterface[TestSideEffects]) -> 
 # Test adding a callback
 def test_add_callback() -> None:
     state_interface = StateInterface({}, TestSideEffects(), True)
-    initial_count = len(state_interface._new_callbacks)
+    initial_callbacks = list(state_interface._new_callbacks)
     state_interface.add_callback(default_async_callback)
-    assert len(state_interface._new_callbacks) == initial_count + 1
+    assert state_interface._new_callbacks == [*initial_callbacks, default_async_callback]
+    initial_callbacks.append(default_async_callback)
+    state_interface.add_callback(default_async_callback)
+    assert state_interface._new_callbacks == [*initial_callbacks, default_async_callback]
 
 
-# Fixture to create an ActionScope with a mocked DBWrapper2
-@pytest.fixture
-async def action_scope() -> AsyncIterator[ActionScope[TestSideEffects]]:
+@pytest.fixture(name="action_scope")
+async def action_scope_fixture() -> AsyncIterator[ActionScope[TestSideEffects]]:
     async with ActionScope.new_scope(TestSideEffects) as scope:
         yield scope
 
 
-# Test creating a new ActionScope and ensuring tables are created
 @pytest.mark.anyio
 async def test_new_action_scope(action_scope: ActionScope[TestSideEffects]) -> None:
+    """
+    Assert we can immediately check out some initial state
+    """
     async with action_scope.use() as interface:
         assert interface == StateInterface({}, TestSideEffects(), True)
 
 
 @pytest.mark.anyio
 async def test_scope_persistence(action_scope: ActionScope[TestSideEffects]) -> None:
+    """ """
     async with action_scope.use() as interface:
         interface.memos[b"foo"] = b"bar"
-        interface.side_effects.buf = b"bar"
+        interface.side_effects.buf = b"baz"
 
     async with action_scope.use() as interface:
         assert interface.memos[b"foo"] == b"bar"
-        assert interface.side_effects.buf == b"bar"
+        assert interface.side_effects.buf == b"baz"
 
 
 @pytest.mark.anyio
 async def test_transactionality(action_scope: ActionScope[TestSideEffects]) -> None:
     async with action_scope.use() as interface:
         interface.memos[b"foo"] = b"bar"
-        interface.side_effects.buf = b"bar"
+        interface.side_effects.buf = b"baz"
 
-    try:
+    with pytest.raises(Exception, match="Going to be caught"):
         async with action_scope.use() as interface:
             interface.memos[b"foo"] = b"qux"
             interface.side_effects.buf = b"qat"
             raise RuntimeError("Going to be caught")
-    except RuntimeError:
-        pass
 
     async with action_scope.use() as interface:
         assert interface.memos[b"foo"] == b"bar"
-        assert interface.side_effects.buf == b"bar"
+        assert interface.side_effects.buf == b"baz"
 
 
 @pytest.mark.anyio
@@ -103,7 +107,7 @@ async def test_callback_in_callback_error() -> None:
 
 @pytest.mark.anyio
 async def test_no_callbacks_if_error() -> None:
-    try:
+    with pytest.raises(Exception, match="This should prevent the callbacks from being called"):
         async with ActionScope.new_scope(TestSideEffects) as action_scope:
             async with action_scope.use() as interface:
 
@@ -114,5 +118,14 @@ async def test_no_callbacks_if_error() -> None:
 
             async with action_scope.use() as interface:
                 raise RuntimeError("This should prevent the callbacks from being called")
-    except RuntimeError:
-        pass
+
+    with pytest.raises(Exception, match="This should prevent the callbacks from being called"):
+        async with ActionScope.new_scope(TestSideEffects) as action_scope:
+            async with action_scope.use() as interface:
+
+                async def callback(interface: StateInterface[TestSideEffects]) -> None:
+                    raise NotImplementedError("Should not get here")  # pragma: no cover
+
+                interface.add_callback(callback)
+
+            raise RuntimeError("This should prevent the callbacks from being called")

--- a/chia/util/action_scope.py
+++ b/chia/util/action_scope.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass, field
+from typing import AsyncIterator, Awaitable, Callable, Dict, Generic, List, Optional, Protocol, Type, TypeVar
+
+import aiosqlite
+
+from chia.util.db_wrapper import DBWrapper2, execute_fetchone
+
+
+class ResourceManager(Protocol):
+    @classmethod
+    @contextlib.asynccontextmanager
+    async def managed(cls, initial_resource: SideEffects) -> AsyncIterator[ResourceManager]:
+        # We have to put this yield here for mypy to recognize the function as a generator
+        yield  # type: ignore[misc]
+
+    @contextlib.asynccontextmanager
+    async def use(self) -> AsyncIterator[None]:
+        # We have to put this yield here for mypy to recognize the function as a generator
+        yield
+
+    async def get_resource(self, resource_type: Type[_T_SideEffects]) -> _T_SideEffects: ...
+
+    async def save_resource(self, resource: SideEffects) -> None: ...
+
+    async def get_memos(self) -> Dict[bytes, bytes]: ...
+
+    async def save_memos(self, memos: Dict[bytes, bytes]) -> None: ...
+
+
+@dataclass
+class SQLiteResourceManager:
+
+    _db: DBWrapper2
+    _active_writer: Optional[aiosqlite.Connection] = field(init=False, default=None)
+
+    def get_active_writer(self) -> aiosqlite.Connection:
+        if self._active_writer is None:
+            raise RuntimeError("Can only access resources while under `use()` context manager")
+
+        return self._active_writer
+
+    @classmethod
+    @contextlib.asynccontextmanager
+    async def managed(cls, initial_resource: SideEffects) -> AsyncIterator[ResourceManager]:
+        async with DBWrapper2.managed(":memory:", reader_count=0) as db:
+            self = cls(db)
+            async with self._db.writer() as conn:
+                await conn.execute("CREATE TABLE memos(" " key blob," " value blob" ")")
+                await conn.execute("CREATE TABLE side_effects(" " total blob" ")")
+                await conn.execute(
+                    "INSERT INTO side_effects VALUES(?)",
+                    (bytes(initial_resource),),
+                )
+            yield self
+
+    @contextlib.asynccontextmanager
+    async def use(self) -> AsyncIterator[None]:
+        async with self._db.writer() as conn:
+            self._active_writer = conn
+            yield
+            self._active_writer = None
+
+    async def get_resource(self, resource_type: Type[_T_SideEffects]) -> _T_SideEffects:
+        row = await execute_fetchone(self.get_active_writer(), "SELECT total FROM side_effects")
+        assert row is not None
+        side_effects = resource_type.from_bytes(row[0])
+        return side_effects
+
+    async def save_resource(self, resource: SideEffects) -> None:
+        await self.get_active_writer().execute("DELETE FROM side_effects")
+        await self.get_active_writer().execute(
+            "INSERT INTO side_effects VALUES(?)",
+            (bytes(resource),),
+        )
+
+    async def get_memos(self) -> Dict[bytes, bytes]:
+        rows = await self.get_active_writer().execute_fetchall("SELECT key, value FROM memos")
+        memos = {row[0]: row[1] for row in rows}
+        return memos
+
+    async def save_memos(self, memos: Dict[bytes, bytes]) -> None:
+        await self.get_active_writer().execute("DELETE FROM memos")
+        await self.get_active_writer().executemany(
+            "INSERT INTO memos VALUES(?, ?)",
+            memos.items(),
+        )
+
+
+class SideEffects(Protocol):
+    def __bytes__(self) -> bytes: ...
+
+    @classmethod
+    def from_bytes(cls: Type[_T_SideEffects], blob: bytes) -> _T_SideEffects: ...
+
+
+_T_SideEffects = TypeVar("_T_SideEffects", bound=SideEffects)
+
+
+@dataclass
+class ActionScope(Generic[_T_SideEffects]):
+    """
+    The idea of a wallet action is to map a single user input to many potentially distributed wallet functions and side
+    effects. The eventual goal is to have this be the only connection between a wallet type and the WSM.
+
+    Utilizes a "resource manager" to hold the state in order to take advantage of rollbacks and prevent concurrent tasks
+    from interferring with each other.
+    """
+
+    _resource_manager: ResourceManager
+    _side_effects_format: Type[_T_SideEffects]
+    _callbacks: List[Callable[[StateInterface[_T_SideEffects]], Awaitable[None]]] = field(default_factory=list)
+    _final_side_effects: Optional[_T_SideEffects] = field(init=False, default=None)
+
+    @property
+    def side_effects(self) -> _T_SideEffects:
+        if self._final_side_effects is None:
+            raise RuntimeError(
+                "Can only request ActionScope.side_effects after exiting context manager. "
+                "While in context manager, use ActionScope.use()."
+            )
+
+        return self._final_side_effects
+
+    @classmethod
+    @contextlib.asynccontextmanager
+    async def new_scope(
+        cls,
+        side_effects_format: Type[_T_SideEffects],
+        resource_manager_backend: Type[ResourceManager] = SQLiteResourceManager,
+    ) -> AsyncIterator[ActionScope[_T_SideEffects]]:
+        async with resource_manager_backend.managed(side_effects_format()) as resource_manager:
+            self = cls(_resource_manager=resource_manager, _side_effects_format=side_effects_format)
+            try:
+                yield self
+            except Exception:
+                raise
+            else:
+                async with self.use(_callbacks_allowed=False) as interface:
+                    for callback in self._callbacks:
+                        await callback(interface)
+                    self._final_side_effects = interface.side_effects
+
+    @contextlib.asynccontextmanager
+    async def use(self, _callbacks_allowed: bool = True) -> AsyncIterator[StateInterface[_T_SideEffects]]:
+        async with self._resource_manager.use():
+            memos = await self._resource_manager.get_memos()
+            side_effects = await self._resource_manager.get_resource(self._side_effects_format)
+            interface = StateInterface(memos, side_effects, _callbacks_allowed)
+            yield interface
+            await self._resource_manager.save_memos(interface.memos)
+            await self._resource_manager.save_resource(interface.side_effects)
+            self._callbacks.extend(interface._new_callbacks)
+
+
+@dataclass
+class StateInterface(Generic[_T_SideEffects]):
+    memos: Dict[bytes, bytes]
+    side_effects: _T_SideEffects
+    _callbacks_allowed: bool
+    _new_callbacks: List[Callable[[StateInterface[_T_SideEffects]], Awaitable[None]]] = field(default_factory=list)
+
+    def add_callback(self, callback: Callable[[StateInterface[_T_SideEffects]], Awaitable[None]]) -> None:
+        if not self._callbacks_allowed:
+            raise ValueError("Cannot create a new callback from within another callback")
+        self._new_callbacks.append(callback)

--- a/chia/util/action_scope.py
+++ b/chia/util/action_scope.py
@@ -60,8 +60,10 @@ class SQLiteResourceManager:
     async def use(self) -> AsyncIterator[None]:
         async with self._db.writer() as conn:
             self._active_writer = conn
-            yield
-            self._active_writer = None
+            try:
+                yield
+            finally:
+                self._active_writer = None
 
     async def get_resource(self, resource_type: Type[_T_SideEffects]) -> _T_SideEffects:
         row = await execute_fetchone(self.get_active_writer(), "SELECT total FROM side_effects")

--- a/chia/util/action_scope.py
+++ b/chia/util/action_scope.py
@@ -69,6 +69,7 @@ class SQLiteResourceManager:
         return side_effects
 
     async def save_resource(self, resource: SideEffects) -> None:
+        # This sets all rows (there's only one) to the new serialization
         await self.get_active_writer().execute(
             "UPDATE side_effects SET total=?",
             (bytes(resource),),

--- a/chia/util/action_scope.py
+++ b/chia/util/action_scope.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass, field
-from typing import AsyncIterator, Awaitable, Callable, Dict, Generic, List, Optional, Protocol, Type, TypeVar, final
+from typing import AsyncIterator, Awaitable, Callable, Generic, List, Optional, Protocol, Type, TypeVar, final
 
 import aiosqlite
 
@@ -25,10 +25,6 @@ class ResourceManager(Protocol):
 
     async def save_resource(self, resource: SideEffects) -> None: ...
 
-    async def get_memos(self) -> Dict[bytes, bytes]: ...
-
-    async def save_memos(self, memos: Dict[bytes, bytes]) -> None: ...
-
 
 @dataclass
 class SQLiteResourceManager:
@@ -48,7 +44,6 @@ class SQLiteResourceManager:
         async with DBWrapper2.managed(":memory:", reader_count=0) as db:
             self = cls(db)
             async with self._db.writer() as conn:
-                await conn.execute("CREATE TABLE memos(key blob, value blob)")
                 await conn.execute("CREATE TABLE side_effects(total blob)")
                 await conn.execute(
                     "INSERT INTO side_effects VALUES(?)",
@@ -76,18 +71,6 @@ class SQLiteResourceManager:
         await self.get_active_writer().execute(
             "INSERT INTO side_effects VALUES(?)",
             (bytes(resource),),
-        )
-
-    async def get_memos(self) -> Dict[bytes, bytes]:
-        rows = await self.get_active_writer().execute_fetchall("SELECT key, value FROM memos")
-        memos = {row[0]: row[1] for row in rows}
-        return memos
-
-    async def save_memos(self, memos: Dict[bytes, bytes]) -> None:
-        await self.get_active_writer().execute("DELETE FROM memos")
-        await self.get_active_writer().executemany(
-            "INSERT INTO memos VALUES(?, ?)",
-            memos.items(),
         )
 
 
@@ -147,22 +130,19 @@ class ActionScope(Generic[_T_SideEffects]):
     @contextlib.asynccontextmanager
     async def use(self, _callbacks_allowed: bool = True) -> AsyncIterator[StateInterface[_T_SideEffects]]:
         async with self._resource_manager.use():
-            memos = await self._resource_manager.get_memos()
             side_effects = await self._resource_manager.get_resource(self._side_effects_format)
-            interface = StateInterface(memos, side_effects, _callbacks_allowed)
+            interface = StateInterface(side_effects, _callbacks_allowed)
             try:
                 yield interface
             except Exception:
                 raise
             else:
-                await self._resource_manager.save_memos(interface.memos)
                 await self._resource_manager.save_resource(interface.side_effects)
                 self._callbacks.extend(interface._new_callbacks)
 
 
 @dataclass
 class StateInterface(Generic[_T_SideEffects]):
-    memos: Dict[bytes, bytes]
     side_effects: _T_SideEffects
     _callbacks_allowed: bool
     _new_callbacks: List[Callable[[StateInterface[_T_SideEffects]], Awaitable[None]]] = field(default_factory=list)


### PR DESCRIPTION
This PR creates a new utility called `ActionScope`.  The motivation for this originated in the wallet, but this utility could be more broadly applicable.  The purpose is to provide a standard way for multiple functions/coroutines to access and modify some shared state as part of a single transaction.

When an action scope is created the scope is passed from function to coroutine etc.  and if a logical process wishes to update or read from the state, it must "check out" the state and return it when it is done. No other process can check out the state while it is checked out by another.  Processes may also register callbacks to be run when the action scope is about to close.  Right before the action scope is closed, these callbacks run and then the state is deleted.  Other layers on top can choose to commit that state or whatever else if they so wish.

The wallet motivation more specifically is to provide a single hub for all of the state changes that will happen as part of creating a transaction.  Right now, every function is responsible for just making side effects at will and some higher process is responsible for making sure these side effects don't happen prematurely and get rolled back if something goes wrong.  Every step along the way needs to make sure the information is sent up and down properly so that everything works properly.  It's quite a burden.  With action scopes, everything just modifies this temporary state and then the thing that made the action scope can decide what to do with everything when it closes.  In addition, every function that is called can see the _whole_ context it is operating in rather than just what its caller has told it.  This will be important for vault singletons later on.

This may sound very similar to the `DBWrapper` functionality.  You would be correct in thinking that as that is what action scopes use as a back end.  It's not clear we want to always use an in memory sqlite DB but it's the fastest path to getting all of these features.  In any case, the backend is a protocol that can be switched out at a later date, even if only in some areas.