### PR TITLE
Use foreground-scripts with initial npm ci to see if it resolves strange mac dlopen problem

### DIFF
--- a/build_scripts/build_macos-1-gui.sh
+++ b/build_scripts/build_macos-1-gui.sh
@@ -6,7 +6,7 @@ git status
 
 echo "Installing global npm packages"
 cd npm_macos || exit 1
-npm ci
+npm ci --foreground-scripts
 cd ../../ || exit 1
 git submodule update --init chia-blockchain-gui
 


### PR DESCRIPTION
It seems the strange macos DL open issue may still happen even with the version update https://github.com/Chia-Network/chia-blockchain/commit/1e677831c11c99e927de97b01e59996e1a6cc08c

This is another possible workaround based on my own testing, but I have no idea if it really fixes it as the problem isn't always present or fully understood...