### PR TITLE
CHIA-1084: Address some problems launching the daemon from the GUI on Windows

### DIFF
--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -22,8 +22,11 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
     if sys.platform == "win32":
         creationflags = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
 
+    print(f"launch_start_daemon sys.argv[0]: {sys.argv[0]}")
     path_helper: Path = Path(sys.argv[0])
+    print(f"launch_start_daemon path_helper: {str(path_helper)}")
     cmd_to_execute = shutil.which(cmd=path_helper.name, path=path_helper.parent)
+    print(f"launch_start_daemon cmd_to_execute: {cmd_to_execute}")
     if cmd_to_execute is None:
         cmd_to_execute = sys.argv[0]
 
@@ -42,7 +45,7 @@ async def create_start_daemon_connection(
 ) -> Optional[DaemonProxy]:
     connection = await connect_to_daemon_and_validate(root_path, config)
     if connection is None:
-        print("Starting daemon")
+        print("Starting daemon", flush=True)
         # launch a daemon
         process = launch_start_daemon(root_path)
         # give the daemon a chance to start up

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -24,8 +24,8 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
 
     print(f"launch_start_daemon sys.argv[0]: {sys.argv[0]}")
     path_helper: Path = Path(sys.argv[0])
-    print(f"launch_start_daemon path_helper: {str(path_helper)}")
-    cmd_to_execute = shutil.which(cmd=path_helper.name, path=path_helper.parent)
+    if len(path_helper.suffix) == 0:
+        cmd_to_execute = shutil.which(cmd=path_helper.name, path=path_helper.parent)
     print(f"launch_start_daemon cmd_to_execute: {cmd_to_execute}")
     if cmd_to_execute is None:
         cmd_to_execute = sys.argv[0]

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -22,7 +22,6 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
     if sys.platform == "win32":
         creationflags = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
 
-    print(f"launch_start_daemon sys.argv[0]: {sys.argv[0]}")
     path_helper: Path = Path(sys.argv[0])
     cmd_to_execute = None
     if len(path_helper.suffix) == 0:
@@ -31,7 +30,7 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
     if cmd_to_execute is None:
         cmd_to_execute = sys.argv[0]
 
-    print(f"launch_start_daemon cmd_to_execute: {cmd_to_execute}")
+    print(f"Starting daemon: {cmd_to_execute} run_daemon --wait-for-unlock", flush=True)
     process = subprocess.Popen(
         [cmd_to_execute, "run_daemon", "--wait-for-unlock"],
         encoding="utf-8",

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -24,6 +24,7 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
 
     print(f"launch_start_daemon sys.argv[0]: {sys.argv[0]}")
     path_helper: Path = Path(sys.argv[0])
+    cmd_to_execute = None
     if len(path_helper.suffix) == 0:
         cmd_to_execute = shutil.which(cmd=path_helper.name, path=path_helper.parent)
     print(f"launch_start_daemon cmd_to_execute: {cmd_to_execute}")

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -27,10 +27,11 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
     cmd_to_execute = None
     if len(path_helper.suffix) == 0:
         cmd_to_execute = shutil.which(cmd=path_helper.name, path=path_helper.parent)
-    print(f"launch_start_daemon cmd_to_execute: {cmd_to_execute}")
+    
     if cmd_to_execute is None:
         cmd_to_execute = sys.argv[0]
 
+    print(f"launch_start_daemon cmd_to_execute: {cmd_to_execute}")
     process = subprocess.Popen(
         [cmd_to_execute, "run_daemon", "--wait-for-unlock"],
         encoding="utf-8",

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -27,7 +27,7 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
     cmd_to_execute = None
     if len(path_helper.suffix) == 0:
         cmd_to_execute = shutil.which(cmd=path_helper.name, path=path_helper.parent)
-    
+
     if cmd_to_execute is None:
         cmd_to_execute = sys.argv[0]
 


### PR DESCRIPTION
The GUI exe is also called `chia.exe` - on Windows, the `shutil.which` command prepends the current directory to the path when searching for executables. When chia is launched from the GUI, the current directory is the directory with the GUI app (`Chia.exe`) , this then results in the app chia will try to launch for the daemon.

Adjust `launch_start_daemon` to only use `shutil.which` when `argv[0]` doesn't have an extension. The GUI will always launch Chia with an extension (either `.exe` or `.cmd`)

Hopefully this will now work in all cases however chia is launched