### PR TITLE
CHIA-902 make Program.run() and Program.run_with_cost() default to enabling all the most recent features

### DIFF
--- a/chia/_tests/clvm/test_program.py
+++ b/chia/_tests/clvm/test_program.py
@@ -119,10 +119,28 @@ def test_run() -> None:
     ret = div.run([10, -5])
     assert ret.atom == bytes([0xFE])
 
+    # run()
+    with pytest.raises(ValueError, match="div operator with negative operands is deprecated"):
+        cost, ret = div.run_with_cost(100000, [10, -5], 0)
+
+    cost, ret = div.run_with_cost(100000, [10, -5], ENABLE_FIXED_DIV)
+    assert cost == 1107
+    print(ret)
+    assert ret.atom == bytes([0xFE])
+
+    # run_with_flags()
     with pytest.raises(ValueError, match="div operator with negative operands is deprecated"):
         cost, ret = div.run_with_flags(100000, 0, [10, -5])
 
     cost, ret = div.run_with_flags(100000, ENABLE_FIXED_DIV, [10, -5])
     assert cost == 1107
+    print(ret)
+    assert ret.atom == bytes([0xFE])
+
+    # run_with_cost()
+    with pytest.raises(ValueError, match="div operator with negative operands is deprecated"):
+        ret = div.run([10, -5], 100000, 0)
+
+    ret = div.run([10, -5], 100000, ENABLE_FIXED_DIV)
     print(ret)
     assert ret.atom == bytes([0xFE])

--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -29,6 +29,15 @@ from .tree_hash import sha256_treehash
 
 INFINITE_COST = 11000000000
 
+DEFAULT_FLAGS = (
+    ENABLE_SOFTFORK_CONDITION
+    | ENABLE_BLS_OPS_OUTSIDE_GUARD
+    | ENABLE_FIXED_DIV
+    | AGG_SIG_ARGS
+    | ENABLE_MESSAGE_CONDITIONS
+    | DISALLOW_INFINITY_G1
+    | MEMPOOL_MODE
+)
 
 T_CLVMStorage = TypeVar("T_CLVMStorage", bound=CLVMStorage)
 T_Program = TypeVar("T_Program", bound="Program")
@@ -139,22 +148,13 @@ class Program(SExp):
         cost, r = run_chia_program(self.as_bin(), prog_args.as_bin(), max_cost, flags)
         return cost, Program.to(r)
 
-    def run_with_cost(self, max_cost: int, args: Any) -> Tuple[int, Program]:
+    def run_with_cost(self, max_cost: int, args: Any, flags=DEFAULT_FLAGS) -> Tuple[int, Program]:
         # when running puzzles in the wallet, default to enabling all soft-forks
         # as well as enabling mempool-mode (i.e. strict mode)
-        default_flags = (
-            ENABLE_SOFTFORK_CONDITION
-            | ENABLE_BLS_OPS_OUTSIDE_GUARD
-            | ENABLE_FIXED_DIV
-            | AGG_SIG_ARGS
-            | ENABLE_MESSAGE_CONDITIONS
-            | DISALLOW_INFINITY_G1
-            | MEMPOOL_MODE
-        )
-        return self._run(max_cost, default_flags, args)
+        return self._run(max_cost, flags, args)
 
-    def run(self, args: Any) -> Program:
-        cost, r = self.run_with_cost(INFINITE_COST, args)
+    def run(self, args: Any, max_cost=INFINITE_COST, flags=DEFAULT_FLAGS) -> Program:
+        cost, r = self._run(max_cost, flags, args)
         return r
 
     def run_with_flags(self, max_cost: int, flags: int, args: Any) -> Tuple[int, Program]:


### PR DESCRIPTION
### Purpose:

This is a follow-up on https://github.com/Chia-Network/chia-blockchain/pull/18287

This came out of a conversation with @trepca . Testing puzzles that use features from recent soft-forks (and the hard fork) is made more difficult because the default `run()` functions don't enable those features. This patch fixes that by enabling everything.

It also runs in mempool-mode by default.

Additionally, a new `run()` variant is added to control exactly which features (`flags`) are enabled.

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

`Program.run()` does not support new opcodes, and ignores unknown ones.

### New Behavior:

`Program.run()` does supports new opcodes, and fails on unknown ones.