### PR TITLE
CHIA-752 - set permissions in postinst.sh for chrome-sandbox

### DIFF
--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -434,6 +434,7 @@ jobs:
           fi
 
       - name: Check permissions of /opt/chia/chrome-sandbox
+        shell: bash
         if: matrix.mode.name == 'GUI'
         run: |
           [ $(stat -c %a:%G:%U /opt/chia/chrome-sandbox) == "4755:root:root" ]

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -437,7 +437,7 @@ jobs:
         if: matrix.mode.name == 'GUI'
         run: |
           [ $(stat -c %a:%G:%U /opt/chia/chrome-sandbox) == "4755:root:root" ]
-  
+
       - name: Remove package
         run: |
           apt-get remove --yes ${{ matrix.mode.package }}

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -433,6 +433,12 @@ jobs:
             false
           fi
 
+      - name: Check permissions of /opt/chia/chrome-sandbox
+        if: matrix.mode.name == 'GUI'
+        run: |
+          [ $(stat -c %a /opt/chia/chrome-sandbox) == "4755" ]
+          [ $(stat -c %G:%U /opt/chia/chrome-sandbox) == "root:root" ]
+  
       - name: Remove package
         run: |
           apt-get remove --yes ${{ matrix.mode.package }}

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -436,8 +436,7 @@ jobs:
       - name: Check permissions of /opt/chia/chrome-sandbox
         if: matrix.mode.name == 'GUI'
         run: |
-          [ $(stat -c %a /opt/chia/chrome-sandbox) == "4755" ]
-          [ $(stat -c %G:%U /opt/chia/chrome-sandbox) == "root:root" ]
+          [ $(stat -c %a:%G:%U /opt/chia/chrome-sandbox) == "4755:root:root" ]
   
       - name: Remove package
         run: |

--- a/build_scripts/assets/deb/postinst.sh
+++ b/build_scripts/assets/deb/postinst.sh
@@ -3,5 +3,7 @@
 
 set -e
 
+chown -f root:root /opt/chia/chrome-sandbox || true
+chmod -f 4755 /opt/chia/chrome-sandbox || true
 ln -s /opt/chia/resources/app.asar.unpacked/daemon/chia /usr/bin/chia || true
 ln -s /opt/chia/chia-blockchain /usr/bin/chia-blockchain || true


### PR DESCRIPTION
Set the owner and permissions for `/opt/chia/chrome-sandbox` in the DEB `postinst.sh` script

Fixes #17956 

- [x] Needs Testing - CI test added to verify permissions