### PR TITLE
Add prune old peers functionality for crawler

### DIFF
--- a/chia/_tests/core/test_crawler.py
+++ b/chia/_tests/core/test_crawler.py
@@ -106,3 +106,42 @@ async def test_crawler_to_db(crawler_service: CrawlerService, one_node: Simulato
 
     # validate the db data
     await time_out_assert(20, crawl_store.get_good_peers, [peer_address])
+
+@pytest.mark.anyio
+async def test_crawler_peer_cleanup(crawler_service: CrawlerService, one_node: SimulatorsAndWalletsServices) -> None:
+    """
+    This is a lot more of an integration test, but it tests the whole process. We add multiple nodes to the crawler,
+    then we save them to the db and validate. One of the nodes is older than the 90 day cutoff, so we also
+    call the prune function and ensure the node is deleted as expected
+    """
+    [full_node_service], _, _ = one_node
+    full_node = full_node_service._node
+    crawler = crawler_service._node
+    crawl_store = crawler.crawl_store
+    assert crawl_store is not None
+    peer_addresses = ["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"]
+
+    for peer_address in peer_addresses:
+        # create peer records
+        peer_record = PeerRecord(
+            peer_address,
+            peer_address,
+            uint32(full_node.server.get_port()),
+            False,
+            uint64(0),
+            uint32(0),
+            uint64(0),
+            uint64(int(time.time())),
+            uint64(0),
+            "undefined",
+            uint64(0),
+            tls_version="unknown",
+        )
+        peer_reliability = PeerReliability(peer_address, tries=1, successes=1)
+
+        # add peer to the db & mark it as connected
+        await crawl_store.add_peer(peer_record, peer_reliability)
+        assert peer_record == crawl_store.host_to_records[peer_address]
+
+    # validate the db data
+    await time_out_assert(20, crawl_store.get_good_peers, peer_addresses)

--- a/chia/_tests/core/test_crawler.py
+++ b/chia/_tests/core/test_crawler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from datetime import datetime, timedelta
@@ -24,10 +23,10 @@ from chia.util.ints import uint32, uint64, uint128
 
 @pytest.mark.anyio
 async def test_unknown_messages(
-        self_hostname: str,
-        one_node: SimulatorsAndWalletsServices,
-        crawler_service: CrawlerService,
-        caplog: pytest.LogCaptureFixture,
+    self_hostname: str,
+    one_node: SimulatorsAndWalletsServices,
+    crawler_service: CrawlerService,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     [full_node_service], _, _ = one_node
     crawler = crawler_service._node
@@ -48,10 +47,10 @@ async def test_unknown_messages(
 
 @pytest.mark.anyio
 async def test_valid_message(
-        self_hostname: str,
-        one_node: SimulatorsAndWalletsServices,
-        crawler_service: CrawlerService,
-        caplog: pytest.LogCaptureFixture,
+    self_hostname: str,
+    one_node: SimulatorsAndWalletsServices,
+    crawler_service: CrawlerService,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     [full_node_service], _, _ = one_node
     crawler = crawler_service._node

--- a/chia/seeder/crawl_store.py
+++ b/chia/seeder/crawl_store.py
@@ -5,6 +5,7 @@ import logging
 import random
 import time
 from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta
 from typing import Dict, List
 
 import aiosqlite
@@ -380,3 +381,31 @@ class CrawlStore:
         if len(result) > 0:
             random.shuffle(result)  # mix up the peers
         return result
+
+    async def prune_old_peers(self, older_than_days: int) -> None:
+        cutoff = int((datetime.now() - timedelta(days=older_than_days)).timestamp())
+
+        # Deletes the old records from the DB
+        await self.crawl_db.execute("delete from peer_records where best_timestamp < ?", (cutoff,))
+        await self.crawl_db.execute(
+            """
+            delete from peer_reliability
+            where not exists (
+                select peer_records.peer_id
+                from peer_records
+                where peer_records.peer_id = peer_reliability.peer_id
+            )
+            """
+        )
+        await self.crawl_db.execute("VACUUM")
+
+        # Deletes the old records from the in memory Dicts
+        for peer_id, peer_record in self.host_to_records.items():
+            if peer_record.best_timestamp < cutoff:
+                del self.host_to_records[peer_id]
+
+            if peer_id in self.host_to_selected_time:
+                del self.host_to_selected_time[peer_id]
+
+            if peer_id in self.host_to_reliability:
+                del self.host_to_reliability[peer_id]

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -304,7 +304,9 @@ class Crawler:
                 if len(peers_to_crawl) == 0:
                     continue
 
+                peer_cutoff = int(self.config.get("crawler", {}).get("prune_peer_days", 90))
                 await self.save_to_db()
+                await self.crawl_store.prune_old_peers(older_than_days=peer_cutoff)
                 await self.print_summary(t_start, total_nodes, tried_nodes)
                 await asyncio.sleep(15)  # 15 seconds between db updates
                 self._state_changed("crawl_batch_completed")

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -72,6 +72,7 @@ class Crawler:
     version_cache: List[Tuple[str, str]] = field(default_factory=list)
     handshake_time: Dict[str, uint64] = field(default_factory=dict)
     best_timestamp_per_peer: Dict[str, uint64] = field(default_factory=dict)
+    start_crawler_loop: bool = True
 
     @property
     def server(self) -> ChiaServer:
@@ -90,9 +91,10 @@ class Crawler:
 
         # Connect to the DB
         self.crawl_store: CrawlStore = await CrawlStore.create(await aiosqlite.connect(self.db_path))
-        # Bootstrap the initial peers
-        await self.load_bootstrap_peers()
-        self.crawl_task = asyncio.create_task(self.crawl())
+        if self.start_crawler_loop:
+            # Bootstrap the initial peers
+            await self.load_bootstrap_peers()
+            self.crawl_task = asyncio.create_task(self.crawl())
         try:
             yield
         finally:

--- a/chia/seeder/start_crawler.py
+++ b/chia/seeder/start_crawler.py
@@ -35,12 +35,7 @@ def create_full_node_crawler_service(
     service_config = config[SERVICE_NAME]
     crawler_config = service_config["crawler"]
 
-    crawler = Crawler(
-        service_config,
-        root_path=root_path,
-        constants=consensus_constants,
-        start_crawler_loop=False
-    )
+    crawler = Crawler(service_config, root_path=root_path, constants=consensus_constants, start_crawler_loop=False)
     api = CrawlerAPI(crawler)
 
     network_id = service_config["selected_network"]

--- a/chia/seeder/start_crawler.py
+++ b/chia/seeder/start_crawler.py
@@ -39,6 +39,7 @@ def create_full_node_crawler_service(
         service_config,
         root_path=root_path,
         constants=consensus_constants,
+        start_crawler_loop=False
     )
     api = CrawlerAPI(crawler)
 

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -118,6 +118,7 @@ seeder:
   crawler:
     start_rpc_server: True
     rpc_port: 8561
+    prune_peer_days: 90 # Peers older than this many days will be removed from the crawler database
     ssl:
       private_crt: "config/ssl/crawler/private_crawler.crt"
       private_key: "config/ssl/crawler/private_crawler.key"


### PR DESCRIPTION
Keeps the database size and write times under control

### Purpose:

Currently, the crawler DB will grow infinitely over time. We used to run similar queries when backing up the crawlers, and since they were recreated periodically, our DBs were mostly kept under control. This moves that pruning to the actual crawler's areas of responsibility, and benefits others running the crawler.
