### PR TITLE
CHIA-818 Add Soft Fork options to simulator config

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -654,3 +654,8 @@ simulator:
   # Should we use real time in the simulated chain?
   # most tests don't need this, however it is pretty important when writing ChiaLisp
   use_current_time: True
+
+  # Fork Settings
+  HARD_FORK_HEIGHT: 0
+  SOFT_FORK4_HEIGHT: 0
+  SOFT_FORK5_HEIGHT: 0


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
Allow user to set simulator fork block height


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
No forks active on simulator (copy main net values, way too high for sim)


### New Behavior:
All forks active by default (block height zero)

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
Not sure if needed, as existing consensus code is used. This just adds a shortcut to enable the forks on the simulator.


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
