### PR TITLE
Bump chia rs 0.10.0

### DIFF
--- a/chia/_tests/core/full_node/test_conditions.py
+++ b/chia/_tests/core/full_node/test_conditions.py
@@ -9,7 +9,8 @@ import logging
 from typing import List, Optional, Tuple
 
 import pytest
-from chia_rs import G2Element
+from chia_rs import AugSchemeMPL, G2Element
+from clvm.casts import int_to_bytes
 from clvm_tools.binutils import assemble
 
 from chia._tests.conftest import ConsensusMode
@@ -22,6 +23,7 @@ from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
+from chia.util.condition_tools import agg_sig_additional_data
 from chia.util.errors import Err
 from chia.util.ints import uint32, uint64
 from chia.wallet.conditions import AssertCoinAnnouncement, AssertPuzzleAnnouncement
@@ -99,12 +101,14 @@ async def check_conditions(
     condition_solution: Program,
     expected_err: Optional[Err] = None,
     spend_reward_index: int = -2,
+    *,
+    aggsig: G2Element = G2Element(),
 ) -> Tuple[List[CoinRecord], List[CoinRecord], FullBlock]:
     blocks = await initial_blocks(bt)
     coin = blocks[spend_reward_index].get_included_reward_coins()[0]
 
     coin_spend = make_spend(coin, EASY_PUZZLE, SerializedProgram.from_program(condition_solution))
-    spend_bundle = SpendBundle([coin_spend], G2Element())
+    spend_bundle = SpendBundle([coin_spend], aggsig)
 
     # now let's try to create a block with the spend bundle and ensure that it doesn't validate
 
@@ -495,3 +499,84 @@ class TestConditions:
         else:
             expected_error = None
         await check_conditions(bt, conditions, expected_error)
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "opcode",
+        [
+            ConditionOpcode.AGG_SIG_PARENT,
+            ConditionOpcode.AGG_SIG_PUZZLE,
+            ConditionOpcode.AGG_SIG_AMOUNT,
+            ConditionOpcode.AGG_SIG_PUZZLE_AMOUNT,
+            ConditionOpcode.AGG_SIG_PARENT_AMOUNT,
+            ConditionOpcode.AGG_SIG_PARENT_PUZZLE,
+            ConditionOpcode.AGG_SIG_UNSAFE,
+            ConditionOpcode.AGG_SIG_ME,
+        ],
+    )
+    async def test_agg_sig_illegal_suffix(
+        self,
+        opcode: ConditionOpcode,
+        bt: BlockTools,
+        consensus_mode: ConsensusMode,
+    ) -> None:
+
+        c = bt.constants
+
+        additional_data = agg_sig_additional_data(c.AGG_SIG_ME_ADDITIONAL_DATA)
+        assert c.AGG_SIG_ME_ADDITIONAL_DATA == additional_data[ConditionOpcode.AGG_SIG_ME]
+        assert c.AGG_SIG_PARENT_ADDITIONAL_DATA == additional_data[ConditionOpcode.AGG_SIG_PARENT]
+        assert c.AGG_SIG_PUZZLE_ADDITIONAL_DATA == additional_data[ConditionOpcode.AGG_SIG_PUZZLE]
+        assert c.AGG_SIG_AMOUNT_ADDITIONAL_DATA == additional_data[ConditionOpcode.AGG_SIG_AMOUNT]
+        assert c.AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA == additional_data[ConditionOpcode.AGG_SIG_PUZZLE_AMOUNT]
+        assert c.AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA == additional_data[ConditionOpcode.AGG_SIG_PARENT_AMOUNT]
+        assert c.AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA == additional_data[ConditionOpcode.AGG_SIG_PARENT_PUZZLE]
+
+        blocks = await initial_blocks(bt)
+        if consensus_mode < ConsensusMode.HARD_FORK_2_0 and opcode in [
+            ConditionOpcode.AGG_SIG_PARENT,
+            ConditionOpcode.AGG_SIG_PUZZLE,
+            ConditionOpcode.AGG_SIG_AMOUNT,
+            ConditionOpcode.AGG_SIG_PUZZLE_AMOUNT,
+            ConditionOpcode.AGG_SIG_PARENT_AMOUNT,
+            ConditionOpcode.AGG_SIG_PARENT_PUZZLE,
+        ]:
+            expected_error = Err.BAD_AGGREGATE_SIGNATURE
+        elif opcode == ConditionOpcode.AGG_SIG_UNSAFE:
+            expected_error = Err.INVALID_CONDITION
+        else:
+            expected_error = None
+
+        sk = AugSchemeMPL.key_gen(b"8" * 32)
+        pubkey = sk.get_g1()
+        coin = blocks[-2].get_included_reward_coins()[0]
+        for msg in [
+            c.AGG_SIG_PARENT_ADDITIONAL_DATA,
+            c.AGG_SIG_PUZZLE_ADDITIONAL_DATA,
+            c.AGG_SIG_AMOUNT_ADDITIONAL_DATA,
+            c.AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA,
+            c.AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA,
+            c.AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA,
+        ]:
+            print(f"op: {opcode} msg: {msg}")
+            message = "0x" + msg.hex()
+            if opcode == ConditionOpcode.AGG_SIG_ME:
+                suffix = coin.name() + c.AGG_SIG_ME_ADDITIONAL_DATA
+            elif opcode == ConditionOpcode.AGG_SIG_PARENT:
+                suffix = coin.parent_coin_info + c.AGG_SIG_PARENT_ADDITIONAL_DATA
+            elif opcode == ConditionOpcode.AGG_SIG_PUZZLE:
+                suffix = coin.puzzle_hash + c.AGG_SIG_PUZZLE_ADDITIONAL_DATA
+            elif opcode == ConditionOpcode.AGG_SIG_AMOUNT:
+                suffix = int_to_bytes(coin.amount) + c.AGG_SIG_AMOUNT_ADDITIONAL_DATA
+            elif opcode == ConditionOpcode.AGG_SIG_PUZZLE_AMOUNT:
+                suffix = coin.puzzle_hash + int_to_bytes(coin.amount) + c.AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA
+            elif opcode == ConditionOpcode.AGG_SIG_PARENT_AMOUNT:
+                suffix = coin.parent_coin_info + int_to_bytes(coin.amount) + c.AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA
+            elif opcode == ConditionOpcode.AGG_SIG_PARENT_PUZZLE:
+                suffix = coin.parent_coin_info + coin.puzzle_hash + c.AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA
+            else:
+                suffix = b""
+            sig = AugSchemeMPL.sign(sk, msg + suffix, pubkey)
+            conditions = Program.to(assemble(f"(({opcode.value[0]} 0x{bytes(pubkey).hex()} {message}))"))
+
+            await check_conditions(bt, conditions, expected_error, aggsig=sig)

--- a/chia/_tests/core/full_node/test_conditions.py
+++ b/chia/_tests/core/full_node/test_conditions.py
@@ -577,6 +577,7 @@ class TestConditions:
             else:
                 suffix = b""
             sig = AugSchemeMPL.sign(sk, msg + suffix, pubkey)
-            conditions = Program.to(assemble(f"(({opcode.value[0]} 0x{bytes(pubkey).hex()} {message}))"))
-
-            await check_conditions(bt, conditions, expected_error, aggsig=sig)
+            solution = SerializedProgram.to(assemble(f"(({opcode.value[0]} 0x{bytes(pubkey).hex()} {message}))"))
+            coin_spend = make_spend(coin, EASY_PUZZLE, solution)
+            spend_bundle = SpendBundle([coin_spend], sig)
+            await check_spend_bundle_validity(bt, blocks, spend_bundle, expected_err=expected_error)

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -127,13 +127,21 @@ async def test_sync_no_farmer(
 
     # full node 1 has the complete chain
     for block_batch in to_batches(blocks, 64):
-        await full_node_1.full_node.add_block_batch(block_batch.entries, PeerInfo("0.0.0.0", 8884), None)
+        success, change, err = await full_node_1.full_node.add_block_batch(
+            block_batch.entries, PeerInfo("0.0.0.0", 8884), None
+        )
+        assert err is None
+        assert success is True
 
     target_peak = full_node_1.full_node.blockchain.get_peak()
 
     # full node 2 is behind by 800 blocks
     for block_batch in to_batches(blocks[:-800], 64):
-        await full_node_2.full_node.add_block_batch(block_batch.entries, PeerInfo("0.0.0.0", 8884), None)
+        success, change, err = await full_node_2.full_node.add_block_batch(
+            block_batch.entries, PeerInfo("0.0.0.0", 8884), None
+        )
+        assert err is None
+        assert success is True
 
     # connect the nodes and wait for node 2 to sync up to node 1
     await connect_and_get_peer(server_1, server_2, self_hostname)
@@ -2295,7 +2303,11 @@ async def test_long_reorg(
         b = block_batch.entries[0]
         if (b.height % 128) == 0:
             print(f"main chain: {b.height:4} weight: {b.weight}")
-        await node.full_node.add_block_batch(block_batch.entries, PeerInfo("0.0.0.0", 8884), None)
+        success, change, err = await node.full_node.add_block_batch(
+            block_batch.entries, PeerInfo("0.0.0.0", 8884), None
+        )
+        assert err is None
+        assert success is True
 
     peak = node.full_node.blockchain.get_peak()
     chain_1_height = peak.height
@@ -2385,14 +2397,22 @@ async def test_long_reorg_nodes(
         b = block_batch.entries[0]
         if (b.height % 128) == 0:
             print(f"main chain: {b.height:4} weight: {b.weight}")
-        await full_node_1.full_node.add_block_batch(block_batch.entries, PeerInfo("0.0.0.0", 8884), None)
+        success, change, err = await full_node_1.full_node.add_block_batch(
+            block_batch.entries, PeerInfo("0.0.0.0", 8884), None
+        )
+        assert err is None
+        assert success is True
 
     # full node 2 has the reorg-chain
     for block_batch in to_batches(reorg_blocks[:-1], 64):
         b = block_batch.entries[0]
         if (b.height % 128) == 0:
             print(f"reorg chain: {b.height:4} weight: {b.weight}")
-        await full_node_2.full_node.add_block_batch(block_batch.entries, PeerInfo("0.0.0.0", 8884), None)
+        success, change, err = await full_node_2.full_node.add_block_batch(
+            block_batch.entries, PeerInfo("0.0.0.0", 8884), None
+        )
+        assert err is None
+        assert success is True
 
     await connect_and_get_peer(full_node_1.full_node.server, full_node_2.full_node.server, self_hostname)
 
@@ -2427,7 +2447,11 @@ async def test_long_reorg_nodes(
         b = block_batch.entries[0]
         if (b.height % 128) == 0:
             print(f"main chain: {b.height:4} weight: {b.weight}")
-        await full_node_3.full_node.add_block_batch(block_batch.entries, PeerInfo("0.0.0.0", 8884), None)
+        success, change, err = await full_node_3.full_node.add_block_batch(
+            block_batch.entries, PeerInfo("0.0.0.0", 8884), None
+        )
+        assert err is None
+        assert success is True
 
     print("connecting node 3")
     await connect_and_get_peer(full_node_3.full_node.server, full_node_1.full_node.server, self_hostname)

--- a/chia/_tests/tools/test_run_block.py
+++ b/chia/_tests/tools/test_run_block.py
@@ -9,10 +9,19 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
+from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64, uint128
 
+AGG_SIG_DATA = bytes32.fromhex("ae83525ba8d1dd3f09b277de18ca3e43fc0af20d20c4b3e92ef2a48bd291ccb2")
+
 constants = DEFAULT_CONSTANTS.replace(
-    AGG_SIG_ME_ADDITIONAL_DATA=bytes32.fromhex("ae83525ba8d1dd3f09b277de18ca3e43fc0af20d20c4b3e92ef2a48bd291ccb2"),
+    AGG_SIG_ME_ADDITIONAL_DATA=AGG_SIG_DATA,
+    AGG_SIG_PARENT_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([43])),
+    AGG_SIG_PUZZLE_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([44])),
+    AGG_SIG_AMOUNT_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([45])),
+    AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([46])),
+    AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([47])),
+    AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([48])),
     DIFFICULTY_CONSTANT_FACTOR=uint128(10052721566054),
     DIFFICULTY_STARTING=uint64(30),
     EPOCH_BLOCKS=uint32(768),

--- a/chia/_tests/util/test_condition_tools.py
+++ b/chia/_tests/util/test_condition_tools.py
@@ -179,32 +179,6 @@ class TestPkmPairs:
         assert [bytes(pk) for pk in pks] == [bytes(PK2), bytes(PK1)]
         assert msgs == [b"msg2", b"msg1" + value + addendum]
 
-    @pytest.mark.parametrize(
-        "opcode",
-        [
-            ConditionOpcode.AGG_SIG_PARENT,
-            ConditionOpcode.AGG_SIG_PUZZLE,
-            ConditionOpcode.AGG_SIG_AMOUNT,
-            ConditionOpcode.AGG_SIG_PUZZLE_AMOUNT,
-            ConditionOpcode.AGG_SIG_PARENT_AMOUNT,
-            ConditionOpcode.AGG_SIG_PARENT_PUZZLE,
-            ConditionOpcode.AGG_SIG_ME,
-        ],
-    )
-    def test_agg_sig_unsafe_restriction(self, opcode: ConditionOpcode) -> None:
-        conds = mk_agg_sig_conditions(opcode, agg_sig_data=[], agg_sig_unsafe_data=[(PK1, b"msg1"), (PK2, b"msg2")])
-        with pytest.raises(ConsensusError, match="INVALID_CONDITION"):
-            pkm_pairs(conds, b"msg1")
-
-        with pytest.raises(ConsensusError, match="INVALID_CONDITION"):
-            pkm_pairs(conds, b"sg1")
-
-        with pytest.raises(ConsensusError, match="INVALID_CONDITION"):
-            pkm_pairs(conds, b"msg2")
-
-        with pytest.raises(ConsensusError, match="INVALID_CONDITION"):
-            pkm_pairs(conds, b"g2")
-
 
 class TestPkmPairsForConditionDict:
     def test_agg_sig_unsafe_restriction(self) -> None:

--- a/chia/_tests/util/test_replace_str_to_bytes.py
+++ b/chia/_tests/util/test_replace_str_to_bytes.py
@@ -5,7 +5,10 @@ from chia_rs import ConsensusConstants
 
 from chia.consensus.constants import replace_str_to_bytes
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64, uint128
+
+AGG_SIG_DATA = bytes32.fromhex("ccd5bb71183532bff220ba46c268991a3ff07eb358e8255a65c30a2dce0e5fbb")
 
 test_constants = ConsensusConstants(
     SLOT_BLOCKS_TARGET=uint32(32),
@@ -28,7 +31,13 @@ test_constants = ConsensusConstants(
     MAX_FUTURE_TIME2=uint32(2 * 60),
     NUMBER_OF_TIMESTAMPS=uint8(11),
     GENESIS_CHALLENGE=bytes32.fromhex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
-    AGG_SIG_ME_ADDITIONAL_DATA=bytes.fromhex("ccd5bb71183532bff220ba46c268991a3ff07eb358e8255a65c30a2dce0e5fbb"),
+    AGG_SIG_ME_ADDITIONAL_DATA=AGG_SIG_DATA,
+    AGG_SIG_PARENT_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([43])),
+    AGG_SIG_PUZZLE_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([44])),
+    AGG_SIG_AMOUNT_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([45])),
+    AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([46])),
+    AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([47])),
+    AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([48])),
     GENESIS_PRE_FARM_POOL_PUZZLE_HASH=bytes32.fromhex(
         "d23da14695a188ae5708dd152263c4db883eb27edeb936178d4d988b8f3ce5fc"
     ),
@@ -70,6 +79,28 @@ def test_replace_str_to_bytes() -> None:
     )
     assert test2.GENESIS_PRE_FARM_FARMER_PUZZLE_HASH == bytes32.fromhex(
         "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    )
+
+
+def test_replace_str_to_bytes_additional_data() -> None:
+    test2 = replace_str_to_bytes(
+        test_constants,
+        AGG_SIG_ME_ADDITIONAL_DATA="0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    )
+
+    # if we update AGG_SIG_ME_ADDITIONAL_DATA, the other additional data is also
+    # updated
+
+    AGG_SIG_DATA = bytes32.fromhex("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+    assert test2 == replace_str_to_bytes(
+        test_constants,
+        AGG_SIG_ME_ADDITIONAL_DATA="0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        AGG_SIG_PARENT_ADDITIONAL_DATA="0x" + std_hash(AGG_SIG_DATA + bytes([43])).hex(),
+        AGG_SIG_PUZZLE_ADDITIONAL_DATA="0x" + std_hash(AGG_SIG_DATA + bytes([44])).hex(),
+        AGG_SIG_AMOUNT_ADDITIONAL_DATA="0x" + std_hash(AGG_SIG_DATA + bytes([45])).hex(),
+        AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA="0x" + std_hash(AGG_SIG_DATA + bytes([46])).hex(),
+        AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA="0x" + std_hash(AGG_SIG_DATA + bytes([47])).hex(),
+        AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA="0x" + std_hash(AGG_SIG_DATA + bytes([48])).hex(),
     )
 
 

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -6,6 +6,7 @@ from typing import Any
 from chia_rs import ConsensusConstants as ConsensusConstants
 
 from chia.util.byte_types import hexstr_to_bytes
+from chia.util.hash import std_hash
 
 log = logging.getLogger(__name__)
 
@@ -26,6 +27,23 @@ def replace_str_to_bytes(constants: ConsensusConstants, **changes: Any) -> Conse
             filtered_changes[k] = hexstr_to_bytes(v)
         else:
             filtered_changes[k] = v
+
+    # if we override the additional data (replay protection across forks)
+    # make sure the other variants of the AGG_SIG_* conditions are also covered
+    if "AGG_SIG_ME_ADDITIONAL_DATA" in filtered_changes:
+        AGG_SIG_DATA = filtered_changes["AGG_SIG_ME_ADDITIONAL_DATA"]
+        if "AGG_SIG_PARENT_ADDITIONAL_DATA" not in filtered_changes:
+            filtered_changes["AGG_SIG_PARENT_ADDITIONAL_DATA"] = std_hash(AGG_SIG_DATA + bytes([43]))
+        if "AGG_SIG_PUZZLE_ADDITIONAL_DATA" not in filtered_changes:
+            filtered_changes["AGG_SIG_PUZZLE_ADDITIONAL_DATA"] = std_hash(AGG_SIG_DATA + bytes([44]))
+        if "AGG_SIG_AMOUNT_ADDITIONAL_DATA" not in filtered_changes:
+            filtered_changes["AGG_SIG_AMOUNT_ADDITIONAL_DATA"] = std_hash(AGG_SIG_DATA + bytes([45]))
+        if "AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA" not in filtered_changes:
+            filtered_changes["AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA"] = std_hash(AGG_SIG_DATA + bytes([46]))
+        if "AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA" not in filtered_changes:
+            filtered_changes["AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA"] = std_hash(AGG_SIG_DATA + bytes([47]))
+        if "AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA" not in filtered_changes:
+            filtered_changes["AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA"] = std_hash(AGG_SIG_DATA + bytes([48]))
 
     # TODO: this is too magical here and is really only used for configuration unmarshalling
     return constants.replace(**filtered_changes)  # type: ignore[arg-type]

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64, uint128
 
 from .constants import ConsensusConstants
+
+AGG_SIG_DATA = bytes32.fromhex("ccd5bb71183532bff220ba46c268991a3ff07eb358e8255a65c30a2dce0e5fbb")
 
 DEFAULT_CONSTANTS = ConsensusConstants(
     SLOT_BLOCKS_TARGET=uint32(32),
@@ -34,8 +37,15 @@ DEFAULT_CONSTANTS = ConsensusConstants(
     # We override this value based on the chain being run (testnet0, testnet1, mainnet, etc)
     # Default used for tests is std_hash(b'')
     GENESIS_CHALLENGE=bytes32.fromhex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
-    # Forks of chia should change this value to provide replay attack protection. This is set to mainnet genesis chall
-    AGG_SIG_ME_ADDITIONAL_DATA=bytes.fromhex("ccd5bb71183532bff220ba46c268991a3ff07eb358e8255a65c30a2dce0e5fbb"),
+    # Forks of chia should change the AGG_SIG_*_ADDITIONAL_DATA values to provide
+    # replay attack protection. This is set to mainnet genesis challange
+    AGG_SIG_ME_ADDITIONAL_DATA=AGG_SIG_DATA,
+    AGG_SIG_PARENT_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([43])),
+    AGG_SIG_PUZZLE_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([44])),
+    AGG_SIG_AMOUNT_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([45])),
+    AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([46])),
+    AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([47])),
+    AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA=std_hash(AGG_SIG_DATA + bytes([48])),
     GENESIS_PRE_FARM_POOL_PUZZLE_HASH=bytes32.fromhex(
         "d23da14695a188ae5708dd152263c4db883eb27edeb936178d4d988b8f3ce5fc"
     ),

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -95,7 +95,7 @@ def get_name_puzzle_conditions(
 
     try:
         block_args = [bytes(gen) for gen in generator.generator_refs]
-        err, result = run_block(bytes(generator.program), block_args, max_cost, flags)
+        err, result = run_block(bytes(generator.program), block_args, max_cost, flags, DEFAULT_CONSTANTS)
         assert (err is None) != (result is None)
         if err is not None:
             return NPCResult(uint16(err), None)

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -12,7 +12,6 @@ from chia_rs import (
     ENABLE_MESSAGE_CONDITIONS,
     ENABLE_SOFTFORK_CONDITION,
     MEMPOOL_MODE,
-    NO_RELATIVE_CONDITIONS_ON_EPHEMERAL,
 )
 from chia_rs import get_puzzle_and_solution_for_coin as get_puzzle_and_solution_for_coin_rust
 from chia_rs import run_block_generator, run_block_generator2, run_chia_program
@@ -41,7 +40,7 @@ log = logging.getLogger(__name__)
 
 
 def get_flags_for_height_and_constants(height: int, constants: ConsensusConstants) -> int:
-    flags = NO_RELATIVE_CONDITIONS_ON_EPHEMERAL
+    flags = 0
 
     if height >= constants.SOFT_FORK4_HEIGHT:
         flags = flags | ENABLE_MESSAGE_CONDITIONS

--- a/chia/util/condition_tools.py
+++ b/chia/util/condition_tools.py
@@ -106,9 +106,6 @@ def pkm_pairs(conditions: SpendBundleConditions, additional_data: bytes) -> Tupl
     for pk, msg in conditions.agg_sig_unsafe:
         ret[0].append(pk)
         ret[1].append(msg)
-        for disallowed in data.values():
-            if msg.endswith(disallowed):
-                raise ConsensusError(Err.INVALID_CONDITION)
 
     for spend in conditions.spends:
         condition_items_pairs = [

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dependencies = [
     "chiapos==2.0.4",  # proof of space
     "clvm==0.9.10",
     "clvm_tools==0.4.9",  # Currying, Program.to, other conveniences
-    "chia_rs==0.9.0",
+    "chia_rs==0.10.0",
     "clvm-tools-rs==0.1.40",  # Rust implementation of clvm_tools' compiler
     "aiohttp==3.9.4",  # HTTP server for full node rpc
     "aiosqlite==0.20.0",  # asyncio wrapper for sqlite, to store blocks

--- a/tools/analyze-chain.py
+++ b/tools/analyze-chain.py
@@ -35,6 +35,7 @@ def run_gen(
             block_program_args,
             DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
             flags,
+            DEFAULT_CONSTANTS,
         )
         run_time = time() - start_time
         return err, result, run_time


### PR DESCRIPTION
This PR is best reviewed one commit at a time.

### Purpose:

Update chia_rs to the latest version, 0.10.0.

In this version, there were two major changes to the API:

The `ConsensusConstants` class, in addition to `AGG_SIG_ME_ADDITIONAL_DATA`, contains the constants for all other `AGG_SIG_*` conditions as well. i.e. this is the suffix we append to the condition message before signing or verifying the signature.

These fields are now used by the condition parser (in rust) to validate that `AGG_SIG_UNSAFE` messages do not end with any of these reserved suffixes. Doing so is a consensus violation. This check is currently performed in `pkm_pairs()`, and this patch removes it, and updates the tests to be end-to-end, to cover the rust condition parser.

The second major change is that `NO_RELATIVE_CONDITIONS_ON_EPHEMERAL` was removed, and always on. This was a soft-fork that has activated and is now part of the consensus rules.

### Current Behavior:

The agg sig additional data is checked in `pkm_pairs()`, in python.

relative conditions are explicitly disallowed.

### New Behavior:

The agg sig additional data is checked in the condition parser, in `chia_rs`.

relative conditions are implicitly disallowed by being always-on in the new `chia_rs` version.