### PR TITLE
Remove the coin amount from state layer solution

### DIFF
--- a/chia/wallet/nft_wallet/metadata_outer_puzzle.py
+++ b/chia/wallet/nft_wallet/metadata_outer_puzzle.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Tuple
 
-from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.util.ints import uint64
 from chia.wallet.puzzle_drivers import PuzzleInfo, Solver
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
 from chia.wallet.uncurried_puzzle import UncurriedPuzzle, uncurry_puzzle

--- a/chia/wallet/nft_wallet/metadata_outer_puzzle.py
+++ b/chia/wallet/nft_wallet/metadata_outer_puzzle.py
@@ -27,8 +27,8 @@ def puzzle_for_metadata_layer(metadata: Program, updater_hash: bytes32, inner_pu
     return NFT_STATE_LAYER_MOD.curry(NFT_STATE_LAYER_MOD_HASH, metadata, updater_hash, inner_puzzle)
 
 
-def solution_for_metadata_layer(amount: uint64, inner_solution: Program) -> Program:
-    return Program.to([inner_solution, amount])
+def solution_for_metadata_layer(inner_solution: Program) -> Program:
+    return Program.to([inner_solution])
 
 
 @dataclass(frozen=True)
@@ -88,12 +88,7 @@ class MetadataOuterPuzzle:
             return my_inner_solution
 
     def solve(self, constructor: PuzzleInfo, solver: Solver, inner_puzzle: Program, inner_solution: Program) -> Program:
-        coin_bytes: bytes = solver["coin"]
-        coin: Coin = Coin(bytes32(coin_bytes[0:32]), bytes32(coin_bytes[32:64]), uint64.from_bytes(coin_bytes[64:72]))
         also = constructor.also()
         if also is not None:
             inner_solution = self._solve(also, solver, inner_puzzle, inner_solution)
-        return solution_for_metadata_layer(
-            uint64(coin.amount),
-            inner_solution,
-        )
+        return solution_for_metadata_layer(inner_solution)


### PR DESCRIPTION
### Purpose:

Removes the coin amount (typically `1`) from the end of the NFT state layer (referred to here as "metadata" layer) solution. The actual puzzle's solution does not contain more than one argument, the inner solution.

The way it is now increases the cost slightly, and breaks code which expects an exact format for the solution. That said, code which does can likely be relaxed a bit to adapt to this.