### PR TITLE
[CHIA-959] Conform to CHIP-0029

### DIFF
--- a/chia/_tests/core/test_rpc_util.py
+++ b/chia/_tests/core/test_rpc_util.py
@@ -81,7 +81,7 @@ async def test_clvm_streamable_marshalling() -> None:
     assert await test_rpc_endpoint(
         None,
         {
-            "sub": "ff81ff80",
+            "sub": "ffff83717578818180",
             "CHIP-0029": True,
         },
-    ) == {"sub": "ff81ff80"}
+    ) == {"sub": "ffff83717578818180"}

--- a/chia/_tests/wallet/test_clvm_streamable.py
+++ b/chia/_tests/wallet/test_clvm_streamable.py
@@ -31,12 +31,12 @@ class BasicCLVMStreamable(Streamable):
 
 def test_basic_serialization() -> None:
     instance = BasicCLVMStreamable(a="1")
-    assert program_serialize_clvm_streamable(instance) == Program.to(["1"])
-    assert byte_serialize_clvm_streamable(instance).hex() == "ff3180"
-    assert json_serialize_with_clvm_streamable(instance) == "ff3180"
-    assert program_deserialize_clvm_streamable(Program.to(["1"]), BasicCLVMStreamable) == instance
-    assert byte_deserialize_clvm_streamable(bytes.fromhex("ff3180"), BasicCLVMStreamable) == instance
-    assert json_deserialize_with_clvm_streamable("ff3180", BasicCLVMStreamable) == instance
+    assert program_serialize_clvm_streamable(instance) == Program.to([("a", "1")])
+    assert byte_serialize_clvm_streamable(instance).hex() == "ffff613180"
+    assert json_serialize_with_clvm_streamable(instance) == "ffff613180"
+    assert program_deserialize_clvm_streamable(Program.to([("a", "1")]), BasicCLVMStreamable) == instance
+    assert byte_deserialize_clvm_streamable(bytes.fromhex("ffff613180"), BasicCLVMStreamable) == instance
+    assert json_deserialize_with_clvm_streamable("ffff613180", BasicCLVMStreamable) == instance
 
 
 @streamable
@@ -55,17 +55,23 @@ class OutsideCLVM(Streamable):
 
 def test_nested_serialization() -> None:
     instance = OutsideStreamable(a="1", inside=BasicCLVMStreamable(a="1"))
-    assert json_serialize_with_clvm_streamable(instance) == {"inside": "ff3180", "a": "1"}
-    assert json_deserialize_with_clvm_streamable({"inside": "ff3180", "a": "1"}, OutsideStreamable) == instance
+    assert json_serialize_with_clvm_streamable(instance) == {"inside": "ffff613180", "a": "1"}
+    assert json_deserialize_with_clvm_streamable({"inside": "ffff613180", "a": "1"}, OutsideStreamable) == instance
     assert OutsideStreamable.from_json_dict({"a": "1", "inside": {"a": "1"}}) == instance
 
     instance_clvm = OutsideCLVM(a="1", inside=BasicCLVMStreamable(a="1"))
-    assert program_serialize_clvm_streamable(instance_clvm) == Program.to([["1"], "1"])
-    assert byte_serialize_clvm_streamable(instance_clvm).hex() == "ffff3180ff3180"
-    assert json_serialize_with_clvm_streamable(instance_clvm) == "ffff3180ff3180"
-    assert program_deserialize_clvm_streamable(Program.to([["1"], "1"]), OutsideCLVM) == instance_clvm
-    assert byte_deserialize_clvm_streamable(bytes.fromhex("ffff3180ff3180"), OutsideCLVM) == instance_clvm
-    assert json_deserialize_with_clvm_streamable("ffff3180ff3180", OutsideCLVM) == instance_clvm
+    assert program_serialize_clvm_streamable(instance_clvm) == Program.to([["inside", ("a", "1")], ("a", "1")])
+    assert byte_serialize_clvm_streamable(instance_clvm).hex() == "ffff86696e73696465ffff613180ffff613180"
+    assert json_serialize_with_clvm_streamable(instance_clvm) == "ffff86696e73696465ffff613180ffff613180"
+    assert (
+        program_deserialize_clvm_streamable(Program.to([["inside", ("a", "1")], ("a", "1")]), OutsideCLVM)
+        == instance_clvm
+    )
+    assert (
+        byte_deserialize_clvm_streamable(bytes.fromhex("ffff86696e73696465ffff613180ffff613180"), OutsideCLVM)
+        == instance_clvm
+    )
+    assert json_deserialize_with_clvm_streamable("ffff86696e73696465ffff613180ffff613180", OutsideCLVM) == instance_clvm
 
 
 @streamable
@@ -85,8 +91,10 @@ class CompoundCLVM(Streamable):
 def test_compound_type_serialization() -> None:
     # regular streamable + regular values
     instance = Compound(optional=BasicCLVMStreamable(a="1"), list=[BasicCLVMStreamable(a="1")])
-    assert json_serialize_with_clvm_streamable(instance) == {"optional": "ff3180", "list": ["ff3180"]}
-    assert json_deserialize_with_clvm_streamable({"optional": "ff3180", "list": ["ff3180"]}, Compound) == instance
+    assert json_serialize_with_clvm_streamable(instance) == {"optional": "ffff613180", "list": ["ffff613180"]}
+    assert (
+        json_deserialize_with_clvm_streamable({"optional": "ffff613180", "list": ["ffff613180"]}, Compound) == instance
+    )
     assert Compound.from_json_dict({"optional": {"a": "1"}, "list": [{"a": "1"}]}) == instance
 
     # regular streamable + falsey values
@@ -97,21 +105,48 @@ def test_compound_type_serialization() -> None:
 
     # clvm streamable + regular values
     instance_clvm = CompoundCLVM(optional=BasicCLVMStreamable(a="1"), list=[BasicCLVMStreamable(a="1")])
-    assert program_serialize_clvm_streamable(instance_clvm) == Program.to([[True, "1"], [["1"]]])
-    assert byte_serialize_clvm_streamable(instance_clvm).hex() == "ffff01ff3180ffffff31808080"
-    assert json_serialize_with_clvm_streamable(instance_clvm) == "ffff01ff3180ffffff31808080"
-    assert program_deserialize_clvm_streamable(Program.to([[True, "1"], [["1"]]]), CompoundCLVM) == instance_clvm
-    assert byte_deserialize_clvm_streamable(bytes.fromhex("ffff01ff3180ffffff31808080"), CompoundCLVM) == instance_clvm
-    assert json_deserialize_with_clvm_streamable("ffff01ff3180ffffff31808080", CompoundCLVM) == instance_clvm
+    assert program_serialize_clvm_streamable(instance_clvm) == Program.to(
+        [["optional", 1, (97, 49)], ["list", [(97, 49)]]]
+    )
+    assert (
+        byte_serialize_clvm_streamable(instance_clvm).hex()
+        == "ffff886f7074696f6e616cff01ffff613180ffff846c697374ffffff6131808080"
+    )
+    assert (
+        json_serialize_with_clvm_streamable(instance_clvm)
+        == "ffff886f7074696f6e616cff01ffff613180ffff846c697374ffffff6131808080"
+    )
+    assert (
+        program_deserialize_clvm_streamable(Program.to([["optional", 1, (97, 49)], ["list", [(97, 49)]]]), CompoundCLVM)
+        == instance_clvm
+    )
+    assert (
+        byte_deserialize_clvm_streamable(
+            bytes.fromhex("ffff886f7074696f6e616cff01ffff613180ffff846c697374ffffff6131808080"), CompoundCLVM
+        )
+        == instance_clvm
+    )
+    assert (
+        json_deserialize_with_clvm_streamable(
+            "ffff886f7074696f6e616cff01ffff613180ffff846c697374ffffff6131808080", CompoundCLVM
+        )
+        == instance_clvm
+    )
 
     # clvm streamable + falsey values
     instance_clvm = CompoundCLVM(optional=None, list=[])
-    assert program_serialize_clvm_streamable(instance_clvm) == Program.to([[0], []])
-    assert byte_serialize_clvm_streamable(instance_clvm).hex() == "ffff8080ff8080"
-    assert json_serialize_with_clvm_streamable(instance_clvm) == "ffff8080ff8080"
-    assert program_deserialize_clvm_streamable(Program.to([[0, 0], []]), CompoundCLVM) == instance_clvm
-    assert byte_deserialize_clvm_streamable(bytes.fromhex("ffff8080ff8080"), CompoundCLVM) == instance_clvm
-    assert json_deserialize_with_clvm_streamable("ffff8080ff8080", CompoundCLVM) == instance_clvm
+    assert program_serialize_clvm_streamable(instance_clvm) == Program.to([["optional", 0], ["list"]])
+    assert byte_serialize_clvm_streamable(instance_clvm).hex() == "ffff886f7074696f6e616cff8080ffff846c6973748080"
+    assert json_serialize_with_clvm_streamable(instance_clvm) == "ffff886f7074696f6e616cff8080ffff846c6973748080"
+    assert program_deserialize_clvm_streamable(Program.to([["optional", 0], ["list"]]), CompoundCLVM) == instance_clvm
+    assert (
+        byte_deserialize_clvm_streamable(bytes.fromhex("ffff886f7074696f6e616cff8080ffff846c6973748080"), CompoundCLVM)
+        == instance_clvm
+    )
+    assert (
+        json_deserialize_with_clvm_streamable("ffff886f7074696f6e616cff8080ffff846c6973748080", CompoundCLVM)
+        == instance_clvm
+    )
 
     with pytest.raises(ValueError, match="@clvm_streamable"):
 

--- a/chia/wallet/util/clvm_streamable.py
+++ b/chia/wallet/util/clvm_streamable.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+from types import MappingProxyType
 from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar, Union, get_args, get_type_hints
 
 from hsms.clvm_serde import from_program_for_type, to_program_for_type
@@ -27,6 +28,7 @@ def clvm_streamable(cls: Type[Streamable]) -> Type[Streamable]:
     hints = get_type_hints(cls)
     # no way to hint that wrapped_cls is a dataclass here but @streamable checks that
     for field in dataclasses.fields(wrapped_cls):  # type: ignore[arg-type]
+        field.metadata = MappingProxyType({"key": field.name, **field.metadata})
         if is_type_Tuple(hints[field.name]):
             raise ValueError("@clvm_streamable does not support tuples")
 


### PR DESCRIPTION
Through some redesigns clvm_streamable was accidentally changed to not conform to the specified serialization in CHIP-0029.  This is in error and should be fixed.