### PR TITLE
[CHIA-1126] Remove `PrivateKey` type from wallet

### DIFF
--- a/chia/_tests/wallet/test_main_wallet_protocol.py
+++ b/chia/_tests/wallet/test_main_wallet_protocol.py
@@ -129,7 +129,7 @@ class AnyoneCanSpend(Wallet):
                 )
             )
 
-    def puzzle_for_pk(self, pubkey: G1Element) -> Program:  # pragma: no cover
+    def puzzle_for_pk(self, pubkey: ObservationRoot) -> Program:  # pragma: no cover
         raise ValueError("This won't work")
 
     async def puzzle_for_puzzle_hash(self, puzzle_hash: bytes32) -> Program:
@@ -183,7 +183,7 @@ class AnyoneCanSpend(Wallet):
     async def get_puzzle(self, new: bool) -> Program:  # pragma: no cover
         return ACS
 
-    def puzzle_hash_for_pk(self, pubkey: G1Element) -> bytes32:  # pragma: no cover
+    def puzzle_hash_for_pk(self, pubkey: ObservationRoot) -> bytes32:  # pragma: no cover
         raise ValueError("This won't work")
 
     def require_derivation_paths(self) -> bool:

--- a/chia/_tests/wallet/test_signer_protocol.py
+++ b/chia/_tests/wallet/test_signer_protocol.py
@@ -312,7 +312,8 @@ async def test_p2dohp_wallet_signer_protocol(wallet_environments: WalletTestFram
 @pytest.mark.anyio
 async def test_p2blsdohp_execute_signing_instructions(wallet_environments: WalletTestFramework) -> None:
     wallet: MainWalletProtocol = wallet_environments.environments[0].xch_wallet
-    root_sk: PrivateKey = wallet.wallet_state_manager.get_master_private_key()
+    root_sk = wallet.wallet_state_manager.get_master_private_key()
+    assert isinstance(root_sk, PrivateKey)
     root_pk: G1Element = root_sk.get_g1()
     root_fingerprint: bytes = root_pk.get_fingerprint().to_bytes(4, "big")
 

--- a/chia/_tests/wallet/test_wallet.py
+++ b/chia/_tests/wallet/test_wallet.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
-from chia_rs import AugSchemeMPL, G1Element, G2Element
+from chia_rs import AugSchemeMPL, G1Element, G2Element, PrivateKey
 
 from chia._tests.environments.wallet import WalletStateTransition, WalletTestFramework
 from chia._tests.util.time_out_assert import time_out_assert
@@ -1875,9 +1875,11 @@ class TestWalletSimulator:
         peak = full_node_api.full_node.blockchain.get_peak_height()
         assert peak is not None
 
-        puzzle_hashes = []
+        puzzle_hashes: List[bytes32] = []
         for i in range(211):
-            pubkey = master_sk_to_wallet_sk(wallet.wallet_state_manager.get_master_private_key(), uint32(i)).get_g1()
+            sk = wallet.wallet_state_manager.get_master_private_key()
+            assert isinstance(sk, PrivateKey)
+            pubkey = master_sk_to_wallet_sk(sk, uint32(i)).public_key()
             puzzle: Program = wallet.puzzle_for_pk(pubkey)
             puzzle_hash: bytes32 = puzzle.get_tree_hash()
             puzzle_hashes.append(puzzle_hash)

--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -649,7 +649,7 @@ async def test_get_last_used_fingerprint_if_exists(
     assert node.wallet_state_manager.private_key is not None
     assert (
         await node.get_last_used_fingerprint_if_exists()
-        == node.wallet_state_manager.private_key.get_g1().get_fingerprint()
+        == node.wallet_state_manager.private_key.public_key().get_fingerprint()
     )
     await node.keychain_proxy.delete_all_keys()
     assert await node.get_last_used_fingerprint_if_exists() is None

--- a/chia/_tests/wallet/test_wallet_state_manager.py
+++ b/chia/_tests/wallet/test_wallet_state_manager.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from typing import AsyncIterator, List
 
 import pytest
-from chia_rs import G2Element
+from chia_rs import G2Element, PrivateKey
 
 from chia._tests.environments.wallet import WalletTestFramework
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
@@ -68,11 +68,13 @@ async def test_get_private_key(simulator_and_wallet: OldSimulatorsAndWallets, ha
     wallet_state_manager: WalletStateManager = wallet_node.wallet_state_manager
     derivation_index = uint32(10000)
     conversion_method = master_sk_to_wallet_sk if hardened else master_sk_to_wallet_sk_unhardened
-    expected_private_key = conversion_method(wallet_state_manager.get_master_private_key(), derivation_index)
+    sk = wallet_state_manager.get_master_private_key()
+    assert isinstance(sk, PrivateKey)
+    expected_private_key = conversion_method(sk, derivation_index)
     record = DerivationRecord(
         derivation_index,
         bytes32(b"0" * 32),
-        expected_private_key.get_g1(),
+        bytes(expected_private_key.public_key()),
         WalletType.STANDARD_WALLET,
         uint32(1),
         hardened,

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -439,9 +439,11 @@ class PoolWallet:
         return p2_singleton_puzzle_hash, launcher_coin_id
 
     async def _get_owner_key_cache(self) -> Tuple[PrivateKey, uint32]:
+        private_key = self.wallet_state_manager.get_master_private_key()
+        assert isinstance(private_key, PrivateKey)
         if self._owner_sk_and_index is None:
             self._owner_sk_and_index = find_owner_sk(
-                [self.wallet_state_manager.get_master_private_key()],
+                [private_key],
                 (await self.get_current_state()).current.owner_pubkey,
             )
         assert self._owner_sk_and_index is not None

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -975,9 +975,9 @@ class WalletRpcApi:
                     if max_pwi + 1 >= (MAX_POOL_WALLETS - 1):
                         raise ValueError(f"Too many pool wallets ({max_pwi}), cannot create any more on this key.")
 
-                    owner_sk: PrivateKey = master_sk_to_singleton_owner_sk(
-                        self.service.wallet_state_manager.get_master_private_key(), uint32(max_pwi + 1)
-                    )
+                    master_sk = self.service.wallet_state_manager.get_master_private_key()
+                    assert isinstance(master_sk, PrivateKey), "Pooling only works with BLS keys at this time"
+                    owner_sk: PrivateKey = master_sk_to_singleton_owner_sk(master_sk, uint32(max_pwi + 1))
                     owner_pk: G1Element = owner_sk.get_g1()
 
                     initial_target_state = initial_pool_state_from_dict(

--- a/chia/wallet/derivation_record.py
+++ b/chia/wallet/derivation_record.py
@@ -28,3 +28,10 @@ class DerivationRecord:
     def pubkey(self) -> G1Element:
         assert isinstance(self._pubkey, G1Element)
         return self._pubkey
+
+    @property
+    def pubkey_bytes(self) -> bytes:
+        if isinstance(self._pubkey, G1Element):
+            return bytes(self._pubkey)
+        else:
+            return self._pubkey

--- a/chia/wallet/vault/vault_wallet.py
+++ b/chia/wallet/vault/vault_wallet.py
@@ -20,6 +20,7 @@ from chia.types.signing_mode import SigningMode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64, uint128
+from chia.util.observation_root import ObservationRoot
 from chia.wallet.coin_selection import select_coins
 from chia.wallet.conditions import (
     AssertCoinAnnouncement,
@@ -314,7 +315,7 @@ class Vault(Wallet):
 
         return all_spends
 
-    def puzzle_for_pk(self, pubkey: G1Element) -> Program:
+    def puzzle_for_pk(self, pubkey: ObservationRoot) -> Program:
         raise NotImplementedError("vault wallet")
 
     async def puzzle_for_puzzle_hash(self, puzzle_hash: bytes32) -> Program:
@@ -438,7 +439,7 @@ class Vault(Wallet):
             )
             return puzzle
 
-    def puzzle_hash_for_pk(self, pubkey: G1Element) -> bytes32:
+    def puzzle_hash_for_pk(self, pubkey: ObservationRoot) -> bytes32:
         raise ValueError("This won't work")
 
     def require_derivation_paths(self) -> bool:

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -17,6 +17,7 @@ from chia.types.spend_bundle import SpendBundle
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64, uint128
+from chia.util.observation_root import ObservationRoot
 from chia.util.streamable import Streamable
 from chia.wallet.coin_selection import select_coins
 from chia.wallet.conditions import (
@@ -169,10 +170,12 @@ class Wallet:
     def require_derivation_paths(self) -> bool:
         return True
 
-    def puzzle_for_pk(self, pubkey: G1Element) -> Program:
+    def puzzle_for_pk(self, pubkey: ObservationRoot) -> Program:
+        assert isinstance(pubkey, G1Element), "Standard wallet cannot support non-BLS keys yet"
         return puzzle_for_pk(pubkey)
 
-    def puzzle_hash_for_pk(self, pubkey: G1Element) -> bytes32:
+    def puzzle_hash_for_pk(self, pubkey: ObservationRoot) -> bytes32:
+        assert isinstance(pubkey, G1Element), "Standard wallet cannot support non-BLS keys yet"
         return puzzle_hash_for_pk(pubkey)
 
     async def convert_puzzle_hash(self, puzzle_hash: bytes32) -> bytes32:
@@ -397,6 +400,7 @@ class Wallet:
         # CHIP-0002 message signing as documented at:
         # https://github.com/Chia-Network/chips/blob/80e4611fe52b174bf1a0382b9dff73805b18b8c6/CHIPs/chip-0002.md#signmessage
         private = await self.wallet_state_manager.get_private_key(puzzle_hash)
+        assert isinstance(private, PrivateKey)
         synthetic_secret_key = calculate_synthetic_secret_key(private, DEFAULT_HIDDEN_PUZZLE_HASH)
         synthetic_pk = synthetic_secret_key.get_g1()
         if mode == SigningMode.CHIP_0002_HEX_INPUT:
@@ -557,7 +561,9 @@ class Wallet:
         root_fingerprint: bytes = self.wallet_state_manager.observation_root.get_fingerprint().to_bytes(4, "big")
         if index is None:
             # Pool wallet may have a secret key here
-            if self.wallet_state_manager.private_key is not None:
+            if self.wallet_state_manager.private_key is not None and isinstance(
+                self.wallet_state_manager.private_key, PrivateKey
+            ):
                 for pool_wallet_index in range(MAX_POOL_WALLETS):
                     try_owner_sk = master_sk_to_singleton_owner_sk(
                         self.wallet_state_manager.private_key, uint32(pool_wallet_index)
@@ -578,20 +584,20 @@ class Wallet:
     ) -> List[SigningResponse]:
         assert isinstance(self.wallet_state_manager.observation_root, G1Element)
         root_pubkey: G1Element = self.wallet_state_manager.observation_root
-        pk_lookup: Dict[int, G1Element] = (
-            {root_pubkey.get_fingerprint(): root_pubkey} if self.wallet_state_manager.private_key is not None else {}
-        )
-        sk_lookup: Dict[int, PrivateKey] = (
-            {root_pubkey.get_fingerprint(): self.wallet_state_manager.get_master_private_key()}
-            if self.wallet_state_manager.private_key is not None
-            else {}
-        )
+        pk_lookup: Dict[int, G1Element] = {}
+        sk_lookup: Dict[int, PrivateKey] = {}
         aggregate_responses_at_end: bool = True
         responses: List[SigningResponse] = []
 
         # TODO: expand path hints and sum hints recursively (a sum hint can give a new key to path hint)
         # Next, expand our pubkey set with path hints
         if self.wallet_state_manager.private_key is not None:
+            root_secret_key = self.wallet_state_manager.get_master_private_key()
+            assert isinstance(root_secret_key, PrivateKey)
+            root_fingerprint = root_pubkey.get_fingerprint()
+            pk_lookup[root_fingerprint] = root_pubkey
+            sk_lookup[root_fingerprint] = root_secret_key
+
             for path_hint in signing_instructions.key_hints.path_hints:
                 if int.from_bytes(path_hint.root_fingerprint, "big") != root_pubkey.get_fingerprint():
                     if not partial_allowed:
@@ -600,12 +606,10 @@ class Wallet:
                         continue
                 else:
                     path = [int(step) for step in path_hint.path]
-                    derive_child_sk = _derive_path(self.wallet_state_manager.get_master_private_key(), path)
-                    derive_child_sk_unhardened = _derive_path_unhardened(
-                        self.wallet_state_manager.get_master_private_key(), path
-                    )
-                    derive_child_pk = derive_child_sk.get_g1()
-                    derive_child_pk_unhardened = derive_child_sk_unhardened.get_g1()
+                    derive_child_sk = _derive_path(root_secret_key, path)
+                    derive_child_sk_unhardened = _derive_path_unhardened(root_secret_key, path)
+                    derive_child_pk = derive_child_sk.public_key()
+                    derive_child_pk_unhardened = derive_child_sk_unhardened.public_key()
                     pk_lookup[derive_child_pk.get_fingerprint()] = derive_child_pk
                     pk_lookup[derive_child_pk_unhardened.get_fingerprint()] = derive_child_pk_unhardened
                     sk_lookup[derive_child_pk.get_fingerprint()] = derive_child_sk

--- a/chia/wallet/wallet_protocol.py
+++ b/chia/wallet/wallet_protocol.py
@@ -12,6 +12,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.signing_mode import SigningMode
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64, uint128
+from chia.util.observation_root import ObservationRoot
 from chia.wallet.conditions import Condition
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.nft_wallet.nft_info import NFTCoinInfo
@@ -114,7 +115,7 @@ class MainWalletProtocol(WalletProtocol[ClawbackMetadata], Protocol):
         **kwargs: Unpack[GSTOptionalArgs],
     ) -> None: ...
 
-    def puzzle_for_pk(self, pubkey: G1Element) -> Program: ...
+    def puzzle_for_pk(self, pubkey: ObservationRoot) -> Program: ...
 
     async def puzzle_for_puzzle_hash(self, puzzle_hash: bytes32) -> Program: ...
 

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -84,7 +84,7 @@ class WalletPuzzleStore:
             sql_records.append(
                 (
                     record.index,
-                    bytes(record._pubkey).hex(),
+                    record.pubkey_bytes.hex(),
                     record.puzzle_hash.hex(),
                     record.wallet_type,
                     record.wallet_id,


### PR DESCRIPTION
This PR attempts to remove the `PrivateKey` type from the wallet insofar as is possible.  The object is to be able to use any type of private key with the wallet's `.private_key` member variable.