### PR TITLE
Resolve problems on Windows running the sub processes when in editable mode

### DIFF
--- a/chia/_tests/cmds/test_daemon.py
+++ b/chia/_tests/cmds/test_daemon.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -9,7 +10,7 @@ from click.testing import CliRunner
 from pytest_mock import MockerFixture
 
 from chia.cmds.chia import cli
-from chia.cmds.start_funcs import create_start_daemon_connection
+from chia.cmds.start_funcs import create_start_daemon_connection, launch_start_daemon
 
 
 @pytest.mark.anyio
@@ -50,6 +51,15 @@ async def test_daemon(
         assert captured.out.endswith("Skipping to unlock keyring\n")
     else:
         assert not captured.out.endswith("Skipping to unlock keyring\n")
+
+
+@pytest.mark.anyio
+def test_launch_start_daemon(tmp_path: Path) -> None:
+    sys.argv[0] = "chia"
+    process = launch_start_daemon(tmp_path)
+    assert process is not None
+    process.kill()
+    process.wait()
 
 
 def test_start_daemon(tmp_path: Path, empty_keyring: Any, mocker: MockerFixture) -> None:

--- a/chia/_tests/cmds/test_daemon.py
+++ b/chia/_tests/cmds/test_daemon.py
@@ -55,7 +55,12 @@ async def test_daemon(
 
 @pytest.mark.anyio
 def test_launch_start_daemon(tmp_path: Path) -> None:
-    sys.argv[0] = "chia"
+    sys.argv[0] = "not-exist"
+    with pytest.raises(FileNotFoundError):
+        launch_start_daemon(tmp_path)
+
+    helper: Path = Path(sys.executable)
+    sys.argv[0] = str(helper.parent) + "/chia"
     process = launch_start_daemon(tmp_path)
     assert process is not None
     process.kill()

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -24,6 +24,9 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
 
     path_helper: Path = Path(sys.argv[0])
     cmd_to_execute = shutil.which(cmd=path_helper.name, path=path_helper.parent)
+    if cmd_to_execute is None:
+        cmd_to_execute = sys.argv[0]
+
     process = subprocess.Popen(
         [cmd_to_execute, "run_daemon", "--wait-for-unlock"],
         encoding="utf-8",

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shutil
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
@@ -21,8 +22,10 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
     if sys.platform == "win32":
         creationflags = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
 
+    path_helper: Path = Path(sys.argv[0])
+    cmd_to_execute = shutil.which(cmd=path_helper.name, path=path_helper.parent)
     process = subprocess.Popen(
-        [sys.argv[0], "run_daemon", "--wait-for-unlock"],
+        [cmd_to_execute, "run_daemon", "--wait-for-unlock"],
         encoding="utf-8",
         stdout=subprocess.PIPE,
         creationflags=creationflags,

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -5,6 +5,7 @@ import dataclasses
 import json
 import logging
 import os
+import shutil
 import signal
 import ssl
 import subprocess
@@ -112,7 +113,7 @@ else:
     application_path = os.path.dirname(__file__)
 
     def executable_for_service(service_name: str) -> str:
-        return service_name
+        return shutil.which(service_name)
 
 
 async def ping() -> Dict[str, Any]:

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -113,7 +113,8 @@ else:
     application_path = os.path.dirname(__file__)
 
     def executable_for_service(service_name: str) -> str:
-        return shutil.which(service_name)
+        cmd_to_exec = shutil.which(service_name)
+        return cmd_to_exec if cmd_to_exec is not None else service_name
 
 
 async def ping() -> Dict[str, Any]:


### PR DESCRIPTION
Use `shutil.which` to find the exe to launch (either a `.cmd` or a `.exe`). Primarily needed on Windows where depending on how the source install was done (`editable` vs `non-editable: -i`) the commands will end in `.cmd` or `.exe`.

However, the code works in a cross-platform way so it should be safe to use generically.