### PR TITLE
minor fix for make_spend function

### DIFF
--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -30,11 +30,14 @@ def make_spend(
         pr = puzzle_reveal
     elif isinstance(puzzle_reveal, Program):
         pr = SerializedProgram.from_program(puzzle_reveal)
-
+    else:
+        raise ValueError("Only [SerializedProgram, Program] supported for puzzle reveal")
     if isinstance(solution, SerializedProgram):
         sol = solution
     elif isinstance(solution, Program):
         sol = SerializedProgram.from_program(solution)
+    else:
+        raise ValueError("Only [SerializedProgram, Program] supported for solution")
 
     return CoinSpend(coin, pr, sol)
 


### PR DESCRIPTION
raise error when passing wrong type to `make_spend` to avoid ambiguous `UnboundLocalError` exception 