### PR TITLE
Update to macos-12 for build and remove macos-11 (cherrypick from main)

### DIFF
--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         os:
-          - runs-on: macos-11
+          - runs-on: macos-12
             name: intel
             bladebit-suffix: macos-x86-64.tar.gz
           - runs-on: [MacOS, ARM64]
@@ -74,7 +74,7 @@ jobs:
         uses: Chia-Network/actions/setjobenv@main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MACOSX_DEPLOYMENT_TARGET: 11
+          MACOSX_DEPLOYMENT_TARGET: 12
 
       - name: Check tag type
         shell: bash
@@ -391,11 +391,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - name: 11
-            matrix: 11
-            runs-on:
-              intel: macos-11
-              arm: [macos, arm64]
           - name: 12
             matrix: 12
             runs-on:

--- a/.github/workflows/check_wheel_availability.yaml
+++ b/.github/workflows/check_wheel_availability.yaml
@@ -33,7 +33,7 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              intel: macos-11
+              intel: macos-12
               arm: [macos, arm64]
           - name: Windows
             matrix: windows


### PR DESCRIPTION
Cherrypick from main of PR 18238

Removes macos-11 from the build and test list