### PR TITLE
[CHIA-839] Refactor KeywringWrapper/FileKeyring for better ergonomics

### DIFF
--- a/chia/_tests/core/util/test_file_keyring_synchronization.py
+++ b/chia/_tests/core/util/test_file_keyring_synchronization.py
@@ -40,7 +40,7 @@ def dummy_set_passphrase(service, user, passphrase, keyring_path, index):
             sleep(0.1)
         assert started
 
-        KeyringWrapper.get_shared_instance().set_passphrase(service=service, user=user, passphrase=passphrase)
+        KeyringWrapper.get_shared_instance().keyring.set_key(service=service, user=user, key=passphrase)
 
         found_passphrase = KeyringWrapper.get_shared_instance().keyring.get_key(service, user)
         if found_passphrase != passphrase:

--- a/chia/_tests/core/util/test_file_keyring_synchronization.py
+++ b/chia/_tests/core/util/test_file_keyring_synchronization.py
@@ -10,9 +10,9 @@ from time import sleep
 
 from chia._tests.core.util.test_lockfile import wait_for_enough_files_in_directory
 from chia.simulator.keyring import TempKeyring
+from chia.util.file_keyring import Key
 from chia.util.keyring_wrapper import KeyringWrapper
 from chia.util.timing import adjusted_timeout
-from chia.util.file_keyring import Key
 
 log = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ class TestFileKeyringSynchronization:
         num_workers = 10
         keyring_path = str(KeyringWrapper.get_shared_instance().keyring.keyring_path)
         passphrase_list = [
-            ("test-service", f"test-user-{index}", Key(f"passphrase {index}".encode("utf8")), keyring_path, index)
+            ("test-service", f"test-user-{index}", Key(f"passphrase {index}".encode()), keyring_path, index)
             for index in range(num_workers)
         ]
 

--- a/chia/_tests/core/util/test_file_keyring_synchronization.py
+++ b/chia/_tests/core/util/test_file_keyring_synchronization.py
@@ -12,6 +12,7 @@ from chia._tests.core.util.test_lockfile import wait_for_enough_files_in_directo
 from chia.simulator.keyring import TempKeyring
 from chia.util.keyring_wrapper import KeyringWrapper
 from chia.util.timing import adjusted_timeout
+from chia.util.file_keyring import Key
 
 log = logging.getLogger(__name__)
 
@@ -64,7 +65,7 @@ class TestFileKeyringSynchronization:
         num_workers = 10
         keyring_path = str(KeyringWrapper.get_shared_instance().keyring.keyring_path)
         passphrase_list = [
-            ("test-service", f"test-user-{index}", f"passphrase {index}", keyring_path, index)
+            ("test-service", f"test-user-{index}", Key(f"passphrase {index}".encode("utf8")), keyring_path, index)
             for index in range(num_workers)
         ]
 

--- a/chia/_tests/core/util/test_file_keyring_synchronization.py
+++ b/chia/_tests/core/util/test_file_keyring_synchronization.py
@@ -42,7 +42,7 @@ def dummy_set_passphrase(service, user, passphrase, keyring_path, index):
 
         KeyringWrapper.get_shared_instance().set_passphrase(service=service, user=user, passphrase=passphrase)
 
-        found_passphrase = KeyringWrapper.get_shared_instance().get_passphrase(service, user)
+        found_passphrase = KeyringWrapper.get_shared_instance().keyring.get_key(service, user)
         if found_passphrase != passphrase:
             log.error(
                 f"[pid:{os.getpid()}] error: didn't get expected passphrase: "
@@ -100,5 +100,5 @@ class TestFileKeyringSynchronization:
         # Expect: parent process should be able to find all passphrases that were set by the child processes
         for item in passphrase_list:
             expected_passphrase = item[2]
-            actual_passphrase = KeyringWrapper.get_shared_instance().get_passphrase(service=item[0], user=item[1])
+            actual_passphrase = KeyringWrapper.get_shared_instance().keyring.get_key(service=item[0], user=item[1])
             assert expected_passphrase == actual_passphrase

--- a/chia/_tests/core/util/test_keychain.py
+++ b/chia/_tests/core/util/test_keychain.py
@@ -454,14 +454,14 @@ async def test_delete_drops_labels(get_temp_keyring: Keychain, delete_all: bool)
         keychain.add_key(mnemonic_or_pk=key_data.mnemonic_str(), label=key_data.label)
         assert key_data == keychain.get_key(key_data.fingerprint, include_secrets=True)
         assert key_data.label is not None
-        assert keychain.keyring_wrapper.get_label(key_data.fingerprint) == key_data.label
+        assert keychain.keyring_wrapper.keyring.get_label(key_data.fingerprint) == key_data.label
     if delete_all:
         # Delete the keys via `delete_all` and make sure no labels are left
         keychain.delete_all_keys()
         for key_data in keys:
-            assert keychain.keyring_wrapper.get_label(key_data.fingerprint) is None
+            assert keychain.keyring_wrapper.keyring.get_label(key_data.fingerprint) is None
     else:
         # Delete the keys via fingerprint and make sure the label gets dropped
         for key_data in keys:
             keychain.delete_key_by_fingerprint(key_data.fingerprint)
-            assert keychain.keyring_wrapper.get_label(key_data.fingerprint) is None
+            assert keychain.keyring_wrapper.keyring.get_label(key_data.fingerprint) is None

--- a/chia/_tests/core/util/test_keyring_wrapper.py
+++ b/chia/_tests/core/util/test_keyring_wrapper.py
@@ -211,9 +211,8 @@ class TestKeyringWrapper:
         KeyringWrapper.get_shared_instance().keyring.set_key("service-abc", "user-xyz", Key(b"super secret passphrase"))
 
         # Expect: passphrase lookup should succeed
-        assert (
-            KeyringWrapper.get_shared_instance().keyring.get_key("service-abc", "user-xyz").secret
-            == b"super secret passphrase"
+        assert KeyringWrapper.get_shared_instance().keyring.get_key("service-abc", "user-xyz") == Key(
+            b"super secret passphrase"
         )
 
         # Expect: non-existent passphrase lookup should fail
@@ -230,18 +229,16 @@ class TestKeyringWrapper:
         KeyringWrapper.get_shared_instance().keyring.set_key("service-xyz", "user-123", Key(b"initial passphrase"))
 
         # Expect: passphrase lookup should succeed
-        assert (
-            KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123").secret
-            == b"initial passphrase"
+        assert KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123") == Key(
+            b"initial passphrase"
         )
 
         # When: updating the same passphrase
         KeyringWrapper.get_shared_instance().keyring.set_key("service-xyz", "user-123", Key(b"updated passphrase"))
 
         # Expect: the updated passphrase should be retrieved
-        assert (
-            KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123").secret
-            == b"updated passphrase"
+        assert KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123") == Key(
+            b"updated passphrase"
         )
 
     # When: using a new empty keyring
@@ -256,8 +253,8 @@ class TestKeyringWrapper:
         KeyringWrapper.get_shared_instance().keyring.set_key("some service", "some user", Key(b"500p3r 53cr37"))
 
         # Expect: passphrase retrieval should succeed
-        assert (
-            KeyringWrapper.get_shared_instance().keyring.get_key("some service", "some user").secret == b"500p3r 53cr37"
+        assert KeyringWrapper.get_shared_instance().keyring.get_key("some service", "some user") == Key(
+            b"500p3r 53cr37"
         )
 
         # When: deleting the passphrase

--- a/chia/_tests/core/util/test_keyring_wrapper.py
+++ b/chia/_tests/core/util/test_keyring_wrapper.py
@@ -7,6 +7,7 @@ import pytest
 
 from chia.simulator.keyring import TempKeyring
 from chia.util.errors import KeychainFingerprintNotFound, KeychainLabelError, KeychainLabelExists, KeychainLabelInvalid
+from chia.util.file_keyring import Key
 from chia.util.keyring_wrapper import DEFAULT_PASSPHRASE_IF_NO_MASTER_PASSPHRASE, KeyringWrapper
 
 log = logging.getLogger(__name__)
@@ -207,9 +208,7 @@ class TestKeyringWrapper:
         assert KeyringWrapper.get_shared_instance().keyring.get_key("service-abc", "user-xyz") is None
 
         # When: setting a passphrase
-        KeyringWrapper.get_shared_instance().keyring.set_key(
-            "service-abc", "user-xyz", b"super secret passphrase".hex()
-        )
+        KeyringWrapper.get_shared_instance().keyring.set_key("service-abc", "user-xyz", Key(b"super secret passphrase"))
 
         # Expect: passphrase lookup should succeed
         assert (
@@ -228,7 +227,7 @@ class TestKeyringWrapper:
         Overwriting a previously-set passphrase should work
         """
         # When: initially setting the passphrase
-        KeyringWrapper.get_shared_instance().keyring.set_key("service-xyz", "user-123", b"initial passphrase".hex())
+        KeyringWrapper.get_shared_instance().keyring.set_key("service-xyz", "user-123", Key(b"initial passphrase"))
 
         # Expect: passphrase lookup should succeed
         assert (
@@ -237,7 +236,7 @@ class TestKeyringWrapper:
         )
 
         # When: updating the same passphrase
-        KeyringWrapper.get_shared_instance().keyring.set_key("service-xyz", "user-123", b"updated passphrase".hex())
+        KeyringWrapper.get_shared_instance().keyring.set_key("service-xyz", "user-123", Key(b"updated passphrase"))
 
         # Expect: the updated passphrase should be retrieved
         assert (
@@ -254,7 +253,7 @@ class TestKeyringWrapper:
         KeyringWrapper.get_shared_instance().keyring.delete_key("some service", "some user")
 
         # When: setting a passphrase
-        KeyringWrapper.get_shared_instance().keyring.set_key("some service", "some user", b"500p3r 53cr37".hex())
+        KeyringWrapper.get_shared_instance().keyring.set_key("some service", "some user", Key(b"500p3r 53cr37"))
 
         # Expect: passphrase retrieval should succeed
         assert (

--- a/chia/_tests/core/util/test_keyring_wrapper.py
+++ b/chia/_tests/core/util/test_keyring_wrapper.py
@@ -204,20 +204,20 @@ class TestKeyringWrapper:
         Simple passphrase setting and retrieval
         """
         # Expect: passphrase lookup should return None
-        assert KeyringWrapper.get_shared_instance().get_passphrase("service-abc", "user-xyz") is None
+        assert KeyringWrapper.get_shared_instance().keyring.get_key("service-abc", "user-xyz") is None
 
         # When: setting a passphrase
         KeyringWrapper.get_shared_instance().set_passphrase("service-abc", "user-xyz", b"super secret passphrase".hex())
 
         # Expect: passphrase lookup should succeed
         assert (
-            KeyringWrapper.get_shared_instance().get_passphrase("service-abc", "user-xyz")
+            KeyringWrapper.get_shared_instance().keyring.get_key("service-abc", "user-xyz")
             == b"super secret passphrase".hex()
         )
 
         # Expect: non-existent passphrase lookup should fail
         assert (
-            KeyringWrapper.get_shared_instance().get_passphrase("service-123", "some non-existent passphrase") is None
+            KeyringWrapper.get_shared_instance().keyring.get_key("service-123", "some non-existent passphrase") is None
         )
 
     # When: using a new empty keyring
@@ -230,7 +230,7 @@ class TestKeyringWrapper:
 
         # Expect: passphrase lookup should succeed
         assert (
-            KeyringWrapper.get_shared_instance().get_passphrase("service-xyz", "user-123")
+            KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123")
             == b"initial passphrase".hex()
         )
 
@@ -239,7 +239,7 @@ class TestKeyringWrapper:
 
         # Expect: the updated passphrase should be retrieved
         assert (
-            KeyringWrapper.get_shared_instance().get_passphrase("service-xyz", "user-123")
+            KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123")
             == b"updated passphrase".hex()
         )
 
@@ -256,14 +256,14 @@ class TestKeyringWrapper:
 
         # Expect: passphrase retrieval should succeed
         assert (
-            KeyringWrapper.get_shared_instance().get_passphrase("some service", "some user") == b"500p3r 53cr37".hex()
+            KeyringWrapper.get_shared_instance().keyring.get_key("some service", "some user") == b"500p3r 53cr37".hex()
         )
 
         # When: deleting the passphrase
         KeyringWrapper.get_shared_instance().delete_passphrase("some service", "some user")
 
         # Expect: passphrase retrieval should fail gracefully
-        assert KeyringWrapper.get_shared_instance().get_passphrase("some service", "some user") is None
+        assert KeyringWrapper.get_shared_instance().keyring.get_key("some service", "some user") is None
 
     def test_emoji_master_passphrase(self, empty_temp_file_keyring: TempKeyring):
         """

--- a/chia/_tests/core/util/test_keyring_wrapper.py
+++ b/chia/_tests/core/util/test_keyring_wrapper.py
@@ -207,7 +207,9 @@ class TestKeyringWrapper:
         assert KeyringWrapper.get_shared_instance().keyring.get_key("service-abc", "user-xyz") is None
 
         # When: setting a passphrase
-        KeyringWrapper.get_shared_instance().set_passphrase("service-abc", "user-xyz", b"super secret passphrase".hex())
+        KeyringWrapper.get_shared_instance().keyring.set_key(
+            "service-abc", "user-xyz", b"super secret passphrase".hex()
+        )
 
         # Expect: passphrase lookup should succeed
         assert (
@@ -226,7 +228,7 @@ class TestKeyringWrapper:
         Overwriting a previously-set passphrase should work
         """
         # When: initially setting the passphrase
-        KeyringWrapper.get_shared_instance().set_passphrase("service-xyz", "user-123", b"initial passphrase".hex())
+        KeyringWrapper.get_shared_instance().keyring.set_key("service-xyz", "user-123", b"initial passphrase".hex())
 
         # Expect: passphrase lookup should succeed
         assert (
@@ -235,7 +237,7 @@ class TestKeyringWrapper:
         )
 
         # When: updating the same passphrase
-        KeyringWrapper.get_shared_instance().set_passphrase("service-xyz", "user-123", b"updated passphrase".hex())
+        KeyringWrapper.get_shared_instance().keyring.set_key("service-xyz", "user-123", b"updated passphrase".hex())
 
         # Expect: the updated passphrase should be retrieved
         assert (
@@ -252,7 +254,7 @@ class TestKeyringWrapper:
         KeyringWrapper.get_shared_instance().delete_passphrase("some service", "some user")
 
         # When: setting a passphrase
-        KeyringWrapper.get_shared_instance().set_passphrase("some service", "some user", b"500p3r 53cr37".hex())
+        KeyringWrapper.get_shared_instance().keyring.set_key("some service", "some user", b"500p3r 53cr37".hex())
 
         # Expect: passphrase retrieval should succeed
         assert (

--- a/chia/_tests/core/util/test_keyring_wrapper.py
+++ b/chia/_tests/core/util/test_keyring_wrapper.py
@@ -381,49 +381,49 @@ class TestKeyringWrapper:
     def test_get_label(self, empty_temp_file_keyring: TempKeyring):
         keyring_wrapper = KeyringWrapper.get_shared_instance()
         # label lookup for 1, 2, 3 should return None
-        assert keyring_wrapper.get_label(1) is None
-        assert keyring_wrapper.get_label(2) is None
-        assert keyring_wrapper.get_label(3) is None
+        assert keyring_wrapper.keyring.get_label(1) is None
+        assert keyring_wrapper.keyring.get_label(2) is None
+        assert keyring_wrapper.keyring.get_label(3) is None
 
         # Set and validate a label for 1
-        keyring_wrapper.set_label(1, "one")
-        assert keyring_wrapper.get_label(1) == "one"
+        keyring_wrapper.keyring.set_label(1, "one")
+        assert keyring_wrapper.keyring.get_label(1) == "one"
 
         # Set and validate a label for 3
-        keyring_wrapper.set_label(3, "three")
+        keyring_wrapper.keyring.set_label(3, "three")
 
         # And validate all match the expected values
-        assert keyring_wrapper.get_label(1) == "one"
-        assert keyring_wrapper.get_label(2) is None
-        assert keyring_wrapper.get_label(3) == "three"
+        assert keyring_wrapper.keyring.get_label(1) == "one"
+        assert keyring_wrapper.keyring.get_label(2) is None
+        assert keyring_wrapper.keyring.get_label(3) == "three"
 
     def test_set_label(self, empty_temp_file_keyring: TempKeyring):
         keyring_wrapper = KeyringWrapper.get_shared_instance()
         # Set and validate a label for 1
-        keyring_wrapper.set_label(1, "one")
-        assert keyring_wrapper.get_label(1) == "one"
+        keyring_wrapper.keyring.set_label(1, "one")
+        assert keyring_wrapper.keyring.get_label(1) == "one"
 
         # Set and validate a label for 2
-        keyring_wrapper.set_label(2, "two")
-        assert keyring_wrapper.get_label(2) == "two"
+        keyring_wrapper.keyring.set_label(2, "two")
+        assert keyring_wrapper.keyring.get_label(2) == "two"
 
         # Change the label of 2
-        keyring_wrapper.set_label(2, "two!")
-        assert keyring_wrapper.get_label(2) == "two!"
+        keyring_wrapper.keyring.set_label(2, "two!")
+        assert keyring_wrapper.keyring.get_label(2) == "two!"
         # 1 should still have the same label
-        assert keyring_wrapper.get_label(1) == "one"
+        assert keyring_wrapper.keyring.get_label(1) == "one"
 
         # Change the label of 2 again
-        keyring_wrapper.set_label(2, "two!!")
-        assert keyring_wrapper.get_label(2) == "two!!"
+        keyring_wrapper.keyring.set_label(2, "two!!")
+        assert keyring_wrapper.keyring.get_label(2) == "two!!"
         # 1 should still have the same label
-        assert keyring_wrapper.get_label(1) == "one"
+        assert keyring_wrapper.keyring.get_label(1) == "one"
 
         # Change the label of 1
-        keyring_wrapper.set_label(1, "one!")
-        assert keyring_wrapper.get_label(1) == "one!"
+        keyring_wrapper.keyring.set_label(1, "one!")
+        assert keyring_wrapper.keyring.get_label(1) == "one!"
         # 2 should still have the same label
-        assert keyring_wrapper.get_label(2) == "two!!"
+        assert keyring_wrapper.keyring.get_label(2) == "two!!"
 
     @pytest.mark.parametrize(
         "label",
@@ -435,8 +435,8 @@ class TestKeyringWrapper:
     )
     def test_set_special_labels(self, label: str, empty_temp_file_keyring: TempKeyring):
         keyring_wrapper = KeyringWrapper.get_shared_instance()
-        keyring_wrapper.set_label(1, label)
-        assert keyring_wrapper.get_label(1) == label
+        keyring_wrapper.keyring.set_label(1, label)
+        assert keyring_wrapper.keyring.get_label(1) == label
 
     @pytest.mark.parametrize(
         "label, exception, message",
@@ -458,9 +458,9 @@ class TestKeyringWrapper:
         self, label: str, exception: Type[KeychainLabelError], message: str, empty_temp_file_keyring: TempKeyring
     ) -> None:
         keyring_wrapper = KeyringWrapper.get_shared_instance()
-        keyring_wrapper.set_label(1, "one")
+        keyring_wrapper.keyring.set_label(1, "one")
         with pytest.raises(exception, match=message) as e:
-            keyring_wrapper.set_label(1, label)
+            keyring_wrapper.keyring.set_label(1, label)
         assert e.value.label == label
         if isinstance(e.value, KeychainLabelExists):
             assert e.value.label == "one"
@@ -469,20 +469,20 @@ class TestKeyringWrapper:
     def test_delete_label(self, empty_temp_file_keyring: TempKeyring) -> None:
         keyring_wrapper = KeyringWrapper.get_shared_instance()
         # Set labels for 1,2 and validate them
-        keyring_wrapper.set_label(1, "one")
-        keyring_wrapper.set_label(2, "two")
-        assert keyring_wrapper.get_label(1) == "one"
-        assert keyring_wrapper.get_label(2) == "two"
+        keyring_wrapper.keyring.set_label(1, "one")
+        keyring_wrapper.keyring.set_label(2, "two")
+        assert keyring_wrapper.keyring.get_label(1) == "one"
+        assert keyring_wrapper.keyring.get_label(2) == "two"
         # Remove the label of 1
-        keyring_wrapper.delete_label(1)
-        assert keyring_wrapper.get_label(1) is None
-        assert keyring_wrapper.get_label(2) == "two"
+        keyring_wrapper.keyring.delete_label(1)
+        assert keyring_wrapper.keyring.get_label(1) is None
+        assert keyring_wrapper.keyring.get_label(2) == "two"
         # Remove the label of 2
-        keyring_wrapper.delete_label(2)
-        assert keyring_wrapper.get_label(1) is None
-        assert keyring_wrapper.get_label(2) is None
+        keyring_wrapper.keyring.delete_label(2)
+        assert keyring_wrapper.keyring.get_label(1) is None
+        assert keyring_wrapper.keyring.get_label(2) is None
         # Make sure the deletion fails for 0-2
         for i in range(3):
             with pytest.raises(KeychainFingerprintNotFound) as e:
-                keyring_wrapper.delete_label(i)
+                keyring_wrapper.keyring.delete_label(i)
             assert e.value.fingerprint == i

--- a/chia/_tests/core/util/test_keyring_wrapper.py
+++ b/chia/_tests/core/util/test_keyring_wrapper.py
@@ -200,69 +200,63 @@ class TestKeyringWrapper:
         )
 
     # When: using a new empty keyring
-    def test_get_passphrase(self, empty_temp_file_keyring: TempKeyring):
+    def test_get_key(self, empty_temp_file_keyring: TempKeyring):
         """
-        Simple passphrase setting and retrieval
+        Simple key setting and retrieval
         """
-        # Expect: passphrase lookup should return None
+        # Expect: key lookup should return None
         assert KeyringWrapper.get_shared_instance().keyring.get_key("service-abc", "user-xyz") is None
 
-        # When: setting a passphrase
+        # When: setting a key
         KeyringWrapper.get_shared_instance().keyring.set_key(
-            "service-abc", "user-xyz", Key(b"super secret passphrase", {"foo": "bar"})
+            "service-abc", "user-xyz", Key(b"super secret key", {"foo": "bar"})
         )
 
-        # Expect: passphrase lookup should succeed
+        # Expect: key lookup should succeed
         assert KeyringWrapper.get_shared_instance().keyring.get_key("service-abc", "user-xyz") == Key(
-            b"super secret passphrase", {"foo": "bar"}
+            b"super secret key", {"foo": "bar"}
         )
 
-        # Expect: non-existent passphrase lookup should fail
-        assert (
-            KeyringWrapper.get_shared_instance().keyring.get_key("service-123", "some non-existent passphrase") is None
-        )
+        # Expect: non-existent key lookup should fail
+        assert KeyringWrapper.get_shared_instance().keyring.get_key("service-123", "some non-existent key") is None
 
     # When: using a new empty keyring
-    def test_set_passphrase_overwrite(self, empty_temp_file_keyring: TempKeyring):
+    def test_set_key_overwrite(self, empty_temp_file_keyring: TempKeyring):
         """
-        Overwriting a previously-set passphrase should work
+        Overwriting a previously-set key should work
         """
-        # When: initially setting the passphrase
-        KeyringWrapper.get_shared_instance().keyring.set_key("service-xyz", "user-123", Key(b"initial passphrase"))
+        # When: initially setting the key
+        KeyringWrapper.get_shared_instance().keyring.set_key("service-xyz", "user-123", Key(b"initial key"))
 
-        # Expect: passphrase lookup should succeed
-        assert KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123") == Key(
-            b"initial passphrase"
-        )
+        # Expect: key lookup should succeed
+        assert KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123") == Key(b"initial key")
 
-        # When: updating the same passphrase
-        KeyringWrapper.get_shared_instance().keyring.set_key("service-xyz", "user-123", Key(b"updated passphrase"))
+        # When: updating the same key
+        KeyringWrapper.get_shared_instance().keyring.set_key("service-xyz", "user-123", Key(b"updated key"))
 
-        # Expect: the updated passphrase should be retrieved
-        assert KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123") == Key(
-            b"updated passphrase"
-        )
+        # Expect: the updated key should be retrieved
+        assert KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123") == Key(b"updated key")
 
     # When: using a new empty keyring
-    def test_delete_passphrase(self, empty_temp_file_keyring: TempKeyring):
+    def test_delete_key(self, empty_temp_file_keyring: TempKeyring):
         """
-        Deleting a non-existent passphrase should fail gracefully (no exceptions)
+        Deleting a non-existent key should fail gracefully (no exceptions)
         """
-        # Expect: deleting a non-existent passphrase should fail gracefully
+        # Expect: deleting a non-existent key should fail gracefully
         KeyringWrapper.get_shared_instance().keyring.delete_key("some service", "some user")
 
-        # When: setting a passphrase
+        # When: setting a key
         KeyringWrapper.get_shared_instance().keyring.set_key("some service", "some user", Key(b"500p3r 53cr37"))
 
-        # Expect: passphrase retrieval should succeed
+        # Expect: key retrieval should succeed
         assert KeyringWrapper.get_shared_instance().keyring.get_key("some service", "some user") == Key(
             b"500p3r 53cr37"
         )
 
-        # When: deleting the passphrase
+        # When: deleting the key
         KeyringWrapper.get_shared_instance().keyring.delete_key("some service", "some user")
 
-        # Expect: passphrase retrieval should fail gracefully
+        # Expect: key retrieval should fail gracefully
         assert KeyringWrapper.get_shared_instance().keyring.get_key("some service", "some user") is None
 
         # Check that metadata is properly deleted

--- a/chia/_tests/core/util/test_keyring_wrapper.py
+++ b/chia/_tests/core/util/test_keyring_wrapper.py
@@ -212,8 +212,8 @@ class TestKeyringWrapper:
 
         # Expect: passphrase lookup should succeed
         assert (
-            KeyringWrapper.get_shared_instance().keyring.get_key("service-abc", "user-xyz")
-            == b"super secret passphrase".hex()
+            KeyringWrapper.get_shared_instance().keyring.get_key("service-abc", "user-xyz").secret
+            == b"super secret passphrase"
         )
 
         # Expect: non-existent passphrase lookup should fail
@@ -231,8 +231,8 @@ class TestKeyringWrapper:
 
         # Expect: passphrase lookup should succeed
         assert (
-            KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123")
-            == b"initial passphrase".hex()
+            KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123").secret
+            == b"initial passphrase"
         )
 
         # When: updating the same passphrase
@@ -240,8 +240,8 @@ class TestKeyringWrapper:
 
         # Expect: the updated passphrase should be retrieved
         assert (
-            KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123")
-            == b"updated passphrase".hex()
+            KeyringWrapper.get_shared_instance().keyring.get_key("service-xyz", "user-123").secret
+            == b"updated passphrase"
         )
 
     # When: using a new empty keyring
@@ -257,7 +257,7 @@ class TestKeyringWrapper:
 
         # Expect: passphrase retrieval should succeed
         assert (
-            KeyringWrapper.get_shared_instance().keyring.get_key("some service", "some user") == b"500p3r 53cr37".hex()
+            KeyringWrapper.get_shared_instance().keyring.get_key("some service", "some user").secret == b"500p3r 53cr37"
         )
 
         # When: deleting the passphrase

--- a/chia/_tests/core/util/test_keyring_wrapper.py
+++ b/chia/_tests/core/util/test_keyring_wrapper.py
@@ -251,7 +251,7 @@ class TestKeyringWrapper:
         Deleting a non-existent passphrase should fail gracefully (no exceptions)
         """
         # Expect: deleting a non-existent passphrase should fail gracefully
-        KeyringWrapper.get_shared_instance().delete_passphrase("some service", "some user")
+        KeyringWrapper.get_shared_instance().keyring.delete_key("some service", "some user")
 
         # When: setting a passphrase
         KeyringWrapper.get_shared_instance().keyring.set_key("some service", "some user", b"500p3r 53cr37".hex())
@@ -262,7 +262,7 @@ class TestKeyringWrapper:
         )
 
         # When: deleting the passphrase
-        KeyringWrapper.get_shared_instance().delete_passphrase("some service", "some user")
+        KeyringWrapper.get_shared_instance().keyring.delete_key("some service", "some user")
 
         # Expect: passphrase retrieval should fail gracefully
         assert KeyringWrapper.get_shared_instance().keyring.get_key("some service", "some user") is None

--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -208,9 +208,9 @@ class DecrpytedKeyringData:
         return cls(
             {
                 service: {user: Key.parse_w_backcompat(key) for user, key in users.items()}
-                for service, users in data_dict["keys"].items()
+                for service, users in data_dict.get("keys", {}).items()
             },
-            data_dict["labels"],
+            data_dict.get("labels", {}),
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -274,7 +274,7 @@ class FileKeyring(FileSystemEventHandler):
         labels_dict: Dict[int, str] = self.cached_data_dict["labels"]
         return labels_dict
 
-    def get_password(self, service: str, user: str) -> Optional[str]:
+    def get_key(self, service: str, user: str) -> Optional[str]:
         """
         Returns the passphrase named by the 'user' parameter from the cached
         keyring data (does not force a read from disk)

--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -295,7 +295,7 @@ class FileKeyring(FileSystemEventHandler):
             keys[service][user] = key
             self.write_keyring()
 
-    def delete_password(self, service: str, user: str) -> None:
+    def delete_key(self, service: str, user: str) -> None:
         """
         Deletes the passphrase named by the 'user' parameter from the keyring data
         (will force a write to keyring.yaml on success)

--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -78,8 +78,8 @@ def decrypt_data(input_data: bytes, key: bytes, nonce: bytes) -> bytes:
     return output[len(CHECKBYTES_VALUE) :]
 
 
-def default_file_keyring_data() -> DecrpytedKeyringData:
-    return DecrpytedKeyringData({}, {})
+def default_file_keyring_data() -> DecryptedKeyringData:
+    return DecryptedKeyringData({}, {})
 
 
 def keyring_path_from_root(keys_root_path: Path) -> Path:
@@ -153,7 +153,7 @@ class FileKeyringContent:
         return dict(yaml.safe_load(data_yml))
 
     def update_encrypted_data_dict(
-        self, passphrase: str, decrypted_dict: DecrpytedKeyringData, update_salt: bool
+        self, passphrase: str, decrypted_dict: DecryptedKeyringData, update_salt: bool
     ) -> None:
         self.nonce = generate_nonce()
         if update_salt:
@@ -193,12 +193,12 @@ Services = Dict[str, Users]
 
 
 @dataclass
-class DecrpytedKeyringData:
+class DecryptedKeyringData:
     services: Services
     labels: Dict[int, str]  # {fingerprint: label}
 
     @classmethod
-    def from_dict(cls, data_dict: Dict[str, Any]) -> DecrpytedKeyringData:
+    def from_dict(cls, data_dict: Dict[str, Any]) -> DecryptedKeyringData:
         return cls(
             {
                 service: {
@@ -240,7 +240,7 @@ class FileKeyring(FileSystemEventHandler):
     load_keyring_lock: threading.RLock = field(default_factory=threading.RLock)  # Guards access to needs_load_keyring
     needs_load_keyring: bool = False
     # Cache of the decrypted YAML contained in keyring.data
-    cached_data_dict: DecrpytedKeyringData = field(default_factory=default_file_keyring_data)
+    cached_data_dict: DecryptedKeyringData = field(default_factory=default_file_keyring_data)
     keyring_last_mod_time: Optional[float] = None
     # Key/value pairs to set on the outer payload on the next write
     file_content_properties_for_next_write: Dict[str, Any] = field(default_factory=dict)
@@ -430,7 +430,7 @@ class FileKeyring(FileSystemEventHandler):
             # TODO, this prompts for the passphrase interactively, move this out
             passphrase = obtain_current_passphrase(use_passphrase_cache=True)
 
-        self.cached_data_dict = DecrpytedKeyringData.from_dict(
+        self.cached_data_dict = DecryptedKeyringData.from_dict(
             self.cached_file_content.get_decrypted_data_dict(passphrase)
         )
 

--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -282,7 +282,7 @@ class FileKeyring(FileSystemEventHandler):
         with self.lock_and_reload_if_required():
             return self.cached_keys().get(service, {}).get(user)
 
-    def set_password(self, service: str, user: str, passphrase: str) -> None:
+    def set_key(self, service: str, user: str, key: str) -> None:
         """
         Store the passphrase to the keyring data using the name specified by the
         'user' parameter. Will force a write to keyring.yaml on success.
@@ -292,7 +292,7 @@ class FileKeyring(FileSystemEventHandler):
             # Ensure a dictionary exists for the 'service'
             if keys.get(service) is None:
                 keys[service] = {}
-            keys[service][user] = passphrase
+            keys[service][user] = key
             self.write_keyring()
 
     def delete_password(self, service: str, user: str) -> None:

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -520,7 +520,7 @@ class Keychain:
                         # Just try to delete the label and move on if there wasn't one
                         pass
                     try:
-                        self.keyring_wrapper.delete_passphrase(self.service, get_private_key_user(self.user, index))
+                        self.keyring_wrapper.keyring.delete_key(self.service, get_private_key_user(self.user, index))
                         removed += 1
                     except Exception:
                         pass

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -395,7 +395,7 @@ class Keychain:
             self.keyring_wrapper.set_label(fingerprint, label)
 
         try:
-            self.keyring_wrapper.set_passphrase(
+            self.keyring_wrapper.keyring.set_key(
                 self.service,
                 get_private_key_user(self.user, index),
                 key_data,

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -324,7 +324,7 @@ class Keychain:
         return KeyData(
             fingerprint=uint32(fingerprint),
             public_key=public_key,
-            label=self.keyring_wrapper.get_label(fingerprint),
+            label=self.keyring_wrapper.keyring.get_label(fingerprint),
             secrets=KeyDataSecrets.from_entropy(entropy) if include_secrets and entropy is not None else None,
         )
 
@@ -392,7 +392,7 @@ class Keychain:
         # Try to set the label first, it may fail if the label is invalid or already exists.
         # This can probably just be moved into `FileKeyring.set_passphrase` after the legacy keyring stuff was dropped.
         if label is not None:
-            self.keyring_wrapper.set_label(fingerprint, label)
+            self.keyring_wrapper.keyring.set_label(fingerprint, label)
 
         try:
             self.keyring_wrapper.keyring.set_key(
@@ -402,7 +402,7 @@ class Keychain:
             )
         except Exception:
             if label is not None:
-                self.keyring_wrapper.delete_label(fingerprint)
+                self.keyring_wrapper.keyring.delete_label(fingerprint)
             raise
 
         return key
@@ -412,13 +412,13 @@ class Keychain:
         Assigns the given label to the first key with the given fingerprint.
         """
         self.get_key(fingerprint)  # raise if the fingerprint doesn't exist
-        self.keyring_wrapper.set_label(fingerprint, label)
+        self.keyring_wrapper.keyring.set_label(fingerprint, label)
 
     def delete_label(self, fingerprint: int) -> None:
         """
         Removes the label assigned to the key with the given fingerprint.
         """
-        self.keyring_wrapper.delete_label(fingerprint)
+        self.keyring_wrapper.keyring.delete_label(fingerprint)
 
     def get_first_private_key(self) -> Optional[Tuple[PrivateKey, bytes]]:
         """
@@ -515,7 +515,7 @@ class Keychain:
                 key_data = self._get_key_data(index, include_secrets=False)
                 if key_data.fingerprint == fingerprint:
                     try:
-                        self.keyring_wrapper.delete_label(key_data.fingerprint)
+                        self.keyring_wrapper.keyring.delete_label(key_data.fingerprint)
                     except (KeychainException, NotImplementedError):
                         # Just try to delete the label and move on if there wasn't one
                         pass

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -309,7 +309,7 @@ class Keychain:
         is represented by the class `KeyData`.
         """
         user = get_private_key_user(self.user, index)
-        read_str = self.keyring_wrapper.get_passphrase(self.service, user)
+        read_str = self.keyring_wrapper.keyring.get_key(self.service, user)
         if read_str is None or len(read_str) == 0:
             raise KeychainUserNotFound(self.service, user)
         str_bytes = bytes.fromhex(read_str)

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -267,9 +267,6 @@ class KeyringWrapper:
 
     # Keyring interface
 
-    def set_passphrase(self, service: str, user: str, passphrase: str) -> None:
-        self.get_keyring().set_password(service, user, passphrase)
-
     def delete_passphrase(self, service: str, user: str) -> None:
         self.get_keyring().delete_password(service, user)
 

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -264,14 +264,3 @@ class KeyringWrapper:
 
     def get_master_passphrase_hint(self) -> Optional[str]:
         return self.keyring.get_passphrase_hint()
-
-    # Keyring interface
-
-    def get_label(self, fingerprint: int) -> Optional[str]:
-        return self.keyring.get_label(fingerprint)
-
-    def set_label(self, fingerprint: int, label: str) -> None:
-        self.keyring.set_label(fingerprint, label)
-
-    def delete_label(self, fingerprint: int) -> None:
-        self.keyring.delete_label(fingerprint)

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -267,9 +267,6 @@ class KeyringWrapper:
 
     # Keyring interface
 
-    def get_passphrase(self, service: str, user: str) -> Optional[str]:
-        return self.get_keyring().get_password(service, user)
-
     def set_passphrase(self, service: str, user: str, passphrase: str) -> None:
         self.get_keyring().set_password(service, user, passphrase)
 

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -267,9 +267,6 @@ class KeyringWrapper:
 
     # Keyring interface
 
-    def delete_passphrase(self, service: str, user: str) -> None:
-        self.get_keyring().delete_password(service, user)
-
     def get_label(self, fingerprint: int) -> Optional[str]:
         return self.keyring.get_label(fingerprint)
 


### PR DESCRIPTION
The keyring interface used to be more complicated and support different backends, but now we only support one type of keyring backend, the file keyring.  This actually is now constraining our functionality because the file keyring is much more flexible that the python os keyring library and by shoehorning it into an interface that fits both, we kneecap our potential. 

This PR makes the file keyring a little bit more ergonomic and adds a path towards upgrading the format in the future.