### PR TITLE
[CHIA-1068] Utilize streamable for `WalletSideEffects` serialization

### DIFF
--- a/chia/wallet/wallet_action_scope.py
+++ b/chia/wallet/wallet_action_scope.py
@@ -6,12 +6,21 @@ from typing import TYPE_CHECKING, AsyncIterator, List, Optional, cast, final
 
 from chia.types.spend_bundle import SpendBundle
 from chia.util.action_scope import ActionScope
+from chia.util.streamable import Streamable, streamable
 from chia.wallet.signer_protocol import SigningResponse
 from chia.wallet.transaction_record import TransactionRecord
 
 if TYPE_CHECKING:
     # Avoid a circular import here
     from chia.wallet.wallet_state_manager import WalletStateManager
+
+
+@streamable
+@dataclass(frozen=True)
+class _StreamableWalletSideEffects(Streamable):
+    transactions: List[TransactionRecord]
+    signing_responses: List[SigningResponse]
+    extra_spends: List[SpendBundle]
 
 
 @dataclass
@@ -21,48 +30,11 @@ class WalletSideEffects:
     extra_spends: List[SpendBundle] = field(default_factory=list)
 
     def __bytes__(self) -> bytes:
-        blob = b""
-        blob += len(self.transactions).to_bytes(4, "big")
-        for tx in self.transactions:
-            tx_bytes = bytes(tx)
-            blob += len(tx_bytes).to_bytes(4, "big") + tx_bytes
-        blob += len(self.signing_responses).to_bytes(4, "big")
-        for sr in self.signing_responses:
-            sr_bytes = bytes(sr)
-            blob += len(sr_bytes).to_bytes(4, "big") + sr_bytes
-        blob += len(self.extra_spends).to_bytes(4, "big")
-        for sb in self.extra_spends:
-            sb_bytes = bytes(sb)
-            blob += len(sb_bytes).to_bytes(4, "big") + sb_bytes
-        return blob
+        return bytes(_StreamableWalletSideEffects(**self.__dict__))
 
     @classmethod
     def from_bytes(cls, blob: bytes) -> WalletSideEffects:
-        instance = cls()
-        while blob != b"":
-            tx_len_prefix = int.from_bytes(blob[:4], "big")
-            blob = blob[4:]
-            for _ in range(0, tx_len_prefix):
-                len_prefix = int.from_bytes(blob[:4], "big")
-                blob = blob[4:]
-                instance.transactions.append(TransactionRecord.from_bytes(blob[:len_prefix]))
-                blob = blob[len_prefix:]
-            sr_len_prefix = int.from_bytes(blob[:4], "big")
-            blob = blob[4:]
-            for _ in range(0, sr_len_prefix):
-                len_prefix = int.from_bytes(blob[:4], "big")
-                blob = blob[4:]
-                instance.signing_responses.append(SigningResponse.from_bytes(blob[:len_prefix]))
-                blob = blob[len_prefix:]
-            sb_len_prefix = int.from_bytes(blob[:4], "big")
-            blob = blob[4:]
-            for _ in range(0, sb_len_prefix):
-                len_prefix = int.from_bytes(blob[:4], "big")
-                blob = blob[4:]
-                instance.extra_spends.append(SpendBundle.from_bytes(blob[:len_prefix]))
-                blob = blob[len_prefix:]
-
-        return instance
+        return cls(**_StreamableWalletSideEffects.from_bytes(blob).__dict__)
 
 
 @final


### PR DESCRIPTION
I think that `WalletSideEffects` was initially not streamable because it had a dict as a part of it and because it needs to not be frozen.  However, we can still utilize streamable to save ourselves the headache of rolling our own serialization whenever we want to add something.