### PR TITLE
Source offer confirmed height from original coin state

### DIFF
--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -186,7 +186,7 @@ class TradeManager:
         coin_state_names: List[bytes32] = [cs.coin.name() for cs in coin_states]
         # If any of our settlement_payments were spent, this offer was a success!
         if set(our_addition_ids) == set(coin_state_names):
-            height = coin_states[0].created_height
+            height = coin_state.spent_height
             assert height is not None
             await self.trade_store.set_status(trade.trade_id, TradeStatus.CONFIRMED, index=height)
             tx_records: List[TransactionRecord] = await self.calculate_tx_records_for_offer(offer, False)


### PR DESCRIPTION
I can't really identify the root cause of the issue here, but it seems like sometimes we're trying to process a coin in an offer that is not responsible for any additions of the offer.  This causes an exception when we try to index into a list that assumes we have at least one result.  However, we don't really need to be indexing into that list to get the information we need so, instead, we'll just pull the information from somewhere else and dodge the potential raise entirely.

https://github.com/Chia-Network/chia-blockchain/issues/18330