### PR TITLE
[CHIA-683] Drop unknown tables when resetting wallet sync DB

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -2440,6 +2440,7 @@ async def test_set_wallet_resync_on_startup_disable(wallet_rpc_environment: Wall
 
 
 @pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
 async def test_set_wallet_resync_schema(wallet_rpc_environment: WalletRpcTestEnvironment):
     env: WalletRpcTestEnvironment = wallet_rpc_environment
     full_node_api: FullNodeSimulator = env.full_node.api
@@ -2454,17 +2455,11 @@ async def test_set_wallet_resync_schema(wallet_rpc_environment: WalletRpcTestEnv
     dbw: DBWrapper2 = wallet_node.wallet_state_manager.db_wrapper
     conn: aiosqlite.Connection
     async with dbw.writer() as conn:
-        await conn.execute("ALTER TABLE coin_record RENAME TO coin_record_temp")
-    assert not await wallet_node.reset_sync_db(db_path, fingerprint)
-    async with dbw.writer() as conn:
-        await conn.execute("ALTER TABLE coin_record_temp RENAME TO coin_record")
-    assert await wallet_node.reset_sync_db(db_path, fingerprint)
-    async with dbw.writer() as conn:
-        await conn.execute("CREATE TABLE testing_schema (a int, b bool)")
-    assert not await wallet_node.reset_sync_db(db_path, fingerprint)
-    async with dbw.writer() as conn:
-        await conn.execute("DROP TABLE testing_schema")
-    assert await wallet_node.reset_sync_db(db_path, fingerprint)
+        await conn.execute("CREATE TABLE blah(temp int)")
+    await wallet_node.reset_sync_db(db_path, fingerprint)
+    assert (
+        len(list(await conn.execute_fetchall("SELECT name FROM sqlite_master WHERE type='table' AND name='blah'"))) == 0
+    )
 
 
 @pytest.mark.anyio

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -321,7 +321,7 @@ class WalletNode:
         conn: aiosqlite.Connection
         # are not part of core wallet tables, but might appear later
         ignore_tables = {"lineage_proofs_", "sqlite_", "MIGRATED_VALID_TIMES_TXS", "MIGRATED_VALID_TIMES_TRADES"}
-        required_tables = [
+        known_tables = [
             "coin_record",
             "transaction_record",
             "derivation_paths",
@@ -354,22 +354,21 @@ class WalletNode:
             self.log.info("Resetting wallet sync data...")
             rows = list(await conn.execute_fetchall("SELECT name FROM sqlite_master WHERE type='table'"))
             names = {x[0] for x in rows}
-            names = names - set(required_tables)
+            names = names - set(known_tables)
+            tables_to_drop = []
             for name in names:
                 for ignore_name in ignore_tables:
                     if name.startswith(ignore_name):
                         break
                 else:
-                    self.log.error(
-                        f"Mismatch in expected schema to reset, found unexpected table: {name}. "
-                        "Please check if you've run all migration scripts."
-                    )
-                    return False
+                    tables_to_drop.append(name)
 
             await conn.execute("BEGIN")
             commit = True
             tables = [row[0] for row in rows]
             try:
+                for table in tables_to_drop:
+                    await conn.execute(f"DROP TABLE {table}")
                 if "coin_record" in tables:
                     await conn.execute("DELETE FROM coin_record")
                 if "interested_coins" in tables:


### PR DESCRIPTION
In the wallet node, there is a function called `reset_sync_db` the purpose of which is to delete relevant information from specific wallet tables that gives you “sync state” so that you can try again if the wallet gets into a bad state.

There’s a problem with this function, which is that it specifies a list of all existing tables and throws an error if any exist that are not mentioned in that list.  When you add a table, you have to add it to that list in order for the function to work but if you _downgrade_ then that addition is no longer in the code, but it the table remains in the DB and the function throws an error about an unexpected table.

The way I see it, there’s a few potential solutions, some more robust than others:

1) *Delete the check about unknown tables* - The purpose of this is dubious at best.  I can’t personally think of a reason it exists, but it must have been place in there for a reason.  Maybe to force new tables to think about how to reset themselves? If so, the test checking that that list is complete should be enough.
2) *Automatically delete unknown tables* - If we have downgraded, we don’t necessarily have need of these tables so maybe we can just delete them instead of erroring
3) *Store instructions for how to reset each table in the DB somehow* - This is probably the most robust, although most complicated, solution.  This removes the reset logic from versions, it simply lives in the DB and the code to reset remains static even as the DB schema changes

This PR takes the second approach to avoid the complexity of the third approach and provide more consistent behavior than the first approach likely provides.