### PR TITLE
[CHIA-1015] Add a `fee` option to `push_transactions`

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -382,7 +382,7 @@ async def test_push_transactions(wallet_rpc_environment: WalletRpcTestEnvironmen
     full_node_api: FullNodeSimulator = env.full_node.api
     client: WalletRpcClient = env.wallet_1.rpc_client
 
-    await generate_funds(full_node_api, env.wallet_1)
+    await generate_funds(full_node_api, env.wallet_1, num_blocks=2)
 
     outputs = await create_tx_outputs(wallet, [(1234321, None)])
 
@@ -394,18 +394,29 @@ async def test_push_transactions(wallet_rpc_environment: WalletRpcTestEnvironmen
         )
     ).signed_tx
 
-    await client.push_transactions([tx])
-    resp = await client.fetch("push_transactions", {"transactions": [tx.to_json_dict_convenience(wallet_node.config)]})
+    resp_client = await client.push_transactions([tx], fee=uint64(10))
+    resp = await client.fetch(
+        "push_transactions", {"transactions": [tx.to_json_dict_convenience(wallet_node.config)], "fee": 10}
+    )
     assert resp["success"]
-    resp = await client.fetch("push_transactions", {"transactions": [tx.to_json_dict()]})
+    resp = await client.fetch("push_transactions", {"transactions": [tx.to_json_dict()], "fee": 10})
     assert resp["success"]
 
-    spend_bundle = tx.spend_bundle
+    spend_bundle = SpendBundle.aggregate(
+        [
+            # We ARE checking that the spendbundle is not None but mypy can't recognize this
+            TransactionRecord.from_json_dict_convenience(tx).spend_bundle  # type: ignore[misc]
+            for tx in resp_client["transactions"]
+            if tx["spend_bundle"] is not None
+        ]
+    )
     assert spend_bundle is not None
     await farm_transaction(full_node_api, wallet_node, spend_bundle)
 
-    tx = await client.get_transaction(transaction_id=tx.name)
-    assert tx.confirmed
+    for tx_json in resp_client["transactions"]:
+        tx = TransactionRecord.from_json_dict_convenience(tx_json)
+        tx = await client.get_transaction(transaction_id=tx.name)
+        assert tx.confirmed
 
 
 @pytest.mark.anyio

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -148,10 +148,12 @@ class WalletRpcClient(RpcClient):
     async def push_tx(self, spend_bundle: SpendBundle) -> Dict[str, Any]:
         return await self.fetch("push_tx", {"spend_bundle": bytes(spend_bundle).hex()})
 
-    async def push_transactions(self, txs: List[TransactionRecord], sign: bool = False) -> Dict[str, Any]:
+    async def push_transactions(
+        self, txs: List[TransactionRecord], fee: uint64 = uint64(0), sign: bool = False
+    ) -> Dict[str, Any]:
         transactions = [bytes(tx).hex() for tx in txs]
 
-        return await self.fetch("push_transactions", {"transactions": transactions, "sign": sign})
+        return await self.fetch("push_transactions", {"transactions": transactions, "fee": fee, "sign": sign})
 
     async def farm_block(self, address: str) -> Dict[str, Any]:
         return await self.fetch("farm_block", {"address": address})


### PR DESCRIPTION
A desirable capability to have on a wallet is the ability to add a fee to a transaction that another wallet has generated when pushing it.  This PR adds that capability to the existing `push_transactions` RPC.