### PR TITLE
Swap to ThreadPoolExecutor and use chia_rs version of validate_clvm_and_signature()

### DIFF
--- a/benchmarks/mempool-long-lived.py
+++ b/benchmarks/mempool-long-lived.py
@@ -114,7 +114,7 @@ async def run_mempool_benchmark() -> None:
                 coin.name(): CoinRecord(coin, uint32(height // 2), uint32(0), False, uint64(timestamp // 2))
             }
             spend_bundle_id = sb.name()
-            sbc = await mempool.pre_validate_spendbundle(sb, None, spend_bundle_id)
+            sbc = await mempool.pre_validate_spendbundle(sb, spend_bundle_id)
             assert sbc is not None
             await mempool.add_spend_bundle(sb, sbc, spend_bundle_id, uint32(height))
 

--- a/benchmarks/mempool.py
+++ b/benchmarks/mempool.py
@@ -173,7 +173,7 @@ async def run_mempool_benchmark() -> None:
         async def add_spend_bundles(spend_bundles: List[SpendBundle]) -> None:
             for tx in spend_bundles:
                 spend_bundle_id = tx.name()
-                npc = await mempool.pre_validate_spendbundle(tx, None, spend_bundle_id)
+                npc = await mempool.pre_validate_spendbundle(tx, spend_bundle_id)
                 assert npc is not None
                 info = await mempool.add_spend_bundle(tx, npc, spend_bundle_id, height)
                 assert info.status == MempoolInclusionStatus.SUCCESS

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -935,8 +935,8 @@ class TestFullNodeProtocol:
         # these numbers reflect the capacity of the mempool. In these
         # tests MEMPOOL_BLOCK_BUFFER is 1. The other factors are COST_PER_BYTE
         # and MAX_BLOCK_COST_CLVM
-        assert included_tx == 23
-        assert not_included_tx == 10
+        assert included_tx == 27
+        assert not_included_tx == 6
         assert seen_bigger_transaction_has_high_fee
 
         # Mempool is full

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -581,7 +581,7 @@ async def test_same_sb_twice_with_eligible_coin() -> None:
     sb = SpendBundle.aggregate([sb1, sb2])
     sb_name = sb.name()
     result = await add_spendbundle(mempool_manager, sb, sb_name)
-    expected_cost = uint64(10268283)
+    expected_cost = uint64(6600088)
     assert result == (expected_cost, MempoolInclusionStatus.SUCCESS, None)
     assert mempool_manager.get_spendbundle(sb_name) == sb
     result = await add_spendbundle(mempool_manager, sb, sb_name)
@@ -614,7 +614,7 @@ async def test_sb_twice_with_eligible_coin_and_different_spends_order() -> None:
     assert mempool_manager.get_spendbundle(sb_name) is None
     assert mempool_manager.get_spendbundle(reordered_sb_name) is None
     result = await add_spendbundle(mempool_manager, sb, sb_name)
-    expected_cost = uint64(13091510)
+    expected_cost = uint64(7800132)
     assert result == (expected_cost, MempoolInclusionStatus.SUCCESS, None)
     assert mempool_manager.get_spendbundle(sb_name) == sb
     assert mempool_manager.get_spendbundle(reordered_sb_name) is None

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -1053,7 +1053,7 @@ async def test_create_bundle_from_mempool_on_max_cost(num_skipped_items: int, ca
         g1 = sk.get_g1()
         sig = AugSchemeMPL.sign(sk, IDENTITY_PUZZLE_HASH, g1)
         aggsig = G2Element()
-        for _ in range(169):
+        for _ in range(318):
             conditions.append([ConditionOpcode.AGG_SIG_UNSAFE, g1, IDENTITY_PUZZLE_HASH])
             aggsig += sig
         conditions.append([ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, coin.amount - 10_000_000])

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -387,7 +387,7 @@ def spend_bundle_from_conditions(
 async def add_spendbundle(
     mempool_manager: MempoolManager, sb: SpendBundle, sb_name: bytes32
 ) -> Tuple[Optional[uint64], MempoolInclusionStatus, Optional[Err]]:
-    sbc = await mempool_manager.pre_validate_spendbundle(sb, None, sb_name)
+    sbc = await mempool_manager.pre_validate_spendbundle(sb, sb_name)
     ret = await mempool_manager.add_spend_bundle(sb, sbc, sb_name, TEST_HEIGHT)
     invariant_check_mempool(mempool_manager.mempool)
     return ret.cost, ret.status, ret.error
@@ -461,7 +461,7 @@ async def test_empty_spend_bundle() -> None:
     mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_records)
     sb = SpendBundle([], G2Element())
     with pytest.raises(ValidationError, match="INVALID_SPEND_BUNDLE"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -470,7 +470,7 @@ async def test_negative_addition_amount() -> None:
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, -1]]
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="COIN_AMOUNT_NEGATIVE"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -481,7 +481,7 @@ async def test_valid_addition_amount() -> None:
     coin = Coin(IDENTITY_PUZZLE_HASH, IDENTITY_PUZZLE_HASH, max_amount)
     sb = spend_bundle_from_conditions(conditions, coin)
     # ensure this does not throw
-    _ = await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+    _ = await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -491,7 +491,7 @@ async def test_too_big_addition_amount() -> None:
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, max_amount + 1]]
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="COIN_AMOUNT_EXCEEDS_MAXIMUM"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -503,7 +503,7 @@ async def test_duplicate_output() -> None:
     ]
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="DUPLICATE_OUTPUT"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -514,7 +514,7 @@ async def test_block_cost_exceeds_max() -> None:
         conditions.append([ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, i])
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="BLOCK_COST_EXCEEDS_MAX"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -524,7 +524,7 @@ async def test_double_spend_prevalidation() -> None:
     sb = spend_bundle_from_conditions(conditions)
     sb_twice: SpendBundle = SpendBundle.aggregate([sb, sb])
     with pytest.raises(ValidationError, match="DOUBLE_SPEND"):
-        await mempool_manager.pre_validate_spendbundle(sb_twice, None, sb_twice.name())
+        await mempool_manager.pre_validate_spendbundle(sb_twice, sb_twice.name())
 
 
 @pytest.mark.anyio
@@ -532,11 +532,11 @@ async def test_minting_coin() -> None:
     mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_records)
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, TEST_COIN_AMOUNT]]
     sb = spend_bundle_from_conditions(conditions)
-    _ = await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+    _ = await mempool_manager.pre_validate_spendbundle(sb, sb.name())
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, TEST_COIN_AMOUNT + 1]]
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="MINTING_COIN"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -544,11 +544,11 @@ async def test_reserve_fee_condition() -> None:
     mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_records)
     conditions = [[ConditionOpcode.RESERVE_FEE, TEST_COIN_AMOUNT]]
     sb = spend_bundle_from_conditions(conditions)
-    _ = await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+    _ = await mempool_manager.pre_validate_spendbundle(sb, sb.name())
     conditions = [[ConditionOpcode.RESERVE_FEE, TEST_COIN_AMOUNT + 1]]
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="RESERVE_FEE_CONDITION_FAILED"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -581,7 +581,7 @@ async def test_same_sb_twice_with_eligible_coin() -> None:
     sb = SpendBundle.aggregate([sb1, sb2])
     sb_name = sb.name()
     result = await add_spendbundle(mempool_manager, sb, sb_name)
-    expected_cost = uint64(6600088)
+    expected_cost = uint64(6_600_088)
     assert result == (expected_cost, MempoolInclusionStatus.SUCCESS, None)
     assert mempool_manager.get_spendbundle(sb_name) == sb
     result = await add_spendbundle(mempool_manager, sb, sb_name)

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -614,7 +614,7 @@ async def test_sb_twice_with_eligible_coin_and_different_spends_order() -> None:
     assert mempool_manager.get_spendbundle(sb_name) is None
     assert mempool_manager.get_spendbundle(reordered_sb_name) is None
     result = await add_spendbundle(mempool_manager, sb, sb_name)
-    expected_cost = uint64(7800132)
+    expected_cost = uint64(7_800_132)
     assert result == (expected_cost, MempoolInclusionStatus.SUCCESS, None)
     assert mempool_manager.get_spendbundle(sb_name) == sb
     assert mempool_manager.get_spendbundle(reordered_sb_name) is None

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -510,7 +510,7 @@ async def test_duplicate_output() -> None:
 async def test_block_cost_exceeds_max() -> None:
     mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_records)
     conditions = []
-    for i in range(2400):
+    for i in range(3800):
         conditions.append([ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, i])
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="BLOCK_COST_EXCEEDS_MAX"):

--- a/chia/_tests/core/mempool/test_singleton_fast_forward.py
+++ b/chia/_tests/core/mempool/test_singleton_fast_forward.py
@@ -461,11 +461,9 @@ async def test_singleton_fast_forward_different_block(is_eligible_for_ff: bool) 
             # version which is the grandchild in this scenario
             assert status == MempoolInclusionStatus.SUCCESS
             assert error is None
-            old_lineage_info = unspent_lineage_info
             unspent_lineage_info = await sim_client.service.coin_store.get_unspent_lineage_info_for_puzzle_hash(
                 singleton_puzzle_hash
             )
-            assert old_lineage_info != unspent_lineage_info
             singleton_grandchild, [remaining_coin] = await get_singleton_and_remaining_coins(sim)
             assert unspent_lineage_info == UnspentLineageInfo(
                 coin_id=singleton_grandchild.name(),

--- a/chia/_tests/core/mempool/test_singleton_fast_forward.py
+++ b/chia/_tests/core/mempool/test_singleton_fast_forward.py
@@ -461,9 +461,11 @@ async def test_singleton_fast_forward_different_block(is_eligible_for_ff: bool) 
             # version which is the grandchild in this scenario
             assert status == MempoolInclusionStatus.SUCCESS
             assert error is None
+            old_lineage_info = unspent_lineage_info
             unspent_lineage_info = await sim_client.service.coin_store.get_unspent_lineage_info_for_puzzle_hash(
                 singleton_puzzle_hash
             )
+            assert old_lineage_info != unspent_lineage_info
             singleton_grandchild, [remaining_coin] = await get_singleton_and_remaining_coins(sim)
             assert unspent_lineage_info == UnspentLineageInfo(
                 coin_id=singleton_grandchild.name(),

--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -268,7 +268,6 @@ class SpendSim:
                     get_unspent_lineage_info_for_puzzle_hash=self.coin_store.get_unspent_lineage_info_for_puzzle_hash,
                     item_inclusion_filter=item_inclusion_filter,
                 )
-
                 if result is not None:
                     bundle, additions = result
                     generator_bundle = bundle

--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -336,7 +336,7 @@ class SimClient:
     async def push_tx(self, spend_bundle: SpendBundle) -> Tuple[MempoolInclusionStatus, Optional[Err]]:
         try:
             spend_bundle_id = spend_bundle.name()
-            sbc = await self.service.mempool_manager.pre_validate_spendbundle(spend_bundle, None, spend_bundle_id)
+            sbc = await self.service.mempool_manager.pre_validate_spendbundle(spend_bundle, spend_bundle_id)
         except ValidationError as e:
             return MempoolInclusionStatus.FAILED, e.code
         assert self.service.mempool_manager.peak is not None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2356,7 +2356,7 @@ class FullNode:
         else:
             try:
                 cost_result = await self.mempool_manager.pre_validate_spendbundle(
-                    transaction, tx_bytes, spend_name, self._bls_cache
+                    transaction, spend_name, self._bls_cache
                 )
             except ValidationError as e:
                 self.mempool_manager.remove_seen(spend_name)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -279,7 +279,6 @@ class FullNode:
             self._mempool_manager = MempoolManager(
                 get_coin_records=self.coin_store.get_coin_records,
                 consensus_constants=self.constants,
-                multiprocessing_context=self.multiprocessing_context,
                 single_threaded=single_threaded,
             )
 

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -521,6 +521,7 @@ class Mempool:
                         unique_additions.extend(spend_data.additions)
                     cost_saving = 0
                 else:
+                    # item gets modified in the following call
                     await eligible_coin_spends.process_fast_forward_spends(
                         mempool_item=item,
                         get_unspent_lineage_info_for_puzzle_hash=get_unspent_lineage_info_for_puzzle_hash,

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -521,7 +521,7 @@ class Mempool:
                         unique_additions.extend(spend_data.additions)
                     cost_saving = 0
                 else:
-                    # item gets modified in the following call
+                    # Update this item with fast forwarded spends, if it has any.
                     await eligible_coin_spends.process_fast_forward_spends(
                         mempool_item=item,
                         get_unspent_lineage_info_for_puzzle_hash=get_unspent_lineage_info_for_puzzle_hash,

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -286,8 +286,10 @@ class MempoolManager:
                 self.peak.height,
                 bls_cache,
             )
-        except Exception as e:
-            raise ValidationError(e)
+        except Exception as e:  # take returned TypeError and turn into ValidationError class by 
+            error = Err(e.args[0])
+            # breakpoint()
+            raise ValidationError(error)
         finally:
             self._worker_queue_size -= 1
 

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from concurrent.futures import Executor
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Executor, ThreadPoolExecutor
 from dataclasses import dataclass
 from multiprocessing.context import BaseContext
 from typing import Awaitable, Callable, Collection, Dict, List, Optional, Set, Tuple, TypeVar

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -176,7 +176,6 @@ class MempoolManager:
         else:
             self.pool = ThreadPoolExecutor(
                 max_workers=2,
-                mp_context=multiprocessing_context,
                 initializer=setproctitle,
                 initargs=(f"{getproctitle()}_mempool_worker",),
             )
@@ -278,13 +277,14 @@ class MempoolManager:
 
         self._worker_queue_size += 1
         try:
-            _spend, sbc, new_cache_entries, duration = await asyncio.get_running_loop().run_in_executor(
+            sbc, new_cache_entries, duration = await asyncio.get_running_loop().run_in_executor(
                 self.pool,
                 validate_clvm_and_signature,
-                new_spend_bytes,
+                new_spend,
                 self.max_tx_clvm_cost,
                 self.constants,
                 self.peak.height,
+                bls_cache,
             )
         except Exception as e:
             raise ValidationError(e)

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -287,7 +287,7 @@ class MempoolManager:
                 error = Err(e.args[0])
                 raise ValidationError(error)
             else:
-                raise ValidationError
+                raise ValidationError(Err.UNKNOWN)
         finally:
             self._worker_queue_size -= 1
 

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -302,7 +302,9 @@ class MempoolManager:
         if ret.error is not None:
             raise ValidationError(Err(ret.error), "pre_validate_spendbundle failed")
         assert ret.conds is not None
-        return ret.conds
+        # TODO: this cost padding is temporary, until we update the mempool's
+        # block creation logic to take the block overhead into account
+        return ret.conds.replace(cost=ret.conds.cost + 10000000)
 
     async def add_spend_bundle(
         self,

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -5,7 +5,6 @@ import logging
 import time
 from concurrent.futures import Executor, ThreadPoolExecutor
 from dataclasses import dataclass
-from multiprocessing.context import BaseContext
 from typing import Awaitable, Callable, Collection, Dict, List, Optional, Set, Tuple, TypeVar
 
 from chia_rs import ELIGIBLE_FOR_DEDUP, ELIGIBLE_FOR_FF, BLSCache, supports_fast_forward, validate_clvm_and_signature

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -283,8 +283,11 @@ class MempoolManager:
                 self.peak.height,
             )
         except Exception as e:  # take returned TypeError and turn into ValidationError class by
-            error = Err(e.args[0])
-            raise ValidationError(error)
+            if len(e.args) > 0:
+                error = Err(e.args[0])
+                raise ValidationError(error)
+            else:
+                raise ValidationError
         finally:
             self._worker_queue_size -= 1
 

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -259,7 +259,6 @@ class MempoolManager:
     async def pre_validate_spendbundle(
         self,
         new_spend: SpendBundle,
-        new_spend_bytes: Optional[bytes],
         spend_name: bytes32,
         bls_cache: Optional[BLSCache] = None,
     ) -> SpendBundleConditions:
@@ -267,8 +266,6 @@ class MempoolManager:
         Errors are included within the cached_result.
         This runs in another process so we don't block the main thread
         """
-        if new_spend_bytes is None:
-            new_spend_bytes = bytes(new_spend)
 
         if new_spend.coin_spends == []:
             raise ValidationError(Err.INVALID_SPEND_BUNDLE, "Empty SpendBundle")

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -284,7 +284,6 @@ class MempoolManager:
                 self.max_tx_clvm_cost,
                 self.constants,
                 self.peak.height,
-                bls_cache,
             )
         except Exception as e:  # take returned TypeError and turn into ValidationError class by
             error = Err(e.args[0])
@@ -293,7 +292,7 @@ class MempoolManager:
             self._worker_queue_size -= 1
 
         if bls_cache is not None:
-            bls_cache.update(new_cache_entries)
+            bls_cache.update([(e[0], bytes(e[1])) for e in new_cache_entries])
 
         ret = NPCResult(None, sbc)
 

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -286,9 +286,8 @@ class MempoolManager:
                 self.peak.height,
                 bls_cache,
             )
-        except Exception as e:  # take returned TypeError and turn into ValidationError class by 
+        except Exception as e:  # take returned TypeError and turn into ValidationError class by
             error = Err(e.args[0])
-            # breakpoint()
             raise ValidationError(error)
         finally:
             self._worker_queue_size -= 1

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -142,7 +142,6 @@ class MempoolManager:
         self,
         get_coin_records: Callable[[Collection[bytes32]], Awaitable[List[CoinRecord]]],
         consensus_constants: ConsensusConstants,
-        multiprocessing_context: Optional[BaseContext] = None,
         *,
         single_threaded: bool = False,
         max_tx_clvm_cost: Optional[uint64] = None,

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -282,7 +282,7 @@ class MempoolManager:
                 self.constants,
                 self.peak.height,
             )
-        except Exception as e:  # take returned TypeError and turn into ValidationError class by
+        except Exception as e:  # take returned TypeError and turn raise it as a ValidationError
             if len(e.args) > 0:
                 error = Err(e.args[0])
                 raise ValidationError(error)

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -868,7 +868,7 @@ class FullNodeRpcApi:
             spend_bundle: SpendBundle = SpendBundle.from_json_dict(request["spend_bundle"])
             spend_name = spend_bundle.name()
             conds: SpendBundleConditions = await self.service.mempool_manager.pre_validate_spendbundle(
-                spend_bundle, None, spend_name
+                spend_bundle, spend_name
             )
             cost = conds.cost
         elif "cost" in request:

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -331,7 +331,6 @@ class EligibleCoinSpends:
             coin_spends=new_coin_spends, aggregated_signature=mempool_item.spend_bundle.aggregated_signature
         )
         # We need to run the new spend bundle to make sure it remains valid
-        # generator = simple_solution_generator(new_sb)
         assert mempool_item.conds is not None
         try:
             new_sbc_result = get_conditions_from_spendbundle(

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -7,7 +7,6 @@ from chia_rs import fast_forward_singleton, get_conditions_from_spendbundle
 
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.constants import ConsensusConstants
-from chia.consensus.cost_calculator import NPCResult
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -333,18 +332,17 @@ class EligibleCoinSpends:
         )
         # We need to run the new spend bundle to make sure it remains valid
         # generator = simple_solution_generator(new_sb)
-        assert mempool_item.npc_result.conds is not None
+        assert mempool_item.conds is not None
         try:
             new_sbc_result = get_conditions_from_spendbundle(
                 new_sb,
-                mempool_item.npc_result.conds.cost,
+                mempool_item.conds.cost,
                 constants,
                 height,
             )
         except TypeError as e:
             error = Err(e.args[0])
             raise ValueError(f"Mempool item became invalid after singleton fast forward with error {error}.")
-        new_npc_result = NPCResult(None, new_sbc_result)
         # Update bundle_coin_spends using the collected data
         for coin_id in replaced_coin_ids:
             mempool_item.bundle_coin_spends.pop(coin_id, None)
@@ -356,4 +354,4 @@ class EligibleCoinSpends:
         # change. Still, it's good form to update the spend bundle with the
         # new coin spends
         mempool_item.spend_bundle = new_sb
-        mempool_item.conds = new_npc_result.conds
+        mempool_item.conds = new_sbc_result

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -14,8 +14,8 @@ from chia.types.coin_spend import CoinSpend
 from chia.types.internal_mempool_item import InternalMempoolItem
 from chia.types.mempool_item import BundleCoinSpend
 from chia.types.spend_bundle import SpendBundle
-from chia.util.ints import uint32, uint64
 from chia.util.errors import Err
+from chia.util.ints import uint32, uint64
 
 
 @dataclasses.dataclass(frozen=True)

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -341,7 +341,6 @@ class EligibleCoinSpends:
                 height,
             )
         except TypeError as e:
-            error = Err(e.args[0])
             if len(e.args) > 0:
                 error = Err(e.args[0])
                 raise ValueError(f"Mempool item became invalid after singleton fast forward with error {error}.")

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -342,7 +342,12 @@ class EligibleCoinSpends:
             )
         except TypeError as e:
             error = Err(e.args[0])
-            raise ValueError(f"Mempool item became invalid after singleton fast forward with error {error}.")
+            if len(e.args) > 0:
+                error = Err(e.args[0])
+                raise ValueError(f"Mempool item became invalid after singleton fast forward with error {error}.")
+            else:
+                raise ValueError(f"Mempool item became invalid after singleton fast forward with an unspecified error.")
+            
         # Update bundle_coin_spends using the collected data
         for coin_id in replaced_coin_ids:
             mempool_item.bundle_coin_spends.pop(coin_id, None)

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -8,8 +8,6 @@ from chia_rs import fast_forward_singleton, get_name_puzzle_conditions
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.cost_calculator import NPCResult
-from chia.full_node.bundle_tools import simple_solution_generator
-from chia.util.errors import Err, ValidationError
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -16,6 +16,7 @@ from chia.types.internal_mempool_item import InternalMempoolItem
 from chia.types.mempool_item import BundleCoinSpend
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64
+from chia.util.errors import Err, ValueError
 
 
 @dataclasses.dataclass(frozen=True)

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -346,8 +346,8 @@ class EligibleCoinSpends:
                 error = Err(e.args[0])
                 raise ValueError(f"Mempool item became invalid after singleton fast forward with error {error}.")
             else:
-                raise ValueError(f"Mempool item became invalid after singleton fast forward with an unspecified error.")
-            
+                raise ValueError("Mempool item became invalid after singleton fast forward with an unspecified error.")
+
         # Update bundle_coin_spends using the collected data
         for coin_id in replaced_coin_ids:
             mempool_item.bundle_coin_spends.pop(coin_id, None)

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -333,7 +333,7 @@ class EligibleCoinSpends:
         # We need to run the new spend bundle to make sure it remains valid
         assert mempool_item.conds is not None
         try:
-            new_sbc_result = get_conditions_from_spendbundle(
+            new_conditions = get_conditions_from_spendbundle(
                 new_sb,
                 mempool_item.conds.cost,
                 constants,
@@ -357,4 +357,4 @@ class EligibleCoinSpends:
         # change. Still, it's good form to update the spend bundle with the
         # new coin spends
         mempool_item.spend_bundle = new_sb
-        mempool_item.conds = new_sbc_result
+        mempool_item.conds = new_conditions

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -16,7 +16,7 @@ from chia.types.internal_mempool_item import InternalMempoolItem
 from chia.types.mempool_item import BundleCoinSpend
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64
-from chia.util.errors import Err, ValueError
+from chia.util.errors import Err
 
 
 @dataclasses.dataclass(frozen=True)

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 from typing import Awaitable, Callable, Dict, List, Optional, Tuple
 
-from chia_rs import fast_forward_singleton, get_name_puzzle_conditions
+from chia_rs import fast_forward_singleton, get_conditions_from_spendbundle
 
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.constants import ConsensusConstants
@@ -335,11 +335,10 @@ class EligibleCoinSpends:
         # generator = simple_solution_generator(new_sb)
         assert mempool_item.npc_result.conds is not None
         try:
-            new_sbc_result = get_name_puzzle_conditions(
+            new_sbc_result = get_conditions_from_spendbundle(
                 new_sb,
                 mempool_item.npc_result.conds.cost,
                 constants,
-                True,
                 height,
             )
         except TypeError as e:


### PR DESCRIPTION
### Purpose:
Migrate to using the chia_rs version of validate_clvm_and_signature and use ThreadPools for faster concurrent execution.
Until chia-rs is bumped to include the pyfunctions `get_name_puzzle_conditions` and `validate_clvm_and_signature` the tests for this will fail.


### Current Behavior:
We currently use the Python version of validate_clvm_and_signature which forces us to use ProcessPools


### New Behavior:
Use the chia_rs version of validate_clvm_and_signature and use ThreadPools for faster concurrent execution.

