### PR TITLE
update cryptography, remove ecdsa dependency

### DIFF
--- a/chia/_tests/wallet/vault/test_vault_clsp.py
+++ b/chia/_tests/wallet/vault/test_vault_clsp.py
@@ -37,7 +37,7 @@ secp_pk = secp_sk.public_key().public_bytes(Encoding.X962, PublicFormat.Compress
 
 
 def sign_message(private_key: ec.EllipticCurvePrivateKey, message: bytes) -> bytes:
-    der_sig = private_key.sign(message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True))  # type: ignore[call-arg]
+    der_sig = private_key.sign(message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True))
     r, s = decode_dss_signature(der_sig)
     return r.to_bytes(32, byteorder="big") + s.to_bytes(32, byteorder="big")
 

--- a/chia/_tests/wallet/vault/test_vault_clsp.py
+++ b/chia/_tests/wallet/vault/test_vault_clsp.py
@@ -37,7 +37,7 @@ secp_pk = secp_sk.public_key().public_bytes(Encoding.X962, PublicFormat.Compress
 
 
 def sign_message(private_key: ec.EllipticCurvePrivateKey, message: bytes) -> bytes:
-    der_sig = private_key.sign(message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True))
+    der_sig = private_key.sign(message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True))  # type: ignore[call-arg]
     r, s = decode_dss_signature(der_sig)
     return r.to_bytes(32, byteorder="big") + s.to_bytes(32, byteorder="big")
 

--- a/chia/_tests/wallet/vault/test_vault_lifecycle.py
+++ b/chia/_tests/wallet/vault/test_vault_lifecycle.py
@@ -45,7 +45,7 @@ HIDDEN_PUZZLE_HASH = Program.to("hph").get_tree_hash()
 
 
 def sign_message(private_key: ec.EllipticCurvePrivateKey, message: bytes) -> bytes:
-    der_sig = private_key.sign(message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True))  # type: ignore[call-arg]
+    der_sig = private_key.sign(message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True))
     r, s = decode_dss_signature(der_sig)
     return r.to_bytes(32, byteorder="big") + s.to_bytes(32, byteorder="big")
 

--- a/chia/_tests/wallet/vault/test_vault_lifecycle.py
+++ b/chia/_tests/wallet/vault/test_vault_lifecycle.py
@@ -45,7 +45,7 @@ HIDDEN_PUZZLE_HASH = Program.to("hph").get_tree_hash()
 
 
 def sign_message(private_key: ec.EllipticCurvePrivateKey, message: bytes) -> bytes:
-    der_sig = private_key.sign(message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True))
+    der_sig = private_key.sign(message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True))  # type: ignore[call-arg]
     r, s = decode_dss_signature(der_sig)
     return r.to_bytes(32, byteorder="big") + s.to_bytes(32, byteorder="big")
 

--- a/chia/ssl/create_ssl.py
+++ b/chia/ssl/create_ssl.py
@@ -68,6 +68,7 @@ def generate_ca_signed_cert(ca_crt: bytes, ca_key: bytes, cert_out: Path, key_ou
     one_day = datetime.timedelta(1, 0, 0)
     root_cert = x509.load_pem_x509_certificate(ca_crt, default_backend())
     root_key = load_pem_private_key(ca_key, None, default_backend())
+    assert isinstance(root_key, rsa.RSAPrivateKey)
 
     cert_key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
     new_subject = x509.Name(

--- a/chia/wallet/vault/vault_wallet.py
+++ b/chia/wallet/vault/vault_wallet.py
@@ -385,7 +385,9 @@ class Vault(Wallet):
             fingerprint: int = int.from_bytes(target.fingerprint, "big")
             if fingerprint not in sk_lookup:
                 raise ValueError(f"Pubkey {fingerprint} not found")
-            der_sig = sk_lookup[fingerprint].sign(target.message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True))
+            der_sig = sk_lookup[fingerprint].sign(
+                target.message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True)  # type: ignore[call-arg]
+            )
             r, s = decode_dss_signature(der_sig)
             sig = r.to_bytes(32, byteorder="big") + s.to_bytes(32, byteorder="big")
             responses.append(

--- a/chia/wallet/vault/vault_wallet.py
+++ b/chia/wallet/vault/vault_wallet.py
@@ -385,9 +385,7 @@ class Vault(Wallet):
             fingerprint: int = int.from_bytes(target.fingerprint, "big")
             if fingerprint not in sk_lookup:
                 raise ValueError(f"Pubkey {fingerprint} not found")
-            der_sig = sk_lookup[fingerprint].sign(
-                target.message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True)  # type: ignore[call-arg]
-            )
+            der_sig = sk_lookup[fingerprint].sign(target.message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True))
             r, s = decode_dss_signature(der_sig)
             sig = r.to_bytes(32, byteorder="big") + s.to_bytes(32, byteorder="big")
             responses.append(

--- a/chia/wallet/vault/vault_wallet.py
+++ b/chia/wallet/vault/vault_wallet.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from chia_rs import G1Element, G2Element
-from ecdsa.keys import SigningKey
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 from typing_extensions import Unpack
 
 from chia.protocols.wallet_protocol import CoinState
@@ -372,8 +374,9 @@ class Vault(Wallet):
         self, signing_instructions: SigningInstructions, partial_allowed: bool = False
     ) -> List[SigningResponse]:
         root_pubkey = self.wallet_state_manager.observation_root
-        sk: SigningKey = self.wallet_state_manager.config["test_sk"]  # Temporary access to private key
-        sk_lookup: Dict[int, SigningKey] = {root_pubkey.get_fingerprint(): sk}
+        # Temporary access to private key
+        sk: ec.EllipticCurvePrivateKey = self.wallet_state_manager.config["test_sk"]
+        sk_lookup: Dict[int, ec.EllipticCurvePrivateKey] = {root_pubkey.get_fingerprint(): sk}
         responses: List[SigningResponse] = []
 
         # We don't need to expand path and sum hints since vault signer always uses the same keys
@@ -382,9 +385,12 @@ class Vault(Wallet):
             fingerprint: int = int.from_bytes(target.fingerprint, "big")
             if fingerprint not in sk_lookup:
                 raise ValueError(f"Pubkey {fingerprint} not found")
+            der_sig = sk_lookup[fingerprint].sign(target.message, ec.ECDSA(hashes.SHA256(), deterministic_signing=True))
+            r, s = decode_dss_signature(der_sig)
+            sig = r.to_bytes(32, byteorder="big") + s.to_bytes(32, byteorder="big")
             responses.append(
                 SigningResponse(
-                    sk_lookup[fingerprint].sign_deterministic(target.message),
+                    sig,
                     target.hook,
                 )
             )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ dependencies = [
     "colorama==0.4.6",  # Colorizes terminal output
     "colorlog==6.8.2",  # Adds color to logs
     "concurrent-log-handler==0.9.25",  # Concurrently log and rotate logs
-    "cryptography==42.0.5",  # Python cryptography library for TLS - keyring conflict
+    "cryptography==43.0.0",  # Python cryptography library for TLS - keyring conflict
     "filelock==3.14.0",  # For reading and writing config multiprocess and multithread safely  (non-reentrant locks)
     "importlib-resources==6.4.0",
     "keyring==25.1.0",  # Store keys in MacOS Keychain, Windows Credential Locker
@@ -38,7 +38,6 @@ dependencies = [
     "packaging==24.0",
     "psutil==5.9.4",
     "hsms==0.3.1",
-    "ecdsa==0.19.0",  # For SECP
 ]
 
 upnp_dependencies = [

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ dev_dependencies = [
     "aiohttp_cors==0.7.0",  # For blackd
     "pyinstaller==6.7.0",
     "types-aiofiles==23.2.0.20240311",
-    "types-cryptography==3.3.23.2",
     "types-pyyaml==6.0.12.20240311",
     "types-setuptools==70.0.0.20240524",
 ]


### PR DESCRIPTION
Update cryptography to 43.0.0 which enables deterministic signing for ecdsa.

Note that stubs for the ECDSA class are not updated in types-cryptography. The cryptography maintainer suggested removing dependence on types-cryptography as it has very out-of-date type stubs. 