### PR TITLE
Fix backwards compatibility for add_private_key (cherrypick from main)

### DIFF
--- a/chia/daemon/keychain_server.py
+++ b/chia/daemon/keychain_server.py
@@ -174,9 +174,9 @@ class KeychainServer:
     async def handle_command(self, command: str, data: Dict[str, Any]) -> Dict[str, Any]:
         try:
             if command == "add_private_key":
-                return await self.add_key(
-                    {"mnemonic_or_pk": data.get("mnemonic", None), "label": data.get("label", None), "private": True}
-                )
+                data["private"] = True
+                data["mnemonic_or_pk"] = data.get("mnemonic_or_pk", data.get("mnemonic", None))
+                return await self.add_key(data)
             elif command == "add_key":
                 return await self.add_key(data)
             elif command == "check_keys":


### PR DESCRIPTION
cherrypick from main PR 18237 for the `add_private_key` fix

This was suggested by Bill for inclusion into 2.4.2