### PR TITLE
Replace `get_flags_for_height_and_constants()` with Rust version

### DIFF
--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -4,6 +4,7 @@ import logging
 from typing import Dict, List, Optional
 
 from chia_rs import ALLOW_BACKREFS, DISALLOW_INFINITY_G1, ENABLE_BLS_OPS_OUTSIDE_GUARD, ENABLE_FIXED_DIV, MEMPOOL_MODE
+from chia_rs import get_flags_for_height_and_constants
 from chia_rs import get_puzzle_and_solution_for_coin as get_puzzle_and_solution_for_coin_rust
 from chia_rs import run_block_generator, run_block_generator2, run_chia_program
 
@@ -28,15 +29,6 @@ DESERIALIZE_MOD = load_serialized_clvm_maybe_recompile(
 )
 
 log = logging.getLogger(__name__)
-
-
-def get_flags_for_height_and_constants(height: int, constants: ConsensusConstants) -> int:
-    flags = ENABLE_BLS_OPS_OUTSIDE_GUARD | ENABLE_FIXED_DIV | ALLOW_BACKREFS
-
-    if height >= constants.SOFT_FORK5_HEIGHT:
-        flags = flags | DISALLOW_INFINITY_G1
-
-    return flags
 
 
 def get_name_puzzle_conditions(

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Dict, List, Optional
 
-from chia_rs import (
-    MEMPOOL_MODE,
-    get_flags_for_height_and_constants,
-)
+from chia_rs import MEMPOOL_MODE, get_flags_for_height_and_constants
 from chia_rs import get_puzzle_and_solution_for_coin as get_puzzle_and_solution_for_coin_rust
 from chia_rs import run_block_generator, run_block_generator2, run_chia_program
 

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import logging
 from typing import Dict, List, Optional
 
-from chia_rs import ALLOW_BACKREFS, DISALLOW_INFINITY_G1, ENABLE_BLS_OPS_OUTSIDE_GUARD, ENABLE_FIXED_DIV, MEMPOOL_MODE
-from chia_rs import get_flags_for_height_and_constants
+from chia_rs import (
+    MEMPOOL_MODE,
+    get_flags_for_height_and_constants,
+)
 from chia_rs import get_puzzle_and_solution_for_coin as get_puzzle_and_solution_for_coin_rust
 from chia_rs import run_block_generator, run_block_generator2, run_chia_program
 


### PR DESCRIPTION
Replaces the now duplicated Python version of `get_flags_for_height_and_constants()` with the version used in Rust bindings.
This reduces duplication and allows greater synchronisation as more code is migrated into Rust.

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
