### PR TITLE
Fix backwards compatibility for `add_private_key`

### DIFF
--- a/chia/daemon/keychain_server.py
+++ b/chia/daemon/keychain_server.py
@@ -174,9 +174,8 @@ class KeychainServer:
     async def handle_command(self, command: str, data: Dict[str, Any]) -> Dict[str, Any]:
         try:
             if command == "add_private_key":
-                return await self.add_key(
-                    {"mnemonic_or_pk": data.get("mnemonic", None), "label": data.get("label", None), "private": True}
-                )
+                data["private"] = True
+                return await self.add_key(data)
             elif command == "add_key":
                 return await self.add_key(data)
             elif command == "check_keys":

--- a/chia/daemon/keychain_server.py
+++ b/chia/daemon/keychain_server.py
@@ -175,6 +175,7 @@ class KeychainServer:
         try:
             if command == "add_private_key":
                 data["private"] = True
+                data["mnemonic_or_pk"] = data.get("mnemonic_or_pk", data.get("mnemonic", None))
                 return await self.add_key(data)
             elif command == "add_key":
                 return await self.add_key(data)


### PR DESCRIPTION
Accidentally broke this endpoint in #17792 by specifying exactly what was part of `data` rather than just updating the relevant part of the user's request.