### PR TITLE
re-introduce sleep(0) calls when deriving keys

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -449,22 +449,27 @@ class WalletStateManager:
         hardened_keys: Dict[int, G1Element] = {}
         unhardened_keys: Dict[int, G1Element] = {}
 
+        counter = 0
         if self.private_key is not None:
             # Hardened
             intermediate_sk = master_sk_to_wallet_sk_intermediate(self.private_key)
             for index in range(start_index, last_index):
                 hardened_keys[index] = _derive_path(intermediate_sk, [index]).get_g1()
-                # We await sleep here to allow an asyncio context switch (since the other parts of this loop do
-                # not have await and therefore block). This can prevent networking layer from responding to ping.
-                await asyncio.sleep(0)
+                counter += 1
+                if (counter & 0x7F) == 0:
+                    # We await sleep here to allow an asyncio context switch (since the other parts of this loop do
+                    # not have await and therefore block). This can prevent networking layer from responding to ping.
+                    await asyncio.sleep(0)
 
         # Unhardened
         intermediate_pk_un = master_pk_to_wallet_pk_unhardened_intermediate(self.root_pubkey)
         for index in range(start_index, last_index):
             unhardened_keys[index] = _derive_pk_unhardened(intermediate_pk_un, [index])
-            # We await sleep here to allow an asyncio context switch (since the other parts of this loop do
-            # not have await and therefore block). This can prevent networking layer from responding to ping.
-            await asyncio.sleep(0)
+            counter += 1
+            if (counter & 0x7F) == 0:
+                # We await sleep here to allow an asyncio context switch (since the other parts of this loop do
+                # not have await and therefore block). This can prevent networking layer from responding to ping.
+                await asyncio.sleep(0)
 
         for wallet_id, start_index in start_index_by_wallet.items():
             target_wallet = self.wallets[wallet_id]
@@ -497,9 +502,11 @@ class WalletStateManager:
                 self.log.debug(
                     f"Puzzle at index {index} wallet ID {wallet_id} puzzle hash {puzzlehash_unhardened.hex()}"
                 )
-                # We await sleep here to allow an asyncio context switch (since the other parts of this loop do
-                # not have await and therefore block). This can prevent networking layer from responding to ping.
-                await asyncio.sleep(0)
+                counter += 1
+                if (counter & 0x7F) == 0:
+                    # We await sleep here to allow an asyncio context switch (since the other parts of this loop do
+                    # not have await and therefore block). This can prevent networking layer from responding to ping.
+                    await asyncio.sleep(0)
                 derivation_paths.append(
                     DerivationRecord(
                         uint32(index),

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -454,11 +454,17 @@ class WalletStateManager:
             intermediate_sk = master_sk_to_wallet_sk_intermediate(self.private_key)
             for index in range(start_index, last_index):
                 hardened_keys[index] = _derive_path(intermediate_sk, [index]).get_g1()
+                # We await sleep here to allow an asyncio context switch (since the other parts of this loop do
+                # not have await and therefore block). This can prevent networking layer from responding to ping.
+                await asyncio.sleep(0)
 
         # Unhardened
         intermediate_pk_un = master_pk_to_wallet_pk_unhardened_intermediate(self.root_pubkey)
         for index in range(start_index, last_index):
             unhardened_keys[index] = _derive_pk_unhardened(intermediate_pk_un, [index])
+            # We await sleep here to allow an asyncio context switch (since the other parts of this loop do
+            # not have await and therefore block). This can prevent networking layer from responding to ping.
+            await asyncio.sleep(0)
 
         for wallet_id, start_index in start_index_by_wallet.items():
             target_wallet = self.wallets[wallet_id]
@@ -491,6 +497,9 @@ class WalletStateManager:
                 self.log.debug(
                     f"Puzzle at index {index} wallet ID {wallet_id} puzzle hash {puzzlehash_unhardened.hex()}"
                 )
+                # We await sleep here to allow an asyncio context switch (since the other parts of this loop do
+                # not have await and therefore block). This can prevent networking layer from responding to ping.
+                await asyncio.sleep(0)
                 derivation_paths.append(
                     DerivationRecord(
                         uint32(index),


### PR DESCRIPTION
(and computing puzzle hashes) in wallet_state_manager

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

https://github.com/Chia-Network/chia-blockchain/pull/17991 reorganized a loop that derived keys and computed puzzle hashes. The original loop had an `await sleep(0)` which was removed. This is believed to cause sync issues on hardware that's slow enough to cause this task to block too long.

This PR reintroduces the `sleep(0)`, but since the two inner loops were hoisted out of the outer loop, there are now 3 places we may need to yield.

### Current Behavior:

Deriving keys and computing puzzle hashes are done in a task that's not interrupted, blocking other tasks, potentially causing them to time-out.

### New Behavior:

Deriving keys and computing puzzle hashes are done in a task that's allowed to be interrupted, so that other tasks also get a chance to run, avoiding time-outs.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
