### PR TITLE
Set correct empty/default value for pool_public_keys

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -203,7 +203,7 @@ farmer:
     - host: *self_hostname
       port: 8444
 
-  pool_public_keys: []
+  pool_public_keys: !!set {}
 
   # Replace this with a real receive address
   # xch_target_address: txch102gkhhzs60grx7cfnpng5n6rjecr89r86l5s8xux2za8k820cxsq64ssdg


### PR DESCRIPTION
When pool public keys has data, it looks like:

```yaml
pool_public_keys: !!set
    abcd1234hash: null
    abcd1234hash: null
    abcd1234hash: null
    abcd1234hash: null
 ```

So I believe the default should be `!!set {}`, not `[]` since its not a list. Python doesn't seem to care too much, but trying to parse the config in a more strict language ended up complaining/failing.