### PR TITLE
Crawler Loop Fix + Test Improvements

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -1054,7 +1054,7 @@ async def timelord_service(bt: BlockTools) -> AsyncIterator[TimelordService]:
 
 @pytest.fixture(scope="function")
 async def crawler_service(root_path_populated_with_config: Path, database_uri: str) -> AsyncIterator[CrawlerService]:
-    async with setup_crawler(root_path_populated_with_config, database_uri) as service:
+    async with setup_crawler(root_path_populated_with_config, database_uri, start_crawler_loop=False) as service:
         yield service
 
 

--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -1054,6 +1054,14 @@ async def timelord_service(bt: BlockTools) -> AsyncIterator[TimelordService]:
 
 @pytest.fixture(scope="function")
 async def crawler_service(root_path_populated_with_config: Path, database_uri: str) -> AsyncIterator[CrawlerService]:
+    async with setup_crawler(root_path_populated_with_config, database_uri) as service:
+        yield service
+
+
+@pytest.fixture(scope="function")
+async def crawler_service_no_loop(
+    root_path_populated_with_config: Path, database_uri: str
+) -> AsyncIterator[CrawlerService]:
     async with setup_crawler(root_path_populated_with_config, database_uri, start_crawler_loop=False) as service:
         yield service
 

--- a/chia/_tests/core/test_crawler.py
+++ b/chia/_tests/core/test_crawler.py
@@ -25,11 +25,11 @@ from chia.util.ints import uint32, uint64, uint128
 async def test_unknown_messages(
     self_hostname: str,
     one_node: SimulatorsAndWalletsServices,
-    crawler_service: CrawlerService,
+    crawler_service_no_loop: CrawlerService,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     [full_node_service], _, _ = one_node
-    crawler = crawler_service._node
+    crawler = crawler_service_no_loop._node
     full_node = full_node_service._node
     assert await crawler.server.start_client(
         PeerInfo(self_hostname, cast(FullNodeAPI, full_node_service._api).server.get_port()), None
@@ -49,11 +49,11 @@ async def test_unknown_messages(
 async def test_valid_message(
     self_hostname: str,
     one_node: SimulatorsAndWalletsServices,
-    crawler_service: CrawlerService,
+    crawler_service_no_loop: CrawlerService,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     [full_node_service], _, _ = one_node
-    crawler = crawler_service._node
+    crawler = crawler_service_no_loop._node
     full_node = full_node_service._node
     assert await crawler.server.start_client(
         PeerInfo(self_hostname, cast(FullNodeAPI, full_node_service._api).server.get_port()), None
@@ -72,14 +72,14 @@ async def test_valid_message(
 
 
 @pytest.mark.anyio
-async def test_crawler_to_db(crawler_service: CrawlerService, one_node: SimulatorsAndWalletsServices) -> None:
+async def test_crawler_to_db(crawler_service_no_loop: CrawlerService, one_node: SimulatorsAndWalletsServices) -> None:
     """
     This is a lot more of an integration test, but it tests the whole process. We add a node to the crawler, then we
     save it to the db and validate.
     """
     [full_node_service], _, _ = one_node
     full_node = full_node_service._node
-    crawler = crawler_service._node
+    crawler = crawler_service_no_loop._node
     crawl_store = crawler.crawl_store
     assert crawl_store is not None
     peer_address = "127.0.0.1"
@@ -110,7 +110,9 @@ async def test_crawler_to_db(crawler_service: CrawlerService, one_node: Simulato
 
 
 @pytest.mark.anyio
-async def test_crawler_peer_cleanup(crawler_service: CrawlerService, one_node: SimulatorsAndWalletsServices) -> None:
+async def test_crawler_peer_cleanup(
+    crawler_service_no_loop: CrawlerService, one_node: SimulatorsAndWalletsServices
+) -> None:
     """
     This is a lot more of an integration test, but it tests the whole process. We add multiple nodes to the crawler,
     then we save them to the db and validate. One of the nodes is older than the 90 day cutoff, so we also
@@ -118,7 +120,7 @@ async def test_crawler_peer_cleanup(crawler_service: CrawlerService, one_node: S
     """
     [full_node_service], _, _ = one_node
     full_node = full_node_service._node
-    crawler = crawler_service._node
+    crawler = crawler_service_no_loop._node
     crawl_store = crawler.crawl_store
     assert crawl_store is not None
     peer_addresses = ["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"]

--- a/chia/_tests/core/test_crawler.py
+++ b/chia/_tests/core/test_crawler.py
@@ -22,6 +22,24 @@ from chia.util.ints import uint32, uint64, uint128
 
 
 @pytest.mark.anyio
+async def test_crawler_loops_by_default(crawler_service: CrawlerService) -> None:
+    """
+    Ensures that when the crawler is started with all defaults, the crawling loop is started
+    """
+    crawler = crawler_service._node
+    assert crawler.crawl_task is not None
+
+
+@pytest.mark.anyio
+async def test_crawler_no_loops(crawler_service_no_loop: CrawlerService) -> None:
+    """
+    Ensures that when the crawler is call in no loop mode, there is no loop running
+    """
+    crawler = crawler_service_no_loop._node
+    assert crawler.crawl_task is None
+
+
+@pytest.mark.anyio
 async def test_unknown_messages(
     self_hostname: str,
     one_node: SimulatorsAndWalletsServices,

--- a/chia/seeder/crawl_store.py
+++ b/chia/seeder/crawl_store.py
@@ -260,19 +260,19 @@ class CrawlStore:
         return self.reliable_peers
 
     async def load_to_db(self) -> None:
-        log.info("Saving peers to DB...")
+        log.warning("Saving peers to DB...")
         for peer_id in list(self.host_to_reliability.keys()):
             if peer_id in self.host_to_reliability and peer_id in self.host_to_records:
                 reliability = self.host_to_reliability[peer_id]
                 record = self.host_to_records[peer_id]
                 await self.add_peer(record, reliability, True)
         await self.crawl_db.commit()
-        log.info(" - Done saving peers to DB")
+        log.warning(" - Done saving peers to DB")
 
     async def unload_from_db(self) -> None:
         self.host_to_records = {}
         self.host_to_reliability = {}
-        log.info("Loading peer reliability records...")
+        log.warning("Loading peer reliability records...")
         cursor = await self.crawl_db.execute(
             "SELECT * from peer_reliability",
         )
@@ -302,8 +302,8 @@ class CrawlStore:
                 row[19],
             )
             self.host_to_reliability[reliability.peer_id] = reliability
-        log.info("  - Done loading peer reliability records...")
-        log.info("Loading peer records...")
+        log.warning("  - Done loading peer reliability records...")
+        log.warning("Loading peer records...")
         cursor = await self.crawl_db.execute(
             "SELECT * from peer_records",
         )
@@ -314,7 +314,7 @@ class CrawlStore:
                 row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11]
             )
             self.host_to_records[peer.peer_id] = peer
-        log.info("  - Done loading peer records...")
+        log.warning("  - Done loading peer records...")
 
     # Crawler -> DNS.
     async def load_reliable_peers_to_db(self) -> None:
@@ -323,13 +323,13 @@ class CrawlStore:
             if reliability.is_reliable():
                 peers.append(peer_id)
         self.reliable_peers = len(peers)
-        log.info("Deleting old good_peers from DB...")
+        log.warning("Deleting old good_peers from DB...")
         cursor = await self.crawl_db.execute(
             "DELETE from good_peers",
         )
         await cursor.close()
-        log.info(" - Done deleting old good_peers...")
-        log.info("Saving new good_peers to DB...")
+        log.warning(" - Done deleting old good_peers...")
+        log.warning("Saving new good_peers to DB...")
         for peer_id in peers:
             cursor = await self.crawl_db.execute(
                 "INSERT OR REPLACE INTO good_peers VALUES(?)",
@@ -337,7 +337,7 @@ class CrawlStore:
             )
             await cursor.close()
         await self.crawl_db.commit()
-        log.info(" - Done saving new good_peers to DB...")
+        log.warning(" - Done saving new good_peers to DB...")
 
     def load_host_to_version(self) -> tuple[dict[str, str], dict[str, uint64]]:
         versions = {}

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -214,7 +214,7 @@ class Crawler:
         # Sometimes, the daemon connection + state changed callback isn't up and ready
         # by the time we get to the first _state_changed call, so this just ensures it's there before moving on
         while self.state_changed_callback is None:
-            self.log.info("Waiting for state changed callback...")
+            self.log.warning("Waiting for state changed callback...")
             await asyncio.sleep(0.1)
         assert self.crawl_store is not None
         t_start = time.time()

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -216,6 +216,7 @@ class Crawler:
         while self.state_changed_callback is None:
             self.log.warning("Waiting for state changed callback...")
             await asyncio.sleep(0.1)
+        self.log.warning("  - Got state changed callback...")
         assert self.crawl_store is not None
         t_start = time.time()
         total_nodes = 0

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -224,6 +224,7 @@ class Crawler:
         try:
             while not self._shut_down:
                 peers_to_crawl = await self.crawl_store.get_peers_to_crawl(25000, 250000)
+                self.log.warning(f"Crawling {len(peers_to_crawl)} peers...")
                 tasks = set()
                 for peer in peers_to_crawl:
                     if peer.port == self.other_peers_port:

--- a/chia/seeder/start_crawler.py
+++ b/chia/seeder/start_crawler.py
@@ -31,11 +31,14 @@ def create_full_node_crawler_service(
     config: Dict[str, Any],
     consensus_constants: ConsensusConstants,
     connect_to_daemon: bool = True,
+    start_crawler_loop: bool = True,
 ) -> CrawlerService:
     service_config = config[SERVICE_NAME]
     crawler_config = service_config["crawler"]
 
-    crawler = Crawler(service_config, root_path=root_path, constants=consensus_constants, start_crawler_loop=False)
+    crawler = Crawler(
+        service_config, root_path=root_path, constants=consensus_constants, start_crawler_loop=start_crawler_loop
+    )
     api = CrawlerAPI(crawler)
 
     network_id = service_config["selected_network"]

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -169,7 +169,7 @@ async def setup_full_node(
 
 @asynccontextmanager
 async def setup_crawler(
-    root_path_populated_with_config: Path, database_uri: str
+    root_path_populated_with_config: Path, database_uri: str, start_crawler_loop: bool = True
 ) -> AsyncGenerator[CrawlerService, None]:
     create_all_ssl(
         root_path=root_path_populated_with_config,
@@ -193,6 +193,7 @@ async def setup_crawler(
         config,
         updated_constants,
         connect_to_daemon=False,
+        start_crawler_loop=start_crawler_loop,
     )
     async with service.manage():
         if not service_config["crawler"]["start_rpc_server"]:  # otherwise the loops don't work.


### PR DESCRIPTION
Fixes the default crawler loop behavior (regression from https://github.com/Chia-Network/chia-blockchain/pull/18310) and adds some additional testing for the crawler.

Also moves a bunch of crawler logs back to warning from info, since crawlers typically run in warning mode to avoid the connection log spam (but we want to still see what is happening in the crawler itself)