### PR TITLE
root hash, does `None` mean empty or unspecified?

### DIFF
--- a/chia/cmds/data_funcs.py
+++ b/chia/cmds/data_funcs.py
@@ -154,6 +154,7 @@ async def get_keys_cmd(
 async def get_keys_values_cmd(
     rpc_port: Optional[int],
     store_id: bytes32,
+    # TODO: a none root hash means unspecified here, not empty
     root_hash: Optional[bytes32],
     fingerprint: Optional[int],
     page: Optional[int],

--- a/chia/cmds/data_funcs.py
+++ b/chia/cmds/data_funcs.py
@@ -50,6 +50,7 @@ async def get_value_cmd(
     rpc_port: Optional[int],
     store_id: bytes32,
     key: str,
+    # NOTE: being outside the rpc, this retains the none-means-unspecified semantics
     root_hash: Optional[bytes32],
     fingerprint: Optional[int],
 ) -> None:
@@ -137,6 +138,7 @@ async def submit_all_pending_roots_cmd(
 async def get_keys_cmd(
     rpc_port: Optional[int],
     store_id: bytes32,
+    # NOTE: being outside the rpc, this retains the none-means-unspecified semantics
     root_hash: Optional[bytes32],
     fingerprint: Optional[int],
     page: Optional[int],
@@ -154,7 +156,7 @@ async def get_keys_cmd(
 async def get_keys_values_cmd(
     rpc_port: Optional[int],
     store_id: bytes32,
-    # TODO: a none root hash means unspecified here, not empty
+    # NOTE: being outside the rpc, this retains the none-means-unspecified semantics
     root_hash: Optional[bytes32],
     fingerprint: Optional[int],
     page: Optional[int],

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -51,8 +51,10 @@ from chia.data_layer.data_layer_util import (
     Subscription,
     SyncStatus,
     TerminalNode,
+    Unspecified,
     UnsubscribeData,
     leaf_hash,
+    unspecified,
 )
 from chia.data_layer.data_layer_wallet import DataLayerWallet, Mirror, SingletonRecord, verify_offer
 from chia.data_layer.data_store import DataStore
@@ -384,7 +386,7 @@ class DataLayer:
         self,
         store_id: bytes32,
         key: bytes,
-        root_hash: Optional[bytes32] = None,
+        root_hash: Union[bytes32, Unspecified] = unspecified,
     ) -> bytes32:
         await self._update_confirmation_status(store_id=store_id)
 
@@ -392,7 +394,9 @@ class DataLayer:
             node = await self.data_store.get_node_by_key(store_id=store_id, key=key, root_hash=root_hash)
             return node.hash
 
-    async def get_value(self, store_id: bytes32, key: bytes, root_hash: Optional[bytes32] = None) -> bytes:
+    async def get_value(
+        self, store_id: bytes32, key: bytes, root_hash: Union[bytes32, Unspecified] = unspecified
+    ) -> bytes:
         await self._update_confirmation_status(store_id=store_id)
 
         async with self.data_store.transaction():
@@ -403,8 +407,7 @@ class DataLayer:
     async def get_keys_values(
         self,
         store_id: bytes32,
-        # TODO: a none root hash means unspecified here, not empty
-        root_hash: Optional[bytes32],
+        root_hash: Union[bytes32, Unspecified],
     ) -> List[TerminalNode]:
         await self._update_confirmation_status(store_id=store_id)
 
@@ -416,8 +419,7 @@ class DataLayer:
     async def get_keys_values_paginated(
         self,
         store_id: bytes32,
-        # TODO: a none root hash means unspecified here, not empty
-        root_hash: Optional[bytes32],
+        root_hash: Union[bytes32, Unspecified],
         page: int,
         max_page_size: Optional[int] = None,
     ) -> KeysValuesPaginationData:
@@ -428,7 +430,7 @@ class DataLayer:
         res = await self.data_store.get_keys_values_paginated(store_id, page, max_page_size, root_hash)
         return res
 
-    async def get_keys(self, store_id: bytes32, root_hash: Optional[bytes32]) -> List[bytes]:
+    async def get_keys(self, store_id: bytes32, root_hash: Union[bytes32, Unspecified]) -> List[bytes]:
         await self._update_confirmation_status(store_id=store_id)
 
         res = await self.data_store.get_keys(store_id, root_hash)
@@ -437,8 +439,7 @@ class DataLayer:
     async def get_keys_paginated(
         self,
         store_id: bytes32,
-        # TODO: a none root hash means unspecified here, not empty
-        root_hash: Optional[bytes32],
+        root_hash: Union[bytes32, Unspecified],
         page: int,
         max_page_size: Optional[int] = None,
     ) -> KeysPaginationData:

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -400,7 +400,12 @@ class DataLayer:
             res = await self.data_store.get_node_by_key(store_id=store_id, key=key, root_hash=root_hash)
             return res.value
 
-    async def get_keys_values(self, store_id: bytes32, root_hash: Optional[bytes32]) -> List[TerminalNode]:
+    async def get_keys_values(
+        self,
+        store_id: bytes32,
+        # TODO: a none root hash means unspecified here, not empty
+        root_hash: Optional[bytes32],
+    ) -> List[TerminalNode]:
         await self._update_confirmation_status(store_id=store_id)
 
         res = await self.data_store.get_keys_values(store_id, root_hash)
@@ -411,6 +416,7 @@ class DataLayer:
     async def get_keys_values_paginated(
         self,
         store_id: bytes32,
+        # TODO: a none root hash means unspecified here, not empty
         root_hash: Optional[bytes32],
         page: int,
         max_page_size: Optional[int] = None,
@@ -431,6 +437,7 @@ class DataLayer:
     async def get_keys_paginated(
         self,
         store_id: bytes32,
+        # TODO: a none root hash means unspecified here, not empty
         root_hash: Optional[bytes32],
         page: int,
         max_page_size: Optional[int] = None,
@@ -820,7 +827,14 @@ class DataLayer:
         return await self.data_store.get_kv_diff(store_id, hash_1, hash_2)
 
     async def get_kv_diff_paginated(
-        self, store_id: bytes32, hash_1: bytes32, hash_2: bytes32, page: int, max_page_size: Optional[int] = None
+        self,
+        store_id: bytes32,
+        # TODO: a none root hash means unspecified here, not empty
+        #       though in this case we disallow none
+        hash_1: bytes32,
+        hash_2: bytes32,
+        page: int,
+        max_page_size: Optional[int] = None,
     ) -> KVDiffPaginationData:
         if max_page_size is None:
             max_page_size = 40 * 1024 * 1024

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -830,8 +830,7 @@ class DataLayer:
     async def get_kv_diff_paginated(
         self,
         store_id: bytes32,
-        # TODO: a none root hash means unspecified here, not empty
-        #       though in this case we disallow none
+        # NOTE: empty is expressed as zeros
         hash_1: bytes32,
         hash_2: bytes32,
         page: int,

--- a/chia/data_layer/data_layer_util.py
+++ b/chia/data_layer/data_layer_util.py
@@ -86,7 +86,13 @@ async def _debug_dump(db: DBWrapper2, description: str = "") -> None:
                 print(f"        {dict(row)}")
 
 
-async def _dot_dump(data_store: DataStore, store_id: bytes32, root_hash: bytes32) -> str:
+async def _dot_dump(
+    data_store: DataStore,
+    store_id: bytes32,
+    # TODO: a none root hash means unspecified here, not empty
+    #       though it happens to be disallowed here
+    root_hash: bytes32,
+) -> str:
     terminal_nodes = await data_store.get_keys_values(store_id=store_id, root_hash=root_hash)
     internal_nodes = await data_store.get_internal_nodes(store_id=store_id, root_hash=root_hash)
 

--- a/chia/data_layer/data_layer_util.py
+++ b/chia/data_layer/data_layer_util.py
@@ -89,8 +89,6 @@ async def _debug_dump(db: DBWrapper2, description: str = "") -> None:
 async def _dot_dump(
     data_store: DataStore,
     store_id: bytes32,
-    # TODO: a none root hash means unspecified here, not empty
-    #       though it happens to be disallowed here
     root_hash: bytes32,
 ) -> str:
     terminal_nodes = await data_store.get_keys_values(store_id=store_id, root_hash=root_hash)

--- a/chia/data_layer/data_layer_util.py
+++ b/chia/data_layer/data_layer_util.py
@@ -331,6 +331,16 @@ class InternalNode:
         raise Exception("provided hash not present")
 
 
+class Unspecified:
+    def __repr__(self) -> str:
+        return "TreeId.Unspecified"
+
+
+# TODO: this is kinda ugly especially since `is` won't type narrow in mypy anyways
+#       can we make mypy "singleton"-aware?
+unspecified: Unspecified = Unspecified()
+
+
 @dataclass(frozen=True)
 class Root:
     store_id: bytes32

--- a/chia/data_layer/data_layer_util.py
+++ b/chia/data_layer/data_layer_util.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass, field
-from enum import IntEnum
+from enum import Enum, IntEnum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 # TODO: remove or formalize this
@@ -331,14 +331,17 @@ class InternalNode:
         raise Exception("provided hash not present")
 
 
-class Unspecified:
+class Unspecified(Enum):
+    # not beautiful, improve when a better way is known
+    # https://github.com/python/typing/issues/236#issuecomment-229515556
+
+    instance = None
+
     def __repr__(self) -> str:
         return "Unspecified"
 
 
-# TODO: this is kinda ugly especially since `is` won't type narrow in mypy anyways
-#       can we make mypy "singleton"-aware?
-unspecified: Unspecified = Unspecified()
+unspecified = Unspecified.instance
 
 
 @dataclass(frozen=True)

--- a/chia/data_layer/data_layer_util.py
+++ b/chia/data_layer/data_layer_util.py
@@ -333,7 +333,7 @@ class InternalNode:
 
 class Unspecified:
     def __repr__(self) -> str:
-        return "TreeId.Unspecified"
+        return "Unspecified"
 
 
 # TODO: this is kinda ugly especially since `is` won't type narrow in mypy anyways

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -785,7 +785,12 @@ class DataStore:
             {"root_hash": root_hash, "node_type": NodeType.TERMINAL},
         )
 
-    async def get_keys_values(self, store_id: bytes32, root_hash: Optional[bytes32] = None) -> List[TerminalNode]:
+    async def get_keys_values(
+        self,
+        store_id: bytes32,
+        # TODO: a none root hash means unspecified here, not empty
+        root_hash: Optional[bytes32] = None,
+    ) -> List[TerminalNode]:
         async with self.db_wrapper.reader() as reader:
             if root_hash is None:
                 root = await self.get_tree_root(store_id=store_id)
@@ -814,7 +819,10 @@ class DataStore:
         return terminal_nodes
 
     async def get_keys_values_compressed(
-        self, store_id: bytes32, root_hash: Optional[bytes32] = None
+        self,
+        store_id: bytes32,
+        # TODO: a none root hash means unspecified here, not empty
+        root_hash: Optional[bytes32] = None,
     ) -> KeysValuesCompressed:
         async with self.db_wrapper.reader() as reader:
             if root_hash is None:
@@ -853,7 +861,12 @@ class DataStore:
         return result
 
     async def get_keys_paginated(
-        self, store_id: bytes32, page: int, max_page_size: int, root_hash: Optional[bytes32] = None
+        self,
+        store_id: bytes32,
+        page: int,
+        max_page_size: int,
+        # TODO: a none root hash means unspecified here, not empty
+        root_hash: Optional[bytes32] = None,
     ) -> KeysPaginationData:
         keys_values_compressed = await self.get_keys_values_compressed(store_id, root_hash)
         pagination_data = get_hashes_for_page(page, keys_values_compressed.key_hash_to_length, max_page_size)
@@ -873,7 +886,12 @@ class DataStore:
         )
 
     async def get_keys_values_paginated(
-        self, store_id: bytes32, page: int, max_page_size: int, root_hash: Optional[bytes32] = None
+        self,
+        store_id: bytes32,
+        page: int,
+        max_page_size: int,
+        # TODO: a none root hash means unspecified here, not empty
+        root_hash: Optional[bytes32] = None,
     ) -> KeysValuesPaginationData:
         keys_values_compressed = await self.get_keys_values_compressed(store_id, root_hash)
         pagination_data = get_hashes_for_page(page, keys_values_compressed.leaf_hash_to_length, max_page_size)
@@ -892,7 +910,13 @@ class DataStore:
         )
 
     async def get_kv_diff_paginated(
-        self, store_id: bytes32, page: int, max_page_size: int, hash1: bytes32, hash2: bytes32
+        self,
+        store_id: bytes32,
+        page: int,
+        max_page_size: int,
+        # TODO: a none root hash means unspecified here, not empty
+        hash1: bytes32,
+        hash2: bytes32,
     ) -> KVDiffPaginationData:
         old_pairs = await self.get_keys_values_compressed(store_id, hash1)
         if len(old_pairs.keys_values_hashed) == 0 and hash1 != bytes32([0] * 32):
@@ -1031,11 +1055,21 @@ class DataStore:
                 root=root,
             )
 
-    async def get_keys_values_dict(self, store_id: bytes32, root_hash: Optional[bytes32] = None) -> Dict[bytes, bytes]:
+    async def get_keys_values_dict(
+        self,
+        store_id: bytes32,
+        # TODO: a none root hash means unspecified here, not empty
+        root_hash: Optional[bytes32] = None,
+    ) -> Dict[bytes, bytes]:
         pairs = await self.get_keys_values(store_id=store_id, root_hash=root_hash)
         return {node.key: node.value for node in pairs}
 
-    async def get_keys(self, store_id: bytes32, root_hash: Optional[bytes32] = None) -> List[bytes]:
+    async def get_keys(
+        self,
+        store_id: bytes32,
+        # TODO: a none root hash means unspecified here, not empty
+        root_hash: Optional[bytes32] = None,
+    ) -> List[bytes]:
         async with self.db_wrapper.reader() as reader:
             if root_hash is None:
                 root = await self.get_tree_root(store_id=store_id)
@@ -1782,6 +1816,7 @@ class DataStore:
         self,
         key: bytes,
         store_id: bytes32,
+        # TODO: a none root hash means unspecified here, not empty
         root_hash: Optional[bytes32] = None,
     ) -> TerminalNode:
         if root_hash is None:
@@ -2193,6 +2228,8 @@ class DataStore:
     async def get_kv_diff(
         self,
         store_id: bytes32,
+        # TODO: a none root hash means unspecified here, not empty
+        #       though it happens to be disallowed here
         hash_1: bytes32,
         hash_2: bytes32,
     ) -> Set[DiffData]:

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -918,7 +918,7 @@ class DataStore:
         store_id: bytes32,
         page: int,
         max_page_size: int,
-        # TODO: a none root hash means unspecified here, not empty
+        # NOTE: empty is expressed as zeros
         hash1: bytes32,
         hash2: bytes32,
     ) -> KVDiffPaginationData:
@@ -2229,8 +2229,7 @@ class DataStore:
     async def get_kv_diff(
         self,
         store_id: bytes32,
-        # TODO: a none root hash means unspecified here, not empty
-        #       though it happens to be disallowed here
+        # NOTE: empty is expressed as zeros
         hash_1: bytes32,
         hash_2: bytes32,
     ) -> Set[DiffData]:

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -794,7 +794,7 @@ class DataStore:
     ) -> List[TerminalNode]:
         async with self.db_wrapper.reader() as reader:
             resolved_root_hash: Optional[bytes32]
-            if isinstance(root_hash, Unspecified):
+            if root_hash is unspecified:
                 root = await self.get_tree_root(store_id=store_id)
                 resolved_root_hash = root.node_hash
             else:
@@ -829,7 +829,7 @@ class DataStore:
     ) -> KeysValuesCompressed:
         async with self.db_wrapper.reader() as reader:
             resolved_root_hash: Optional[bytes32]
-            if isinstance(root_hash, Unspecified):
+            if root_hash is unspecified:
                 root = await self.get_tree_root(store_id=store_id)
                 resolved_root_hash = root.node_hash
             else:
@@ -1820,7 +1820,7 @@ class DataStore:
         store_id: bytes32,
         root_hash: Union[bytes32, Unspecified] = unspecified,
     ) -> TerminalNode:
-        if isinstance(root_hash, Unspecified):
+        if root_hash is unspecified:
             return await self.get_node_by_key_latest_generation(key, store_id)
 
         nodes = await self.get_keys_values(store_id=store_id, root_hash=root_hash)

--- a/chia/rpc/data_layer_rpc_api.py
+++ b/chia/rpc/data_layer_rpc_api.py
@@ -199,7 +199,7 @@ class DataLayerRpcApi:
             keys = keys_paginated.keys
 
         # TODO: here in fact we do support zeros as the empty root, or at least we check for it
-        if keys == [] and not isinstance(resolved_root_hash, Unspecified) and resolved_root_hash != bytes32([0] * 32):
+        if keys == [] and resolved_root_hash is not unspecified and resolved_root_hash != bytes32([0] * 32):
             raise Exception(f"Can't find keys for {resolved_root_hash}")
 
         response: EndpointResult = {"keys": [f"0x{key.hex()}" for key in keys]}
@@ -240,11 +240,7 @@ class DataLayerRpcApi:
         json_nodes = [recurse_jsonify(dataclasses.asdict(node)) for node in keys_values]
         # TODO: here in fact we do support zeros as the empty root, or at least we check for it
         # TODO: here and elsewhere, the isinstance may not be needed?
-        if (
-            not json_nodes
-            and not isinstance(resolved_root_hash, Unspecified)
-            and resolved_root_hash != bytes32([0] * 32)
-        ):
+        if not json_nodes and resolved_root_hash is not unspecified and resolved_root_hash != bytes32([0] * 32):
             raise Exception(f"Can't find keys and values for {resolved_root_hash}")
 
         response: EndpointResult = {"keys_values": json_nodes}

--- a/chia/rpc/data_layer_rpc_api.py
+++ b/chia/rpc/data_layer_rpc_api.py
@@ -239,7 +239,6 @@ class DataLayerRpcApi:
 
         json_nodes = [recurse_jsonify(dataclasses.asdict(node)) for node in keys_values]
         # TODO: here in fact we do support zeros as the empty root, or at least we check for it
-        # TODO: here and elsewhere, the isinstance may not be needed?
         if not json_nodes and resolved_root_hash is not unspecified and resolved_root_hash != bytes32([0] * 32):
             raise Exception(f"Can't find keys and values for {resolved_root_hash}")
 

--- a/chia/rpc/data_layer_rpc_api.py
+++ b/chia/rpc/data_layer_rpc_api.py
@@ -198,7 +198,7 @@ class DataLayerRpcApi:
             keys_paginated = await self.service.get_keys_paginated(store_id, resolved_root_hash, page, max_page_size)
             keys = keys_paginated.keys
 
-        # TODO: here in fact we do support zeros as the empty root, or at least we check for it
+        # NOTE: here we do support zeros as the empty root
         if keys == [] and resolved_root_hash is not unspecified and resolved_root_hash != bytes32([0] * 32):
             raise Exception(f"Can't find keys for {resolved_root_hash}")
 
@@ -238,7 +238,7 @@ class DataLayerRpcApi:
             keys_values = keys_values_paginated.keys_values
 
         json_nodes = [recurse_jsonify(dataclasses.asdict(node)) for node in keys_values]
-        # TODO: here in fact we do support zeros as the empty root, or at least we check for it
+        # NOTE: here we do support zeros as the empty root
         if not json_nodes and resolved_root_hash is not unspecified and resolved_root_hash != bytes32([0] * 32):
             raise Exception(f"Can't find keys and values for {resolved_root_hash}")
 

--- a/chia/rpc/data_layer_rpc_api.py
+++ b/chia/rpc/data_layer_rpc_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 from chia.data_layer.data_layer_errors import OfferIntegrityError
 from chia.data_layer.data_layer_util import (
@@ -22,8 +22,10 @@ from chia.data_layer.data_layer_util import (
     Subscription,
     TakeOfferRequest,
     TakeOfferResponse,
+    Unspecified,
     VerifyOfferResponse,
     VerifyProofResponse,
+    unspecified,
 )
 from chia.data_layer.data_layer_wallet import DataLayerWallet, Mirror, verify_offer
 from chia.rpc.data_layer_rpc_util import marshal
@@ -161,12 +163,16 @@ class DataLayerRpcApi:
     async def get_value(self, request: Dict[str, Any]) -> EndpointResult:
         store_id = bytes32.from_hexstr(request["id"])
         key = hexstr_to_bytes(request["key"])
-        root_hash = request.get("root_hash")
+        # NOTE: being outside the rpc, this retains the none-means-unspecified semantics
+        root_hash: Optional[str] = request.get("root_hash")
+        resolved_root_hash: Union[bytes32, Unspecified]
         if root_hash is not None:
-            root_hash = bytes32.from_hexstr(root_hash)
+            resolved_root_hash = bytes32.from_hexstr(root_hash)
+        else:
+            resolved_root_hash = unspecified
         if self.service is None:
             raise Exception("Data layer not created")
-        value = await self.service.get_value(store_id=store_id, key=key, root_hash=root_hash)
+        value = await self.service.get_value(store_id=store_id, key=key, root_hash=resolved_root_hash)
         hex = None
         if value is not None:
             hex = value.hex()
@@ -174,22 +180,27 @@ class DataLayerRpcApi:
 
     async def get_keys(self, request: Dict[str, Any]) -> EndpointResult:
         store_id = bytes32.from_hexstr(request["id"])
-        root_hash = request.get("root_hash")
+        # NOTE: being outside the rpc, this retains the none-means-unspecified semantics
+        root_hash: Optional[str] = request.get("root_hash")
         page = request.get("page", None)
         max_page_size = request.get("max_page_size", None)
+        resolved_root_hash: Union[bytes32, Unspecified]
         if root_hash is not None:
-            root_hash = bytes32.from_hexstr(root_hash)
+            resolved_root_hash = bytes32.from_hexstr(root_hash)
+        else:
+            resolved_root_hash = unspecified
         if self.service is None:
             raise Exception("Data layer not created")
 
         if page is None:
-            keys = await self.service.get_keys(store_id, root_hash)
+            keys = await self.service.get_keys(store_id, resolved_root_hash)
         else:
-            keys_paginated = await self.service.get_keys_paginated(store_id, root_hash, page, max_page_size)
+            keys_paginated = await self.service.get_keys_paginated(store_id, resolved_root_hash, page, max_page_size)
             keys = keys_paginated.keys
 
-        if keys == [] and root_hash is not None and root_hash != bytes32([0] * 32):
-            raise Exception(f"Can't find keys for {root_hash}")
+        # TODO: here in fact we do support zeros as the empty root, or at least we check for it
+        if keys == [] and not isinstance(resolved_root_hash, Unspecified) and resolved_root_hash != bytes32([0] * 32):
+            raise Exception(f"Can't find keys for {resolved_root_hash}")
 
         response: EndpointResult = {"keys": [f"0x{key.hex()}" for key in keys]}
 
@@ -206,25 +217,35 @@ class DataLayerRpcApi:
 
     async def get_keys_values(self, request: Dict[str, Any]) -> EndpointResult:
         store_id = bytes32(hexstr_to_bytes(request["id"]))
-        root_hash = request.get("root_hash")
+        # NOTE: being outside the rpc, this retains the none-means-unspecified semantics
+        root_hash: Optional[str] = request.get("root_hash")
         page = request.get("page", None)
         max_page_size = request.get("max_page_size", None)
+        resolved_root_hash: Union[bytes32, Unspecified]
         if root_hash is not None:
-            root_hash = bytes32.from_hexstr(root_hash)
+            resolved_root_hash = bytes32.from_hexstr(root_hash)
+        else:
+            resolved_root_hash = unspecified
         if self.service is None:
             raise Exception("Data layer not created")
 
         if page is None:
-            keys_values = await self.service.get_keys_values(store_id, root_hash)
+            keys_values = await self.service.get_keys_values(store_id, resolved_root_hash)
         else:
             keys_values_paginated = await self.service.get_keys_values_paginated(
-                store_id, root_hash, page, max_page_size
+                store_id, resolved_root_hash, page, max_page_size
             )
             keys_values = keys_values_paginated.keys_values
 
         json_nodes = [recurse_jsonify(dataclasses.asdict(node)) for node in keys_values]
-        if not json_nodes and root_hash is not None and root_hash != bytes32([0] * 32):
-            raise Exception(f"Can't find keys and values for {root_hash}")
+        # TODO: here in fact we do support zeros as the empty root, or at least we check for it
+        # TODO: here and elsewhere, the isinstance may not be needed?
+        if (
+            not json_nodes
+            and not isinstance(resolved_root_hash, Unspecified)
+            and resolved_root_hash != bytes32([0] * 32)
+        ):
+            raise Exception(f"Can't find keys and values for {resolved_root_hash}")
 
         response: EndpointResult = {"keys_values": json_nodes}
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:

The intent is to keep interfaces (RPC and CLI) unchanged at present.  Inside of those we introduce the `Unspecified` class and a single instance of it to represent, well, an unspecified root.  `None` is now used to represent the root of an empty tree.

<!-- Does this PR introduce a breaking change? -->
### Current Behavior:



### New Behavior:



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:



<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
