### PR TITLE
Timelord logging: Updated peak to hex from bytestring

### DIFF
--- a/chia/timelord/timelord_state.py
+++ b/chia/timelord/timelord_state.py
@@ -110,7 +110,7 @@ class LastState:
         reward_challenge: Optional[bytes32] = self.get_challenge(Chain.REWARD_CHAIN)
         assert reward_challenge is not None  # Reward chain always has VDFs
         self.reward_challenge_cache.append((reward_challenge, self.total_iters))
-        log.info(f"Updated timelord peak to {reward_challenge}, total iters: {self.total_iters}")
+        log.info(f"Updated timelord peak to {reward_challenge.hex}, total iters: {self.total_iters}")
         while len(self.reward_challenge_cache) > 2 * self.constants.MAX_SUB_SLOT_BLOCKS:
             self.reward_challenge_cache.pop(0)
 

--- a/chia/timelord/timelord_state.py
+++ b/chia/timelord/timelord_state.py
@@ -110,7 +110,7 @@ class LastState:
         reward_challenge: Optional[bytes32] = self.get_challenge(Chain.REWARD_CHAIN)
         assert reward_challenge is not None  # Reward chain always has VDFs
         self.reward_challenge_cache.append((reward_challenge, self.total_iters))
-        log.info(f"Updated timelord peak to {reward_challenge.hex}, total iters: {self.total_iters}")
+        log.info(f"Updated timelord peak to {bytes.hex(reward_challenge)}, total iters: {self.total_iters}")
         while len(self.reward_challenge_cache) > 2 * self.constants.MAX_SUB_SLOT_BLOCKS:
             self.reward_challenge_cache.pop(0)
 

--- a/chia/timelord/timelord_state.py
+++ b/chia/timelord/timelord_state.py
@@ -110,7 +110,7 @@ class LastState:
         reward_challenge: Optional[bytes32] = self.get_challenge(Chain.REWARD_CHAIN)
         assert reward_challenge is not None  # Reward chain always has VDFs
         self.reward_challenge_cache.append((reward_challenge, self.total_iters))
-        log.info(f"Updated timelord peak to {bytes.hex(reward_challenge)}, total iters: {self.total_iters}")
+        log.info(f"Updated timelord peak to {reward_challenge.hex()}, total iters: {self.total_iters}")
         while len(self.reward_challenge_cache) > 2 * self.constants.MAX_SUB_SLOT_BLOCKS:
             self.reward_challenge_cache.pop(0)
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
Improve readability and block tracing in Timelord logs
<!-- Does this PR introduce a breaking change? -->

### Current Behavior:
`Updated timelord peak to b'\\Ea\xf4\xc0\x93z\x9f\xect\xc5\xa1\x86V\xbe\xa7MZJWII\x86\xb9Pn\xcdh\xa0\x07\xc2\x1d', total iters: 43172559927875`

### New Behavior:
`Updated timelord peak to 142a52586c6c65f69ba99f45c596f45b449e8632a7dc03e756ec1373fae0511d, total iters: 43172559927875`
<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:
No additional tests needed.

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
