### PR TITLE
Fixed an issue where `npx --no lerna clean -f` didn't work

### DIFF
--- a/build_scripts/build_linux_deb-1-gui.sh
+++ b/build_scripts/build_linux_deb-1-gui.sh
@@ -8,7 +8,7 @@ git submodule update --init chia-blockchain-gui
 cd ./chia-blockchain-gui || exit 1
 
 echo "npm build"
-npx --no lerna clean -y # With --no option, `npx` guarantees not to install package from remote registry
+npx lerna clean -y # Removes packages/*/node_modules
 npm ci
 # Audit fix does not currently work with Lerna. See https://github.com/lerna/lerna/issues/1663
 # npm audit fix

--- a/build_scripts/build_linux_rpm-1-gui.sh
+++ b/build_scripts/build_linux_rpm-1-gui.sh
@@ -7,7 +7,7 @@ git submodule update --init chia-blockchain-gui
 
 cd ./chia-blockchain-gui || exit 1
 echo "npm build"
-npx --no lerna clean -y # With --no option, `npx` guarantees not to install package from remote registry
+npx lerna clean -y # Removes packages/*/node_modules
 npm ci
 # Audit fix does not currently work with Lerna. See https://github.com/lerna/lerna/issues/1663
 # npm audit fix

--- a/build_scripts/build_macos-1-gui.sh
+++ b/build_scripts/build_macos-1-gui.sh
@@ -9,7 +9,7 @@ git submodule update --init chia-blockchain-gui
 
 cd ./chia-blockchain-gui || exit 1
 echo "npm build"
-npx --no lerna clean -y # With --no option, `npx` guarantees not to install package from remote registry
+npx lerna clean -y # Removes packages/*/node_modules
 npm ci
 # Audit fix does not currently work with Lerna. See https://github.com/lerna/lerna/issues/1663
 # npm audit fix

--- a/build_scripts/build_windows-1-gui.ps1
+++ b/build_scripts/build_windows-1-gui.ps1
@@ -14,8 +14,8 @@ Write-Output "Build GUI npm modules"
 Write-Output "   ---"
 $Env:NODE_OPTIONS = "--max-old-space-size=3000"
 
-Write-Output "lerna clean -y"
-npx --no lerna clean -y # With --no option, `npx` guarantees not to install package from remote registry
+Write-Output "npx lerna clean -y"
+npx lerna clean -y # Removes packages/*/node_modules
 Write-Output "npm ci"
 npm ci
 # Audit fix does not currently work with Lerna. See https://github.com/lerna/lerna/issues/1663


### PR DESCRIPTION
This fixes error in build-installer CI job.
After GUI cache is reset, `lerna` install is also removed.
`npx --no <command>` fails if no `comand` is found in local `node_modules`.

So `npx --no lerna clean -f` diddn't work since `lerna` was removed along with cache (including `node_modules`).
This PR removes `--no` flag from `npx`.

Without `--no` option, `npx` installs `lerna` in global cache but this global cache doesn't hurt. (even it allows version mismatch between globally installed `lerna` and `lerna` installed locally by `npm ci` since `lerna clean -f` only does remove `packages/*/node_modules`)