### PR TITLE
CHIA-942 Use launcher_id as the primary key when updating (current) pool config.

### DIFF
--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -92,7 +92,7 @@ def update_pool_config_entry(
         updated = False
         for pool_config_dict in pool_list:
             try:
-                if hexstr_to_bytes(pool_config_dict["owner_public_key"]) == bytes(pool_wallet_config.owner_public_key):
+                if hexstr_to_bytes(pool_config_dict["launcher_id"]) == bytes(pool_wallet_config.launcher_id):
                     if update_closure(pool_config_dict):
                         updated = True
             except Exception as e:
@@ -101,6 +101,8 @@ def update_pool_config_entry(
         log.info(update_log_message)
         config["pool"]["pool_list"] = pool_list
         save_config(root_path, "config.yaml", config)
+    else:
+        log.error(f"Failed to update pool config entry for launcher_id {pool_wallet_config.launcher_id}")
 
 
 async def update_pool_config(root_path: Path, pool_config_list: List[PoolWalletConfig]) -> None:


### PR DESCRIPTION
Add an error diagnostic for the case where updating fails due to the supplied closure.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose: Remove bug

<!-- Does this PR introduce a breaking change? -->

### Current Behavior: Can update incorrect pool entry when multiple entries share the same owner key

### New Behavior: Only update the specified launcher_id

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
