### PR TITLE
Display sync percentage in 'chia show -s'

### DIFF
--- a/chia/cmds/show_funcs.py
+++ b/chia/cmds/show_funcs.py
@@ -43,7 +43,7 @@ async def print_blockchain_state(node_client: FullNodeRpcClient, config: Dict[st
         sync_current_block = blockchain_state["sync"]["sync_progress_height"]
         print(
             f"Current Blockchain Status: Syncing {sync_current_block}/{sync_max_block} "
-            f"({sync_max_block - sync_current_block} behind)."
+            f"({sync_max_block - sync_current_block} behind). ({sync_current_block*100.0/sync_max_block:2.2f}% synced)"
         )
         print("Peak: Hash:", bytes32(peak.header_hash) if peak is not None else "")
     elif peak is not None:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

No breaking changes

### Current Behavior:

```
    Current Blockchain Status: Syncing 5109645/5496001 (386356 behind).
```

Displays number of blocks to be synced

### New Behavior:

```
    Current Blockchain Status: Syncing 5109645/5496001 (386356 behind). (15.06% synced)
```

Displays number of blocks to be synced
AND
percentage of blockchain synced

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
