### PR TITLE
[CHIA-1129] Extract coin splitting logic from CLI -> RPC

### DIFF
--- a/chia/cmds/coins.py
+++ b/chia/cmds/coins.py
@@ -210,7 +210,9 @@ def combine_cmd(
     type=AmountParamType(),
     required=True,
 )
-@click.option("-t", "--target-coin-id", type=str, required=True, help="The coin id of the coin we are splitting.")
+@click.option(
+    "-t", "--target-coin-id", type=Bytes32ParamType(), required=True, help="The coin id of the coin we are splitting."
+)
 @tx_out_cmd
 def split_cmd(
     wallet_rpc_port: Optional[int],
@@ -219,7 +221,7 @@ def split_cmd(
     number_of_coins: int,
     fee: uint64,
     amount_per_coin: CliAmount,
-    target_coin_id: str,
+    target_coin_id: bytes32,
     push: bool,
 ) -> List[TransactionRecord]:
     from .coin_funcs import async_split
@@ -232,7 +234,7 @@ def split_cmd(
             fee=fee,
             number_of_coins=number_of_coins,
             amount_per_coin=amount_per_coin,
-            target_coin_id_str=target_coin_id,
+            target_coin_id=target_coin_id,
             push=push,
         )
     )

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from typing_extensions import dataclass_transform
@@ -123,10 +123,10 @@ class TransactionEndpointResponse(Streamable):
 @streamable
 @kw_only_dataclass
 class SplitCoins(TransactionEndpointRequest):
-    wallet_id: uint32
-    number_of_coins: uint16
-    amount_per_coin: uint64
-    target_coin_id: bytes32
+    wallet_id: uint32 = field(default_factory=default_raise)
+    number_of_coins: uint16 = field(default_factory=default_raise)
+    amount_per_coin: uint64 = field(default_factory=default_raise)
+    target_coin_id: bytes32 = field(default_factory=default_raise)
 
 
 @streamable

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-field-call
+
 from __future__ import annotations
 
 import sys

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Type, TypeVar, dataclass_transform
+from typing import Any, Dict, List, Optional, Type, TypeVar
+
+from typing_extensions import dataclass_transform
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Type, TypeVar
+from typing import Any, Dict, List, Optional, Type, TypeVar, dataclass_transform
 
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle
-from chia.util.ints import uint32
+from chia.util.ints import uint16, uint32, uint64
 from chia.util.streamable import Streamable, streamable
 from chia.wallet.notification_store import Notification
 from chia.wallet.signer_protocol import (
@@ -22,6 +23,18 @@ from chia.wallet.util.clvm_streamable import json_deserialize_with_clvm_streamab
 from chia.wallet.vc_wallet.vc_store import VCRecord
 
 _T_OfferEndpointResponse = TypeVar("_T_OfferEndpointResponse", bound="_OfferEndpointResponse")
+
+
+@dataclass_transform(frozen_default=True, kw_only_default=True)
+def kw_only_dataclass(cls: Type[Any]) -> Type[Any]:
+    if sys.version_info < (3, 10):
+        return dataclass(frozen=True)(cls)  # pragma: no cover
+    else:
+        return dataclass(frozen=True, kw_only=True)(cls)
+
+
+def default_raise() -> Any:  # pragma: no cover
+    raise RuntimeError("This should be impossible to hit and is just for < 3.10 compatibility")
 
 
 @streamable
@@ -88,11 +101,36 @@ class ExecuteSigningInstructionsResponse(Streamable):
     signing_responses: List[SigningResponse]
 
 
+# When inheriting from this class you must set any non default arguments with:
+# field(default_factory=default_raise)
+# (this is for < 3.10 compatibility)
+@streamable
+@kw_only_dataclass
+class TransactionEndpointRequest(Streamable):
+    fee: uint64 = uint64(0)
+    push: Optional[bool] = None
+
+
 @streamable
 @dataclass(frozen=True)
 class TransactionEndpointResponse(Streamable):
     unsigned_transactions: List[UnsignedTransaction]
     transactions: List[TransactionRecord]
+
+
+@streamable
+@kw_only_dataclass
+class SplitCoins(TransactionEndpointRequest):
+    wallet_id: uint32
+    number_of_coins: uint16
+    amount_per_coin: uint64
+    target_coin_id: bytes32
+
+
+@streamable
+@dataclass(frozen=True)
+class SplitCoinsResponse(TransactionEndpointResponse):
+    pass
 
 
 # TODO: The section below needs corresponding request types

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -28,6 +28,8 @@ from chia.rpc.wallet_request_types import (
     GatherSigningInfoResponse,
     GetNotifications,
     GetNotificationsResponse,
+    SplitCoins,
+    SplitCoinsResponse,
     SubmitTransactions,
     SubmitTransactionsResponse,
 )
@@ -200,6 +202,7 @@ class WalletRpcApi:
             "/sign_message_by_id": self.sign_message_by_id,
             "/verify_signature": self.verify_signature,
             "/get_transaction_memo": self.get_transaction_memo,
+            "/split_coins": self.split_coins,
             # CATs and trading
             "/cat_set_name": self.cat_set_name,
             "/cat_asset_id_to_name": self.cat_asset_id_to_name,
@@ -1082,6 +1085,76 @@ class WalletRpcApi:
         for coin_id, memo_list in memos.items():
             response[coin_id.hex()] = [memo.hex() for memo in memo_list]
         return {transaction_id.hex(): response}
+
+    @tx_endpoint(push=False)
+    @marshal
+    async def split_coins(
+        self, request: SplitCoins, action_scope: WalletActionScope, extra_conditions: Tuple[Condition, ...] = tuple()
+    ) -> SplitCoinsResponse:
+        if request.number_of_coins > 500:
+            raise ValueError(f"{request.number_of_coins} coins is greater then the maximum limit of 500 coins.")
+
+        optional_coin = await self.service.wallet_state_manager.coin_store.get_coin_record(request.target_coin_id)
+        if optional_coin is None:
+            raise ValueError(f"Could not find coin with ID {request.target_coin_id}")
+        else:
+            coin = optional_coin.coin
+
+        total_amount = request.amount_per_coin * request.number_of_coins
+
+        if coin.amount < total_amount:
+            raise ValueError(
+                f"Coin amount: {coin.amount} is less than the total amount of the split: {total_amount}, exiting."
+            )
+
+        wallet = self.service.wallet_state_manager.wallets[request.wallet_id]
+        if not isinstance(wallet, (Wallet, CATWallet)):
+            raise ValueError("Cannot split coins from non-fungible wallet types")
+
+        outputs = [
+            Payment(await wallet.get_puzzle_hash(new=True), request.amount_per_coin)
+            for _ in range(request.number_of_coins)
+        ]
+        if len(outputs) == 0:
+            return SplitCoinsResponse([], [])
+
+        # TODO: unify GST API
+        if wallet.type() == WalletType.STANDARD_WALLET:
+            assert isinstance(wallet, Wallet)
+            if coin.amount < total_amount + request.fee:
+                coins = await wallet.select_coins(
+                    uint64(total_amount + request.fee - coin.amount),
+                    dataclasses.replace(
+                        action_scope.config.tx_config.coin_selection_config,
+                        excluded_coin_ids=[
+                            coin.name(),
+                            *action_scope.config.tx_config.coin_selection_config.excluded_coin_ids,
+                        ],
+                    ),
+                )
+            else:
+                coins = {coin}
+            await wallet.generate_signed_transaction(
+                outputs[0].amount,
+                outputs[0].puzzle_hash,
+                action_scope,
+                request.fee,
+                coins,
+                outputs[1:] if len(outputs) > 1 else None,
+                extra_conditions=extra_conditions,
+            )
+        else:
+            assert isinstance(wallet, CATWallet)
+            await wallet.generate_signed_transaction(
+                [output.amount for output in outputs],
+                [output.puzzle_hash for output in outputs],
+                action_scope,
+                request.fee,
+                coins={coin},
+                extra_conditions=extra_conditions,
+            )
+
+        return SplitCoinsResponse([], [])  # tx_endpoint will take care to fill this out
 
     async def get_transactions(self, request: Dict[str, Any]) -> EndpointResult:
         wallet_id = int(request["wallet_id"])

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -39,6 +39,8 @@ from chia.rpc.wallet_request_types import (
     NFTTransferNFTResponse,
     SendTransactionMultiResponse,
     SendTransactionResponse,
+    SplitCoins,
+    SplitCoinsResponse,
     SubmitTransactions,
     SubmitTransactionsResponse,
     TakeOfferResponse,
@@ -1699,4 +1701,13 @@ class WalletRpcClient(RpcClient):
     ) -> ExecuteSigningInstructionsResponse:
         return ExecuteSigningInstructionsResponse.from_json_dict(
             await self.fetch("execute_signing_instructions", args.to_json_dict())
+        )
+
+    async def split_coins(
+        self,
+        args: SplitCoins,
+        tx_config: TXConfig,
+    ) -> SplitCoinsResponse:
+        return SplitCoinsResponse.from_json_dict(
+            await self.fetch("split_coins", {*args.to_json_dict(), *tx_config.to_json_dict()})
         )

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -1709,5 +1709,5 @@ class WalletRpcClient(RpcClient):
         tx_config: TXConfig,
     ) -> SplitCoinsResponse:
         return SplitCoinsResponse.from_json_dict(
-            await self.fetch("split_coins", {*args.to_json_dict(), *tx_config.to_json_dict()})
+            await self.fetch("split_coins", {**args.to_json_dict(), **tx_config.to_json_dict()})
         )


### PR DESCRIPTION
Right now the splitting of coins is implemented on the client side.  This is overly complicated functionality to leave to a client, and using the RPCs to accomplish this ends up being a hack that causes headaches.  This PR instead makes an RPC for this and only requires the client to specify parameters.


