### PR TITLE
[CHIA-958] In cmd class framework: help -> short_help

### DIFF
--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -252,7 +252,7 @@ def chia_command(cmd: click.Group, name: str, help: str) -> Callable[[Type[ChiaC
                 kw_only=True,
             )(cls)
 
-        cmd.command(name, help=help)(_convert_class_to_function(wrapped_cls))
+        cmd.command(name, short_help=help)(_convert_class_to_function(wrapped_cls))
         return wrapped_cls
 
     return _chia_command


### PR DESCRIPTION
Apparently `short_help` is derived from help and truncates it if it's longer than the desired width.  I'm not sure why this would ever be desirable so we'll just manually set short_help instead.