### PR TITLE
`pre_validate_blocks_multiprocessing` Warm up the cache once per batch

### DIFF
--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -216,33 +216,34 @@ async def pre_validate_blocks_multiprocessing(
         block_record_was_present.append(block_records.contains_block(header_hash))
 
     diff_ssis: List[Tuple[uint64, uint64]] = []
-    for block in blocks:
-        if block.height != 0:
-            if prev_b is None:
-                prev_b = await block_records.get_block_record_from_db(block.prev_header_hash)
-            assert prev_b is not None
 
-            # the call to block_to_block_record() requires the previous
-            # block is in the cache
-            # and make_sub_epoch_summary() requires all blocks until we find one
-            # that includes a sub_epoch_summary
-            curr = prev_b
+    if blocks[0].height != 0:
+        if prev_b is None:
+            prev_b = await block_records.get_block_record_from_db(blocks[0].prev_header_hash)
+        assert prev_b is not None
+
+        # the call to block_to_block_record() requires the previous
+        # block is in the cache
+        # and make_sub_epoch_summary() requires all blocks until we find one
+        # that includes a sub_epoch_summary
+        curr = prev_b
+        block_records.add_block_record(curr)
+        counter = 0
+        # TODO: It would probably be better to make
+        # get_next_sub_slot_iters_and_difficulty() async and able to pull
+        # from the database rather than trying to predict which blocks it
+        # may need in the cache
+        while (
+            curr.sub_epoch_summary_included is None
+            or counter < 3 * constants.MAX_SUB_SLOT_BLOCKS + constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK + 3
+        ):
+            curr = await block_records.get_block_record_from_db(curr.prev_hash)
+            if curr is None:
+                break
             block_records.add_block_record(curr)
-            counter = 0
-            # TODO: It would probably be better to make
-            # get_next_sub_slot_iters_and_difficulty() async and able to pull
-            # from the database rather than trying to predict which blocks it
-            # may need in the cache
-            while (
-                curr.sub_epoch_summary_included is None
-                or counter < 3 * constants.MAX_SUB_SLOT_BLOCKS + constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK + 3
-            ):
-                curr = await block_records.get_block_record_from_db(curr.prev_hash)
-                if curr is None:
-                    break
-                block_records.add_block_record(curr)
-                counter += 1
+            counter += 1
 
+    for block in blocks:
         sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
             constants, len(block.finished_sub_slots) > 0, prev_b, block_records
         )


### PR DESCRIPTION
### Purpose:

This is a small improvement towards a more efficient long sync.

The section this patch moves makes sure the block record cache contains sufficient blocks going back from the current block.
Currently we do this *inside* the loop over the blocks in the batch, which is unnecessary. The batch is expected to be contiguous anyway, so warming up the cache once outside the loop is sufficient.

This offers a small speed-up and slight simplification to `pre_validate_blocks_multiprocessing()`. Although, this code should ideally be moved to where we start a long sync (or maybe even a deep reorg). The code was only added to address issues in deep reorgs, where the cache may be cold.

The sync rate goes from ~24 blocks/second to ~28 blocks/second. A speedup of ~ 1.16

This commit is probably best reviewed with whitespaces ignored, as it changes the indentation level for the code in question.

### Current Behavior:

Warm up the cache for every block.

### New Behavior:

Warm up the cache once, for the first block.

### Testing Notes:

Sync test [here](https://grafana.fmt.chiatechlab.com/d/oBgwkDI7z/blockchain-sync-tests?orgId=1&from=now-2d&to=now&var-ref=0a76e22489513ac0add5e31ca27b78a1c074536b&var-ref=simplify-pre-validate&var-repo=All&var-network=mainnet&var-network=testnet11).