### PR TITLE
[CHIA-1008] Make vault endpoints more paradigmatic

### DIFF
--- a/chia/_tests/cmds/wallet/test_vault.py
+++ b/chia/_tests/cmds/wallet/test_vault.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Tuple
 
-from chia_rs import Coin, G1Element, G2Element
+from chia_rs import G1Element
 
 from chia._tests.cmds.cmd_test_utils import TestRpcClients, TestWalletRpcClient, run_cli_command_and_assert
-from chia._tests.cmds.wallet.test_consts import FINGERPRINT_ARG, WALLET_ID_ARG, get_bytes32
-from chia.types.spend_bundle import SpendBundle
-from chia.util.ints import uint8, uint32, uint64
-from chia.wallet.conditions import ConditionValidTimes
-from chia.wallet.transaction_record import TransactionRecord
-from chia.wallet.util.transaction_type import TransactionType
+from chia._tests.cmds.wallet.test_consts import FINGERPRINT_ARG, STD_TX, STD_UTX, WALLET_ID_ARG
+from chia.rpc.wallet_request_types import VaultCreate, VaultCreateResponse, VaultRecovery, VaultRecoveryResponse
 from chia.wallet.util.tx_config import TXConfig
 
 
@@ -22,39 +18,15 @@ def test_vault_create(capsys: object, get_test_cli_clients: Tuple[TestRpcClients
     class CreateVaultRpcClient(TestWalletRpcClient):
         async def vault_create(
             self,
-            secp_pk: bytes,
-            hp_index: uint32,
+            args: VaultCreate,
             tx_config: TXConfig,
-            bls_pk: Optional[bytes] = None,
-            timelock: Optional[uint64] = None,
-            fee: uint64 = uint64(0),
-            push: bool = True,
-        ) -> List[TransactionRecord]:
-            tx_rec = TransactionRecord(
-                confirmed_at_height=uint32(1),
-                created_at_time=uint64(1234),
-                to_puzzle_hash=get_bytes32(1),
-                amount=uint64(12345678),
-                fee_amount=uint64(1234567),
-                confirmed=False,
-                sent=uint32(0),
-                spend_bundle=SpendBundle([], G2Element()),
-                additions=[Coin(get_bytes32(1), get_bytes32(2), uint64(12345678))],
-                removals=[Coin(get_bytes32(2), get_bytes32(4), uint64(12345678))],
-                wallet_id=uint32(1),
-                sent_to=[("aaaaa", uint8(1), None)],
-                trade_id=None,
-                type=uint32(TransactionType.OUTGOING_TX.value),
-                name=get_bytes32(2),
-                memos=[(get_bytes32(3), [bytes([4] * 32)])],
-                valid_times=ConditionValidTimes(),
-            )
-            return [tx_rec]
+        ) -> VaultCreateResponse:
+            return VaultCreateResponse([STD_UTX], [STD_TX])
 
     inst_rpc_client = CreateVaultRpcClient()  # pylint: disable=no-value-for-parameter
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
-    pk = get_bytes32(0).hex()
-    recovery_pk = get_bytes32(1).hex()
+    pk = bytes(G1Element()).hex()
+    recovery_pk = bytes(G1Element()).hex()
     timelock = "100"
     hidden_puzzle_index = "10"
     fee = "0.1"
@@ -77,45 +49,22 @@ def test_vault_create(capsys: object, get_test_cli_clients: Tuple[TestRpcClients
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
 
 
-def test_vault_recovery(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Path]) -> None:
+def test_vault_recovery(capsys: object, get_test_cli_clients: Tuple[TestRpcClients, Path], tmp_path: Path) -> None:
     test_rpc_clients, root_dir = get_test_cli_clients
 
     # set RPC clients
     class CreateVaultRpcClient(TestWalletRpcClient):
         async def vault_recovery(
             self,
-            wallet_id: uint32,
-            secp_pk: bytes,
-            hp_index: uint32,
+            args: VaultRecovery,
             tx_config: TXConfig,
-            bls_pk: Optional[G1Element] = None,
-            timelock: Optional[uint64] = None,
-        ) -> List[TransactionRecord]:
-            tx_rec = TransactionRecord(
-                confirmed_at_height=uint32(1),
-                created_at_time=uint64(1234),
-                to_puzzle_hash=get_bytes32(1),
-                amount=uint64(12345678),
-                fee_amount=uint64(1234567),
-                confirmed=False,
-                sent=uint32(0),
-                spend_bundle=SpendBundle([], G2Element()),
-                additions=[Coin(get_bytes32(1), get_bytes32(2), uint64(12345678))],
-                removals=[Coin(get_bytes32(2), get_bytes32(4), uint64(12345678))],
-                wallet_id=uint32(1),
-                sent_to=[("aaaaa", uint8(1), None)],
-                trade_id=None,
-                type=uint32(TransactionType.OUTGOING_TX.value),
-                name=get_bytes32(2),
-                memos=[(get_bytes32(3), [bytes([4] * 32)])],
-                valid_times=ConditionValidTimes(),
-            )
-            return [tx_rec, tx_rec]
+        ) -> VaultRecoveryResponse:
+            return VaultRecoveryResponse([STD_UTX, STD_UTX], [STD_TX, STD_TX])
 
     inst_rpc_client = CreateVaultRpcClient()  # pylint: disable=no-value-for-parameter
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
-    pk = get_bytes32(0).hex()
-    recovery_pk = get_bytes32(1).hex()
+    pk = bytes(G1Element()).hex()
+    recovery_pk = bytes(G1Element()).hex()
     timelock = "100"
     hidden_puzzle_index = "10"
     command_args = [
@@ -130,12 +79,14 @@ def test_vault_recovery(capsys: object, get_test_cli_clients: Tuple[TestRpcClien
         "-i",
         hidden_puzzle_index,
         "-ri",
-        "recovery_init.json",
+        str(tmp_path / "recovery_init.json"),
         "-rf",
-        "recovery_finish.json",
+        str(tmp_path / "recovery_finish.json"),
     ]
     assert_list = [
-        "Initiate Recovery transaction written to: recovery_init.json",
-        "Finish Recovery transaction written to: recovery_finish.json",
+        "Initiate Recovery transaction written to:",
+        "recovery_init.json",
+        "Finish Recovery transaction written to:",
+        "recovery_finish.json",
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args + [FINGERPRINT_ARG, WALLET_ID_ARG], assert_list)

--- a/chia/_tests/wallet/vault/test_vault_wallet.py
+++ b/chia/_tests/wallet/vault/test_vault_wallet.py
@@ -40,11 +40,12 @@ async def vault_setup(wallet_environments: WalletTestFramework, with_recovery: b
     res = await client.vault_create(
         VaultCreate(
             secp_pk=SECP_PK,
-            tx_config=wallet_environments.tx_config,
             hp_index=hidden_puzzle_index,
             bls_pk=bls_pk,
             timelock=timelock,
-        )
+            push=True,
+        ),
+        tx_config=wallet_environments.tx_config,
     )
 
     all_removals = [coin for tx in res.transactions for coin in tx.removals]
@@ -302,10 +303,10 @@ async def test_vault_recovery(
                 wallet_id=wallet.id(),
                 secp_pk=RECOVERY_SECP_PK,
                 hp_index=uint32(0),
-                tx_config=DEFAULT_TX_CONFIG,
                 bls_pk=bls_pk,
                 timelock=timelock,
-            )
+            ),
+            tx_config=wallet_environments.tx_config,
         )
     ).transactions
 

--- a/chia/_tests/wallet/vault/test_vault_wallet.py
+++ b/chia/_tests/wallet/vault/test_vault_wallet.py
@@ -38,7 +38,13 @@ async def vault_setup(wallet_environments: WalletTestFramework, with_recovery: b
         timelock = uint64(10)
     hidden_puzzle_index = uint32(0)
     res = await client.vault_create(
-        VaultCreate(SECP_PK, wallet_environments.tx_config, hidden_puzzle_index, bls_pk=bls_pk, timelock=timelock)
+        VaultCreate(
+            secp_pk=SECP_PK,
+            tx_config=wallet_environments.tx_config,
+            hp_index=hidden_puzzle_index,
+            bls_pk=bls_pk,
+            timelock=timelock,
+        )
     )
 
     all_removals = [coin for tx in res.transactions for coin in tx.removals]

--- a/chia/cmds/vault_funcs.py
+++ b/chia/cmds/vault_funcs.py
@@ -40,12 +40,12 @@ async def create_vault(
         try:
             await wallet_client.vault_create(
                 VaultCreate(
-                    bytes.fromhex(public_key),
-                    uint32(hidden_puzzle_index),
-                    tx_config,
-                    G1Element.from_bytes(bytes.fromhex(recovery_public_key)) if recovery_public_key else None,
-                    uint64(timelock) if timelock else None,
-                    fee,
+                    secp_pk=bytes.fromhex(public_key),
+                    hp_index=uint32(hidden_puzzle_index),
+                    tx_config=tx_config,
+                    bls_pk=G1Element.from_bytes(bytes.fromhex(recovery_public_key)) if recovery_public_key else None,
+                    timelock=uint64(timelock) if timelock else None,
+                    fee=fee,
                     push=True,
                 )
             )
@@ -82,12 +82,12 @@ async def recover_vault(
         try:
             response = await wallet_client.vault_recovery(
                 VaultRecovery(
-                    uint32(wallet_id),
-                    bytes.fromhex(public_key),
-                    tx_config,
-                    uint32(hidden_puzzle_index),
-                    G1Element.from_bytes(bytes.fromhex(recovery_public_key)) if recovery_public_key else None,
-                    uint64(timelock) if timelock else None,
+                    wallet_id=uint32(wallet_id),
+                    secp_pk=bytes.fromhex(public_key),
+                    tx_config=tx_config,
+                    hp_index=uint32(hidden_puzzle_index),
+                    bls_pk=G1Element.from_bytes(bytes.fromhex(recovery_public_key)) if recovery_public_key else None,
+                    timelock=uint64(timelock) if timelock else None,
                 )
             )
             # TODO: do not rely on ordering of transactions here

--- a/chia/cmds/vault_funcs.py
+++ b/chia/cmds/vault_funcs.py
@@ -42,12 +42,12 @@ async def create_vault(
                 VaultCreate(
                     secp_pk=bytes.fromhex(public_key),
                     hp_index=uint32(hidden_puzzle_index),
-                    tx_config=tx_config,
                     bls_pk=G1Element.from_bytes(bytes.fromhex(recovery_public_key)) if recovery_public_key else None,
                     timelock=uint64(timelock) if timelock else None,
                     fee=fee,
                     push=True,
-                )
+                ),
+                tx_config=tx_config,
             )
             print("Successfully created a Vault wallet")
         except Exception as e:
@@ -84,11 +84,11 @@ async def recover_vault(
                 VaultRecovery(
                     wallet_id=uint32(wallet_id),
                     secp_pk=bytes.fromhex(public_key),
-                    tx_config=tx_config,
                     hp_index=uint32(hidden_puzzle_index),
                     bls_pk=G1Element.from_bytes(bytes.fromhex(recovery_public_key)) if recovery_public_key else None,
                     timelock=uint64(timelock) if timelock else None,
-                )
+                ),
+                tx_config=tx_config,
             )
             # TODO: do not rely on ordering of transactions here
             with open(initiate_file, "w") as f:

--- a/chia/cmds/vault_funcs.py
+++ b/chia/cmds/vault_funcs.py
@@ -8,7 +8,7 @@ from chia_rs import G1Element
 from chia.cmds.cmds_util import CMDTXConfigLoader, get_wallet_client
 from chia.cmds.param_types import CliAmount
 from chia.cmds.units import units
-from chia.rpc.wallet_rpc_types import VaultCreate, VaultRecovery
+from chia.rpc.wallet_request_types import VaultCreate, VaultRecovery
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint32, uint64
 

--- a/chia/cmds/vault_funcs.py
+++ b/chia/cmds/vault_funcs.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import json
 from typing import Optional, Sequence
 
+from chia_rs import G1Element
+
 from chia.cmds.cmds_util import CMDTXConfigLoader, get_wallet_client
 from chia.cmds.param_types import CliAmount
 from chia.cmds.units import units
+from chia.rpc.wallet_rpc_types import VaultCreate, VaultRecovery
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint32, uint64
 
@@ -36,13 +39,15 @@ async def create_vault(
             assert timelock > 0
         try:
             await wallet_client.vault_create(
-                bytes.fromhex(public_key),
-                uint32(hidden_puzzle_index),
-                tx_config,
-                bytes.fromhex(recovery_public_key) if recovery_public_key else None,
-                uint64(timelock) if timelock else None,
-                fee,
-                push=True,
+                VaultCreate(
+                    bytes.fromhex(public_key),
+                    uint32(hidden_puzzle_index),
+                    tx_config,
+                    G1Element.from_bytes(bytes.fromhex(recovery_public_key)) if recovery_public_key else None,
+                    uint64(timelock) if timelock else None,
+                    fee,
+                    push=True,
+                )
             )
             print("Successfully created a Vault wallet")
         except Exception as e:
@@ -76,18 +81,21 @@ async def recover_vault(
         ).to_tx_config(units["chia"], config, fingerprint)
         try:
             response = await wallet_client.vault_recovery(
-                uint32(wallet_id),
-                bytes.fromhex(public_key),
-                uint32(hidden_puzzle_index),
-                tx_config,
-                bytes.fromhex(recovery_public_key) if recovery_public_key else None,
-                uint64(timelock) if timelock else None,
+                VaultRecovery(
+                    uint32(wallet_id),
+                    bytes.fromhex(public_key),
+                    tx_config,
+                    uint32(hidden_puzzle_index),
+                    G1Element.from_bytes(bytes.fromhex(recovery_public_key)) if recovery_public_key else None,
+                    uint64(timelock) if timelock else None,
+                )
             )
+            # TODO: do not rely on ordering of transactions here
             with open(initiate_file, "w") as f:
-                json.dump(response[0].to_json_dict(), f, indent=4)
+                json.dump(response.transactions[0].to_json_dict(), f, indent=4)
             print(f"Initiate Recovery transaction written to: {initiate_file}")
             with open(finish_file, "w") as f:
-                json.dump(response[1].to_json_dict(), f, indent=4)
+                json.dump(response.transactions[1].to_json_dict(), f, indent=4)
             print(f"Finish Recovery transaction written to: {finish_file}")
         except Exception as e:
             print(f"Error creating recovery transactions: {e}")

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -113,6 +113,23 @@ class VaultCreateResponse(TransactionEndpointResponse):
     pass
 
 
+@streamable
+@dataclass(frozen=True)
+class VaultRecovery(Streamable):
+    wallet_id: uint32
+    secp_pk: bytes
+    hp_index: uint32 = uint32(0)
+    fee: uint64 = uint64(0)
+    bls_pk: Optional[G1Element] = None
+    timelock: Optional[uint64] = None
+
+
+@streamable
+@dataclass(frozen=True)
+class VaultRecoveryResponse(TransactionEndpointResponse):
+    pass
+
+
 # TODO: The section below needs corresponding request types
 # TODO: The section below should be added to the API (currently only for client)
 @streamable

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -92,6 +92,14 @@ class ExecuteSigningInstructionsResponse(Streamable):
 
 
 @streamable
+@dataclass(frozen=True, kw_only=True)
+class TransactionEndpointRequest(Streamable):
+    tx_config: TXConfig
+    fee: uint64 = uint64(0)
+    push: Optional[bool] = None
+
+
+@streamable
 @dataclass(frozen=True)
 class TransactionEndpointResponse(Streamable):
     unsigned_transactions: List[UnsignedTransaction]
@@ -99,13 +107,10 @@ class TransactionEndpointResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
-class VaultCreate(Streamable):
+@dataclass(frozen=True, kw_only=True)
+class VaultCreate(TransactionEndpointRequest):
     secp_pk: bytes
-    tx_config: TXConfig
     hp_index: uint32 = uint32(0)
-    fee: uint64 = uint64(0)
-    push: Optional[bool] = None
     bls_pk: Optional[G1Element] = None
     timelock: Optional[uint64] = None
 
@@ -117,14 +122,11 @@ class VaultCreateResponse(TransactionEndpointResponse):
 
 
 @streamable
-@dataclass(frozen=True)
-class VaultRecovery(Streamable):
+@dataclass(frozen=True, kw_only=True)
+class VaultRecovery(TransactionEndpointRequest):
     wallet_id: uint32
     secp_pk: bytes
-    tx_config: TXConfig
     hp_index: uint32 = uint32(0)
-    fee: uint64 = uint64(0)
-    push: Optional[bool] = None
     bls_pk: Optional[G1Element] = None
     timelock: Optional[uint64] = None
 

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -121,7 +121,7 @@ class TransactionEndpointResponse(Streamable):
 @streamable
 @kw_only_dataclass
 class VaultCreate(TransactionEndpointRequest):
-    secp_pk: bytes = field(default=MISSING)  # type: ignore[assignment]
+    secp_pk: bytes = field(default=MISSING, default_factory=MISSING)  # type: ignore[call-overload]
     hp_index: uint32 = uint32(0)
     bls_pk: Optional[G1Element] = None
     timelock: Optional[uint64] = None
@@ -136,8 +136,8 @@ class VaultCreateResponse(TransactionEndpointResponse):
 @streamable
 @kw_only_dataclass
 class VaultRecovery(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default=MISSING)  # type: ignore[assignment]
-    secp_pk: bytes = field(default=MISSING)  # type: ignore[assignment]
+    wallet_id: uint32 = field(default=MISSING, default_factory=MISSING)  # type: ignore[call-overload]
+    secp_pk: bytes = field(default=MISSING, default_factory=MISSING)  # type: ignore[call-overload]
     hp_index: uint32 = uint32(0)
     bls_pk: Optional[G1Element] = None
     timelock: Optional[uint64] = None

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from chia_rs import G1Element
+from typing_extensions import dataclass_transform
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle
@@ -24,6 +26,15 @@ from chia.wallet.util.clvm_streamable import json_deserialize_with_clvm_streamab
 from chia.wallet.vc_wallet.vc_store import VCRecord
 
 _T_OfferEndpointResponse = TypeVar("_T_OfferEndpointResponse", bound="_OfferEndpointResponse")
+_T_KW_Dataclass = TypeVar("_T_KW_Dataclass")
+
+
+@dataclass_transform(frozen_default=True, kw_only_default=True)
+def kw_only_dataclass(cls: Type[Any]) -> Type[Any]:
+    if sys.version_info < (3, 10):
+        return dataclass(frozen=True)(cls)
+    else:
+        return dataclass(frozen=True, kw_only=True)(cls)
 
 
 @streamable
@@ -91,7 +102,7 @@ class ExecuteSigningInstructionsResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True, kw_only=True)
+@kw_only_dataclass
 class TransactionEndpointRequest(Streamable):
     fee: uint64 = uint64(0)
     push: Optional[bool] = None
@@ -105,7 +116,7 @@ class TransactionEndpointResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True, kw_only=True)
+@kw_only_dataclass
 class VaultCreate(TransactionEndpointRequest):
     secp_pk: bytes
     hp_index: uint32 = uint32(0)
@@ -120,7 +131,7 @@ class VaultCreateResponse(TransactionEndpointResponse):
 
 
 @streamable
-@dataclass(frozen=True, kw_only=True)
+@kw_only_dataclass
 class VaultRecovery(TransactionEndpointRequest):
     wallet_id: uint32
     secp_pk: bytes

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -21,6 +21,7 @@ from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.offer import Offer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.clvm_streamable import json_deserialize_with_clvm_streamable
+from chia.wallet.util.tx_config import TXConfig
 from chia.wallet.vc_wallet.vc_store import VCRecord
 
 _T_OfferEndpointResponse = TypeVar("_T_OfferEndpointResponse", bound="_OfferEndpointResponse")
@@ -101,8 +102,10 @@ class TransactionEndpointResponse(Streamable):
 @dataclass(frozen=True)
 class VaultCreate(Streamable):
     secp_pk: bytes
+    tx_config: TXConfig
     hp_index: uint32 = uint32(0)
     fee: uint64 = uint64(0)
+    push: Optional[bool] = None
     bls_pk: Optional[G1Element] = None
     timelock: Optional[uint64] = None
 
@@ -118,8 +121,10 @@ class VaultCreateResponse(TransactionEndpointResponse):
 class VaultRecovery(Streamable):
     wallet_id: uint32
     secp_pk: bytes
+    tx_config: TXConfig
     hp_index: uint32 = uint32(0)
     fee: uint64 = uint64(0)
+    push: Optional[bool] = None
     bls_pk: Optional[G1Element] = None
     timelock: Optional[uint64] = None
 

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Type, TypeVar
 
+from chia_rs import G1Element
+
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle
-from chia.util.ints import uint32
+from chia.util.ints import uint32, uint64
 from chia.util.streamable import Streamable, streamable
 from chia.wallet.notification_store import Notification
 from chia.wallet.signer_protocol import (
@@ -93,6 +95,22 @@ class ExecuteSigningInstructionsResponse(Streamable):
 class TransactionEndpointResponse(Streamable):
     unsigned_transactions: List[UnsignedTransaction]
     transactions: List[TransactionRecord]
+
+
+@streamable
+@dataclass(frozen=True)
+class VaultCreate(Streamable):
+    secp_pk: bytes
+    hp_index: uint32 = uint32(0)
+    fee: uint64 = uint64(0)
+    bls_pk: Optional[G1Element] = None
+    timelock: Optional[uint64] = None
+
+
+@streamable
+@dataclass(frozen=True)
+class VaultCreateResponse(TransactionEndpointResponse):
+    pass
 
 
 # TODO: The section below needs corresponding request types

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-field-call
+
 from __future__ import annotations
 
 import sys

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -34,7 +34,7 @@ _T_KW_Dataclass = TypeVar("_T_KW_Dataclass")
 @dataclass_transform(frozen_default=True, kw_only_default=True)
 def kw_only_dataclass(cls: Type[Any]) -> Type[Any]:
     if sys.version_info < (3, 10):
-        return dataclass(frozen=True)(cls)
+        return dataclass(frozen=True)(cls)  # pragma: no cover
     else:
         return dataclass(frozen=True, kw_only=True)(cls)
 

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -21,7 +21,6 @@ from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.offer import Offer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.clvm_streamable import json_deserialize_with_clvm_streamable
-from chia.wallet.util.tx_config import TXConfig
 from chia.wallet.vc_wallet.vc_store import VCRecord
 
 _T_OfferEndpointResponse = TypeVar("_T_OfferEndpointResponse", bound="_OfferEndpointResponse")
@@ -94,7 +93,6 @@ class ExecuteSigningInstructionsResponse(Streamable):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class TransactionEndpointRequest(Streamable):
-    tx_config: TXConfig
     fee: uint64 = uint64(0)
     push: Optional[bool] = None
 

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from dataclasses import MISSING, dataclass, field
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from chia_rs import G1Element
@@ -35,6 +35,10 @@ def kw_only_dataclass(cls: Type[Any]) -> Type[Any]:
         return dataclass(frozen=True)(cls)
     else:
         return dataclass(frozen=True, kw_only=True)(cls)
+
+
+def default_raise() -> Any:  # pragma: no cover
+    raise RuntimeError("This should be impossible to hit and is just for < 3.10 compatibility")
 
 
 @streamable
@@ -102,7 +106,7 @@ class ExecuteSigningInstructionsResponse(Streamable):
 
 
 # When inheriting from this class you must set any non default arguments with:
-# field(default=MISSING) # type: ignore[assignment]
+# field(default_factory=default_raise)
 # (this is for < 3.10 compatibility)
 @streamable
 @kw_only_dataclass
@@ -121,7 +125,7 @@ class TransactionEndpointResponse(Streamable):
 @streamable
 @kw_only_dataclass
 class VaultCreate(TransactionEndpointRequest):
-    secp_pk: bytes = field(default=MISSING, default_factory=MISSING)  # type: ignore[call-overload]
+    secp_pk: bytes = field(default_factory=default_raise)
     hp_index: uint32 = uint32(0)
     bls_pk: Optional[G1Element] = None
     timelock: Optional[uint64] = None
@@ -136,8 +140,8 @@ class VaultCreateResponse(TransactionEndpointResponse):
 @streamable
 @kw_only_dataclass
 class VaultRecovery(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default=MISSING, default_factory=MISSING)  # type: ignore[call-overload]
-    secp_pk: bytes = field(default=MISSING, default_factory=MISSING)  # type: ignore[call-overload]
+    wallet_id: uint32 = field(default_factory=default_raise)
+    secp_pk: bytes = field(default_factory=default_raise)
     hp_index: uint32 = uint32(0)
     bls_pk: Optional[G1Element] = None
     timelock: Optional[uint64] = None

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass
+from dataclasses import MISSING, dataclass, field
 from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from chia_rs import G1Element
@@ -101,6 +101,9 @@ class ExecuteSigningInstructionsResponse(Streamable):
     signing_responses: List[SigningResponse]
 
 
+# When inheriting from this class you must set any non default arguments with:
+# field(default=MISSING) # type: ignore[assignment]
+# (this is for < 3.10 compatibility)
 @streamable
 @kw_only_dataclass
 class TransactionEndpointRequest(Streamable):
@@ -118,7 +121,7 @@ class TransactionEndpointResponse(Streamable):
 @streamable
 @kw_only_dataclass
 class VaultCreate(TransactionEndpointRequest):
-    secp_pk: bytes
+    secp_pk: bytes = field(default=MISSING)  # type: ignore[assignment]
     hp_index: uint32 = uint32(0)
     bls_pk: Optional[G1Element] = None
     timelock: Optional[uint64] = None
@@ -133,8 +136,8 @@ class VaultCreateResponse(TransactionEndpointResponse):
 @streamable
 @kw_only_dataclass
 class VaultRecovery(TransactionEndpointRequest):
-    wallet_id: uint32
-    secp_pk: bytes
+    wallet_id: uint32 = field(default=MISSING)  # type: ignore[assignment]
+    secp_pk: bytes = field(default=MISSING)  # type: ignore[assignment]
     hp_index: uint32 = uint32(0)
     bls_pk: Optional[G1Element] = None
     timelock: Optional[uint64] = None

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -11,7 +11,6 @@ from chia_rs import AugSchemeMPL, G1Element, G2Element, PrivateKey
 from clvm_tools.binutils import assemble
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward
-from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.data_layer.data_layer_errors import LauncherCoinNotFoundError
 from chia.data_layer.data_layer_util import dl_verify_proof
 from chia.data_layer.data_layer_wallet import DataLayerWallet
@@ -33,6 +32,8 @@ from chia.rpc.wallet_request_types import (
     SubmitTransactionsResponse,
     VaultCreate,
     VaultCreateResponse,
+    VaultRecovery,
+    VaultRecoveryResponse,
 )
 from chia.server.outbound_message import NodeType
 from chia.server.ws_connection import WSChiaConnection
@@ -4664,21 +4665,23 @@ class WalletRpcApi:
         )
         return VaultCreateResponse([], [])  # tx_endpoint will take care of filling this out
 
-    async def vault_recovery(self, request: Dict[str, Any], tx_config: TXConfig = DEFAULT_TX_CONFIG) -> EndpointResult:
+    @marshal
+    async def vault_recovery(
+        self, request: VaultRecovery, tx_config: TXConfig = DEFAULT_TX_CONFIG
+    ) -> VaultRecoveryResponse:
         """
         Initiate Vault Recovery
         """
-        wallet_id = uint32(request["wallet_id"])
-        wallet = self.service.wallet_state_manager.get_wallet(id=wallet_id, required_type=Vault)
-        secp_pk = bytes.fromhex(str(request.get("secp_pk")))
-        hp_index = request.get("hp_index", 0)
-        hidden_puzzle_hash = get_vault_hidden_puzzle_with_index(hp_index).get_tree_hash()
-        bls_str = request.get("bls_pk")
-        bls_pk = G1Element.from_bytes(bytes.fromhex(str(bls_str))) if bls_str else None
-        timelock_int = request.get("timelock")
-        timelock = uint64(timelock_int) if timelock_int else None
-        genesis_challenge = DEFAULT_CONSTANTS.GENESIS_CHALLENGE
+        wallet = self.service.wallet_state_manager.get_wallet(id=request.wallet_id, required_type=Vault)
+        hidden_puzzle_hash = get_vault_hidden_puzzle_with_index(request.hp_index).get_tree_hash()
+        genesis_challenge = self.service.wallet_state_manager.constants.GENESIS_CHALLENGE
         recovery_txs = await wallet.create_recovery_spends(
-            secp_pk, hidden_puzzle_hash, genesis_challenge, tx_config, bls_pk=bls_pk, timelock=timelock
+            request.secp_pk,
+            hidden_puzzle_hash,
+            genesis_challenge,
+            tx_config,
+            bls_pk=request.bls_pk,
+            timelock=request.timelock,
         )
-        return {"transactions": [tx.to_json_dict_convenience(self.service.config) for tx in recovery_txs]}
+        # TODO: port this endpoint to tx_endpoint and action scopes
+        return VaultRecoveryResponse([], recovery_txs)

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -4672,6 +4672,8 @@ class WalletRpcApi:
         """
         Initiate Vault Recovery
         """
+        if request.fee != 0:
+            raise ValueError("Recovery endpoint cannot add fees because it assumes your vault is currently inacessible")
         wallet = self.service.wallet_state_manager.get_wallet(id=request.wallet_id, required_type=Vault)
         hidden_puzzle_hash = get_vault_hidden_puzzle_with_index(request.hp_index).get_tree_hash()
         genesis_challenge = self.service.wallet_state_manager.constants.GENESIS_CHALLENGE

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -1706,11 +1706,17 @@ class WalletRpcClient(RpcClient):
     async def vault_create(
         self,
         args: VaultCreate,
+        tx_config: TXConfig,
     ) -> VaultCreateResponse:
-        return VaultCreateResponse.from_json_dict(await self.fetch("vault_create", args.to_json_dict()))
+        return VaultCreateResponse.from_json_dict(
+            await self.fetch("vault_create", {**args.to_json_dict(), **tx_config.to_json_dict()})
+        )
 
     async def vault_recovery(
         self,
         args: VaultRecovery,
+        tx_config: TXConfig,
     ) -> VaultRecoveryResponse:
-        return VaultRecoveryResponse.from_json_dict(await self.fetch("vault_recovery", args.to_json_dict()))
+        return VaultRecoveryResponse.from_json_dict(
+            await self.fetch("vault_recovery", {**args.to_json_dict(), **tx_config.to_json_dict()})
+        )

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -42,6 +42,10 @@ from chia.rpc.wallet_request_types import (
     SubmitTransactions,
     SubmitTransactionsResponse,
     TakeOfferResponse,
+    VaultCreate,
+    VaultCreateResponse,
+    VaultRecovery,
+    VaultRecoveryResponse,
     VCMintResponse,
     VCRevokeResponse,
     VCSpendResponse,
@@ -1701,45 +1705,12 @@ class WalletRpcClient(RpcClient):
 
     async def vault_create(
         self,
-        secp_pk: bytes,
-        hp_index: uint32,
-        tx_config: TXConfig,
-        bls_pk: Optional[bytes] = None,
-        timelock: Optional[uint64] = None,
-        fee: uint64 = uint64(0),
-        push: bool = True,
-    ) -> List[TransactionRecord]:
-        response = await self.fetch(
-            "vault_create",
-            {
-                "secp_pk": secp_pk.hex(),
-                "hp_index": hp_index,
-                "bls_pk": bls_pk.hex() if bls_pk else None,
-                "timelock": timelock,
-                "fee": fee,
-                "push": push,
-                **tx_config.to_json_dict(),
-            },
-        )
-        return [TransactionRecord.from_json_dict_convenience(tx) for tx in response["transactions"]]
+        args: VaultCreate,
+    ) -> VaultCreateResponse:
+        return VaultCreateResponse.from_json_dict(await self.fetch("vault_create", args.to_json_dict()))
 
     async def vault_recovery(
         self,
-        wallet_id: uint32,
-        secp_pk: bytes,
-        hp_index: uint32,
-        tx_config: TXConfig,
-        bls_pk: Optional[bytes] = None,
-        timelock: Optional[uint64] = None,
-    ) -> List[TransactionRecord]:
-        response = await self.fetch(
-            "vault_recovery",
-            {
-                "wallet_id": wallet_id,
-                "secp_pk": secp_pk.hex(),
-                "hp_index": hp_index,
-                "bls_pk": bls_pk.hex() if bls_pk else None,
-                "timelock": timelock,
-            },
-        )
-        return [TransactionRecord.from_json_dict_convenience(tx) for tx in response["transactions"]]
+        args: VaultRecovery,
+    ) -> VaultRecoveryResponse:
+        return VaultRecoveryResponse.from_json_dict(await self.fetch("vault_recovery", args.to_json_dict()))


### PR DESCRIPTION
These endpoints have been in development for a long time that some of the paradigms have changed from underneath them.  This PR brings the endpoints in conformity with: `@tx_endpoint` & `@marshall` in the RPC and `WalletActionScope` on the backend.