### PR TITLE
[CHIA-1092] Port `test_cat_wallet.py` to `WalletTestFramework`

### DIFF
--- a/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
@@ -58,15 +58,16 @@ async def test_cat_creation(wallet_environments: WalletTestFramework) -> None:
         "xch": 1,
         "cat": 2,
     }
-
+    test_amount = 100
+    test_fee = 10
     async with wallet.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         cat_wallet = await CATWallet.create_new_cat_wallet(
             wsm,
             wallet,
             {"identifier": "genesis_by_id"},
-            uint64(100),
+            uint64(test_amount),
             action_scope,
-            fee=uint64(10),
+            fee=uint64(test_fee),
         )
         # The next 2 lines are basically a noop, it just adds test coverage
         cat_wallet = await CATWallet.create(wsm, wallet, cat_wallet.wallet_info)
@@ -78,25 +79,25 @@ async def test_cat_creation(wallet_environments: WalletTestFramework) -> None:
                 pre_block_balance_updates={
                     "xch": {
                         "confirmed_wallet_balance": 0,
-                        "unconfirmed_wallet_balance": -100 + -10,
-                        "<=#spendable_balance": -100 + -10,
-                        "<=#max_send_amount": -100 + -10,
+                        "unconfirmed_wallet_balance": -test_amount + -test_fee,
+                        "<=#spendable_balance": -test_amount + -test_fee,
+                        "<=#max_send_amount": -test_amount + -test_fee,
                         ">=#pending_change": 1,  # any amount increase
                         "pending_coin_removal_count": 1,
                     },
                     "cat": {
                         "init": True,
                         "confirmed_wallet_balance": 0,
-                        "unconfirmed_wallet_balance": 100,
+                        "unconfirmed_wallet_balance": test_amount,
                         "spendable_balance": 0,
                         "max_send_amount": 0,
-                        "pending_change": 100,
+                        "pending_change": test_amount,
                         "pending_coin_removal_count": 1,
                     },
                 },
                 post_block_balance_updates={
                     "xch": {
-                        "confirmed_wallet_balance": -100 + -10,
+                        "confirmed_wallet_balance": -test_amount + -test_fee,
                         "unconfirmed_wallet_balance": 0,
                         ">=#spendable_balance": 0,
                         ">=#max_send_amount": 0,
@@ -104,11 +105,11 @@ async def test_cat_creation(wallet_environments: WalletTestFramework) -> None:
                         "pending_coin_removal_count": -1,
                     },
                     "cat": {
-                        "confirmed_wallet_balance": 100,
+                        "confirmed_wallet_balance": test_amount,
                         "unconfirmed_wallet_balance": 0,
-                        "spendable_balance": 100,
-                        "max_send_amount": 100,
-                        "pending_change": -100,
+                        "spendable_balance": test_amount,
+                        "max_send_amount": test_amount,
+                        "pending_change": -test_amount,
                         "pending_coin_removal_count": -1,
                         "unspent_coin_count": 1,
                     },
@@ -144,7 +145,7 @@ async def test_cat_creation(wallet_environments: WalletTestFramework) -> None:
             WalletStateTransition(
                 pre_block_balance_updates={
                     "xch": {
-                        "confirmed_wallet_balance": 100 + 10,
+                        "confirmed_wallet_balance": test_amount + test_fee,
                         "unconfirmed_wallet_balance": 0,
                         "<=#spendable_balance": 1,
                         "<=#max_send_amount": 1,
@@ -152,18 +153,18 @@ async def test_cat_creation(wallet_environments: WalletTestFramework) -> None:
                         "pending_coin_removal_count": 1,
                     },
                     "cat": {
-                        "confirmed_wallet_balance": -100,
-                        "unconfirmed_wallet_balance": -100,  # 0 is correct
-                        "spendable_balance": -100,
-                        "max_send_amount": -100,
-                        # "pending_change": 100,
+                        "confirmed_wallet_balance": -test_amount,
+                        "unconfirmed_wallet_balance": -test_amount,  # 0 is correct
+                        "spendable_balance": -test_amount,
+                        "max_send_amount": -test_amount,
+                        # "pending_change": test_amount,
                         # "pending_coin_removal_count": 1,
                         "unspent_coin_count": -1,
                     },
                 },
                 post_block_balance_updates={
                     "xch": {
-                        "confirmed_wallet_balance": -100 + -10,
+                        "confirmed_wallet_balance": -test_amount + -test_fee,
                         "unconfirmed_wallet_balance": 0,
                         ">=#spendable_balance": 0,
                         ">=#max_send_amount": 0,
@@ -171,11 +172,11 @@ async def test_cat_creation(wallet_environments: WalletTestFramework) -> None:
                         "pending_coin_removal_count": -1,
                     },
                     "cat": {
-                        "confirmed_wallet_balance": 100,
-                        "unconfirmed_wallet_balance": 100,  # 0 is correct
-                        "spendable_balance": 100,
-                        "max_send_amount": 100,
-                        # "pending_change": -100,
+                        "confirmed_wallet_balance": test_amount,
+                        "unconfirmed_wallet_balance": test_amount,  # 0 is correct
+                        "spendable_balance": test_amount,
+                        "max_send_amount": test_amount,
+                        # "pending_change": -test_amount,
                         # "pending_coin_removal_count": -1,
                         "unspent_coin_count": 1,
                     },

--- a/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
@@ -1181,7 +1181,7 @@ async def test_cat_max_amount_send(wallet_environments: WalletTestFramework) -> 
     assert action_scope.side_effects.transactions[0].amount == uint64(max_sent_amount)
 
     # 3) Generate transaction that is greater than limit
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Can't select amount higher than our spendable balance."):
         async with cat_wallet.wallet_state_manager.new_action_scope(
             wallet_environments.tx_config, push=False
         ) as action_scope:

--- a/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
@@ -138,7 +138,7 @@ async def test_cat_creation(wallet_environments: WalletTestFramework) -> None:
         ReorgProtocol(uint32(height - 1), uint32(height + 1), bytes32(32 * b"1"), None)
     )
 
-    # The commented out sections here are due to a peculiarity with how the creation method creates an incoming TX
+    # The "set_remainder" sections here are due to a peculiarity with how the creation method creates an incoming TX
     # The creation method is for testing purposes only so we're not going to bother fixing it for any real reason
     await wallet_environments.process_pending_states(
         [
@@ -154,12 +154,10 @@ async def test_cat_creation(wallet_environments: WalletTestFramework) -> None:
                     },
                     "cat": {
                         "confirmed_wallet_balance": -test_amount,
-                        "unconfirmed_wallet_balance": -test_amount,  # 0 is correct
                         "spendable_balance": -test_amount,
                         "max_send_amount": -test_amount,
-                        # "pending_change": test_amount,
-                        # "pending_coin_removal_count": 1,
                         "unspent_coin_count": -1,
+                        "set_remainder": True,
                     },
                 },
                 post_block_balance_updates={
@@ -173,12 +171,10 @@ async def test_cat_creation(wallet_environments: WalletTestFramework) -> None:
                     },
                     "cat": {
                         "confirmed_wallet_balance": test_amount,
-                        "unconfirmed_wallet_balance": test_amount,  # 0 is correct
                         "spendable_balance": test_amount,
                         "max_send_amount": test_amount,
-                        # "pending_change": -test_amount,
-                        # "pending_coin_removal_count": -1,
                         "unspent_coin_count": 1,
+                        "set_remainder": True,
                     },
                 },
             ),

--- a/chia/_tests/wallet/conftest.py
+++ b/chia/_tests/wallet/conftest.py
@@ -148,6 +148,7 @@ async def wallet_environments(
                     **config_overrides,
                 }
                 service._node.wallet_state_manager.config = service._node.config
+                # Shorten the 10 seconds default value
                 service._node.coin_state_retry_seconds = 2
                 await service._node.server.start_client(
                     PeerInfo(bt.config["self_hostname"], full_node[0]._api.full_node.server.get_port()), None

--- a/chia/_tests/wallet/conftest.py
+++ b/chia/_tests/wallet/conftest.py
@@ -148,6 +148,7 @@ async def wallet_environments(
                     **config_overrides,
                 }
                 service._node.wallet_state_manager.config = service._node.config
+                service._node.coin_state_retry_seconds = 2
                 await service._node.server.start_client(
                     PeerInfo(bt.config["self_hostname"], full_node[0]._api.full_node.server.get_port()), None
                 )

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -721,11 +721,12 @@ class FullNodeSimulator(FullNodeAPI):
             return False  # pragma: no cover
         if not await wallet_node.wallet_state_manager.synced():
             return False
+        all_states_retried = await wallet_node.wallet_state_manager.retry_store.get_all_states_to_retry() == []
         wallet_height = await wallet_node.wallet_state_manager.blockchain.get_finished_sync_up_to()
         if peak_height is not None:
-            return wallet_height >= peak_height
+            return wallet_height >= peak_height and all_states_retried
         full_node_height = self.full_node.blockchain.get_peak_height()
-        return wallet_height == full_node_height
+        return wallet_height == full_node_height and all_states_retried
 
     async def wait_for_wallet_synced(
         self,


### PR DESCRIPTION
This changes all tests in `test_cat_wallet.py` to use the newest paradigm of `WalletTestFramework`.  The port revealed no bugs in production CAT code and only one gap in the checking of the framework itself.