### PR TITLE
[CHIA-690] Add offer expiration to CLI

### DIFF
--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -900,13 +900,14 @@ def test_get_offers(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
         FINGERPRINT_ARG,
         "--summaries",
     ]
+    tzinfo = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
     # these are various things that should be in the output
     assert_list = [
         "Timelock information:",
         "  - Not valid until ",
         "  - Expires at ",
-        f"{datetime.date.fromtimestamp(0).strftime('%Y-%m-%d %H:%M:%S')}",
-        f"{datetime.date.fromtimestamp(100).strftime('%Y-%m-%d %H:%M:%S')}",
+        f"{datetime.datetime.fromtimestamp(0, tz=tzinfo).strftime('%Y-%m-%d %H:%M %Z')}",
+        f"{datetime.datetime.fromtimestamp(100, tz=tzinfo).strftime('%Y-%m-%d %H:%M %Z')}",
         "height 0",
         "height 100",
     ]

--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
@@ -855,7 +856,12 @@ def test_get_offers(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
                     ],
                     trade_id=bytes32([1 + i] * 32),
                     status=uint32(TradeStatus.PENDING_ACCEPT.value),
-                    valid_times=ConditionValidTimes(),
+                    valid_times=ConditionValidTimes(
+                        min_time=uint64(0),
+                        max_time=uint64(100),
+                        min_height=uint32(0),
+                        max_height=uint32(100),
+                    ),
                 )
                 records.append(trade_offer)
             return records
@@ -888,6 +894,25 @@ def test_get_offers(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     expected_calls: logType = {"get_all_offers": [(0, 10, None, True, False, True, True, True)]}
+    command_args = [
+        "wallet",
+        "get_offers",
+        FINGERPRINT_ARG,
+        "--summaries",
+    ]
+    # these are various things that should be in the output
+    assert_list = [
+        "Timelock information:",
+        "  - Not valid until ",
+        "  - Expires at ",
+        f"{datetime.date.fromtimestamp(0).strftime('%Y-%m-%d %H:%M:%S')}",
+        f"{datetime.date.fromtimestamp(100).strftime('%Y-%m-%d %H:%M:%S')}",
+        "height 0",
+        "height 100",
+    ]
+    run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
+    assert expected_calls["get_all_offers"] is not None
+    expected_calls["get_all_offers"].append((0, 10, None, False, True, False, False, False))
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
 
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import sys
 import time
-from datetime import date, datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -607,6 +607,11 @@ async def print_offer_summary(
         print(output)
 
 
+def format_timestamp_with_timezone(timestamp: int) -> str:
+    tzinfo = datetime.now(timezone.utc).astimezone().tzinfo
+    return datetime.fromtimestamp(timestamp, tz=tzinfo).strftime("%Y-%m-%d %H:%M %Z")
+
+
 async def print_trade_record(record: TradeRecord, wallet_client: WalletRpcClient, summaries: bool = False) -> None:
     print()
     print(f"Record with id: {record.trade_id}")
@@ -631,18 +636,11 @@ async def print_trade_record(record: TradeRecord, wallet_client: WalletRpcClient
         print(f"Included Fees: {fees / units['chia']} XCH, {fees} mojos")
         print("Timelock information:")
         if record.valid_times.min_time is not None:
-            print(
-                "  - Not valid until "
-                f"{date.fromtimestamp(record.valid_times.min_time).strftime('%Y-%m-%d %H:%M:%S')}"
-            )
+            print("  - Not valid until " f"{format_timestamp_with_timezone(record.valid_times.min_time)}")
         if record.valid_times.min_height is not None:
             print(f"  - Not valid until height {record.valid_times.min_height}")
         if record.valid_times.max_time is not None:
-            print(
-                "  - Expires at "
-                f"{date.fromtimestamp(record.valid_times.max_time).strftime('%Y-%m-%d %H:%M:%S')} "
-                "(+/- 10 min)"
-            )
+            print("  - Expires at " f"{format_timestamp_with_timezone(record.valid_times.max_time)} " "(+/- 10 min)")
         if record.valid_times.max_height is not None:
             print(f"  - Expires at height {record.valid_times.max_height} (wait ~10 blocks after to be reorg safe)")
     print("---------------")

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import sys
 import time
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -629,6 +629,22 @@ async def print_trade_record(record: TradeRecord, wallet_client: WalletRpcClient
         print("Pending Outbound Balances:")
         await print_offer_summary(cat_name_resolver, outbound_balances, has_fee=(fees > 0))
         print(f"Included Fees: {fees / units['chia']} XCH, {fees} mojos")
+        print("Timelock information:")
+        if record.valid_times.min_time is not None:
+            print(
+                "  - Not valid until "
+                f"{date.fromtimestamp(record.valid_times.min_time).strftime('%Y-%m-%d %H:%M:%S')}"
+            )
+        if record.valid_times.min_height is not None:
+            print(f"  - Not valid until height {record.valid_times.min_height}")
+        if record.valid_times.max_time is not None:
+            print(
+                "  - Expires at "
+                f"{date.fromtimestamp(record.valid_times.max_time).strftime('%Y-%m-%d %H:%M:%S')} "
+                "(+/- 10 min)"
+            )
+        if record.valid_times.max_height is not None:
+            print(f"  - Expires at height {record.valid_times.max_height} (wait ~10 blocks after to be reorg safe)")
     print("---------------")
 
 


### PR DESCRIPTION
We didn't have a way to display this information previously which basically meant users had to use the GUI in order to manager expiring offers effectively.

Example:
```
Record with id: 0101010101010101010101010101010101010101010101010101010101010101
---------------
Created at: 1970-05-23 14:21:18
Confirmed at: Not confirmed
Accepted at: N/A
Status: PENDING_ACCEPT
Summary:
  OFFERED:
  REQUESTED:
Pending Outbound Balances:
Included Fees: 0 XCH, 0 mojos
Timelock information:
  - Not valid until 1969-12-31 17:00 Pacific Daylight Time
  - Not valid until height 0
  - Expires at 1969-12-31 17:01 Pacific Daylight Time (+/- 10 min)
  - Expires at height 100 (wait ~10 blocks after to be reorg safe)
---------------
```