### PR TITLE
[CHIA-786] simplify hard-fork consensus rules

### DIFF
--- a/chia/_tests/core/full_node/test_conditions.py
+++ b/chia/_tests/core/full_node/test_conditions.py
@@ -144,10 +144,6 @@ class TestConditions:
         conditions = Program.to(assemble(f"(({opcode} 1337))"))
         additions, removals, new_block = await check_conditions(bt, conditions)
 
-        if consensus_mode < ConsensusMode.HARD_FORK_2_0:
-            # before the hard fork, all unknown conditions have 0 cost
-            expected_cost = 0
-
         # once the hard fork activates, blocks no longer pay the cost of the ROM
         # generator (which includes hashing all puzzles).
         if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
@@ -172,8 +168,6 @@ class TestConditions:
         additions, removals, new_block = await check_conditions(bt, conditions)
 
         if consensus_mode < ConsensusMode.HARD_FORK_2_0:
-            # the SOFTFORK condition is not recognized before the hard fork
-            expected_cost = 0
             block_base_cost = 737056
         else:
             # once the hard fork activates, blocks no longer pay the cost of the ROM
@@ -533,16 +527,7 @@ class TestConditions:
         assert c.AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA == additional_data[ConditionOpcode.AGG_SIG_PARENT_PUZZLE]
 
         blocks = await initial_blocks(bt)
-        if consensus_mode < ConsensusMode.HARD_FORK_2_0 and opcode in [
-            ConditionOpcode.AGG_SIG_PARENT,
-            ConditionOpcode.AGG_SIG_PUZZLE,
-            ConditionOpcode.AGG_SIG_AMOUNT,
-            ConditionOpcode.AGG_SIG_PUZZLE_AMOUNT,
-            ConditionOpcode.AGG_SIG_PARENT_AMOUNT,
-            ConditionOpcode.AGG_SIG_PARENT_PUZZLE,
-        ]:
-            expected_error = Err.BAD_AGGREGATE_SIGNATURE
-        elif opcode == ConditionOpcode.AGG_SIG_UNSAFE:
+        if opcode == ConditionOpcode.AGG_SIG_UNSAFE:
             expected_error = Err.INVALID_CONDITION
         else:
             expected_error = None
@@ -551,6 +536,7 @@ class TestConditions:
         pubkey = sk.get_g1()
         coin = blocks[-2].get_included_reward_coins()[0]
         for msg in [
+            c.AGG_SIG_ME_ADDITIONAL_DATA,
             c.AGG_SIG_PARENT_ADDITIONAL_DATA,
             c.AGG_SIG_PUZZLE_ADDITIONAL_DATA,
             c.AGG_SIG_AMOUNT_ADDITIONAL_DATA,


### PR DESCRIPTION
### Purpose:

Now that the hard fork has activated, some of the new rules can be applied unconditionally, even on older blocks.
Doing so simplifies the code and tests.

Specifically, these flags (affecting the behavior of `chia_rs`'s `run_block_generator()`) are moved to be set unconditionally, where they were previously only set for block heights >= `HARD_FORK_HEIGHT`.

### `ENABLE_SOFTFORK_CONDITION`
Enable 3 features:
    * the `SOFTFORK` condition code, which mimics the `softfork` operator. You specify its cost as the first argument. This allows soft-forking in new condition codes.
    * Unknown condition codes with cost. Certain condition codes are reserved to have a pre-defined cost, but are no-ops. This enables soft-forking in meaning to thes condition codes.
    * Enables the new `AGG_SIG_*` conditions (e.g. `AGG_SIG_PUZZLE`, `AGG_SIG_AMOUNT`, etc.)

### `ENABLE_BLS_OPS_OUTSIDE_GUARD`
Enables the BLS operators directly in chialisp programs. Previously they were only enabled under the softfork guard

### `ENABLE_FIXED_DIV`
Allows operator `/` to have negative operands.

### `AGG_SIG_ARGS`
Harmonizes the argument parsing of the `AGG_SIG_ME` and `AGG_SIG_UNSAFE` conditions. Previously they required exactly 2 parameters and the terminator did not have to be `NIL`. With this flag, they behave like all other conditions, additional parameters are ignored in consensus mode and disallowed in mempool mode.

### `ALLOW_BACKREFS`
Allows the block generator blob to be serialized using back-refs.

The main change of this PR is in `chia/full_node/mempool_check_conditions.py`. The other changes are to update tests that previously ensured these feature would not activate until the hard-fork height.

Setting these flags unconditionally is safe based on the assumption that no block prior to the hard fork activation issued any of these conditions or had programs include any of these operators. It's theoretically possible for a block to issue conditions or execute operators unknown at the time, and consensus rules effectively ignore them.

The validity of this PR hinges on all blocks prior to the hard fork activation remain valid.

### Current Behavior:

The consensus rules are slightly different for blocks whose height is < `HARD_FORK_HEIGHT`.

### New Behavior:

The consensus rules are uniform across all blocks (except for other soft-forks still in flight).

### Testing Notes:

https://grafana.fmt.chiatechlab.com/d/oBgwkDI7z/blockchain-sync-tests?orgId=1&var-ref=hard-fork-has-activated&var-repo=All&from=now-7d&to=now&var-network=mainnet&var-network=testnet11&var-network=testneta&refresh=1h