### PR TITLE
Increase timeout for test_create_coins_with_amounts

### DIFF
--- a/chia/_tests/simulation/test_simulator.py
+++ b/chia/_tests/simulation/test_simulator.py
@@ -199,7 +199,7 @@ async def test_create_coins_with_amounts(
     await full_node_api.farm_rewards_to_wallet(amount=sum(amounts), wallet=wallet)
     # Get some more coins.  The creator helper doesn't get you all the coins you
     # need yet.
-    await full_node_api.farm_blocks_to_wallet(count=2, wallet=wallet)
+    await full_node_api.farm_blocks_to_wallet(count=2, wallet=wallet, timeout=30)
     coins = await full_node_api.create_coins_with_amounts(amounts=amounts, wallet=wallet)
     assert sorted(coin.amount for coin in coins) == sorted(amounts)
 


### PR DESCRIPTION
Increase timeout when farming blocks 