### PR TITLE
CHIA-1101: update `BlockGenerator` type

### DIFF
--- a/chia/_tests/generator/test_rom.py
+++ b/chia/_tests/generator/test_rom.py
@@ -63,7 +63,7 @@ def to_sp(sexp: bytes) -> SerializedProgram:
 
 
 def block_generator() -> BlockGenerator:
-    generator_list = [to_sp(FIRST_GENERATOR), to_sp(SECOND_GENERATOR)]
+    generator_list = [FIRST_GENERATOR, SECOND_GENERATOR]
     return BlockGenerator(to_sp(COMPILED_GENERATOR_CODE), generator_list)
 
 
@@ -80,7 +80,7 @@ EXPECTED_OUTPUT = (
 
 def run_generator(self: BlockGenerator) -> Tuple[int, Program]:
     """This mode is meant for accepting possibly soft-forked transactions into the mempool"""
-    args = Program.to([[bytes(g) for g in self.generator_refs]])
+    args = Program.to([self.generator_refs])
     return GENERATOR_MOD.run_with_cost(MAX_COST, [self.program, args])
 
 

--- a/chia/_tests/util/test_full_block_utils.py
+++ b/chia/_tests/util/test_full_block_utils.py
@@ -253,7 +253,7 @@ async def test_parser():
     for block in get_full_blocks():
         block_bytes = bytes(block)
         gen = generator_from_block(block_bytes)
-        assert gen == block.transactions_generator
+        assert gen == bytes(block.transactions_generator)
         bi = block_info_from_block(block_bytes)
         assert block.transactions_generator == bi.transactions_generator
         assert block.prev_header_hash == bi.prev_header_hash

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -35,7 +35,6 @@ from chia.full_node.coin_store import CoinStore
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.block_protocol import BlockInfo
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from chia.types.blockchain_format.vdf import VDFInfo
@@ -1069,7 +1068,7 @@ class Blockchain(BlockchainInterface):
         if len(ref_list) == 0:
             return BlockGenerator(block.transactions_generator, [])
 
-        result: List[SerializedProgram] = []
+        result: List[bytes] = []
         previous_br = await self.get_block_record_from_db(block.prev_header_hash)
         if previous_br is not None and self.height_to_hash(previous_br.height) == block.prev_header_hash:
             # We are not in a reorg, no need to look up alternate header hashes
@@ -1104,7 +1103,7 @@ class Blockchain(BlockchainInterface):
                     ref_block = additional_height_dict[ref_height]
                     if ref_block.transactions_generator is None:
                         raise ValueError(Err.GENERATOR_REF_HAS_NO_GENERATOR)
-                    result.append(ref_block.transactions_generator)
+                    result.append(bytes(ref_block.transactions_generator))
                 elif ref_height in reorg_chain:
                     gen = await self.block_store.get_generator(reorg_chain[ref_height])
                     if gen is None:

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -52,7 +52,7 @@ def batch_pre_validate_blocks(
     constants: ConsensusConstants,
     blocks_pickled: Dict[bytes, bytes],
     full_blocks_pickled: List[bytes],
-    prev_transaction_generators: List[Optional[bytes]],
+    prev_transaction_generators: List[Optional[List[bytes]]],
     npc_results: Dict[uint32, bytes],
     check_filter: bool,
     expected_difficulty: List[uint64],
@@ -81,10 +81,10 @@ def batch_pre_validate_blocks(
                     removals, tx_additions = [], []
 
             if block.transactions_generator is not None and npc_result is None:
-                prev_generator_bytes = prev_transaction_generators[i]
-                assert prev_generator_bytes is not None
+                prev_generators = prev_transaction_generators[i]
+                assert prev_generators is not None
                 assert block.transactions_info is not None
-                block_generator: BlockGenerator = BlockGenerator.from_bytes(prev_generator_bytes)
+                block_generator = BlockGenerator(block.transactions_generator, prev_generators)
                 assert block_generator.program == block.transactions_generator
                 npc_result = get_name_puzzle_conditions(
                     block_generator,
@@ -312,7 +312,7 @@ async def pre_validate_blocks_multiprocessing(
         end_i = min(i + batch_size, len(blocks))
         blocks_to_validate = blocks[i:end_i]
         b_pickled: List[bytes] = []
-        previous_generators: List[Optional[bytes]] = []
+        previous_generators: List[Optional[List[bytes]]] = []
         for block in blocks_to_validate:
             # We ONLY add blocks which are in the past, based on header hashes (which are validated later) to the
             # prev blocks dict. This is important since these blocks are assumed to be valid and are used as previous
@@ -337,7 +337,7 @@ async def pre_validate_blocks_multiprocessing(
                     )
                 ]
             if block_generator is not None:
-                previous_generators.append(bytes(block_generator))
+                previous_generators.append(block_generator.generator_refs)
             else:
                 previous_generators.append(None)
 

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -9,7 +9,6 @@ import typing_extensions
 import zstd
 
 from chia.consensus.block_record import BlockRecord
-from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.weight_proof import SubEpochChallengeSegment, SubEpochSegments
@@ -264,10 +263,10 @@ class BlockStore:
                     b.foliage.prev_block_hash, b.transactions_generator, b.transactions_generator_ref_list
                 )
 
-    async def get_generator(self, header_hash: bytes32) -> Optional[SerializedProgram]:
+    async def get_generator(self, header_hash: bytes32) -> Optional[bytes]:
         cached = self.block_cache.get(header_hash)
         if cached is not None:
-            return cached.transactions_generator
+            return None if cached.transactions_generator is None else bytes(cached.transactions_generator)
 
         formatted_str = "SELECT block, height from full_blocks WHERE header_hash=?"
         async with self.db_wrapper.reader_no_transaction() as conn:
@@ -278,19 +277,19 @@ class BlockStore:
 
             try:
                 return generator_from_block(block_bytes)
-            except Exception as e:
+            except Exception as e:  # pragma: no cover
                 log.error(f"cheap parser failed for block at height {row[1]}: {e}")
                 # this is defensive, on the off-chance that
                 # generator_from_block() fails, fall back to the reliable
                 # definition of parsing a block
                 b = FullBlock.from_bytes(block_bytes)
-                return b.transactions_generator
+                return None if b.transactions_generator is None else bytes(b.transactions_generator)
 
-    async def get_generators_at(self, heights: List[uint32]) -> List[SerializedProgram]:
+    async def get_generators_at(self, heights: List[uint32]) -> List[bytes]:
         if len(heights) == 0:
             return []
 
-        generators: Dict[uint32, SerializedProgram] = {}
+        generators: Dict[uint32, bytes] = {}
         formatted_str = (
             f"SELECT block, height from full_blocks "
             f'WHERE in_main_chain=1 AND height in ({"?," * (len(heights) - 1)}?)'
@@ -302,13 +301,13 @@ class BlockStore:
 
                     try:
                         gen = generator_from_block(block_bytes)
-                    except Exception as e:
+                    except Exception as e:  # pragma: no cover
                         log.error(f"cheap parser failed for block at height {row[1]}: {e}")
                         # this is defensive, on the off-chance that
                         # generator_from_block() fails, fall back to the reliable
                         # definition of parsing a block
                         b = FullBlock.from_bytes(block_bytes)
-                        gen = b.transactions_generator
+                        gen = None if b.transactions_generator is None else bytes(b.transactions_generator)
                     if gen is None:
                         raise ValueError(Err.GENERATOR_REF_HAS_NO_GENERATOR)
                     generators[uint32(row[1])] = gen

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -47,7 +47,7 @@ def get_name_puzzle_conditions(
         run_block = run_block_generator
 
     try:
-        block_args = [bytes(gen) for gen in generator.generator_refs]
+        block_args = generator.generator_refs
         err, result = run_block(bytes(generator.program), block_args, max_cost, flags, constants)
         assert (err is None) != (result is None)
         if err is not None:
@@ -66,7 +66,7 @@ def get_puzzle_and_solution_for_coin(
     try:
         puzzle, solution = get_puzzle_and_solution_for_coin_rust(
             generator.program,
-            [bytes(a) for a in generator.generator_refs],
+            generator.generator_refs,
             constants.MAX_BLOCK_COST_CLVM,
             coin,
             get_flags_for_height_and_constants(height, constants),
@@ -80,7 +80,7 @@ def get_spends_for_block(generator: BlockGenerator, height: int, constants: Cons
     args = bytearray(b"\xff")
     args += bytes(DESERIALIZE_MOD)
     args += b"\xff"
-    args += bytes(Program.to([bytes(a) for a in generator.generator_refs]))
+    args += bytes(Program.to(generator.generator_refs))
     args += b"\x80\x80"
 
     _, ret = run_chia_program(
@@ -107,7 +107,7 @@ def get_spends_for_block_with_conditions(
     args = bytearray(b"\xff")
     args += bytes(DESERIALIZE_MOD)
     args += b"\xff"
-    args += bytes(Program.to([bytes(a) for a in generator.generator_refs]))
+    args += bytes(Program.to(generator.generator_refs))
     args += b"\x80\x80"
 
     flags = get_flags_for_height_and_constants(height, constants)

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -1940,7 +1940,7 @@ def compute_cost_test(generator: BlockGenerator, constants: ConsensusConstants, 
     clvm_cost = 0
 
     if height >= constants.HARD_FORK_HEIGHT:
-        blocks = [bytes(g) for g in generator.generator_refs]
+        blocks = generator.generator_refs
         cost, result = generator.program._run(INFINITE_COST, MEMPOOL_MODE | ALLOW_BACKREFS, [DESERIALIZE_MOD, blocks])
         clvm_cost += cost
 
@@ -1955,7 +1955,7 @@ def compute_cost_test(generator: BlockGenerator, constants: ConsensusConstants, 
             condition_cost += conditions_cost(result)
 
     else:
-        block_program_args = SerializedProgram.to([[bytes(g) for g in generator.generator_refs]])
+        block_program_args = SerializedProgram.to([generator.generator_refs])
         clvm_cost, result = GENERATOR_MOD._run(INFINITE_COST, MEMPOOL_MODE, [generator.program, block_program_args])
 
         for res in result.first().as_iter():

--- a/chia/types/generator_types.py
+++ b/chia/types/generator_types.py
@@ -19,4 +19,4 @@ class GeneratorBlockCacheInterface:
 @dataclass(frozen=True)
 class BlockGenerator(Streamable):
     program: SerializedProgram
-    generator_refs: List[SerializedProgram]
+    generator_refs: List[bytes]

--- a/chia/util/full_block_utils.py
+++ b/chia/util/full_block_utils.py
@@ -204,7 +204,7 @@ def skip_transactions_info(buf: memoryview) -> memoryview:
     return skip_list(buf, skip_coin)
 
 
-def generator_from_block(buf: memoryview) -> Optional[SerializedProgram]:
+def generator_from_block(buf: memoryview) -> Optional[bytes]:
     buf = skip_list(buf, skip_end_of_sub_slot_bundle)  # finished_sub_slots
     buf = skip_reward_chain_block(buf)  # reward_chain_block
     buf = skip_optional(buf, skip_vdf_proof)  # challenge_chain_sp_proof
@@ -222,7 +222,7 @@ def generator_from_block(buf: memoryview) -> Optional[SerializedProgram]:
 
     buf = buf[1:]
     length = serialized_length(buf)
-    return SerializedProgram.from_bytes(bytes(buf[:length]))
+    return bytes(buf[:length])
 
 
 # this implements the BlockInfo protocol

--- a/tools/analyze-chain.py
+++ b/tools/analyze-chain.py
@@ -95,7 +95,7 @@ def main(file: Path, mempool_mode: bool, start: int, end: Optional[int], call: O
             ref = c.execute("SELECT block FROM full_blocks WHERE height=? and in_main_chain=1", (h,))
             generator = generator_from_block(zstd.decompress(ref.fetchone()[0]))
             assert generator is not None
-            generator_blobs.append(bytes(generator))
+            generator_blobs.append(generator)
             ref.close()
 
         ref_lookup_time = time() - start_time


### PR DESCRIPTION
### Purpose:

Simplify and optimize code around block validation.

The `BlockGenerator` class contains the block generator for a specific block as well as the actual generators for blocks it references.

This PR:

* change the type of `generator_refs` to `List[bytes]` instead of `List[SerializedProgram]`. The only place these items are used are in generators, in CLVM. We always pass plain bytes into CLVM.
* Avoid passing the block generator twice to the worker process for validation. Currently we pass both the `FullBLock` and the `BlockGenerator`. By only passing the previous generators (`List[bytes]`) instead of `BlockGenerator`, we avoid copying the generator twice.

### Current Behavior:

Pass 2 copies of the block generator to `pre_validate_blocks_multiprocessing()`, once in the `FullBlock` and once in the `BlockGenerator`


### New Behavior:

Only pass the block generator once to `pre_validate_blocks_multiprocessing()`, in the `FullBlock`. Instead of the `BlockGenerator` just pass the `generator_refs`.