### PR TITLE
[CHIA-819] Fix 12-word mnemonic support in keychain

### DIFF
--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -316,7 +316,7 @@ class Keychain:
 
         public_key = G1Element.from_bytes(str_bytes[: G1Element.SIZE])
         fingerprint = public_key.get_fingerprint()
-        if len(str_bytes) == G1Element.SIZE + 32:
+        if len(str_bytes) > G1Element.SIZE:
             entropy = str_bytes[G1Element.SIZE : G1Element.SIZE + 32]
         else:
             entropy = None


### PR DESCRIPTION
This is an accidental regression introduced in 2.4.0 which caused 12-word mnemonics, once stored in the keychain, to lose access to the secret information.  The information was still present in the keychain, the daemon just couldn't access it.

https://github.com/Chia-Network/chia-blockchain/issues/18243