### PR TITLE
fix long sync cache

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -353,8 +353,10 @@ class Blockchain(BlockchainInterface):
         # tests that make sure the Blockchain object can handle any blocks,
         # including orphaned ones, without any fork context
         if fork_info is None:
-            if await self.contains_block_from_db(header_hash):
-                # this means we have already seen and validated this block.
+            block_rec = await self.get_block_record_from_db(header_hash)
+            if block_rec is not None:
+                self.add_block_record(block_rec)
+                # this means we have already seen and validated this block.                
                 return AddBlockResult.ALREADY_HAVE_BLOCK, None, None
             elif extending_main_chain:
                 # this is the common and efficient case where we extend the main
@@ -407,13 +409,14 @@ class Blockchain(BlockchainInterface):
             if extending_main_chain:
                 fork_info.reset(block.height - 1, block.prev_header_hash)
 
-            if await self.contains_block_from_db(header_hash):
+            block_rec = await self.get_block_record_from_db(header_hash)
+            if block_rec is not None:
                 # We have already validated the block, but if it's not part of the
                 # main chain, we still need to re-run it to update the additions and
                 # removals in fork_info.
                 await self.advance_fork_info(block, fork_info, {})
                 fork_info.include_spends(npc_result, block, header_hash)
-
+                self.add_block_record(block_rec)
                 return AddBlockResult.ALREADY_HAVE_BLOCK, None, None
 
             if fork_info.peak_hash != block.prev_header_hash:

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -356,7 +356,7 @@ class Blockchain(BlockchainInterface):
             block_rec = await self.get_block_record_from_db(header_hash)
             if block_rec is not None:
                 self.add_block_record(block_rec)
-                # this means we have already seen and validated this block.                
+                # this means we have already seen and validated this block.
                 return AddBlockResult.ALREADY_HAVE_BLOCK, None, None
             elif extending_main_chain:
                 # this is the common and efficient case where we extend the main

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -228,20 +228,6 @@ async def pre_validate_blocks_multiprocessing(
             # that includes a sub_epoch_summary
             curr = prev_b
             block_records.add_block_record(curr)
-            counter = 0
-            # TODO: It would probably be better to make
-            # get_next_sub_slot_iters_and_difficulty() async and able to pull
-            # from the database rather than trying to predict which blocks it
-            # may need in the cache
-            while (
-                curr.sub_epoch_summary_included is None
-                or counter < 3 * constants.MAX_SUB_SLOT_BLOCKS + constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK + 3
-            ):
-                curr = await block_records.get_block_record_from_db(curr.prev_hash)
-                if curr is None:
-                    break
-                block_records.add_block_record(curr)
-                counter += 1
 
         sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
             constants, len(block.finished_sub_slots) > 0, prev_b, block_records

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1057,6 +1057,18 @@ class FullNode:
             self.blockchain, fork_point_height, peers_with_peak, node_next_block_check
         )
         batch_size = self.constants.MAX_BLOCK_COUNT_PER_REQUESTS
+        counter = 0
+        curr = self.blockchain.height_to_block_record(fork_point_height)
+        while (
+            curr.sub_epoch_summary_included is None
+            or counter < 3 * self.constants.MAX_SUB_SLOT_BLOCKS + self.constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK + 3
+        ):
+            res = await self.blockchain.get_block_record_from_db(curr.prev_hash)
+            if res is None:
+                break
+            curr = res
+            self.blockchain.add_block_record(curr)
+            counter += 1
 
         # normally "fork_point" or "fork_height" refers to the first common
         # block between the main chain and the fork. Here "fork_point_height"
@@ -1247,7 +1259,6 @@ class FullNode:
     ) -> Tuple[bool, Optional[StateChangeSummary], Optional[Err]]:
         # Precondition: All blocks must be contiguous blocks, index i+1 must be the parent of index i
         # Returns a bool for success, as well as a StateChangeSummary if the peak was advanced
-
         block_dict: Dict[bytes32, FullBlock] = {}
         for block in all_blocks:
             block_dict[block.header_hash] = block
@@ -1255,7 +1266,10 @@ class FullNode:
         blocks_to_validate: List[FullBlock] = []
         for i, block in enumerate(all_blocks):
             header_hash = block.header_hash
-            if not await self.blockchain.contains_block_from_db(header_hash):
+            rec = await self.blockchain.get_block_record_from_db(header_hash)
+            if rec is not None:
+                self.blockchain.add_block_record(rec)
+            else:
                 blocks_to_validate = all_blocks[i:]
                 break
 
@@ -1285,6 +1299,8 @@ class FullNode:
         if len(blocks_to_validate) == 0:
             return True, None, None
 
+        self.log.info(f"inside add block batch {all_blocks[0].height} - {all_blocks[0].height}")
+
         # Validates signatures in multiprocessing since they take a while, and we don't have cached transactions
         # for these blocks (unlike during normal operation where we validate one at a time)
         pre_validate_start = time.monotonic()
@@ -1313,6 +1329,8 @@ class FullNode:
             # when adding blocks in batches, we won't have any overlapping
             # signatures with the mempool. There won't be any cache hits, so
             # there's no need to pass the BLS cache in
+            if block.height % 100 == 0:
+                self.log.info(f"inside add  block batch add block {block.height}")
             result, error, state_change_summary = await self.blockchain.add_block(
                 block, pre_validation_results[i], None, fork_info
             )

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1058,17 +1058,19 @@ class FullNode:
         )
         batch_size = self.constants.MAX_BLOCK_COUNT_PER_REQUESTS
         counter = 0
-        curr = self.blockchain.height_to_block_record(fork_point_height)
-        while (
-            curr.sub_epoch_summary_included is None
-            or counter < 3 * self.constants.MAX_SUB_SLOT_BLOCKS + self.constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK + 3
-        ):
-            res = await self.blockchain.get_block_record_from_db(curr.prev_hash)
-            if res is None:
-                break
-            curr = res
-            self.blockchain.add_block_record(curr)
-            counter += 1
+        if fork_point_height != 0:
+            # warmup the cache
+            curr = self.blockchain.height_to_block_record(fork_point_height)
+            while (
+                curr.sub_epoch_summary_included is None
+                or counter < 3 * self.constants.MAX_SUB_SLOT_BLOCKS + self.constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK + 3
+            ):
+                res = await self.blockchain.get_block_record_from_db(curr.prev_hash)
+                if res is None:
+                    break
+                curr = res
+                self.blockchain.add_block_record(curr)
+                counter += 1
 
         # normally "fork_point" or "fork_height" refers to the first common
         # block between the main chain and the fork. Here "fork_point_height"


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
only warmup the cache at the forkpoint

this pr pulls the cache warmup up to the sync_from_fork_point call and avoids calling the warmup on each batch

### Current Behavior:
we currently dont add blocks that we already know during reorg long sync that means we need to load these blocks each time from the db

### New Behavior:
add blocks that are already known so we dont have to warmup the cache each time, this is ok since we clean the cache up to BLOCKS_CACHE_SIZE after each batch

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:
since we use add_block in the tests for big reorg we need to manually warmup to the forkpoint before looping and adding each block
<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
