### PR TITLE
Use TYPE_CHECKING to work around python 3.8 limitations with generics

### DIFF
--- a/chia/_tests/wallet/test_new_wallet_protocol.py
+++ b/chia/_tests/wallet/test_new_wallet_protocol.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from asyncio import Queue
 from dataclasses import dataclass
 from random import Random
-from typing import AsyncGenerator, Dict, List, Optional, OrderedDict, Set, Tuple
+from typing import TYPE_CHECKING, AsyncGenerator, Dict, List, Optional, OrderedDict, Set, Tuple
 
 import pytest
 from chia_rs import AugSchemeMPL, Coin, CoinSpend, CoinState, Program
@@ -33,6 +33,10 @@ IDENTITY_PUZZLE = Program.to(1)
 IDENTITY_PUZZLE_HASH = IDENTITY_PUZZLE.get_tree_hash()
 
 OneNode = Tuple[List[SimulatorFullNodeService], List[WalletService], BlockTools]
+if TYPE_CHECKING:
+    Mpu = Tuple[FullNodeSimulator, Queue[Message], WSChiaConnection]
+else:
+    Mpu = Tuple[FullNodeSimulator, Queue, WSChiaConnection]
 
 ALL_FILTER = wallet_protocol.CoinStateFilters(True, True, True, uint64(0))
 
@@ -796,9 +800,6 @@ async def assert_mempool_removed(
 
     update = wallet_protocol.MempoolItemsRemoved.from_bytes(message.data)
     assert set(update.removed_items) == removed_items
-
-
-Mpu = Tuple[FullNodeSimulator, Queue[Message], WSChiaConnection]
 
 
 @pytest.fixture

--- a/chia/_tests/wallet/test_new_wallet_protocol.py
+++ b/chia/_tests/wallet/test_new_wallet_protocol.py
@@ -33,6 +33,7 @@ IDENTITY_PUZZLE = Program.to(1)
 IDENTITY_PUZZLE_HASH = IDENTITY_PUZZLE.get_tree_hash()
 
 OneNode = Tuple[List[SimulatorFullNodeService], List[WalletService], BlockTools]
+# python 3.8 workaround follows - can be removed when 3.8 support is removed
 if TYPE_CHECKING:
     Mpu = Tuple[FullNodeSimulator, Queue[Message], WSChiaConnection]
 else:


### PR DESCRIPTION
Use TYPE_CHECKING to work around limitations in Python 3.8 wrt Generics like asyncio.Queue

https://mypy.readthedocs.io/en/latest/runtime_troubles.html#using-classes-that-are-generic-in-stubs-but-not-at-runtime