### PR TITLE
ad.fee_estimation_fixes

### DIFF
--- a/chia/full_node/fee_estimator.py
+++ b/chia/full_node/fee_estimator.py
@@ -28,7 +28,7 @@ class SmartFeeEstimator:
         median = fee_result.median
 
         if median != -1:
-            return median
+            return median / 1000.0
 
         if fail_bucket.start == 0:
             return -1.0

--- a/chia/full_node/fee_tracker.py
+++ b/chia/full_node/fee_tracker.py
@@ -70,7 +70,7 @@ class FeeStat:  # TxConfirmStats
     # Track historical moving average of this total over block
     tx_ct_avg: List[float]
 
-    # Count the total number of txs confirmed within Y blocks in each bucket
+    # Count the total number of txs confirmed within Y periods in each bucket
     # Track the historical moving average of these totals over blocks
     confirmed_average: List[List[float]]  # confirmed_average [y][x]
 
@@ -84,7 +84,7 @@ class FeeStat:  # TxConfirmStats
 
     decay: float
 
-    # Resolution of blocks with which confirmations are tracked
+    # Resolution of blocks with which confirmations are tracked (number of blocks per period)
     scale: int
 
     # Mempool counts of outstanding transactions
@@ -133,6 +133,7 @@ class FeeStat:  # TxConfirmStats
         if blocks_to_confirm < 1:
             raise ValueError("tx_confirmed called with < 1 block to confirm")
 
+        # convert from number of blocks to number of periods
         periods_to_confirm = int((blocks_to_confirm + self.scale - 1) / self.scale)
 
         fee_rate = item.fee_per_cost * 1000


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
fixes conversion error in fee calculation
fix steady fee pressure test 


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
when the tracker is able to find a passing bucket we divide by 1000 before returning the result currently we don't do that when we don't find a bucket and use the median


### New Behavior:
divide median by 1000 on return



<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
fixed the steady fee pressure test to make sure we get results


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
