### PR TITLE
remove unused `tree_id` parameter from `DataStore.batch_upsert()`

### DIFF
--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -1415,7 +1415,6 @@ class DataStore:
 
     async def batch_upsert(
         self,
-        tree_id: bytes32,
         hash: bytes32,
         to_update_hashes: Set[bytes32],
         pending_upsert_new_hashes: Dict[bytes32, bytes32],
@@ -1425,8 +1424,8 @@ class DataStore:
         node = await self.get_node(hash)
         if isinstance(node, TerminalNode):
             return pending_upsert_new_hashes[hash]
-        new_left_hash = await self.batch_upsert(tree_id, node.left_hash, to_update_hashes, pending_upsert_new_hashes)
-        new_right_hash = await self.batch_upsert(tree_id, node.right_hash, to_update_hashes, pending_upsert_new_hashes)
+        new_left_hash = await self.batch_upsert(node.left_hash, to_update_hashes, pending_upsert_new_hashes)
+        new_right_hash = await self.batch_upsert(node.right_hash, to_update_hashes, pending_upsert_new_hashes)
         return await self._insert_internal_node(new_left_hash, new_right_hash)
 
     async def insert_batch(
@@ -1555,7 +1554,6 @@ class DataStore:
                 assert latest_local_root is not None
                 assert latest_local_root.node_hash is not None
                 new_root_hash = await self.batch_upsert(
-                    store_id,
                     latest_local_root.node_hash,
                     to_update_hashes,
                     pending_upsert_new_hashes,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:



<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
