### PR TITLE
CHIA-590: Add in connect timeout to DL http download

### DIFF
--- a/chia/_tests/core/data_layer/test_data_store.py
+++ b/chia/_tests/core/data_layer/test_data_store.py
@@ -1357,8 +1357,9 @@ async def test_server_http_ban(
         filename: str,
         proxy_url: str,
         server_info: ServerInfo,
-        timeout: aiohttp.ClientTimeout,
+        timeout: int,
         log: logging.Logger,
+        connect_timeout: int,
     ) -> None:
         if error:
             raise aiohttp.ClientConnectionError()
@@ -1373,10 +1374,11 @@ async def test_server_http_ban(
             root_hashes=[bytes32.random(seeded_random)],
             server_info=sinfo,
             client_foldername=tmp_path,
-            timeout=aiohttp.ClientTimeout(total=15, sock_connect=5),
+            timeout=15,
             log=log,
             proxy_url="",
             downloader=None,
+            connect_timeout=5,
         )
 
     assert success is False
@@ -1396,10 +1398,11 @@ async def test_server_http_ban(
             root_hashes=[bytes32.random(seeded_random)],
             server_info=sinfo,
             client_foldername=tmp_path,
-            timeout=aiohttp.ClientTimeout(total=15, sock_connect=5),
+            timeout=15,
             log=log,
             proxy_url="",
             downloader=None,
+            connect_timeout=5,
         )
 
     subscriptions = await data_store.get_subscriptions()
@@ -1903,10 +1906,11 @@ async def test_insert_from_delta_file_correct_file_exists(
         root_hashes=root_hashes,
         server_info=sinfo,
         client_foldername=tmp_path,
-        timeout=aiohttp.ClientTimeout(total=15, sock_connect=5),
+        timeout=15,
         log=log,
         proxy_url="",
         downloader=None,
+        connect_timeout=5,
     )
     assert success
 
@@ -1962,10 +1966,11 @@ async def test_insert_from_delta_file_incorrect_file_exists(
         root_hashes=[incorrect_root_hash],
         server_info=sinfo,
         client_foldername=tmp_path,
-        timeout=aiohttp.ClientTimeout(total=15, sock_connect=5),
+        timeout=15,
         log=log,
         proxy_url="",
         downloader=None,
+        connect_timeout=5,
     )
     assert not success
 

--- a/chia/_tests/core/data_layer/test_data_store.py
+++ b/chia/_tests/core/data_layer/test_data_store.py
@@ -1359,6 +1359,7 @@ async def test_server_http_ban(
         server_info: ServerInfo,
         timeout: int,
         log: logging.Logger,
+        connect_timeout: int,
     ) -> None:
         if error:
             raise aiohttp.ClientConnectionError()

--- a/chia/_tests/core/data_layer/test_data_store.py
+++ b/chia/_tests/core/data_layer/test_data_store.py
@@ -1377,6 +1377,7 @@ async def test_server_http_ban(
             log=log,
             proxy_url="",
             downloader=None,
+            connect_timeout=5,
         )
 
     assert success is False
@@ -1400,6 +1401,7 @@ async def test_server_http_ban(
             log=log,
             proxy_url="",
             downloader=None,
+            connect_timeout=5,
         )
 
     subscriptions = await data_store.get_subscriptions()
@@ -1907,6 +1909,7 @@ async def test_insert_from_delta_file_correct_file_exists(
         log=log,
         proxy_url="",
         downloader=None,
+        connect_timeout=5,
     )
     assert success
 
@@ -1966,6 +1969,7 @@ async def test_insert_from_delta_file_incorrect_file_exists(
         log=log,
         proxy_url="",
         downloader=None,
+        connect_timeout=5,
     )
     assert not success
 

--- a/chia/_tests/core/data_layer/test_data_store.py
+++ b/chia/_tests/core/data_layer/test_data_store.py
@@ -1357,9 +1357,8 @@ async def test_server_http_ban(
         filename: str,
         proxy_url: str,
         server_info: ServerInfo,
-        timeout: int,
+        timeout: aiohttp.ClientTimeout,
         log: logging.Logger,
-        connect_timeout: int,
     ) -> None:
         if error:
             raise aiohttp.ClientConnectionError()
@@ -1374,11 +1373,10 @@ async def test_server_http_ban(
             root_hashes=[bytes32.random(seeded_random)],
             server_info=sinfo,
             client_foldername=tmp_path,
-            timeout=15,
+            timeout=aiohttp.ClientTimeout(total=15, sock_connect=5),
             log=log,
             proxy_url="",
             downloader=None,
-            connect_timeout=5,
         )
 
     assert success is False
@@ -1398,11 +1396,10 @@ async def test_server_http_ban(
             root_hashes=[bytes32.random(seeded_random)],
             server_info=sinfo,
             client_foldername=tmp_path,
-            timeout=15,
+            timeout=aiohttp.ClientTimeout(total=15, sock_connect=5),
             log=log,
             proxy_url="",
             downloader=None,
-            connect_timeout=5,
         )
 
     subscriptions = await data_store.get_subscriptions()
@@ -1906,11 +1903,10 @@ async def test_insert_from_delta_file_correct_file_exists(
         root_hashes=root_hashes,
         server_info=sinfo,
         client_foldername=tmp_path,
-        timeout=15,
+        timeout=aiohttp.ClientTimeout(total=15, sock_connect=5),
         log=log,
         proxy_url="",
         downloader=None,
-        connect_timeout=5,
     )
     assert success
 
@@ -1966,11 +1962,10 @@ async def test_insert_from_delta_file_incorrect_file_exists(
         root_hashes=[incorrect_root_hash],
         server_info=sinfo,
         client_foldername=tmp_path,
-        timeout=15,
+        timeout=aiohttp.ClientTimeout(total=15, sock_connect=5),
         log=log,
         proxy_url="",
         downloader=None,
-        connect_timeout=5,
     )
     assert not success
 

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import dataclasses
+import functools
 import json
 import logging
 import os
@@ -124,7 +125,9 @@ class DataLayer:
     _wallet_rpc: Optional[WalletRpcClient] = None
     subscription_lock: asyncio.Lock = dataclasses.field(default_factory=asyncio.Lock)
     subscription_update_concurrency: int = 5
-    client_timeout: aiohttp.ClientTimeout = aiohttp.ClientTimeout(total=45, sock_connect=5)
+    client_timeout: aiohttp.ClientTimeout = dataclasses.field(
+        default_factory=functools.partial(aiohttp.ClientTimeout, total=45, sock_connect=5)
+    )
 
     @property
     def server(self) -> ChiaServer:

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -124,6 +124,7 @@ class DataLayer:
     _wallet_rpc: Optional[WalletRpcClient] = None
     subscription_lock: asyncio.Lock = dataclasses.field(default_factory=asyncio.Lock)
     subscription_update_concurrency: int = 5
+    client_timeout: aiohttp.ClientTimeout = aiohttp.ClientTimeout(total=45, sock_connect=5)
 
     @property
     def server(self) -> ChiaServer:
@@ -185,6 +186,9 @@ class DataLayer:
             maximum_full_file_count=config.get("maximum_full_file_count", 1),
             subscription_update_concurrency=config.get("subscription_update_concurrency", 5),
             unsubscribe_data_queue=[],
+            client_timeout=aiohttp.ClientTimeout(
+                total=config.get("client_timeout", 45), sock_connect=config.get("connect_timeout", 5)
+            ),
         )
 
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -586,8 +590,6 @@ class DataLayer:
                 max_generation=singleton_record.generation,
             )
             try:
-                timeout = self.config.get("client_timeout", 45)
-                connect_timeout = self.config.get("connect_timeout", 5)
                 proxy_url = self.config.get("proxy_url", None)
                 success = await insert_from_delta_file(
                     self.data_store,
@@ -596,11 +598,10 @@ class DataLayer:
                     [record.root for record in reversed(to_download)],
                     server_info,
                     self.server_files_location,
-                    timeout,
+                    self.client_timeout,
                     self.log,
                     proxy_url,
                     await self.get_downloader(store_id, url),
-                    connect_timeout=connect_timeout,
                 )
                 if success:
                     self.log.info(

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -124,7 +124,6 @@ class DataLayer:
     _wallet_rpc: Optional[WalletRpcClient] = None
     subscription_lock: asyncio.Lock = dataclasses.field(default_factory=asyncio.Lock)
     subscription_update_concurrency: int = 5
-    client_timeout: aiohttp.ClientTimeout = dataclasses.field(default_factory=aiohttp.ClientTimeout)
 
     @property
     def server(self) -> ChiaServer:
@@ -186,9 +185,6 @@ class DataLayer:
             maximum_full_file_count=config.get("maximum_full_file_count", 1),
             subscription_update_concurrency=config.get("subscription_update_concurrency", 5),
             unsubscribe_data_queue=[],
-            client_timeout=aiohttp.ClientTimeout(
-                total=config.get("client_timeout", 45), sock_connect=config.get("connect_timeout", 5)
-            ),
         )
 
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -590,6 +586,8 @@ class DataLayer:
                 max_generation=singleton_record.generation,
             )
             try:
+                timeout = self.config.get("client_timeout", 45)
+                connect_timeout = self.config.get("connect_timeout", 5)
                 proxy_url = self.config.get("proxy_url", None)
                 success = await insert_from_delta_file(
                     self.data_store,
@@ -598,10 +596,11 @@ class DataLayer:
                     [record.root for record in reversed(to_download)],
                     server_info,
                     self.server_files_location,
-                    self.client_timeout,
+                    timeout,
                     self.log,
                     proxy_url,
                     await self.get_downloader(store_id, url),
+                    connect_timeout=connect_timeout,
                 )
                 if success:
                     self.log.info(
@@ -769,10 +768,6 @@ class DataLayer:
 
     async def unsubscribe(self, store_id: bytes32, retain_data: bool) -> None:
         async with self.subscription_lock:
-            subscriptions = await self.data_store.get_subscriptions()
-            if store_id not in (subscription.store_id for subscription in subscriptions):
-                raise RuntimeError("No subscription found for the given store_id.")
-
             # Unsubscribe is processed later, after all fetching of data is done, to avoid races.
             self.unsubscribe_data_queue.append(UnsubscribeData(store_id, retain_data))
 
@@ -870,45 +865,21 @@ class DataLayer:
                 await asyncio.sleep(0.1)
 
         while not self._shut_down:
-            # Add existing subscriptions
             async with self.subscription_lock:
                 subscriptions = await self.data_store.get_subscriptions()
 
-            # pseudo-subscribe to all unsubscribed owned stores
-            # Need this to make sure we process updates and generate DAT files
-            try:
-                owned_stores = await self.get_owned_stores()
-            except ValueError:
-                # Sometimes the DL wallet isn't available, so we can't get the owned stores.
-                # We'll try again next time.
-                owned_stores = []
+            # Subscribe to all local store_ids that we can find on chain.
+            local_store_ids = await self.data_store.get_store_ids()
             subscription_store_ids = {subscription.store_id for subscription in subscriptions}
-            for record in owned_stores:
-                store_id = record.launcher_id
-                if store_id not in subscription_store_ids:
+            for local_id in local_store_ids:
+                if local_id not in subscription_store_ids:
                     try:
-                        # subscription = await self.subscribe(store_id, [])
-                        subscriptions.insert(0, Subscription(store_id=store_id, servers_info=[]))
+                        subscription = await self.subscribe(local_id, [])
+                        subscriptions.insert(0, subscription)
                     except Exception as e:
                         self.log.info(
-                            f"Can't subscribe to owned store {store_id}: {type(e)} {e} {traceback.format_exc()}"
+                            f"Can't subscribe to locally stored {local_id}: {type(e)} {e} {traceback.format_exc()}"
                         )
-
-            # Optionally
-            # Subscribe to all local non-owned store_ids that we can find on chain.
-            # This is the prior behavior where all local stores, both owned and not owned, are subscribed to.
-            if self.config.get("auto_subscribe_to_local_stores", False):
-                local_store_ids = await self.data_store.get_store_ids()
-                subscription_store_ids = {subscription.store_id for subscription in subscriptions}
-                for local_id in local_store_ids:
-                    if local_id not in subscription_store_ids:
-                        try:
-                            subscription = await self.subscribe(local_id, [])
-                            subscriptions.insert(0, subscription)
-                        except Exception as e:
-                            self.log.info(
-                                f"Can't subscribe to local store {local_id}: {type(e)} {e} {traceback.format_exc()}"
-                            )
 
             work_queue: asyncio.Queue[Job[Subscription]] = asyncio.Queue()
             async with QueuedAsyncPool.managed(

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -586,7 +586,8 @@ class DataLayer:
                 max_generation=singleton_record.generation,
             )
             try:
-                timeout = self.config.get("client_timeout", 15)
+                timeout = self.config.get("client_timeout", 45)
+                connect_timeout = self.config.get("connect_timeout", 5)
                 proxy_url = self.config.get("proxy_url", None)
                 success = await insert_from_delta_file(
                     self.data_store,
@@ -599,6 +600,7 @@ class DataLayer:
                     self.log,
                     proxy_url,
                     await self.get_downloader(store_id, url),
+                    connect_timeout=connect_timeout,
                 )
                 if success:
                     self.log.info(

--- a/chia/data_layer/download_data.py
+++ b/chia/data_layer/download_data.py
@@ -145,10 +145,11 @@ async def insert_from_delta_file(
     root_hashes: List[bytes32],
     server_info: ServerInfo,
     client_foldername: Path,
-    timeout: aiohttp.ClientTimeout,
+    timeout: int,
     log: logging.Logger,
     proxy_url: str,
     downloader: Optional[PluginRemote],
+    connect_timeout: int,
 ) -> bool:
     for root_hash in root_hashes:
         timestamp = int(time.time())
@@ -171,6 +172,7 @@ async def insert_from_delta_file(
                         server_info,
                         timeout,
                         log,
+                        connect_timeout=connect_timeout,
                     )
                 except (asyncio.TimeoutError, aiohttp.ClientError):
                     new_server_info = await data_store.server_misses_file(store_id, server_info, timestamp)
@@ -259,8 +261,9 @@ async def http_download(
     filename: str,
     proxy_url: str,
     server_info: ServerInfo,
-    timeout: aiohttp.ClientTimeout,
+    timeout: int,
     log: logging.Logger,
+    connect_timeout: int,
 ) -> None:
     """
     Download a file from a server using aiohttp.
@@ -271,7 +274,7 @@ async def http_download(
         async with session.get(
             server_info.url + "/" + filename,
             headers=headers,
-            timeout=timeout,
+            timeout=aiohttp.ClientTimeout(total=timeout, sock_connect=connect_timeout),
             proxy=proxy_url,
         ) as resp:
             resp.raise_for_status()

--- a/chia/data_layer/download_data.py
+++ b/chia/data_layer/download_data.py
@@ -145,11 +145,10 @@ async def insert_from_delta_file(
     root_hashes: List[bytes32],
     server_info: ServerInfo,
     client_foldername: Path,
-    timeout: int,
+    timeout: aiohttp.ClientTimeout,
     log: logging.Logger,
     proxy_url: str,
     downloader: Optional[PluginRemote],
-    connect_timeout: int,
 ) -> bool:
     for root_hash in root_hashes:
         timestamp = int(time.time())
@@ -172,7 +171,6 @@ async def insert_from_delta_file(
                         server_info,
                         timeout,
                         log,
-                        connect_timeout=connect_timeout,
                     )
                 except (asyncio.TimeoutError, aiohttp.ClientError):
                     new_server_info = await data_store.server_misses_file(store_id, server_info, timestamp)
@@ -261,9 +259,8 @@ async def http_download(
     filename: str,
     proxy_url: str,
     server_info: ServerInfo,
-    timeout: int,
+    timeout: aiohttp.ClientTimeout,
     log: logging.Logger,
-    connect_timeout: int,
 ) -> None:
     """
     Download a file from a server using aiohttp.
@@ -274,7 +271,7 @@ async def http_download(
         async with session.get(
             server_info.url + "/" + filename,
             headers=headers,
-            timeout=aiohttp.ClientTimeout(total=timeout, sock_connect=connect_timeout),
+            timeout=timeout,
             proxy=proxy_url,
         ) as resp:
             resp.raise_for_status()

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -615,7 +615,8 @@ data_layer:
   # The location where the server files will be stored.
   server_files_location: "data_layer/db/server_files_location_CHALLENGE"
   # The timeout for the client to download a file from a server
-  client_timeout: 15
+  client_timeout: 45
+  connect_timeout: 5
   # If you need use a proxy for download data you can use this setting sample
   # proxy_url: http://localhost:8888
 


### PR DESCRIPTION
Some adjustments to timeouts when datalayer is downloading files over HTTP.

The default total timeout is increased to 45s - this could probably be increased further since generally you really want to get the file fully downloaded
A new "socket connect" timeout is added and set to 5s. This means that the socket much connect within 5s - this helps with servers that are blackholing requests behind a firewall (incorrectly configured or down)

I am not sure how to test the socket connect timeout in CI since I doubt it's easy to force a connect timeout (note if the server isn't listening you will get an error immediately)