### PR TITLE
[CHIA-1009] Add @tx_out_cmd to vault_create and dedup transaction output code

### DIFF
--- a/chia/_tests/cmds/wallet/test_vault.py
+++ b/chia/_tests/cmds/wallet/test_vault.py
@@ -84,9 +84,8 @@ def test_vault_recovery(capsys: object, get_test_cli_clients: Tuple[TestRpcClien
         str(tmp_path / "recovery_finish.json"),
     ]
     assert_list = [
-        "Initiate Recovery transaction written to:",
+        "Writing transactions to file ",
         "recovery_init.json",
-        "Finish Recovery transaction written to:",
         "recovery_finish.json",
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args + [FINGERPRINT_ARG, WALLET_ID_ARG], assert_list)

--- a/chia/cmds/cmds_util.py
+++ b/chia/cmds/cmds_util.py
@@ -335,13 +335,17 @@ class TransactionBundle(Streamable):
     txs: List[TransactionRecord]
 
 
+def write_transactions_to_file(txs: List[TransactionRecord], transaction_file: str) -> None:
+    print(f"Writing transactions to file {transaction_file}:")
+    with open(Path(transaction_file), "wb") as file:
+        file.write(bytes(TransactionBundle(txs)))
+
+
 def tx_out_cmd(func: Callable[..., List[TransactionRecord]]) -> Callable[..., None]:
     def original_cmd(transaction_file: Optional[str] = None, **kwargs: Any) -> None:
         txs: List[TransactionRecord] = func(**kwargs)
         if transaction_file is not None:
-            print(f"Writing transactions to file {transaction_file}:")
-            with open(Path(transaction_file), "wb") as file:
-                file.write(bytes(TransactionBundle(txs)))
+            write_transactions_to_file(txs, transaction_file)
 
     return click.option(
         "--push/--no-push", help="Push the transaction to the network", type=bool, is_flag=True, default=True

--- a/chia/cmds/vault.py
+++ b/chia/cmds/vault.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence
 
 import click
 
 from chia.cmds import options
+from chia.cmds.cmds_util import tx_out_cmd
 from chia.cmds.param_types import AmountParamType, Bytes32ParamType, CliAmount, cli_amount_none
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint64
+from chia.wallet.transaction_record import TransactionRecord
 
 
 @click.group("vault", help="Manage your vault")
@@ -88,6 +90,7 @@ def vault_cmd(ctx: click.Context) -> None:
     is_flag=True,
     default=False,
 )
+@tx_out_cmd
 def vault_create_cmd(
     wallet_rpc_port: Optional[int],
     fingerprint: int,
@@ -101,10 +104,11 @@ def vault_create_cmd(
     max_coin_amount: CliAmount,
     coins_to_exclude: Sequence[bytes32],
     reuse: bool,
-) -> None:
+    push: bool,
+) -> List[TransactionRecord]:
     from .vault_funcs import create_vault
 
-    asyncio.run(
+    return asyncio.run(
         create_vault(
             wallet_rpc_port,
             fingerprint,
@@ -118,6 +122,7 @@ def vault_create_cmd(
             max_coin_amount=max_coin_amount,
             excluded_coin_ids=coins_to_exclude,
             reuse_puzhash=True if reuse else None,
+            push=push,
         )
     )
 


### PR DESCRIPTION
This is a little bit of a cleanup to bring the vault endpoints a little closer to newer paradigms.