### PR TITLE
Fix `request_fee_estimates`

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1686,7 +1686,7 @@ class FullNodeAPI:
         msg = make_msg(ProtocolMessageTypes.respond_ses_hashes, response)
         return msg
 
-    @api_request(peer_required=True, reply_types=[ProtocolMessageTypes.respond_fee_estimates])
+    @api_request(reply_types=[ProtocolMessageTypes.respond_fee_estimates])
     async def request_fee_estimates(self, request: wallet_protocol.RequestFeeEstimates) -> Message:
         def get_fee_estimates(est: FeeEstimatorInterface, req_times: List[uint64]) -> List[FeeEstimate]:
             now = datetime.now(timezone.utc)


### PR DESCRIPTION
Currently, making a request for fee estimates using the full node protocol generates the following error:

```
2024-08-17T20:32:51.575 full_node chia.server.rate_limits : WARNING  Message type ProtocolMessageTypes.request_fee_estimates not found in rate limits
2024-08-17T20:32:51.578 full_node full_node_server        : ERROR    Exception: FullNodeAPI.request_fee_estimates() takes 2 positional arguments but 3 were given <class 'TypeError'>, closing connection PeerInfo(_ip=IPv4Address('127.0.0.1'), _port=0). Traceback (most recent call last):
  File "chia/server/ws_connection.py", line 431, in _api_call
  File "chia/util/api_decorators.py", line 69, in wrapper
TypeError: FullNodeAPI.request_fee_estimates() takes 2 positional arguments but 3 were given

2024-08-17T20:32:51.579 full_node full_node_server        : WARNING  Trying to ban localhost for 10, but will not ban
```

I traced this to the handler's decorator, which contains `peer_required=True` while the function doesn't accept a `peer` argument.