### PR TITLE
Switch curl requests to github-glue action

### DIFF
--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -325,18 +325,18 @@ jobs:
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'
         with:
           json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: '${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}'
-          glue_path: 'success/${{ matrix.os.glue-name }}'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}"
+          glue_path: "success/${{ matrix.os.glue-name }}"
 
       - name: Mark release installer complete
         uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.FULL_RELEASE == 'true'
         with:
           json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: '${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}'
-          glue_path: 'success/${{ matrix.os.glue-name }}'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}"
+          glue_path: "success/${{ matrix.os.glue-name }}"
 
   test:
     name: Test ${{ matrix.distribution.name }} ${{ matrix.mode.name }} ${{ matrix.arch.name }}

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -317,9 +317,6 @@ jobs:
             build_scripts/final_installer/chia-blockchain_${CHIA_INSTALLER_VERSION}_${{ matrix.os.arch }}.deb \
             build_scripts/final_installer/chia-blockchain-cli_${CHIA_INSTALLER_VERSION}-1_${{ matrix.os.arch }}.deb
 
-      - uses: Chia-Network/actions/github/jwt@main
-        if: steps.check_secrets.outputs.HAS_GLUE_SECRET
-
       - name: Mark pre-release installer complete
         uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -321,14 +321,22 @@ jobs:
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET
 
       - name: Mark pre-release installer complete
+        uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"chia_ref": "${{ env.RELEASE_TAG }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}/success/${{ matrix.os.glue-name }}
+        with:
+          json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: '${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}'
+          glue_path: 'success/${{ matrix.os.glue-name }}'
 
       - name: Mark release installer complete
+        uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.FULL_RELEASE == 'true'
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"chia_ref": "${{ env.RELEASE_TAG }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}/success/${{ matrix.os.glue-name }}
+        with:
+          json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: '${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}'
+          glue_path: 'success/${{ matrix.os.glue-name }}'
 
   test:
     name: Test ${{ matrix.distribution.name }} ${{ matrix.mode.name }} ${{ matrix.arch.name }}

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -310,9 +310,6 @@ jobs:
             build_scripts/final_installer/chia-blockchain-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm \
             build_scripts/final_installer/chia-blockchain-cli-${CHIA_INSTALLER_VERSION}-1.x86_64.rpm
 
-      - uses: Chia-Network/actions/github/jwt@main
-        if: steps.check_secrets.outputs.HAS_GLUE_SECRET
-
       - name: Mark pre-release installer complete
         uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -318,18 +318,18 @@ jobs:
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'
         with:
           json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: '${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}'
-          glue_path: 'success/build-linux-rpm'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}"
+          glue_path: "success/build-linux-rpm"
 
       - name: Mark release installer complete
         uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.FULL_RELEASE == 'true'
         with:
           json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: '${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}'
-          glue_path: 'success/build-linux-rpm'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}"
+          glue_path: "success/build-linux-rpm"
 
   test:
     name: Test ${{ matrix.distribution.name }} ${{ matrix.mode.name }} ${{ matrix.state.name }}

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -314,14 +314,22 @@ jobs:
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET
 
       - name: Mark pre-release installer complete
+        uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"chia_ref": "${{ env.RELEASE_TAG }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}/success/build-linux-rpm
+        with:
+          json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: '${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}'
+          glue_path: 'success/build-linux-rpm'
 
       - name: Mark release installer complete
+        uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.FULL_RELEASE == 'true'
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"chia_ref": "${{ env.RELEASE_TAG }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}/success/build-linux-rpm
+        with:
+          json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: '${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}'
+          glue_path: 'success/build-linux-rpm'
 
   test:
     name: Test ${{ matrix.distribution.name }} ${{ matrix.mode.name }} ${{ matrix.state.name }}

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -355,9 +355,6 @@ jobs:
             $RELEASE_TAG \
             build_scripts/final_installer/*.dmg
 
-      - uses: Chia-Network/actions/github/jwt@main
-        if: steps.check_secrets.outputs.HAS_GLUE_SECRET
-
       - name: Mark pre-release installer complete
         uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -363,18 +363,18 @@ jobs:
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'
         with:
           json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: '${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}'
-          glue_path: 'success/${{ matrix.os.glue-name }}'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}"
+          glue_path: "success/${{ matrix.os.glue-name }}"
 
       - name: Mark release installer complete
         uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.FULL_RELEASE == 'true'
         with:
           json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: '${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}'
-          glue_path: 'success/${{ matrix.os.glue-name }}'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}"
+          glue_path: "success/${{ matrix.os.glue-name }}"
 
   test:
     name: Test ${{ matrix.os.name }} ${{ matrix.arch.name }}

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -359,14 +359,22 @@ jobs:
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET
 
       - name: Mark pre-release installer complete
+        uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"chia_ref": "${{ env.RELEASE_TAG }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}/success/${{ matrix.os.glue-name }}
+        with:
+          json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: '${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}'
+          glue_path: 'success/${{ matrix.os.glue-name }}'
 
       - name: Mark release installer complete
+        uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.FULL_RELEASE == 'true'
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"chia_ref": "${{ env.RELEASE_TAG }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}/success/${{ matrix.os.glue-name }}
+        with:
+          json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: '${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}'
+          glue_path: 'success/${{ matrix.os.glue-name }}'
 
   test:
     name: Test ${{ matrix.os.name }} ${{ matrix.arch.name }}

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -363,14 +363,22 @@ jobs:
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET
 
       - name: Mark pre-release installer complete
+        uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"chia_ref": "${{ env.RELEASE_TAG }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}/success/build-windows
+        with:
+          json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: '${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}'
+          glue_path: 'success/build-windows'
 
       - name: Mark release installer complete
+        uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.FULL_RELEASE == 'true'
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"chia_ref": "${{ env.RELEASE_TAG }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}/success/build-windows
+        with:
+          json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: '${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}'
+          glue_path: 'success/build-windows'
 
   test:
     name: Test ${{ matrix.os.name }}

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -359,9 +359,6 @@ jobs:
         run: |
           gh release upload --repo ${{ github.repository }} $RELEASE_TAG "${GITHUB_WORKSPACE}"/chia-blockchain-gui/release-builds/windows-installer/ChiaSetup-${{ env.CHIA_INSTALLER_VERSION }}.exe
 
-      - uses: Chia-Network/actions/github/jwt@main
-        if: steps.check_secrets.outputs.HAS_GLUE_SECRET
-
       - name: Mark pre-release installer complete
         uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -367,18 +367,18 @@ jobs:
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.PRE_RELEASE == 'true'
         with:
           json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: '${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}'
-          glue_path: 'success/build-windows'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}"
+          glue_path: "success/build-windows"
 
       - name: Mark release installer complete
         uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_GLUE_SECRET && env.FULL_RELEASE == 'true'
         with:
           json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: '${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}'
-          glue_path: 'success/build-windows'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}"
+          glue_path: "success/build-windows"
 
   test:
     name: Test ${{ matrix.os.name }}

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -21,7 +21,8 @@ jobs:
 
       - uses: Chia-Network/actions/github/jwt@main
 
-      - uses: Chia-Network/actions/github/glue@main
+      - name: Start pre-release
+        uses: Chia-Network/actions/github/glue@main
         if: "github.event.release.prerelease"
         with:
           json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
@@ -29,7 +30,8 @@ jobs:
           glue_project: "${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}"
           glue_path: "start"
 
-      - uses: Chia-Network/actions/github/glue@main
+      - name: Start release
+        uses: Chia-Network/actions/github/glue@main
         if: "!github.event.release.prerelease"
         with:
           json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -21,12 +21,18 @@ jobs:
 
       - uses: Chia-Network/actions/github/jwt@main
 
-      - name: Start pre-release
+      - uses: Chia-Network/actions/github/glue@main
         if: "github.event.release.prerelease"
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"chia_ref": "${{ env.RELEASE_TAG }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}/start
+        with:
+          json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: '${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}'
+          glue_path: 'start'
 
-      - name: Start release
+      - uses: Chia-Network/actions/github/glue@main
         if: "!github.event.release.prerelease"
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"chia_ref": "${{ env.RELEASE_TAG }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}/start
+        with:
+          json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: '${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}'
+          glue_path: 'start'

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -25,14 +25,14 @@ jobs:
         if: "github.event.release.prerelease"
         with:
           json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: '${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}'
-          glue_path: 'start'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "${{ env.RFC_REPO }}-prerelease/${{ env.RELEASE_TAG }}"
+          glue_path: "start"
 
       - uses: Chia-Network/actions/github/glue@main
         if: "!github.event.release.prerelease"
         with:
           json_data: '{"chia_ref": "${{ env.RELEASE_TAG }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: '${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}'
-          glue_path: 'start'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "${{ env.RFC_REPO }}/${{ env.RELEASE_TAG }}"
+          glue_path: "start"

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -19,8 +19,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: Chia-Network/actions/github/jwt@main
-
       - name: Start pre-release
         uses: Chia-Network/actions/github/glue@main
         if: "github.event.release.prerelease"

--- a/.github/workflows/start-sync-test.yml
+++ b/.github/workflows/start-sync-test.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           json_data: '{"test_ref": "${{ env.RELEASE_TAG }}"}'
           glue_url: "${{ secrets.GLUE_API_URL }}"
-          glue_project: "sync-test/$RELEASE_TAG"
+          glue_project: "sync-test/${{ env.RELEASE_TAG }}"
           glue_path: "start"
 
       - name: Trigger sync test workflow success via github-glue
@@ -34,5 +34,5 @@ jobs:
         with:
           json_data: '{"test_ref": "${{ env.RELEASE_TAG }}"}'
           glue_url: "${{ secrets.GLUE_API_URL }}"
-          glue_project: "sync-test/$RELEASE_TAG"
+          glue_project: "sync-test/${{ env.RELEASE_TAG }}"
           glue_path: "success/deploy"

--- a/.github/workflows/start-sync-test.yml
+++ b/.github/workflows/start-sync-test.yml
@@ -25,14 +25,14 @@ jobs:
         uses: Chia-Network/actions/github/glue@main
         with:
           json_data: '{"test_ref": "${{ env.RELEASE_TAG }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: 'sync-test/$RELEASE_TAG'
-          glue_path: 'start'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "sync-test/$RELEASE_TAG"
+          glue_path: "start"
 
       - name: Trigger sync test workflow success via github-glue
         uses: Chia-Network/actions/github/glue@main
         with:
           json_data: '{"test_ref": "${{ env.RELEASE_TAG }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: 'sync-test/$RELEASE_TAG'
-          glue_path: 'success/deploy'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "sync-test/$RELEASE_TAG"
+          glue_path: "success/deploy"

--- a/.github/workflows/start-sync-test.yml
+++ b/.github/workflows/start-sync-test.yml
@@ -21,7 +21,18 @@ jobs:
 
       - uses: Chia-Network/actions/github/jwt@main
 
-      - name: Trigger Workflow
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"test_ref": "${{ env.RELEASE_TAG }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/sync-test/$RELEASE_TAG/start
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"test_ref": "${{ env.RELEASE_TAG }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/sync-test/$RELEASE_TAG/success/deploy
+      - name: Trigger sync test workflow via github-glue
+        uses: Chia-Network/actions/github/glue@main
+        with:
+          json_data: '{"test_ref": "${{ env.RELEASE_TAG }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: 'sync-test/$RELEASE_TAG'
+          glue_path: 'start'
+
+      - name: Trigger sync test workflow success via github-glue
+        uses: Chia-Network/actions/github/glue@main
+        with:
+          json_data: '{"test_ref": "${{ env.RELEASE_TAG }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: 'sync-test/$RELEASE_TAG'
+          glue_path: 'success/deploy'

--- a/.github/workflows/start-sync-test.yml
+++ b/.github/workflows/start-sync-test.yml
@@ -19,8 +19,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: Chia-Network/actions/github/jwt@main
-
       - name: Trigger sync test workflow via github-glue
         uses: Chia-Network/actions/github/glue@main
         with:

--- a/.github/workflows/trigger-docker-dev.yml
+++ b/.github/workflows/trigger-docker-dev.yml
@@ -36,9 +36,6 @@ jobs:
         env:
           GLUE_API_URL: "${{ secrets.GLUE_API_URL }}"
 
-      - uses: Chia-Network/actions/github/jwt@main
-        if: steps.check_secrets.outputs.HAS_SECRET
-
       - name: Trigger docker dev workflow via github-glue
         uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_SECRET

--- a/.github/workflows/trigger-docker-dev.yml
+++ b/.github/workflows/trigger-docker-dev.yml
@@ -44,15 +44,15 @@ jobs:
         if: steps.check_secrets.outputs.HAS_SECRET
         with:
           json_data: '{"sha":"${{ github.sha }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: 'docker-build-dev/${{ github.sha }}'
-          glue_path: 'start'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "docker-build-dev/${{ github.sha }}"
+          glue_path: "start"
 
       - name: Trigger docker dev success via github-glue
         uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_SECRET
         with:
           json_data: '{"sha":"${{ github.sha }}"}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: 'docker-build-dev/${{ github.sha }}'
-          glue_path: 'success/build-dev'
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "docker-build-dev/${{ github.sha }}"
+          glue_path: "success/build-dev"

--- a/.github/workflows/trigger-docker-dev.yml
+++ b/.github/workflows/trigger-docker-dev.yml
@@ -40,7 +40,19 @@ jobs:
         if: steps.check_secrets.outputs.HAS_SECRET
 
       - name: Trigger docker dev workflow via github-glue
+        uses: Chia-Network/actions/github/glue@main
         if: steps.check_secrets.outputs.HAS_SECRET
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"sha":"${{ github.sha }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/docker-build-dev/${{ github.sha }}/start
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{"sha":"${{ github.sha }}"}' ${{ secrets.GLUE_API_URL }}/api/v1/docker-build-dev/${{ github.sha }}/success/build-dev
+        with:
+          json_data: '{"sha":"${{ github.sha }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: 'docker-build-dev/${{ github.sha }}'
+          glue_path: 'start'
+
+      - name: Trigger docker dev success via github-glue
+        uses: Chia-Network/actions/github/glue@main
+        if: steps.check_secrets.outputs.HAS_SECRET
+        with:
+          json_data: '{"sha":"${{ github.sha }}"}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: 'docker-build-dev/${{ github.sha }}'
+          glue_path: 'success/build-dev'

--- a/.github/workflows/trigger-docker-main.yml
+++ b/.github/workflows/trigger-docker-main.yml
@@ -24,6 +24,17 @@ jobs:
       - uses: Chia-Network/actions/github/jwt@main
 
       - name: Trigger docker main workflow via github-glue
-        run: |
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{}' ${{ secrets.GLUE_API_URL }}/api/v1/docker-build-main/${{ github.sha }}/start
-          curl -s -XPOST -H "Authorization: Bearer ${{ env.JWT_TOKEN }}" --data '{}' ${{ secrets.GLUE_API_URL }}/api/v1/docker-build-main/${{ github.sha }}/success/build-main
+        uses: Chia-Network/actions/github/glue@main
+        with:
+          json_data: '{}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: 'docker-build-main/${{ github.sha }}'
+          glue_path: 'start'
+
+      - name: Trigger docker main success via github-glue
+        uses: Chia-Network/actions/github/glue@main
+        with:
+          json_data: '{}'
+          glue_url: '${{ secrets.GLUE_API_URL }}'
+          glue_project: 'docker-build-main/${{ github.sha }}'
+          glue_path: 'success/build-main'

--- a/.github/workflows/trigger-docker-main.yml
+++ b/.github/workflows/trigger-docker-main.yml
@@ -21,8 +21,6 @@ jobs:
     name: Trigger building a new `main` tag for the chia-docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: Chia-Network/actions/github/jwt@main
-
       - name: Trigger docker main workflow via github-glue
         uses: Chia-Network/actions/github/glue@main
         with:

--- a/.github/workflows/trigger-docker-main.yml
+++ b/.github/workflows/trigger-docker-main.yml
@@ -26,15 +26,15 @@ jobs:
       - name: Trigger docker main workflow via github-glue
         uses: Chia-Network/actions/github/glue@main
         with:
-          json_data: '{}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: 'docker-build-main/${{ github.sha }}'
-          glue_path: 'start'
+          json_data: "{}"
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "docker-build-main/${{ github.sha }}"
+          glue_path: "start"
 
       - name: Trigger docker main success via github-glue
         uses: Chia-Network/actions/github/glue@main
         with:
-          json_data: '{}'
-          glue_url: '${{ secrets.GLUE_API_URL }}'
-          glue_project: 'docker-build-main/${{ github.sha }}'
-          glue_path: 'success/build-main'
+          json_data: "{}"
+          glue_url: "${{ secrets.GLUE_API_URL }}"
+          glue_project: "docker-build-main/${{ github.sha }}"
+          glue_path: "success/build-main"


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
### Purpose:
These curl commands don't properly bubble up errors in a way we'd expect CI to behave. When a non-2xx status code is returned by the GitHub Glue service, curl doesn't exit 1. So we're left thinking things were successful until we go and look at workflow logs. The glue Action does some basic error handling to check the status code.


<!-- Does this PR introduce a breaking change? -->
### Current Behavior:
Glue errors don't bubble up to affect CI check outcome.


### New Behavior:
Glue errors bubble up to affect CI check outcome.


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
### Testing Notes:
We ran this Action in the chia-exporter project and observed it working on release there.


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
