### PR TITLE
[CHIA-1036] Refer to separate recovery transactions by IDs

### DIFF
--- a/chia/_tests/cmds/wallet/test_vault.py
+++ b/chia/_tests/cmds/wallet/test_vault.py
@@ -59,7 +59,7 @@ def test_vault_recovery(capsys: object, get_test_cli_clients: Tuple[TestRpcClien
             args: VaultRecovery,
             tx_config: TXConfig,
         ) -> VaultRecoveryResponse:
-            return VaultRecoveryResponse([STD_UTX, STD_UTX], [STD_TX, STD_TX])
+            return VaultRecoveryResponse([STD_UTX, STD_UTX], [STD_TX, STD_TX], STD_TX.name, STD_TX.name)
 
     inst_rpc_client = CreateVaultRpcClient()  # pylint: disable=no-value-for-parameter
     test_rpc_clients.wallet_rpc_client = inst_rpc_client

--- a/chia/cmds/vault_funcs.py
+++ b/chia/cmds/vault_funcs.py
@@ -93,8 +93,7 @@ async def recover_vault(
                 ),
                 tx_config=tx_config,
             )
-            # TODO: do not rely on ordering of transactions here
-            write_transactions_to_file(response.transactions[0:1], initiate_file)
-            write_transactions_to_file(response.transactions[1:2], finish_file)
+            write_transactions_to_file([response.recovery_tx], initiate_file)
+            write_transactions_to_file([response.finish_tx], finish_file)
         except Exception as e:
             print(f"Error creating recovery transactions: {e}")

--- a/chia/rpc/util.py
+++ b/chia/rpc/util.py
@@ -102,6 +102,7 @@ def wrap_http_handler(f) -> Callable:
 def tx_endpoint(
     push: bool = False,
     merge_spends: bool = True,
+    sign: Optional[bool] = None,
 ) -> Callable[[RpcEndpoint], RpcEndpoint]:
     def _inner(func: RpcEndpoint) -> RpcEndpoint:
         async def rpc_endpoint(self, request: Dict[str, Any], *args, **kwargs) -> Dict[str, Any]:
@@ -154,7 +155,7 @@ def tx_endpoint(
                 tx_config,
                 push=request.get("push", push),
                 merge_spends=request.get("merge_spends", merge_spends),
-                sign=request.get("sign", self.service.config.get("auto_sign_txs", True)),
+                sign=request.get("sign", self.service.config.get("auto_sign_txs", True) if sign is None else sign),
             ) as action_scope:
                 response: Dict[str, Any] = await func(
                     self,

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -152,7 +152,16 @@ class VaultRecovery(TransactionEndpointRequest):
 @streamable
 @dataclass(frozen=True)
 class VaultRecoveryResponse(TransactionEndpointResponse):
-    pass
+    recovery_tx_id: bytes32
+    finish_tx_id: bytes32
+
+    @property
+    def recovery_tx(self) -> TransactionRecord:
+        return next(tx for tx in self.transactions if tx.name == self.recovery_tx_id)
+
+    @property
+    def finish_tx(self) -> TransactionRecord:
+        return next(tx for tx in self.transactions if tx.name == self.finish_tx_id)
 
 
 # TODO: The section below needs corresponding request types

--- a/chia/wallet/vault/vault_wallet.py
+++ b/chia/wallet/vault/vault_wallet.py
@@ -45,7 +45,7 @@ from chia.wallet.signer_protocol import (
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.compute_hints import compute_spend_hints_and_additions
 from chia.wallet.util.transaction_type import TransactionType
-from chia.wallet.util.tx_config import CoinSelectionConfig, TXConfig
+from chia.wallet.util.tx_config import CoinSelectionConfig
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend
 from chia.wallet.util.wallet_types import WalletIdentifier
 from chia.wallet.vault.vault_drivers import (
@@ -501,12 +501,12 @@ class Vault(Wallet):
         secp_pk: bytes,
         hidden_puzzle_hash: bytes32,
         genesis_challenge: bytes32,
-        tx_config: TXConfig,
+        action_scope: WalletActionScope,
         bls_pk: Optional[G1Element] = None,
         timelock: Optional[uint64] = None,
-    ) -> List[TransactionRecord]:
+    ) -> Tuple[bytes32, bytes32]:
         """
-        Returns two tx records
+        Returns two tx IDs
         1. Recover the vault which can be taken to the appropriate BLS wallet for signing
         2. Complete the recovery after the timelock has elapsed
         """
@@ -584,7 +584,6 @@ class Vault(Wallet):
             [recovery_coin.name(), new_vault_coin_id], [self.id(), self.id()]
         )
 
-        # make the tx records
         recovery_tx = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
@@ -625,7 +624,10 @@ class Vault(Wallet):
             valid_times=parse_timelock_info(tuple()),
         )
 
-        return [recovery_tx, finish_tx]
+        async with action_scope.use() as interface:
+            interface.side_effects.transactions.extend([recovery_tx, finish_tx])
+
+        return (recovery_tx.name, finish_tx.name)
 
     async def sync_vault_launcher(self) -> None:
         wallet_node: Any = self.wallet_state_manager.wallet_node


### PR DESCRIPTION
This PR makes the vault recovery endpoint return the specific IDs of the two transactions it's creating instead of simply returning a list and expecting the user to understand the order.  There's also a minor change to `@tx_endpoint` to support this.