### PR TITLE
CHIA-210 Introduce WalletSpendBundle and use it across code related to wallets

### DIFF
--- a/benchmarks/mempool.py
+++ b/benchmarks/mempool.py
@@ -106,7 +106,7 @@ async def run_mempool_benchmark() -> None:
 
     height = uint32(1)
 
-    print("Building SpendBundles")
+    print("Building spend bundles")
     for peer in range(NUM_PEERS):
         print(f"  peer {peer}")
         print("     reward coins")
@@ -129,11 +129,9 @@ async def run_mempool_benchmark() -> None:
             unspent.extend([farmer_coin, pool_coin])
 
         print("     spend bundles")
-        bundles: List[SpendBundle] = []
+        bundles = []
         for coin in unspent:
-            tx: SpendBundle = wt.generate_signed_transaction(
-                uint64(coin.amount // 2), wt.get_new_puzzlehash(), coin, fee=peer + idx
-            )
+            tx = wt.generate_signed_transaction(uint64(coin.amount // 2), wt.get_new_puzzlehash(), coin, fee=peer + idx)
             bundles.append(tx)
         spend_bundles.append(bundles)
 

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -1889,7 +1889,7 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx1: SpendBundle = wt.generate_signed_transaction(
+        tx1 = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         coin1: Coin = tx1.additions()[0]
@@ -1914,9 +1914,7 @@ class TestBodyValidation:
             opcode: [ConditionWithArgs(opcode, args + ([b"garbage"] if with_garbage else []))]
         }
 
-        tx2: SpendBundle = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), coin1, condition_dic=conditions
-        )
+        tx2 = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin1, condition_dic=conditions)
         assert coin1 in tx2.removals()
 
         bundles = SpendBundle.aggregate([tx1, tx2])
@@ -2033,9 +2031,7 @@ class TestBodyValidation:
             conditions = {opcode: [ConditionWithArgs(opcode, [int_to_bytes(lock_value)])]}
 
             coin = blocks[-1].get_included_reward_coins()[0]
-            tx: SpendBundle = wt.generate_signed_transaction(
-                uint64(10), wt.get_new_puzzlehash(), coin, condition_dic=conditions
-            )
+            tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin, condition_dic=conditions)
 
             blocks = bt.get_consecutive_blocks(
                 1,
@@ -2094,7 +2090,7 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx1: SpendBundle = wt.generate_signed_transaction(
+        tx1 = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         coin1: Coin = tx1.additions()[0]
@@ -2105,9 +2101,7 @@ class TestBodyValidation:
         args = [bytes(public_key), b"msg"] + ([b"garbage"] if with_garbage else [])
         conditions = {opcode: [ConditionWithArgs(opcode, args)]}
 
-        tx2: SpendBundle = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), coin1, condition_dic=conditions
-        )
+        tx2 = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin1, condition_dic=conditions)
         assert coin1 in tx2.removals()
 
         bundles = SpendBundle.aggregate([tx1, tx2])
@@ -2219,13 +2213,11 @@ class TestBodyValidation:
                 opcode: [ConditionWithArgs(opcode, [int_to_bytes(lock_value)] + ([b"garbage"] if with_garbage else []))]
             }
 
-            tx1: SpendBundle = wt.generate_signed_transaction(
+            tx1 = wt.generate_signed_transaction(
                 uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
             )
             coin1: Coin = tx1.additions()[0]
-            tx2: SpendBundle = wt.generate_signed_transaction(
-                uint64(10), wt.get_new_puzzlehash(), coin1, condition_dic=conditions
-            )
+            tx2 = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin1, condition_dic=conditions)
             assert coin1 in tx2.removals()
             coin2: Coin = tx2.additions()[0]
 
@@ -2451,7 +2443,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, blocks[3])
 
         wt: WalletTool = bt.get_pool_wallet_tool()
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         blocks = bt.get_consecutive_blocks(
@@ -2515,7 +2507,7 @@ class TestBodyValidation:
         # Hash should be correct when there is a ref list
         await _validate_and_add_block(b, blocks[-1])
         wt: WalletTool = bt.get_pool_wallet_tool()
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         blocks = bt.get_consecutive_blocks(5, block_list_input=blocks, guarantee_transaction_block=False)
@@ -2563,7 +2555,7 @@ class TestBodyValidation:
             output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bt.pool_ph, int_to_bytes(i)])
             condition_dict[ConditionOpcode.CREATE_COIN].append(output)
 
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0], condition_dic=condition_dict
         )
 
@@ -2614,7 +2606,7 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
 
@@ -2745,7 +2737,7 @@ class TestBodyValidation:
         #     output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bt_2.pool_ph, int_to_bytes(2 ** 64)])
         #     condition_dict[ConditionOpcode.CREATE_COIN].append(output)
 
-        #     tx: SpendBundle = wt.generate_signed_transaction_multiple_coins(
+        #     tx = wt.generate_signed_transaction_multiple_coins(
         #         uint64(10),
         #         wt.get_new_puzzlehash(),
         #         blocks[1].get_included_reward_coins(),
@@ -2773,7 +2765,7 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
 
@@ -2824,7 +2816,7 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
 
@@ -2864,7 +2856,7 @@ class TestBodyValidation:
             output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bt.pool_ph, int_to_bytes(1)])
             condition_dict[ConditionOpcode.CREATE_COIN].append(output)
 
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0], condition_dic=condition_dict
         )
 
@@ -2889,10 +2881,10 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
-        tx_2: SpendBundle = wt.generate_signed_transaction(
+        tx_2 = wt.generate_signed_transaction(
             uint64(11), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         agg = SpendBundle.aggregate([tx, tx_2])
@@ -2918,7 +2910,7 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
 
@@ -2927,7 +2919,7 @@ class TestBodyValidation:
         )
         await _validate_and_add_block(b, blocks[-1])
 
-        tx_2: SpendBundle = wt.generate_signed_transaction(
+        tx_2 = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-2].get_included_reward_coins()[0]
         )
         blocks = bt.get_consecutive_blocks(
@@ -2952,7 +2944,7 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         blocks = bt.get_consecutive_blocks(
@@ -2961,7 +2953,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, blocks[-1])
 
         new_coin: Coin = tx.additions()[0]
-        tx_2: SpendBundle = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), new_coin)
+        tx_2 = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), new_coin)
         # This is fine because coin exists
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx_2
@@ -3018,7 +3010,7 @@ class TestBodyValidation:
             calculate_base_farmer_reward(blocks_reorg[-1].height),
             bt.constants.GENESIS_CHALLENGE,
         )
-        tx_3: SpendBundle = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), farmer_coin)
+        tx_3 = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), farmer_coin)
 
         blocks_reorg = bt.get_consecutive_blocks(
             1, block_list_input=blocks_reorg, guarantee_transaction_block=True, transaction_data=tx_3
@@ -3051,9 +3043,7 @@ class TestBodyValidation:
         output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bt.pool_ph, int_to_bytes(spend.amount)])
         condition_dict = {ConditionOpcode.CREATE_COIN: [output]}
 
-        tx: SpendBundle = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), spend, condition_dic=condition_dict
-        )
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), spend, condition_dic=condition_dict)
 
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
@@ -3082,7 +3072,7 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
 
@@ -3124,7 +3114,7 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
         )
         blocks = bt.get_consecutive_blocks(
@@ -3480,7 +3470,7 @@ class TestReorgs:
         await _validate_and_add_block(b, blocks[1])
         await _validate_and_add_block(b, blocks[2])
         wt: WalletTool = bt.get_pool_wallet_tool()
-        tx: SpendBundle = wt.generate_signed_transaction(
+        tx = wt.generate_signed_transaction(
             uint64(10), wt.get_new_puzzlehash(), blocks[2].get_included_reward_coins()[0]
         )
         blocks = bt.get_consecutive_blocks(

--- a/chia/_tests/cmds/cmd_test_utils.py
+++ b/chia/_tests/cmds/cmd_test_utils.py
@@ -25,7 +25,6 @@ from chia.simulator.simulator_full_node_rpc_client import SimulatorFullNodeRpcCl
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.signing_mode import SigningMode
-from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.config import load_config
 from chia.util.ints import uint8, uint16, uint32, uint64
@@ -36,6 +35,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import CoinSelectionConfig, TXConfig
 from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 # Any functions that are the same for every command being tested should be below.
 # Functions that are specific to a command should be in the test file for that command.
@@ -119,7 +119,7 @@ class TestWalletRpcClient(TestRpcClient):
             fee_amount=uint64(1234567),
             confirmed=False,
             sent=uint32(0),
-            spend_bundle=SpendBundle([], G2Element()),
+            spend_bundle=WalletSpendBundle([], G2Element()),
             additions=[Coin(bytes32([1] * 32), bytes32([2] * 32), uint64(12345678))],
             removals=[Coin(bytes32([2] * 32), bytes32([4] * 32), uint64(12345678))],
             wallet_id=uint32(1),
@@ -269,7 +269,7 @@ class TestWalletRpcClient(TestRpcClient):
                 fee_amount=uint64(1234567),
                 confirmed=False,
                 sent=uint32(0),
-                spend_bundle=SpendBundle([], G2Element()),
+                spend_bundle=WalletSpendBundle([], G2Element()),
                 additions=[Coin(bytes32([1] * 32), bytes32([2] * 32), uint64(12345678))],
                 removals=[Coin(bytes32([2] * 32), bytes32([4] * 32), uint64(12345678))],
                 wallet_id=uint32(1),

--- a/chia/_tests/cmds/wallet/test_consts.py
+++ b/chia/_tests/cmds/wallet/test_consts.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from chia_rs import Coin, G2Element
 
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64
 from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.signer_protocol import KeyHints, SigningInstructions, TransactionInfo, UnsignedTransaction
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 FINGERPRINT: str = "123456"
 FINGERPRINT_ARG: str = f"-f{FINGERPRINT}"
@@ -31,7 +31,7 @@ STD_TX = TransactionRecord(
     fee_amount=uint64(1234567),
     confirmed=False,
     sent=uint32(0),
-    spend_bundle=SpendBundle([], G2Element()),
+    spend_bundle=WalletSpendBundle([], G2Element()),
     additions=[Coin(get_bytes32(1), get_bytes32(2), uint64(12345678))],
     removals=[Coin(get_bytes32(2), get_bytes32(4), uint64(12345678))],
     wallet_id=uint32(1),

--- a/chia/_tests/cmds/wallet/test_did.py
+++ b/chia/_tests/cmds/wallet/test_did.py
@@ -10,12 +10,12 @@ from chia._tests.cmds.wallet.test_consts import FINGERPRINT_ARG, STD_TX, STD_UTX
 from chia.rpc.wallet_request_types import DIDMessageSpendResponse, DIDTransferDIDResponse, DIDUpdateMetadataResponse
 from chia.types.blockchain_format.sized_bytes import bytes48
 from chia.types.signing_mode import SigningMode
-from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.config import load_config
 from chia.util.ints import uint32
 from chia.wallet.conditions import Condition, CreateCoinAnnouncement, CreatePuzzleAnnouncement
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, TXConfig
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 # DID Commands
 
@@ -185,7 +185,7 @@ def test_did_update_metadata(capsys: object, get_test_cli_clients: Tuple[TestRpc
             push: bool = True,
         ) -> DIDUpdateMetadataResponse:
             self.add_to_log("update_did_metadata", (wallet_id, metadata, tx_config, push))
-            return DIDUpdateMetadataResponse([STD_UTX], [STD_TX], SpendBundle([], G2Element()), uint32(wallet_id))
+            return DIDUpdateMetadataResponse([STD_UTX], [STD_TX], WalletSpendBundle([], G2Element()), uint32(wallet_id))
 
     inst_rpc_client = DidUpdateMetadataRpcClient()  # pylint: disable=no-value-for-parameter
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
@@ -258,7 +258,7 @@ def test_did_message_spend(capsys: object, get_test_cli_clients: Tuple[TestRpcCl
             self, wallet_id: int, tx_config: TXConfig, extra_conditions: Tuple[Condition, ...], push: bool
         ) -> DIDMessageSpendResponse:
             self.add_to_log("did_message_spend", (wallet_id, tx_config, extra_conditions, True))
-            return DIDMessageSpendResponse([STD_UTX], [STD_TX], SpendBundle([], G2Element()))
+            return DIDMessageSpendResponse([STD_UTX], [STD_TX], WalletSpendBundle([], G2Element()))
 
     inst_rpc_client = DidMessageSpendRpcClient()  # pylint: disable=no-value-for-parameter
     test_rpc_clients.wallet_rpc_client = inst_rpc_client

--- a/chia/_tests/cmds/wallet/test_nft.py
+++ b/chia/_tests/cmds/wallet/test_nft.py
@@ -15,11 +15,11 @@ from chia.rpc.wallet_request_types import (
 )
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.signing_mode import SigningMode
-from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.ints import uint8, uint16, uint32, uint64
 from chia.wallet.nft_wallet.nft_info import NFTInfo
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, TXConfig
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 # NFT Commands
 
@@ -123,7 +123,7 @@ def test_nft_mint(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Pa
                 [STD_UTX],
                 [STD_TX],
                 uint32(wallet_id),
-                SpendBundle([], G2Element()),
+                WalletSpendBundle([], G2Element()),
                 bytes32([0] * 32).hex(),
             )
 
@@ -196,7 +196,7 @@ def test_nft_add_uri(capsys: object, get_test_cli_clients: Tuple[TestRpcClients,
             push: bool,
         ) -> NFTAddURIResponse:
             self.add_to_log("add_uri_to_nft", (wallet_id, nft_coin_id, key, uri, fee, tx_config, push))
-            return NFTAddURIResponse([STD_UTX], [STD_TX], uint32(wallet_id), SpendBundle([], G2Element()))
+            return NFTAddURIResponse([STD_UTX], [STD_TX], uint32(wallet_id), WalletSpendBundle([], G2Element()))
 
     inst_rpc_client = NFTAddUriRpcClient()  # pylint: disable=no-value-for-parameter
     nft_coin_id = get_bytes32(2).hex()
@@ -253,7 +253,7 @@ def test_nft_transfer(capsys: object, get_test_cli_clients: Tuple[TestRpcClients
                 [STD_UTX],
                 [STD_TX],
                 uint32(wallet_id),
-                SpendBundle([], G2Element()),
+                WalletSpendBundle([], G2Element()),
             )
 
     inst_rpc_client = NFTTransferRpcClient()  # pylint: disable=no-value-for-parameter
@@ -365,7 +365,7 @@ def test_nft_set_did(capsys: object, get_test_cli_clients: Tuple[TestRpcClients,
                 [STD_UTX],
                 [STD_TX],
                 uint32(wallet_id),
-                SpendBundle([], G2Element()),
+                WalletSpendBundle([], G2Element()),
             )
 
     inst_rpc_client = NFTSetDidRpcClient()  # pylint: disable=no-value-for-parameter

--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -34,7 +34,6 @@ from chia.server.outbound_message import NodeType
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.signing_mode import SigningMode
-from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.ints import uint8, uint32, uint64
 from chia.wallet.conditions import ConditionValidTimes
@@ -48,6 +47,7 @@ from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, TXConfig
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_coin_store import GetCoinRecords
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 test_offer_file_path = importlib_resources.files(__name__.rpartition(".")[0]).joinpath("test_offer.toffer")
 test_offer_file_bech32 = test_offer_file_path.read_text(encoding="utf-8")
@@ -125,7 +125,7 @@ def test_get_transactions(capsys: object, get_test_cli_clients: Tuple[TestRpcCli
                     fee_amount=uint64(1234567 + i),
                     confirmed=False,
                     sent=uint32(0),
-                    spend_bundle=SpendBundle([], G2Element()),
+                    spend_bundle=WalletSpendBundle([], G2Element()),
                     additions=[Coin(bytes32([1 + i] * 32), bytes32([2 + i] * 32), uint64(12345678))],
                     removals=[Coin(bytes32([2 + i] * 32), bytes32([4 + i] * 32), uint64(12345678))],
                     wallet_id=uint32(1),
@@ -338,7 +338,7 @@ def test_send(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Path])
                 fee_amount=uint64(1234567),
                 confirmed=False,
                 sent=uint32(0),
-                spend_bundle=SpendBundle([], G2Element()),
+                spend_bundle=WalletSpendBundle([], G2Element()),
                 additions=[Coin(get_bytes32(1), get_bytes32(2), uint64(12345678))],
                 removals=[Coin(get_bytes32(2), get_bytes32(4), uint64(12345678))],
                 wallet_id=uint32(1),
@@ -740,7 +740,7 @@ def test_make_offer(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
                 (offer_dict, tx_config, driver_dict, solver, fee, validate_only),
             )
 
-            created_offer = Offer({}, SpendBundle([], G2Element()), {})
+            created_offer = Offer({}, WalletSpendBundle([], G2Element()), {})
             trade_offer: TradeRecord = TradeRecord(
                 confirmed_at_index=uint32(0),
                 accepted_at_time=None,
@@ -748,7 +748,7 @@ def test_make_offer(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
                 is_my_offer=True,
                 sent=uint32(0),
                 sent_to=[],
-                offer=bytes(SpendBundle([], G2Element())),
+                offer=bytes(WalletSpendBundle([], G2Element())),
                 taken_offer=None,
                 coins_of_interest=[],
                 trade_id=get_bytes32(2),
@@ -883,7 +883,7 @@ def test_get_offers(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, 
                     is_my_offer=True,
                     sent=uint32(0),
                     sent_to=[],
-                    offer=bytes(SpendBundle([], G2Element())),
+                    offer=bytes(WalletSpendBundle([], G2Element())),
                     taken_offer=None,
                     coins_of_interest=[
                         Coin(bytes32([2 + i] * 32), bytes32([3 + i] * 32), uint64(1000)),

--- a/chia/_tests/core/full_node/stores/test_block_store.py
+++ b/chia/_tests/core/full_node/stores/test_block_store.py
@@ -26,7 +26,6 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.vdf import VDFProof
 from chia.types.full_block import FullBlock
-from chia.types.spend_bundle import SpendBundle
 from chia.util.db_wrapper import get_host_parameter_limit
 from chia.util.full_block_utils import GeneratorBlockInfo
 from chia.util.ints import uint8, uint32, uint64
@@ -59,7 +58,7 @@ async def test_block_store(tmp_dir: Path, db_version: int, bt: BlockTools, use_c
         time_per_block=10,
     )
     wt: WalletTool = bt.get_pool_wallet_tool()
-    tx: SpendBundle = wt.generate_signed_transaction(
+    tx = wt.generate_signed_transaction(
         uint64(10), wt.get_new_puzzlehash(), list(blocks[-1].get_included_reward_coins())[0]
     )
     blocks = bt.get_consecutive_blocks(

--- a/chia/_tests/core/full_node/stores/test_hint_store.py
+++ b/chia/_tests/core/full_node/stores/test_hint_store.py
@@ -16,7 +16,6 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
-from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint64
 
 log = logging.getLogger(__name__)
@@ -166,7 +165,7 @@ async def test_hints_in_blockchain(
     condition_dict = {
         ConditionOpcode.CREATE_COIN: [ConditionWithArgs(ConditionOpcode.CREATE_COIN, [puzzle_hash, amount, hint])]
     }
-    tx: SpendBundle = wt.generate_signed_transaction(
+    tx = wt.generate_signed_transaction(
         uint64(10),
         wt.get_new_puzzlehash(),
         coin_spent,

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -67,6 +67,7 @@ from chia.util.limited_semaphore import LimitedSemaphore
 from chia.util.recursive_replace import recursive_replace
 from chia.util.vdf_prover import get_vdf_info_and_proof
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 
 async def new_transaction_not_requested(incoming, new_spend):
@@ -338,7 +339,7 @@ class TestFullNodeBlockCompression:
                 action_scope,
             )
         [tr] = action_scope.side_effects.transactions
-        extra_spend = SpendBundle(
+        extra_spend = WalletSpendBundle(
             [
                 make_spend(
                     next(coin for coin in tr.additions if coin.puzzle_hash == Program.to(1).get_tree_hash()),
@@ -348,7 +349,7 @@ class TestFullNodeBlockCompression:
             ],
             G2Element(),
         )
-        new_spend_bundle = SpendBundle.aggregate([tr.spend_bundle, extra_spend])
+        new_spend_bundle = WalletSpendBundle.aggregate([tr.spend_bundle, extra_spend])
         new_tr = dataclasses.replace(
             tr,
             spend_bundle=new_spend_bundle,
@@ -386,7 +387,7 @@ class TestFullNodeBlockCompression:
                 action_scope,
             )
         [tr] = action_scope.side_effects.transactions
-        extra_spend = SpendBundle(
+        extra_spend = WalletSpendBundle(
             [
                 make_spend(
                     next(coin for coin in tr.additions if coin.puzzle_hash == Program.to(1).get_tree_hash()),
@@ -396,7 +397,7 @@ class TestFullNodeBlockCompression:
             ],
             G2Element(),
         )
-        new_spend_bundle = SpendBundle.aggregate([tr.spend_bundle, extra_spend])
+        new_spend_bundle = WalletSpendBundle.aggregate([tr.spend_bundle, extra_spend])
         new_tr = dataclasses.replace(
             tr,
             spend_bundle=new_spend_bundle,
@@ -874,7 +875,7 @@ class TestFullNodeProtocol:
         included_tx = 0
         not_included_tx = 0
         seen_bigger_transaction_has_high_fee = False
-        successful_bundle: Optional[SpendBundle] = None
+        successful_bundle: Optional[WalletSpendBundle] = None
 
         # Fill mempool
         receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
@@ -902,7 +903,7 @@ class TestFullNodeProtocol:
                     uint64(500), receiver_puzzlehash, coin_records[0].coin, fee=fee
                 )
             ]
-            spend_bundle = SpendBundle.aggregate(spend_bundles)
+            spend_bundle = WalletSpendBundle.aggregate(spend_bundles)
             assert estimate_fees(spend_bundle) == fee
             respond_transaction = wallet_protocol.SendTransaction(spend_bundle)
 
@@ -1311,7 +1312,7 @@ class TestFullNodeProtocol:
         for idx in range(0, 6):
             # we include a different transaction in each block. This makes the
             # foliage different in each of them, but the reward block (plot) the same
-            tx: SpendBundle = wallet_a.generate_signed_transaction(100 * (idx + 1), puzzle_hash, coin)
+            tx = wallet_a.generate_signed_transaction(100 * (idx + 1), puzzle_hash, coin)
 
             # note that we use the same chain to build the new block on top of every time
             block = bt.get_consecutive_blocks(
@@ -1514,7 +1515,7 @@ class TestFullNodeProtocol:
         blocks: List[FullBlock] = await full_node_1.get_all_full_blocks()
 
         coin = blocks[-1].get_included_reward_coins()[0]
-        tx: SpendBundle = wallet_a.generate_signed_transaction(10000, wallet_receiver.get_new_puzzlehash(), coin)
+        tx = wallet_a.generate_signed_transaction(10000, wallet_receiver.get_new_puzzlehash(), coin)
 
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
@@ -1576,7 +1577,7 @@ class TestFullNodeProtocol:
         for idx in range(0, 6):
             # we include a different transaction in each block. This makes the
             # foliage different in each of them, but the reward block (plot) the same
-            tx: SpendBundle = wallet_a.generate_signed_transaction(100 * (idx + 1), puzzle_hash, coin)
+            tx = wallet_a.generate_signed_transaction(100 * (idx + 1), puzzle_hash, coin)
 
             # note that we use the same chain to build the new block on top of every time
             block = bt.get_consecutive_blocks(

--- a/chia/_tests/core/test_full_node_rpc.py
+++ b/chia/_tests/core/test_full_node_rpc.py
@@ -30,10 +30,10 @@ from chia.types.coin_spend import compute_additions
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.full_block import FullBlock
-from chia.types.spend_bundle import SpendBundle
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.hash import std_hash
 from chia.util.ints import uint8
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 
 @pytest.mark.anyio
@@ -154,12 +154,14 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
         assert len(await client.get_all_mempool_items()) == 1
         assert len(await client.get_all_mempool_tx_ids()) == 1
         assert (
-            SpendBundle.from_json_dict(list((await client.get_all_mempool_items()).values())[0]["spend_bundle"])
+            WalletSpendBundle.from_json_dict(list((await client.get_all_mempool_items()).values())[0]["spend_bundle"])
             == spend_bundle
         )
         assert (await client.get_all_mempool_tx_ids())[0] == spend_bundle.name()
         assert (
-            SpendBundle.from_json_dict((await client.get_mempool_item_by_tx_id(spend_bundle.name()))["spend_bundle"])
+            WalletSpendBundle.from_json_dict(
+                (await client.get_mempool_item_by_tx_id(spend_bundle.name()))["spend_bundle"]
+            )
             == spend_bundle
         )
         assert (await client.get_coin_record_by_name(coin.name())) is None
@@ -179,7 +181,7 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
             await client.get_mempool_item_by_tx_id(spend_bundle_pending.name(), False)
         ) is None  # not strictly in the mempool
         assert (
-            SpendBundle.from_json_dict(
+            WalletSpendBundle.from_json_dict(
                 (await client.get_mempool_item_by_tx_id(spend_bundle_pending.name(), True))["spend_bundle"]
             )
             == spend_bundle_pending  # pending entry into mempool, so include_pending fetches

--- a/chia/_tests/wallet/cat_wallet/test_offer_lifecycle.py
+++ b/chia/_tests/wallet/cat_wallet/test_offer_lifecycle.py
@@ -12,7 +12,6 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import make_spend
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint64
 from chia.wallet.cat_wallet.cat_utils import (
     CAT_MOD,
@@ -25,6 +24,7 @@ from chia.wallet.outer_puzzles import AssetType
 from chia.wallet.payment import Payment
 from chia.wallet.puzzle_drivers import PuzzleInfo
 from chia.wallet.trading.offer import OFFER_MOD, Offer
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 acs = Program.to(1)
 acs_ph = acs.get_tree_hash()
@@ -78,12 +78,12 @@ async def generate_coins(
                 payments.append(Payment(acs_ph, uint64(amount)))
 
     # This bundle creates all of the initial coins
-    parent_bundle = SpendBundle(
+    parent_bundle = WalletSpendBundle(
         [make_spend(parent_coin, acs, Program.to([[51, p.puzzle_hash, p.amount] for p in payments]))], G2Element()
     )
 
     # Then we aggregate it with all of the eve spends
-    await sim_client.push_tx(SpendBundle.aggregate([parent_bundle, *cat_bundles]))
+    await sim_client.push_tx(WalletSpendBundle.aggregate([parent_bundle, *cat_bundles]))
     await sim.farm_block()
 
     # Search for all of the coins and put them into a dictionary
@@ -116,8 +116,8 @@ def generate_secure_bundle(
     announcements: List[AssertPuzzleAnnouncement],
     offered_amount: uint64,
     tail_str: Optional[str] = None,
-) -> SpendBundle:
-    announcement_assertions: List[Program] = [a.to_program() for a in announcements]
+) -> WalletSpendBundle:
+    announcement_assertions = [a.to_program() for a in announcements]
     selected_coin_amount = sum(c.amount for c in selected_coins)
     non_primaries = [] if len(selected_coins) < 2 else selected_coins[1:]
     inner_solution: List[Any] = [
@@ -127,7 +127,7 @@ def generate_secure_bundle(
     ]
 
     if tail_str is None:
-        bundle = SpendBundle(
+        bundle = WalletSpendBundle(
             [
                 make_spend(
                     selected_coins[0],
@@ -259,7 +259,7 @@ async def test_complex_offer(cost_logger: CostLogger) -> None:
             Program.to([[random_hash, [random_hash, 200, ["hey there"]]]]),
         )
         new_spends_list = [blue_spend, *new_offer.to_spend_bundle().coin_spends]
-        tail_offer = Offer.from_spend_bundle(SpendBundle(new_spends_list, G2Element()))
+        tail_offer = Offer.from_spend_bundle(WalletSpendBundle(new_spends_list, G2Element()))
         valid_spend = tail_offer.to_valid_spend(random_hash)
         real_blue_spend = [spend for spend in valid_spend.coin_spends if b"hey there" in bytes(spend)][0]
         real_blue_spend_replaced = real_blue_spend.replace(
@@ -269,7 +269,7 @@ async def test_complex_offer(cost_logger: CostLogger) -> None:
                 )
             ),
         )
-        valid_spend = SpendBundle(
+        valid_spend = WalletSpendBundle(
             [real_blue_spend_replaced, *[spend for spend in valid_spend.coin_spends if spend != real_blue_spend]],
             G2Element(),
         )

--- a/chia/_tests/wallet/cat_wallet/test_trades.py
+++ b/chia/_tests/wallet/cat_wallet/test_trades.py
@@ -36,6 +36,7 @@ from chia.wallet.vc_wallet.cr_cat_drivers import ProofsChecker
 from chia.wallet.vc_wallet.cr_cat_wallet import CRCATWallet
 from chia.wallet.vc_wallet.vc_store import VCProofs
 from chia.wallet.wallet_node import WalletNode
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 OfferSummary = Dict[Union[int, bytes32], int]
 
@@ -1959,7 +1960,7 @@ async def test_trade_bad_spend(
     assert trade_make is not None
     peer = wallet_node_taker.get_full_node_peer()
     offer = Offer.from_bytes(trade_make.offer)
-    bundle = offer._bundle.replace(aggregated_signature=G2Element())
+    bundle = WalletSpendBundle(coin_spends=offer._bundle.coin_spends, aggregated_signature=G2Element())
     offer = dataclasses.replace(offer, _bundle=bundle)
     async with trade_manager_taker.wallet_state_manager.new_action_scope(
         DEFAULT_TX_CONFIG, push=True, sign=False

--- a/chia/_tests/wallet/clawback/test_clawback_lifecycle.py
+++ b/chia/_tests/wallet/clawback/test_clawback_lifecycle.py
@@ -16,7 +16,6 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
 from chia.util.errors import Err
 from chia.util.ints import uint64
@@ -39,6 +38,7 @@ from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.merkle_utils import check_merkle_proof
 from chia.wallet.util.wallet_types import RemarkDataType
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 ACS = Program.to(1)
 ACS_PH = ACS.get_tree_hash()
@@ -47,7 +47,7 @@ ACS_PH = ACS.get_tree_hash()
 async def do_spend(
     sim: SpendSim,
     sim_client: SimClient,
-    spend_bundle: SpendBundle,
+    spend_bundle: WalletSpendBundle,
     expected_result: Tuple[MempoolInclusionStatus, Optional[Err]],
     cost_logger: Optional[CostLogger] = None,
     cost_log_msg: str = "",
@@ -126,7 +126,7 @@ class TestClawbackLifecycle:
             )
             coin_spend = make_spend(starting_coin, sender_puz, sender_sol)
             sig = self.sign_coin_spend(coin_spend, sender_index)
-            spend_bundle = SpendBundle([coin_spend], sig)
+            spend_bundle = WalletSpendBundle([coin_spend], sig)
 
             await do_spend(
                 sim,
@@ -153,7 +153,7 @@ class TestClawbackLifecycle:
             claim_sol = create_merkle_solution(timelock, sender_ph, recipient_ph, recipient_puz, recipient_sol)
             coin_spend = make_spend(clawback_coin, cb_puzzle, claim_sol)
             sig = self.sign_coin_spend(coin_spend, recipient_index)
-            spend_bundle = SpendBundle([coin_spend], sig)
+            spend_bundle = WalletSpendBundle([coin_spend], sig)
 
             await do_spend(
                 sim,
@@ -185,7 +185,7 @@ class TestClawbackLifecycle:
             new_coin = (await sim_client.get_coin_records_by_puzzle_hash(sender_ph, include_spent_coins=False))[0].coin
             coin_spend = make_spend(new_coin, sender_puz, sender_sol)
             sig = self.sign_coin_spend(coin_spend, sender_index)
-            spend_bundle = SpendBundle([coin_spend], sig)
+            spend_bundle = WalletSpendBundle([coin_spend], sig)
 
             await do_spend(
                 sim,
@@ -204,7 +204,7 @@ class TestClawbackLifecycle:
             claw_sol = create_merkle_solution(timelock, sender_ph, recipient_ph, sender_puz, sender_claw_sol)
             coin_spend = make_spend(new_cb_coin, cb_puzzle, claw_sol)
             sig = self.sign_coin_spend(coin_spend, sender_index)
-            spend_bundle = SpendBundle([coin_spend], sig)
+            spend_bundle = WalletSpendBundle([coin_spend], sig)
 
             await do_spend(
                 sim,

--- a/chia/_tests/wallet/dao_wallet/test_dao_clvm.py
+++ b/chia/_tests/wallet/dao_wallet/test_dao_clvm.py
@@ -13,7 +13,6 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution
 from chia.util.errors import Err
 from chia.util.hash import std_hash
@@ -23,6 +22,7 @@ from chia.wallet.dao_wallet.dao_info import DAORules
 from chia.wallet.dao_wallet.dao_utils import curry_singleton, get_p2_singleton_puzhash, get_treasury_puzzle
 from chia.wallet.puzzles.load_clvm import load_clvm
 from chia.wallet.singleton import create_singleton_puzzle_hash
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 CAT_MOD_HASH: bytes32 = CAT_MOD.get_tree_hash()
 SINGLETON_MOD: Program = load_clvm("singleton_top_layer_v1_1.clsp")
@@ -1249,7 +1249,7 @@ async def do_spend(
     spends = []
     for coin, puzzle, solution in zip(coins, puzzles, solutions):
         spends.append(make_spend(coin, puzzle, solution))
-    spend_bundle = SpendBundle(spends, AugSchemeMPL.aggregate([]))
+    spend_bundle = WalletSpendBundle(spends, AugSchemeMPL.aggregate([]))
     result = await sim_client.push_tx(spend_bundle)
     await sim.farm_block()
     return result

--- a/chia/_tests/wallet/db_wallet/test_db_graftroot.py
+++ b/chia/_tests/wallet/db_wallet/test_db_graftroot.py
@@ -11,10 +11,10 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import make_spend
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.types.spend_bundle import SpendBundle
 from chia.util.errors import Err
 from chia.wallet.puzzles.load_clvm import load_clvm
 from chia.wallet.util.merkle_utils import build_merkle_tree, build_merkle_tree_from_binary_tree, simplify_merkle_proof
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 GRAFTROOT_MOD = load_clvm("graftroot_dl_offers.clsp", package_or_requirement="chia.data_layer.puzzles")
 
@@ -112,7 +112,7 @@ async def test_graftroot(cost_logger: CostLogger) -> None:
                 ),
             )
 
-            final_bundle = SpendBundle([fake_spend, graftroot_spend], G2Element())
+            final_bundle = WalletSpendBundle([fake_spend, graftroot_spend], G2Element())
             result = await sim_client.push_tx(final_bundle)
 
             # If this is the satisfactory merkle tree
@@ -134,7 +134,7 @@ async def test_graftroot(cost_logger: CostLogger) -> None:
                     ACS.curry(fake_struct, ACS.curry(ACS_PH, (bytes32([0] * 32), None), None, None)),
                     Program.to([[[62, "$"]]]),
                 )
-                new_final_bundle = SpendBundle([new_fake_spend, graftroot_spend], G2Element())
+                new_final_bundle = WalletSpendBundle([new_fake_spend, graftroot_spend], G2Element())
                 result = await sim_client.push_tx(new_final_bundle)
                 assert result == (MempoolInclusionStatus.FAILED, Err.ASSERT_ANNOUNCE_CONSUMED_FAILED)
             else:

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -17,7 +17,6 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.peer_info import PeerInfo
 from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX
-from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.condition_tools import conditions_dict_for_solution
 from chia.util.ints import uint16, uint32, uint64
@@ -26,6 +25,7 @@ from chia.wallet.singleton import create_singleton_puzzle
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 
 async def get_wallet_num(wallet_manager):
@@ -403,7 +403,7 @@ class TestDIDWallet:
         with pytest.raises(Exception):  # We expect a CLVM 80 error for this test
             async with did_wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=False) as action_scope:
                 await did_wallet.recovery_spend(
-                    coin, ph, info, pubkey, SpendBundle([], AugSchemeMPL.aggregate([])), action_scope
+                    coin, ph, info, pubkey, WalletSpendBundle([], AugSchemeMPL.aggregate([])), action_scope
                 )
 
     @pytest.mark.parametrize(

--- a/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -16,7 +16,6 @@ from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.peer_info import PeerInfo
-from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.did_wallet.did_wallet import DIDWallet
@@ -291,7 +290,7 @@ async def test_nft_mint_from_did_rpc(
                 fee=fee,
                 tx_config=DEFAULT_TX_CONFIG,
             )
-            sb: SpendBundle = resp.spend_bundle
+            sb = resp.spend_bundle
             did_lineage_parent = [cn for cn in sb.removals() if cn.name() == did_coin.name()][0].parent_coin_info.hex()
             did_coin = [cn for cn in sb.additions() if (cn.parent_coin_info == did_coin.name()) and (cn.amount == 1)][0]
             spends.append(sb)
@@ -476,7 +475,7 @@ async def test_nft_mint_from_did_rpc_no_royalties(
                 mint_from_did=True,
                 tx_config=DEFAULT_TX_CONFIG,
             )
-            sb: SpendBundle = resp.spend_bundle
+            sb = resp.spend_bundle
             did_lineage_parent = [cn for cn in sb.removals() if cn.name() == did_coin.name()][0].parent_coin_info.hex()
             did_coin = [cn for cn in sb.additions() if (cn.parent_coin_info == did_coin.name()) and (cn.amount == 1)][0]
             spends.append(sb)
@@ -865,7 +864,7 @@ async def test_nft_mint_from_xch_rpc(
                 fee=fee,
                 tx_config=DEFAULT_TX_CONFIG,
             )
-            sb: SpendBundle = resp.spend_bundle
+            sb = resp.spend_bundle
             spends.append(sb)
             xch_adds = [c for c in sb.additions() if c.puzzle_hash == funding_coin.puzzle_hash]
             assert len(xch_adds) == 1

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -60,7 +60,6 @@ from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.peer_info import PeerInfo
 from chia.types.signing_mode import SigningMode
-from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.config import load_config, lock_and_load_config, save_config
 from chia.util.db_wrapper import DBWrapper2
@@ -98,6 +97,7 @@ from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_coin_store import GetCoinRecords
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_protocol import WalletProtocol
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 log = logging.getLogger(__name__)
 
@@ -133,7 +133,7 @@ def check_mempool_spend_count(full_node_api: FullNodeSimulator, num_of_spends):
     return full_node_api.full_node.mempool_manager.mempool.size() == num_of_spends
 
 
-async def farm_transaction(full_node_api: FullNodeSimulator, wallet_node: WalletNode, spend_bundle: SpendBundle):
+async def farm_transaction(full_node_api: FullNodeSimulator, wallet_node: WalletNode, spend_bundle: WalletSpendBundle):
     await time_out_assert(
         20, full_node_api.full_node.mempool_manager.get_spendbundle, spend_bundle, spend_bundle.name()
     )
@@ -405,10 +405,10 @@ async def test_push_transactions(wallet_rpc_environment: WalletRpcTestEnvironmen
     resp = await client.fetch("push_transactions", {"transactions": [tx.to_json_dict()], "fee": 10})
     assert resp["success"]
 
-    spend_bundle = SpendBundle.aggregate(
+    spend_bundle = WalletSpendBundle.aggregate(
         [
-            # We ARE checking that the spendbundle is not None but mypy can't recognize this
-            TransactionRecord.from_json_dict_convenience(tx).spend_bundle  # type: ignore[misc]
+            # We ARE checking that the spend bundle is not None but mypy can't recognize this
+            TransactionRecord.from_json_dict_convenience(tx).spend_bundle  # type: ignore[type-var]
             for tx in resp_client["transactions"]
             if tx["spend_bundle"] is not None
         ]
@@ -2522,7 +2522,7 @@ async def test_cat_spend_run_tail(wallet_rpc_environment: WalletRpcTestEnvironme
 
     # Do the eve spend back to our wallet
     cat_coin = next(c for c in spend_bundle.additions() if c.amount == tx_amount)
-    eve_spend = SpendBundle(
+    eve_spend = WalletSpendBundle(
         [
             make_spend(
                 cat_coin,

--- a/chia/_tests/wallet/test_debug_spend_bundle.py
+++ b/chia/_tests/wallet/test_debug_spend_bundle.py
@@ -10,10 +10,10 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
-from chia.types.spend_bundle import SpendBundle
 from chia.util.hash import std_hash
 from chia.util.ints import uint64
 from chia.wallet.util.debug_spend_bundle import debug_spend_bundle
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 
 def test_debug_spend_bundle() -> None:
@@ -48,7 +48,7 @@ def test_debug_spend_bundle() -> None:
     sys.stdout = result
 
     debug_spend_bundle(
-        SpendBundle(
+        WalletSpendBundle(
             [
                 make_spend(
                     coin_bad_reveal,

--- a/chia/_tests/wallet/test_signer_protocol.py
+++ b/chia/_tests/wallet/test_signer_protocol.py
@@ -37,7 +37,6 @@ from chia.types.blockchain_format.coin import Coin as ConsensusCoin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, make_spend
-from chia.types.spend_bundle import SpendBundle
 from chia.util.hash import std_hash
 from chia.util.ints import uint64
 from chia.util.streamable import Streamable
@@ -80,6 +79,7 @@ from chia.wallet.util.clvm_streamable import (
 )
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.wallet import Wallet
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 from chia.wallet.wallet_state_manager import WalletStateManager
 
 
@@ -262,7 +262,7 @@ async def test_p2dohp_wallet_signer_protocol(wallet_environments: WalletTestFram
     await wallet_rpc.submit_transactions(SubmitTransactions(signed_transactions=signed_txs))
     await wallet_environments.full_node.wait_bundle_ids_in_mempool(
         [
-            SpendBundle(
+            WalletSpendBundle(
                 [spend.as_coin_spend() for tx in signed_txs for spend in tx.transaction_info.spends],
                 G2Element.from_bytes(signing_responses[0].signature),
             ).name()

--- a/chia/_tests/wallet/test_wallet_action_scope.py
+++ b/chia/_tests/wallet/test_wallet_action_scope.py
@@ -9,16 +9,16 @@ from chia_rs import G2Element
 from chia._tests.cmds.wallet.test_consts import STD_TX
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint64
 from chia.wallet.signer_protocol import SigningResponse
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.wallet_action_scope import WalletSideEffects
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 from chia.wallet.wallet_state_manager import WalletStateManager
 
 MOCK_SR = SigningResponse(b"hey", bytes32([0] * 32))
-MOCK_SB = SpendBundle([], G2Element())
+MOCK_SB = WalletSpendBundle([], G2Element())
 MOCK_COIN = Coin(bytes32([0] * 32), bytes32([0] * 32), uint64(0))
 
 
@@ -36,7 +36,7 @@ def test_back_and_forth_serialization() -> None:
 @dataclass
 class MockWalletStateManager:
     most_recent_call: Optional[
-        Tuple[List[TransactionRecord], bool, bool, bool, List[SigningResponse], List[SpendBundle]]
+        Tuple[List[TransactionRecord], bool, bool, bool, List[SigningResponse], List[WalletSpendBundle]]
     ] = None
 
     async def add_pending_transactions(
@@ -46,7 +46,7 @@ class MockWalletStateManager:
         merge_spends: bool,
         sign: bool,
         additional_signing_responses: List[SigningResponse],
-        extra_spends: List[SpendBundle],
+        extra_spends: List[WalletSpendBundle],
     ) -> List[TransactionRecord]:
         self.most_recent_call = (txs, push, merge_spends, sign, additional_signing_responses, extra_spends)
         return txs

--- a/chia/_tests/wallet/test_wallet_state_manager.py
+++ b/chia/_tests/wallet/test_wallet_state_manager.py
@@ -15,13 +15,13 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import make_spend
 from chia.types.peer_info import PeerInfo
-from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 from chia.wallet.wallet_state_manager import WalletStateManager
 
 
@@ -138,7 +138,7 @@ async def test_commit_transactions_to_db(wallet_environments: WalletTestFramewor
 
     created_txs = action_scope.side_effects.transactions
 
-    def flatten_spend_bundles(txs: List[TransactionRecord]) -> List[SpendBundle]:
+    def flatten_spend_bundles(txs: List[TransactionRecord]) -> List[WalletSpendBundle]:
         return [tx.spend_bundle for tx in txs if tx.spend_bundle is not None]
 
     assert (
@@ -158,7 +158,7 @@ async def test_commit_transactions_to_db(wallet_environments: WalletTestFramewor
     extra_coin_spend = make_spend(
         Coin(bytes32(b"1" * 32), bytes32(b"1" * 32), uint64(0)), Program.to(1), Program.to([])
     )
-    extra_spend = SpendBundle([extra_coin_spend], G2Element())
+    extra_spend = WalletSpendBundle([extra_coin_spend], G2Element())
 
     new_txs = await wsm.add_pending_transactions(
         created_txs,

--- a/chia/_tests/wallet/test_wallet_trade_store.py
+++ b/chia/_tests/wallet/test_wallet_trade_store.py
@@ -9,7 +9,6 @@ from chia_rs import G2Element
 from chia._tests.util.db_connection import DBConnection
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64
 from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.trade_record import TradeRecord, TradeRecordOld
@@ -19,6 +18,7 @@ from chia.wallet.trading.trade_store import TradeStore, migrate_coin_of_interest
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_coin_store import WalletCoinStore
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 module_seeded_random = random.Random()
 module_seeded_random.seed(a=0, version=2)
@@ -132,7 +132,7 @@ async def test_valid_times_migration() -> None:
                 " is_my_offer tinyint)"
             )
 
-        fake_offer = Offer({}, SpendBundle([], G2Element()), {})
+        fake_offer = Offer({}, WalletSpendBundle([], G2Element()), {})
         fake_coin = Coin(bytes32([0] * 32), bytes32([0] * 32), uint64(0))
         old_record = TradeRecordOld(
             confirmed_at_index=uint32(0),

--- a/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
@@ -16,7 +16,6 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import make_spend
 from chia.types.peer_info import PeerInfo
-from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.ints import uint64
 from chia.wallet.cat_wallet.cat_utils import CAT_MOD, construct_cat_puzzle
@@ -31,6 +30,7 @@ from chia.wallet.vc_wallet.cr_cat_wallet import CRCATWallet
 from chia.wallet.vc_wallet.vc_store import VCProofs, VCRecord
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_node import WalletNode
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 
 async def mint_cr_cat(
@@ -69,7 +69,7 @@ async def mint_cr_cat(
 
     # Do the eve spend back to our wallet and add the CR layer
     cat_coin = next(c for c in spend_bundle.additions() if c.amount == CAT_AMOUNT_0)
-    eve_spend = SpendBundle(
+    eve_spend = WalletSpendBundle(
         [
             make_spend(
                 cat_coin,
@@ -104,7 +104,7 @@ async def mint_cr_cat(
         ],
         G2Element(),
     )
-    spend_bundle = SpendBundle.aggregate([spend_bundle, eve_spend])
+    spend_bundle = WalletSpendBundle.aggregate([spend_bundle, eve_spend])
     await wallet_node_0.wallet_state_manager.add_pending_transactions(
         [dataclasses.replace(tx, spend_bundle=spend_bundle, name=spend_bundle.name())]
     )

--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -29,7 +29,7 @@ from chia.types.coin_spend import CoinSpend
 from chia.types.generator_types import BlockGenerator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.mempool_item import MempoolItem
-from chia.types.spend_bundle import SpendBundle
+from chia.types.spend_bundle import SpendBundle, T_SpendBundle
 from chia.util.db_wrapper import DBWrapper2
 from chia.util.errors import Err, ValidationError
 from chia.util.hash import std_hash
@@ -64,7 +64,7 @@ class CostLogger:
         self.cost_dict: Dict[str, int] = {}
         self.cost_dict_no_puzs: Dict[str, int] = {}
 
-    def add_cost(self, descriptor: str, spend_bundle: SpendBundle) -> SpendBundle:
+    def add_cost(self, descriptor: str, spend_bundle: T_SpendBundle) -> T_SpendBundle:
         program: BlockGenerator = simple_solution_generator(spend_bundle)
         npc_result: NPCResult = get_name_puzzle_conditions(
             program,

--- a/chia/cmds/signer.py
+++ b/chia/cmds/signer.py
@@ -19,11 +19,11 @@ from chia.cmds.cmds_util import TransactionBundle
 from chia.cmds.wallet import wallet_cmd
 from chia.rpc.util import ALL_TRANSLATION_LAYERS
 from chia.rpc.wallet_request_types import ApplySignatures, ExecuteSigningInstructions, GatherSigningInfo
-from chia.types.spend_bundle import SpendBundle
 from chia.util.streamable import Streamable
 from chia.wallet.signer_protocol import SignedTransaction, SigningInstructions, SigningResponse, Spend
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.clvm_streamable import byte_deserialize_clvm_streamable, byte_serialize_clvm_streamable
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 
 def _clear_screen() -> None:
@@ -253,9 +253,7 @@ class ApplySignaturesCMD:
                     print("No external spot for non BLS signatures in a spend")
                     return
                 final_signature = AugSchemeMPL.aggregate([final_signature, G2Element.from_bytes(signature.signature)])
-            new_spend_bundle: SpendBundle = SpendBundle(
-                [spend.as_coin_spend() for spend in signed_spends], final_signature
-            )
+            new_spend_bundle = WalletSpendBundle([spend.as_coin_spend() for spend in signed_spends], final_signature)
             new_transactions: List[TransactionRecord] = [
                 replace(
                     self.txs_in.transaction_bundle.txs[0], spend_bundle=new_spend_bundle, name=new_spend_bundle.name()

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -42,7 +42,6 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, compute_additions
-from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64, uint128
 from chia.wallet.conditions import AssertCoinAnnouncement, Condition, ConditionValidTimes
 from chia.wallet.derive_keys import find_owner_sk
@@ -54,6 +53,7 @@ from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_action_scope import WalletActionScope
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_state_manager import WalletStateManager
@@ -531,7 +531,7 @@ class PoolWallet:
         else:
             raise RuntimeError("Invalid state")
 
-        unsigned_spend_bundle = SpendBundle([outgoing_coin_spend], G2Element())
+        unsigned_spend_bundle = WalletSpendBundle([outgoing_coin_spend], G2Element())
         assert unsigned_spend_bundle.removals()[0].puzzle_hash == singleton.puzzle_hash
         assert unsigned_spend_bundle.removals()[0].name() == singleton.name()
         if fee > 0:
@@ -624,7 +624,7 @@ class PoolWallet:
             SerializedProgram.from_program(genesis_launcher_puz),
             SerializedProgram.from_program(genesis_launcher_solution),
         )
-        launcher_sb: SpendBundle = SpendBundle([launcher_cs], G2Element())
+        launcher_sb = WalletSpendBundle([launcher_cs], G2Element())
 
         await standard_wallet.generate_signed_transaction(
             amount,
@@ -796,7 +796,7 @@ class PoolWallet:
         if len(all_spends) == 0 or first_coin_record is None:
             raise ValueError("Nothing to claim, no unspent coinbase rewards")
 
-        claim_spend: SpendBundle = SpendBundle(all_spends, G2Element())
+        claim_spend = WalletSpendBundle(all_spends, G2Element())
 
         # If fee is 0, no signatures are required to absorb
         if fee > 0:

--- a/chia/rpc/util.py
+++ b/chia/rpc/util.py
@@ -10,7 +10,6 @@ from chia_rs import AugSchemeMPL
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.coin_spend import CoinSpend
-from chia.types.spend_bundle import SpendBundle
 from chia.util.json_util import obj_to_response
 from chia.util.streamable import Streamable
 from chia.wallet.conditions import Condition, ConditionValidTimes, conditions_from_json_dicts, parse_timelock_info
@@ -25,6 +24,7 @@ from chia.wallet.util.clvm_streamable import (
 )
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import TXConfig, TXConfigLoader
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 log = logging.getLogger(__name__)
 
@@ -224,7 +224,7 @@ def tx_endpoint(
                     tx.name.hex() for tx in new_txs if tx.type == TransactionType.OUTGOING_CLAWBACK.value
                 ]
             if "spend_bundle" in response:
-                response["spend_bundle"] = SpendBundle.aggregate(
+                response["spend_bundle"] = WalletSpendBundle.aggregate(
                     [tx.spend_bundle for tx in new_txs if tx.spend_bundle is not None]
                 )
             if "signed_txs" in response:
@@ -252,7 +252,7 @@ def tx_endpoint(
                 signed_coin_spends.extend(
                     [spend for spend in old_offer._bundle.coin_spends if spend.coin not in involved_coins]
                 )
-                new_offer_bundle: SpendBundle = SpendBundle(
+                new_offer_bundle = WalletSpendBundle(
                     signed_coin_spends,
                     AugSchemeMPL.aggregate(
                         [tx.spend_bundle.aggregated_signature for tx in new_txs if tx.spend_bundle is not None]

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional, Type, TypeVar
 from typing_extensions import dataclass_transform
 
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint16, uint32, uint64
 from chia.util.streamable import Streamable, streamable
 from chia.wallet.notification_store import Notification
@@ -25,6 +24,7 @@ from chia.wallet.trading.offer import Offer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.clvm_streamable import json_deserialize_with_clvm_streamable
 from chia.wallet.vc_wallet.vc_store import VCRecord
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 _T_OfferEndpointResponse = TypeVar("_T_OfferEndpointResponse", bound="_OfferEndpointResponse")
 
@@ -169,13 +169,13 @@ class DIDUpdateRecoveryIDsResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True)
 class DIDMessageSpendResponse(TransactionEndpointResponse):
-    spend_bundle: SpendBundle
+    spend_bundle: WalletSpendBundle
 
 
 @streamable
 @dataclass(frozen=True)
 class DIDUpdateMetadataResponse(TransactionEndpointResponse):
-    spend_bundle: SpendBundle
+    spend_bundle: WalletSpendBundle
     wallet_id: uint32
 
 
@@ -241,7 +241,7 @@ class CancelOffersResponse(TransactionEndpointResponse):
 @dataclass(frozen=True)
 class NFTMintNFTResponse(TransactionEndpointResponse):
     wallet_id: uint32
-    spend_bundle: SpendBundle
+    spend_bundle: WalletSpendBundle
     nft_id: str
 
 
@@ -249,27 +249,27 @@ class NFTMintNFTResponse(TransactionEndpointResponse):
 @dataclass(frozen=True)
 class NFTAddURIResponse(TransactionEndpointResponse):
     wallet_id: uint32
-    spend_bundle: SpendBundle
+    spend_bundle: WalletSpendBundle
 
 
 @streamable
 @dataclass(frozen=True)
 class NFTTransferNFTResponse(TransactionEndpointResponse):
     wallet_id: uint32
-    spend_bundle: SpendBundle
+    spend_bundle: WalletSpendBundle
 
 
 @streamable
 @dataclass(frozen=True)
 class NFTSetNFTDIDResponse(TransactionEndpointResponse):
     wallet_id: uint32
-    spend_bundle: SpendBundle
+    spend_bundle: WalletSpendBundle
 
 
 @streamable
 @dataclass(frozen=True)
 class NFTMintBulkResponse(TransactionEndpointResponse):
-    spend_bundle: SpendBundle
+    spend_bundle: WalletSpendBundle
     nft_id_list: List[str]
 
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -41,7 +41,6 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend
 from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX, SigningMode
-from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.config import load_config, str2bool
@@ -131,6 +130,7 @@ from chia.wallet.wallet_coin_store import CoinRecordOrder, GetCoinRecords, unspe
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_protocol import WalletProtocol
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 # Timeout for response from wallet/full node for sending a transaction
 TIMEOUT = 30
@@ -617,7 +617,7 @@ class WalletRpcApi:
         nodes = self.service.server.get_connections(NodeType.FULL_NODE)
         if len(nodes) == 0:
             raise ValueError("Wallet is not currently connected to any full node peers")
-        await self.service.push_tx(SpendBundle.from_bytes(hexstr_to_bytes(request["spend_bundle"])))
+        await self.service.push_tx(WalletSpendBundle.from_bytes(hexstr_to_bytes(request["spend_bundle"])))
         return {}
 
     @tx_endpoint(push=True)
@@ -1075,7 +1075,7 @@ class WalletRpcApi:
                 )
                 assert len(coin_state_list) == 1
                 coin_spend = await fetch_coin_spend_for_coin_state(coin_state_list[0], peer)
-                tr = dataclasses.replace(tr, spend_bundle=SpendBundle([coin_spend], G2Element()))
+                tr = dataclasses.replace(tr, spend_bundle=WalletSpendBundle([coin_spend], G2Element()))
             else:
                 raise ValueError(f"Transaction 0x{transaction_id.hex()} doesn't have any coin spend.")
         assert tr.spend_bundle is not None
@@ -2387,7 +2387,7 @@ class WalletRpcApi:
         launcher_id = bytes32(singleton_struct.rest().first().as_atom())
         uncurried_p2 = uncurry_puzzle(p2_puzzle)
         (public_key,) = uncurried_p2.args.as_iter()
-        memos = compute_memos(SpendBundle([coin_spend], G2Element()))
+        memos = compute_memos(WalletSpendBundle([coin_spend], G2Element()))
         hints = []
         coin_memos = memos.get(coin_state.coin.name())
         if coin_memos is not None:
@@ -3800,7 +3800,7 @@ class WalletRpcApi:
                 extra_conditions=extra_conditions,
             )
         async with action_scope.use() as interface:
-            sb = SpendBundle.aggregate(
+            sb = WalletSpendBundle.aggregate(
                 [tx.spend_bundle for tx in interface.side_effects.transactions if tx.spend_bundle is not None]
             )
         nft_id_list = []

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -52,7 +52,6 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
-from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.conditions import Condition, ConditionValidTimes, conditions_to_json_dicts
@@ -66,6 +65,7 @@ from chia.wallet.util.tx_config import CoinSelectionConfig, TXConfig
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.vc_wallet.vc_store import VCRecord
 from chia.wallet.wallet_coin_store import GetCoinRecords
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 
 def parse_result_transactions(result: Dict[str, Any]) -> Dict[str, Any]:
@@ -147,7 +147,7 @@ class WalletRpcClient(RpcClient):
         # TODO: casting due to lack of type checked deserialization
         return cast(uint32, response["height"])
 
-    async def push_tx(self, spend_bundle: SpendBundle) -> Dict[str, Any]:
+    async def push_tx(self, spend_bundle: WalletSpendBundle) -> Dict[str, Any]:
         return await self.fetch("push_tx", {"spend_bundle": bytes(spend_bundle).hex()})
 
     async def push_transactions(

--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TypeVar
+
 import chia_rs
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
@@ -8,6 +10,7 @@ from chia.util.errors import Err, ValidationError
 from .coin_spend import compute_additions_with_cost
 
 SpendBundle = chia_rs.SpendBundle
+T_SpendBundle = TypeVar("T_SpendBundle", bound="SpendBundle")
 
 
 # This function executes all the puzzles to compute the difference between

--- a/chia/wallet/cat_wallet/cat_utils.py
+++ b/chia/wallet/cat_wallet/cat_utils.py
@@ -10,11 +10,11 @@ from chia.types.blockchain_format.program import INFINITE_COST, Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
-from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
 from chia.wallet.uncurried_puzzle import UncurriedPuzzle
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 NULL_SIGNATURE = G2Element()
 
@@ -103,9 +103,11 @@ def next_info_for_spendable_cat(spendable_cat: SpendableCAT) -> Program:
 
 
 # This should probably return UnsignedSpendBundle if that type ever exists
-def unsigned_spend_bundle_for_spendable_cats(mod_code: Program, spendable_cat_list: List[SpendableCAT]) -> SpendBundle:
+def unsigned_spend_bundle_for_spendable_cats(
+    mod_code: Program, spendable_cat_list: List[SpendableCAT]
+) -> WalletSpendBundle:
     """
-    Given a list of `SpendableCAT` objects, create a `SpendBundle` that spends all those coins.
+    Given a list of `SpendableCAT` objects, create a `WalletSpendBundle` that spends all those coins.
     Note that no signing is done here, so it falls on the caller to sign the resultant bundle.
     """
 
@@ -158,4 +160,4 @@ def unsigned_spend_bundle_for_spendable_cats(mod_code: Program, spendable_cat_li
         coin_spend = make_spend(spend_info.coin, puzzle_reveal, Program.to(solution))
         coin_spends.append(coin_spend)
 
-    return SpendBundle(coin_spends, NULL_SIGNATURE)
+    return WalletSpendBundle(coin_spends, NULL_SIGNATURE)

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -16,7 +16,6 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import compute_additions_with_cost
 from chia.types.condition_opcodes import ConditionOpcode
-from chia.types.spend_bundle import SpendBundle
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.errors import Err, ValidationError
 from chia.util.hash import std_hash
@@ -58,6 +57,7 @@ from chia.wallet.wallet_action_scope import WalletActionScope
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_protocol import GSTOptionalArgs, WalletProtocol
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_state_manager import WalletStateManager
@@ -69,7 +69,7 @@ CAT_MOD_HASH_HASH = Program.to(CAT_MOD_HASH).get_tree_hash()
 QUOTED_MOD_HASH = calculate_hash_of_quoted_mod_hash(CAT_MOD_HASH)
 
 
-def not_ephemeral_additions(sp: SpendBundle) -> List[Coin]:
+def not_ephemeral_additions(sp: WalletSpendBundle) -> List[Coin]:
     removals: Set[Coin] = set()
     for cs in sp.coin_spends:
         removals.add(cs.coin)
@@ -633,7 +633,7 @@ class CATWallet:
         cat_discrepancy: Optional[Tuple[int, Program, Program]] = None,  # (extra_delta, tail_reveal, tail_solution)
         coins: Optional[Set[Coin]] = None,
         extra_conditions: Tuple[Condition, ...] = tuple(),
-    ) -> SpendBundle:
+    ) -> WalletSpendBundle:
         if cat_discrepancy is not None:
             extra_delta, tail_reveal, tail_solution = cat_discrepancy
         else:

--- a/chia/wallet/cat_wallet/dao_cat_wallet.py
+++ b/chia/wallet/cat_wallet/dao_cat_wallet.py
@@ -10,7 +10,6 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.spend_bundle import SpendBundle
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint32, uint64, uint128
 from chia.wallet.cat_wallet.cat_utils import (
@@ -42,6 +41,7 @@ from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_action_scope import WalletActionScope
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_state_manager import WalletStateManager
@@ -257,7 +257,7 @@ class DAOCATWallet:
         proposal_id: bytes32,
         is_yes_vote: bool,
         proposal_puzzle: Optional[Program] = None,
-    ) -> SpendBundle:
+    ) -> WalletSpendBundle:
         coins: List[LockedCoinInfo] = await self.advanced_select_coins(amount, proposal_id)
         running_sum = 0  # this will be used for change calculation
         change = sum(c.coin.amount for c in coins) - amount
@@ -498,7 +498,7 @@ class DAOCATWallet:
         proposal_id_list: List[bytes32],
         action_scope: WalletActionScope,
         fee: uint64 = uint64(0),
-    ) -> SpendBundle:
+    ) -> WalletSpendBundle:
         locked_coins: List[Tuple[LockedCoinInfo, List[bytes32]]] = []
         for lci in self.dao_cat_info.locked_coins:
             my_finished_proposals = []

--- a/chia/wallet/notification_manager.py
+++ b/chia/wallet/notification_manager.py
@@ -10,7 +10,6 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, make_spend
-from chia.types.spend_bundle import SpendBundle
 from chia.util.db_wrapper import DBWrapper2
 from chia.util.ints import uint32, uint64
 from chia.wallet.conditions import AssertCoinAnnouncement, Condition
@@ -19,6 +18,7 @@ from chia.wallet.util.compute_memos import compute_memos_for_spend
 from chia.wallet.util.notifications import construct_notification
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_action_scope import WalletActionScope
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 
 class NotificationManager:
@@ -99,7 +99,7 @@ class NotificationManager:
             notification_puzzle,
             Program.to(None),
         )
-        extra_spend_bundle = SpendBundle([notification_spend], G2Element())
+        extra_spend_bundle = WalletSpendBundle([notification_spend], G2Element())
         await self.wallet_state_manager.main_wallet.generate_signed_transaction(
             amount,
             notification_hash,

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -6,7 +6,6 @@ from chia_rs import Coin
 
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.spend_bundle import SpendBundle
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.ints import uint64
 from chia.wallet.cat_wallet.cat_info import CATInfo
@@ -23,6 +22,7 @@ from chia.wallet.payment import Payment
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.wallet_action_scope import WalletActionScope
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 GENESIS_BY_ID_MOD = load_clvm_maybe_recompile(
     "genesis_by_coin_id.clsp", package_or_requirement="chia.wallet.cat_wallet.puzzles"
@@ -57,7 +57,7 @@ class LimitationsProgram:
     @classmethod
     async def generate_issuance_bundle(
         cls, wallet, cat_tail_info: Dict, amount: uint64, action_scope: WalletActionScope
-    ) -> SpendBundle:
+    ) -> WalletSpendBundle:
         raise NotImplementedError("Need to implement 'generate_issuance_bundle' on limitations programs")
 
 
@@ -91,7 +91,7 @@ class GenesisById(LimitationsProgram):
         amount: uint64,
         action_scope: WalletActionScope,
         fee: uint64 = uint64(0),
-    ) -> SpendBundle:
+    ) -> WalletSpendBundle:
         coins = await wallet.standard_wallet.select_coins(amount + fee, action_scope)
 
         origin = coins.copy().pop()
@@ -255,7 +255,7 @@ class GenesisByIdOrSingleton(LimitationsProgram):
         amount: uint64,
         action_scope: WalletActionScope,
         fee: uint64 = uint64(0),
-    ) -> SpendBundle:
+    ) -> WalletSpendBundle:
         if "coins" in tail_info:
             coins: List[Coin] = tail_info["coins"]
             origin_id = coins.copy().pop().name()

--- a/chia/wallet/transaction_record.py
+++ b/chia/wallet/transaction_record.py
@@ -7,13 +7,13 @@ from chia.consensus.coinbase import farmer_parent_id, pool_parent_id
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.errors import Err
 from chia.util.ints import uint8, uint32, uint64
 from chia.util.streamable import Streamable, streamable
 from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.util.transaction_type import TransactionType
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 T = TypeVar("T")
 _T_TransactionRecord = TypeVar("_T_TransactionRecord", bound="TransactionRecordOld")
@@ -41,7 +41,7 @@ class TransactionRecordOld(Streamable):
     fee_amount: uint64
     confirmed: bool
     sent: uint32
-    spend_bundle: Optional[SpendBundle]
+    spend_bundle: Optional[WalletSpendBundle]
     additions: List[Coin]
     removals: List[Coin]
     wallet_id: uint32

--- a/chia/wallet/util/compute_memos.py
+++ b/chia/wallet/util/compute_memos.py
@@ -9,8 +9,8 @@ from chia.types.blockchain_format.program import INFINITE_COST
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode
-from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint64
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 
 def compute_memos_for_spend(coin_spend: CoinSpend) -> Dict[bytes32, List[bytes]]:
@@ -27,7 +27,7 @@ def compute_memos_for_spend(coin_spend: CoinSpend) -> Dict[bytes32, List[bytes]]
     return memos
 
 
-def compute_memos(bundle: SpendBundle) -> Dict[bytes32, List[bytes]]:
+def compute_memos(bundle: WalletSpendBundle) -> Dict[bytes32, List[bytes]]:
     """
     Retrieves the memos for additions in this spend_bundle, which are formatted as a list in the 3rd parameter of
     CREATE_COIN. If there are no memos, the addition coin_id is not included. If they are not formatted as a list

--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -13,7 +13,6 @@ from chia.types.blockchain_format.coin import Coin, coin_as_list
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend
-from chia.types.spend_bundle import SpendBundle
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64, uint128
@@ -58,6 +57,7 @@ from chia.wallet.wallet_action_scope import WalletActionScope
 from chia.wallet.wallet_coin_record import MetadataTypes, WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_protocol import GSTOptionalArgs, WalletProtocol
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_state_manager import WalletStateManager
@@ -241,7 +241,7 @@ class CRCATWallet(CATWallet):
                 self.log.info(f"Found pending approval CRCAT coin {coin.name().hex()}")
                 is_pending = True
                 created_timestamp = await self.wallet_state_manager.wallet_node.get_timestamp_for_height(uint32(height))
-                spend_bundle = SpendBundle([coin_spend], G2Element())
+                spend_bundle = WalletSpendBundle([coin_spend], G2Element())
                 memos = compute_memos(spend_bundle)
                 # This will override the tx created in the wallet state manager
                 tx_record = TransactionRecord(
@@ -404,7 +404,7 @@ class CRCATWallet(CATWallet):
         coins: Optional[Set[Coin]] = None,
         extra_conditions: Tuple[Condition, ...] = tuple(),
         add_authorizations_to_cr_cats: bool = True,
-    ) -> SpendBundle:
+    ) -> WalletSpendBundle:
         if cat_discrepancy is not None:
             extra_delta, tail_reveal, tail_solution = cat_discrepancy
         else:
@@ -592,7 +592,7 @@ class CRCATWallet(CATWallet):
                 ),
             )
 
-        return SpendBundle(coin_spends, G2Element())
+        return WalletSpendBundle(coin_spends, G2Element())
 
     async def generate_signed_transaction(
         self,
@@ -751,7 +751,7 @@ class CRCATWallet(CATWallet):
             vc.launcher_id,
             vc.wrap_inner_with_backdoor().get_tree_hash(),
         )
-        claim_bundle: SpendBundle = SpendBundle(coin_spends, G2Element())
+        claim_bundle = WalletSpendBundle(coin_spends, G2Element())
 
         # Make the Fee TX
         if fee > 0:

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -13,7 +13,6 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX, SigningMode
-from chia.types.spend_bundle import SpendBundle
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64, uint128
 from chia.util.streamable import Streamable
@@ -57,6 +56,7 @@ from chia.wallet.wallet_action_scope import WalletActionScope
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_protocol import GSTOptionalArgs, WalletProtocol
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 if TYPE_CHECKING:
     from chia.server.ws_connection import WSChiaConnection
@@ -431,7 +431,7 @@ class Wallet:
             extra_conditions=extra_conditions,
         )
         assert len(transaction) > 0
-        spend_bundle: SpendBundle = SpendBundle(transaction, G2Element())
+        spend_bundle = WalletSpendBundle(transaction, G2Element())
 
         now = uint64(int(time.time()))
         add_list: List[Coin] = list(spend_bundle.additions())

--- a/chia/wallet/wallet_action_scope.py
+++ b/chia/wallet/wallet_action_scope.py
@@ -5,12 +5,12 @@ from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, AsyncIterator, List, Optional, cast, final
 
 from chia.types.blockchain_format.coin import Coin
-from chia.types.spend_bundle import SpendBundle
 from chia.util.action_scope import ActionScope
 from chia.util.streamable import Streamable, streamable
 from chia.wallet.signer_protocol import SigningResponse
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.tx_config import TXConfig
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 if TYPE_CHECKING:
     # Avoid a circular import here
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 class _StreamableWalletSideEffects(Streamable):
     transactions: List[TransactionRecord]
     signing_responses: List[SigningResponse]
-    extra_spends: List[SpendBundle]
+    extra_spends: List[WalletSpendBundle]
     selected_coins: List[Coin]
 
 
@@ -30,7 +30,7 @@ class _StreamableWalletSideEffects(Streamable):
 class WalletSideEffects:
     transactions: List[TransactionRecord] = field(default_factory=list)
     signing_responses: List[SigningResponse] = field(default_factory=list)
-    extra_spends: List[SpendBundle] = field(default_factory=list)
+    extra_spends: List[WalletSpendBundle] = field(default_factory=list)
     selected_coins: List[Coin] = field(default_factory=list)
 
     def __bytes__(self) -> bytes:
@@ -48,7 +48,7 @@ class WalletActionConfig:
     merge_spends: bool
     sign: Optional[bool]
     additional_signing_responses: List[SigningResponse]
-    extra_spends: List[SpendBundle]
+    extra_spends: List[WalletSpendBundle]
     tx_config: TXConfig
 
     def adjust_for_side_effects(self, side_effects: WalletSideEffects) -> WalletActionConfig:
@@ -72,7 +72,7 @@ async def new_wallet_action_scope(
     merge_spends: bool = True,
     sign: Optional[bool] = None,
     additional_signing_responses: List[SigningResponse] = [],
-    extra_spends: List[SpendBundle] = [],
+    extra_spends: List[WalletSpendBundle] = [],
 ) -> AsyncIterator[WalletActionScope]:
     async with ActionScope.new_scope(
         WalletSideEffects,

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -57,7 +57,6 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.header_block import HeaderBlock
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.types.spend_bundle import SpendBundle
 from chia.types.weight_proof import WeightProof
 from chia.util.batches import to_batches
 from chia.util.config import lock_and_load_config, process_config_start_method, save_config
@@ -84,6 +83,7 @@ from chia.wallet.util.wallet_sync_utils import (
     subscribe_to_phs,
 )
 from chia.wallet.util.wallet_types import CoinType, WalletType
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 from chia.wallet.wallet_state_manager import WalletStateManager
 from chia.wallet.wallet_weight_proof_handler import WalletWeightProofHandler, get_wp_fork_point
 
@@ -1727,7 +1727,7 @@ class WalletNode:
         return response.coin_states
 
     # For RPC only. You should use wallet_state_manager.add_pending_transaction for normal wallet business.
-    async def push_tx(self, spend_bundle: SpendBundle) -> None:
+    async def push_tx(self, spend_bundle: WalletSpendBundle) -> None:
         msg = make_msg(ProtocolMessageTypes.send_transaction, SendTransaction(spend_bundle))
         full_nodes = self.server.get_connections(NodeType.FULL_NODE)
         for peer in full_nodes:

--- a/chia/wallet/wallet_protocol.py
+++ b/chia/wallet/wallet_protocol.py
@@ -9,13 +9,13 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64, uint128
 from chia.wallet.nft_wallet.nft_info import NFTCoinInfo
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_action_scope import WalletActionScope
 from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_state_manager import WalletStateManager
@@ -77,7 +77,7 @@ class GSTOptionalArgs(TypedDict):
     new_owner: NotRequired[Optional[bytes]]
     new_did_inner_hash: NotRequired[Optional[bytes]]
     trade_prices_list: NotRequired[Optional[Program]]
-    additional_bundles: NotRequired[List[SpendBundle]]
+    additional_bundles: NotRequired[List[WalletSpendBundle]]
     metadata_update: NotRequired[Optional[Tuple[str, str]]]
     # CR-CAT Wallet
     add_authorizations_to_cr_cats: NotRequired[bool]

--- a/chia/wallet/wallet_spend_bundle.py
+++ b/chia/wallet/wallet_spend_bundle.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from chia_rs import AugSchemeMPL, G2Element
+
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.types.coin_spend import CoinSpend
+from chia.types.spend_bundle import SpendBundle, T_SpendBundle
+from chia.wallet.util.debug_spend_bundle import debug_spend_bundle
+
+
+class WalletSpendBundle(SpendBundle):
+
+    @classmethod
+    def from_bytes(cls, bytes: bytes) -> WalletSpendBundle:
+        sb = SpendBundle.from_bytes(bytes)
+        return cls(sb.coin_spends, sb.aggregated_signature)
+
+    @classmethod
+    def parse_rust(cls, blob: bytes, flag: bool = False) -> Tuple[WalletSpendBundle, int]:
+        bundle, advance = super(WalletSpendBundle, WalletSpendBundle).parse_rust(blob)
+        return cls(bundle.coin_spends, bundle.aggregated_signature), advance
+
+    @classmethod
+    def from_json_dict(cls, json_dict: Dict[str, Any]) -> WalletSpendBundle:
+        sb = SpendBundle.from_json_dict(json_dict)
+        return cls(sb.coin_spends, sb.aggregated_signature)
+
+    @classmethod
+    def aggregate(cls, spend_bundles: List[T_SpendBundle]) -> WalletSpendBundle:
+        coin_spends: List[CoinSpend] = []
+        sigs: List[G2Element] = []
+        for bundle in spend_bundles:
+            coin_spends += bundle.coin_spends
+            sigs.append(bundle.aggregated_signature)
+        aggregated_signature = AugSchemeMPL.aggregate(sigs)
+        return cls(coin_spends, aggregated_signature)
+
+    def debug(self, agg_sig_additional_data: bytes = DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA) -> None:
+        debug_spend_bundle(self, agg_sig_additional_data)  # pragma: no cover

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -50,7 +50,6 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.types.spend_bundle import SpendBundle
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
 from chia.util.db_synchronous import db_synchronous_on
@@ -155,6 +154,7 @@ from chia.wallet.wallet_pool_store import WalletPoolStore
 from chia.wallet.wallet_protocol import WalletProtocol
 from chia.wallet.wallet_puzzle_store import WalletPuzzleStore
 from chia.wallet.wallet_retry_store import WalletRetryStore
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 from chia.wallet.wallet_transaction_store import WalletTransactionStore
 from chia.wallet.wallet_user_store import WalletUserStore
 
@@ -1018,7 +1018,7 @@ class WalletStateManager:
                 self.log.error(f"Failed to create clawback spend bundle for {coin.name().hex()}: {e}")
         if len(coin_spends) == 0:
             return
-        spend_bundle: SpendBundle = SpendBundle(coin_spends, G2Element())
+        spend_bundle = WalletSpendBundle(coin_spends, G2Element())
         if fee > 0:
             async with self.new_action_scope(action_scope.config.tx_config, push=False) as inner_action_scope:
                 await self.main_wallet.create_tandem_xch_tx(
@@ -1035,7 +1035,7 @@ class WalletStateManager:
                 interface.side_effects.transactions.extend(
                     [dataclasses.replace(tx, spend_bundle=None) for tx in inner_action_scope.side_effects.transactions]
                 )
-            spend_bundle = SpendBundle.aggregate(
+            spend_bundle = WalletSpendBundle.aggregate(
                 [
                     spend_bundle,
                     *(
@@ -1596,7 +1596,7 @@ class WalletStateManager:
             # For the recipient we need to manually subscribe the merkle coin
             await self.add_interested_coin_ids([coin_state.coin.name()])
         if is_recipient is not None:
-            spend_bundle = SpendBundle([coin_spend], G2Element())
+            spend_bundle = WalletSpendBundle([coin_spend], G2Element())
             memos = compute_memos(spend_bundle)
             spent_height: uint32 = uint32(0)
             if coin_state.spent_height is not None:
@@ -1606,7 +1606,7 @@ class WalletStateManager:
                 # Create Clawback outgoing transaction
                 created_timestamp = await self.wallet_node.get_timestamp_for_height(uint32(coin_state.spent_height))
                 clawback_coin_spend: CoinSpend = await fetch_coin_spend_for_coin_state(coin_state, peer)
-                clawback_spend_bundle: SpendBundle = SpendBundle([clawback_coin_spend], G2Element())
+                clawback_spend_bundle = WalletSpendBundle([clawback_coin_spend], G2Element())
                 if await self.puzzle_store.puzzle_hash_exists(clawback_spend_bundle.additions()[0].puzzle_hash):
                     tx_record = TransactionRecord(
                         confirmed_at_height=uint32(coin_state.spent_height),
@@ -2287,7 +2287,7 @@ class WalletStateManager:
         merge_spends: bool = True,
         sign: Optional[bool] = None,
         additional_signing_responses: Optional[List[SigningResponse]] = None,
-        extra_spends: Optional[List[SpendBundle]] = None,
+        extra_spends: Optional[List[WalletSpendBundle]] = None,
     ) -> List[TransactionRecord]:
         """
         Add a list of transactions to be submitted to the full node.
@@ -2295,12 +2295,10 @@ class WalletStateManager:
         """
         if sign is None:
             sign = self.config.get("auto_sign_txs", True)
-        agg_spend: SpendBundle = SpendBundle.aggregate(
-            [tx.spend_bundle for tx in tx_records if tx.spend_bundle is not None]
-        )
+        agg_spend = WalletSpendBundle.aggregate([tx.spend_bundle for tx in tx_records if tx.spend_bundle is not None])
         if extra_spends is not None:
-            agg_spend = SpendBundle.aggregate([agg_spend, *extra_spends])
-        actual_spend_involved: bool = agg_spend != SpendBundle([], G2Element())
+            agg_spend = WalletSpendBundle.aggregate([agg_spend, *extra_spends])
+        actual_spend_involved: bool = agg_spend != WalletSpendBundle([], G2Element())
         if merge_spends and actual_spend_involved:
             tx_records = [
                 dataclasses.replace(
@@ -2312,7 +2310,7 @@ class WalletStateManager:
             ]
         elif extra_spends is not None and extra_spends != []:
             extra_spends.extend([] if tx_records[0].spend_bundle is None else [tx_records[0].spend_bundle])
-            extra_spend_bundle = SpendBundle.aggregate(extra_spends)
+            extra_spend_bundle = WalletSpendBundle.aggregate(extra_spends)
             tx_records = [
                 dataclasses.replace(
                     tx,
@@ -2671,7 +2669,7 @@ class WalletStateManager:
             signing_targets,
         )
 
-    async def gather_signing_info_for_bundles(self, bundles: List[SpendBundle]) -> List[UnsignedTransaction]:
+    async def gather_signing_info_for_bundles(self, bundles: List[WalletSpendBundle]) -> List[UnsignedTransaction]:
         utxs: List[UnsignedTransaction] = []
         for bundle in bundles:
             signer_protocol_spends: List[Spend] = [Spend.from_coin_spend(spend) for spend in bundle.coin_spends]
@@ -2701,10 +2699,10 @@ class WalletStateManager:
     ) -> SignedTransaction:
         return await self.main_wallet.apply_signatures(spends, signing_responses)
 
-    def signed_tx_to_spendbundle(self, signed_tx: SignedTransaction) -> SpendBundle:
+    def signed_tx_to_spendbundle(self, signed_tx: SignedTransaction) -> WalletSpendBundle:
         if len([_ for _ in signed_tx.signatures if _.type != "bls_12381_aug_scheme"]) > 0:
             raise ValueError("Unable to handle signatures that are not bls_12381_aug_scheme")  # pragma: no cover
-        return SpendBundle(
+        return WalletSpendBundle(
             [spend.as_coin_spend() for spend in signed_tx.transaction_info.spends],
             AugSchemeMPL.aggregate([G2Element.from_bytes(sig.signature) for sig in signed_tx.signatures]),
         )
@@ -2763,8 +2761,8 @@ class WalletStateManager:
         coin_spends: List[CoinSpend],
         additional_signing_responses: List[SigningResponse] = [],
         partial_allowed: bool = False,
-    ) -> Tuple[SpendBundle, List[SigningResponse]]:
-        [unsigned_tx] = await self.gather_signing_info_for_bundles([SpendBundle(coin_spends, G2Element())])
+    ) -> Tuple[WalletSpendBundle, List[SigningResponse]]:
+        [unsigned_tx] = await self.gather_signing_info_for_bundles([WalletSpendBundle(coin_spends, G2Element())])
         signing_responses: List[SigningResponse] = await self.execute_signing_instructions(
             unsigned_tx.signing_instructions, partial_allowed=partial_allowed
         )
@@ -2779,7 +2777,7 @@ class WalletStateManager:
         )
 
     async def submit_transactions(self, signed_txs: List[SignedTransaction]) -> List[bytes32]:
-        bundles: List[SpendBundle] = [self.signed_tx_to_spendbundle(tx) for tx in signed_txs]
+        bundles: List[WalletSpendBundle] = [self.signed_tx_to_spendbundle(tx) for tx in signed_txs]
         for bundle in bundles:
             await self.wallet_node.push_tx(bundle)
         return [bundle.name() for bundle in bundles]
@@ -2792,7 +2790,7 @@ class WalletStateManager:
         merge_spends: bool = True,
         sign: Optional[bool] = None,
         additional_signing_responses: List[SigningResponse] = [],
-        extra_spends: List[SpendBundle] = [],
+        extra_spends: List[WalletSpendBundle] = [],
     ) -> AsyncIterator[WalletActionScope]:
         async with new_wallet_action_scope(
             self,


### PR DESCRIPTION
### Purpose:

This allows us to properly separate between the full node spend bundle, and the wallet spend bundles, which for instance inherit from the former but augments it with functionality that is specific to wallets.

### Current Behavior:

We only have one `SpendBundle` type to represent both full node's spend bundles, and wallet spend bundles.

### New Behavior:

We now have full node's spend bundles, and wallet spend bundles, as separate types.