### PR TITLE
[CHIA-1156] Tweak `gather_signing_info` to work with multiple vaults and finish TXs

### DIFF
--- a/chia/wallet/vault/vault_drivers.py
+++ b/chia/wallet/vault/vault_drivers.py
@@ -128,6 +128,13 @@ def match_vault_puzzle(mod: Program, curried_args: Program) -> bool:
     return False
 
 
+def match_p2_delegated_secp(mod: Program, curried_args: Program) -> bool:
+    if mod == P2_DELEGATED_SECP_MOD:
+        return True
+    else:
+        return False
+
+
 def match_recovery_puzzle(mod: Program, curried_args: Program, solution: Program) -> bool:
     if match_vault_puzzle(mod, curried_args):
         try:

--- a/chia/wallet/vault/vault_wallet.py
+++ b/chia/wallet/vault/vault_wallet.py
@@ -67,6 +67,7 @@ from chia.wallet.vault.vault_drivers import (
     get_vault_inner_solution,
     get_vault_proof,
     match_finish_spend,
+    match_p2_delegated_secp,
     match_recovery_puzzle,
     match_vault_puzzle,
 )
@@ -232,7 +233,7 @@ class Vault(Wallet):
             )
         # create the p2_singleton spends
         delegated_puzzle = puzzle_for_conditions(conditions)
-        delegated_solution = solution_for_conditions(conditions)
+        delegated_solution = Program.to(None)
 
         p2_singleton_spends: List[CoinSpend] = []
         for coin in coins:
@@ -336,26 +337,28 @@ class Vault(Wallet):
 
     async def gather_signing_info(self, coin_spends: List[Spend]) -> SigningInstructions:
         pk = self.vault_info.pubkey
-        # match the vault puzzle
+
+        targets = []
         for spend in coin_spends:
             mod, curried_args = spend.puzzle.uncurry()
-            if match_vault_puzzle(mod, curried_args):
+            # match the vault puzzle
+            if match_vault_puzzle(mod, curried_args) and match_p2_delegated_secp(*spend.solution.at("rrfrf").uncurry()):
                 vault_spend = spend
-                break
-        inner_sol = vault_spend.solution.at("rrf")
-        secp_puz = inner_sol.at("rf")
-        secp_sol = inner_sol.at("rrf")
-        _, secp_args = secp_puz.uncurry()
-        genesis_challenge = secp_args.at("f").as_atom()
-        hidden_puzzle_hash = secp_args.at("rrf").as_atom()
-        delegated_puzzle_hash = secp_sol.at("f").get_tree_hash()
-        coin_id = secp_sol.at("rrrf").as_atom()
-        message = delegated_puzzle_hash + coin_id + genesis_challenge + hidden_puzzle_hash
-        fingerprint = self.wallet_state_manager.observation_root.get_fingerprint().to_bytes(4, "big")
-        target = SigningTarget(fingerprint, message, std_hash(pk + message))
+                inner_sol = vault_spend.solution.at("rrf")
+                secp_puz = inner_sol.at("rf")
+                secp_sol = inner_sol.at("rrf")
+                _, secp_args = secp_puz.uncurry()
+                genesis_challenge = secp_args.at("f").as_atom()
+                hidden_puzzle_hash = secp_args.at("rrf").as_atom()
+                delegated_puzzle_hash = secp_sol.at("f").get_tree_hash()
+                coin_id = secp_sol.at("rrrf").as_atom()
+                message = delegated_puzzle_hash + coin_id + genesis_challenge + hidden_puzzle_hash
+                fingerprint = self.wallet_state_manager.observation_root.get_fingerprint().to_bytes(4, "big")
+                targets.append(SigningTarget(fingerprint, message, std_hash(pk + message)))
+
         sig_info = SigningInstructions(
             await self.wallet_state_manager.key_hints_for_pubkeys([pk]),
-            [target],
+            targets,
         )
         return sig_info
 


### PR DESCRIPTION
While doing some other work, I noticed that the Vault's `gather_signing_info` method was a little bit rigid in what it would sign.  It would only sign one single vault spend in a bundle that it saw, and it would also assume that every vault spend that it saw needed to be signed.  This PR makes sure it only attempts to sign vaults that have a p2_delegated_secp puzzle inside and also allows it to sign multiple at once.