### PR TITLE
[CHIA-1211] Use better key resolution logic in derivation commands

### DIFF
--- a/chia/_tests/core/cmds/test_keys.py
+++ b/chia/_tests/core/cmds/test_keys.py
@@ -1342,7 +1342,7 @@ class TestKeysCommands:
             ],
         )
         assert result.exit_code == 0
-        assert result.output.find("Need a private key for non observer derivation of wallet addresses") != -1
+        assert result.output.find("Could not resolve private key for non-observer derivation") != -1
 
     def test_derive_wallet_testnet_address(self, tmp_path, keyring_with_one_public_one_private_key):
         """
@@ -1678,9 +1678,7 @@ class TestKeysCommands:
             ],
         )
 
-        assert isinstance(result.exception, ValueError) and result.exception.args == (
-            "Cannot perform non-observer derivation on an observer-only key",
-        )
+        assert result.output.find("Could not resolve private key for non-observer derivation") != -1
 
         result: Result = runner.invoke(
             cli,

--- a/chia/cmds/keys.py
+++ b/chia/cmds/keys.py
@@ -325,8 +325,8 @@ def search_cmd(
 
     # Specifying the master key is optional for the search command. If not specified, we'll search all keys.
     sk = None
-    if fingerprint is None and filename is not None:
-        sk = resolve_derivation_master_key(filename)
+    if (fingerprint is not None or filename is not None) and non_observer_derivation:
+        sk = resolve_derivation_master_key(filename if filename is not None else fingerprint)
 
     found: bool = search_derive(
         ctx.obj["root_path"],
@@ -376,8 +376,8 @@ def wallet_address_cmd(
     filename: Optional[str] = ctx.obj.get("filename", None)
 
     sk = None
-    if fingerprint is None and filename is not None:
-        sk = resolve_derivation_master_key(filename)
+    if non_observer_derivation:
+        sk = resolve_derivation_master_key(filename if filename is not None else fingerprint)
 
     derive_wallet_address(
         ctx.obj["root_path"], fingerprint, index, count, prefix, non_observer_derivation, show_hd_path, sk
@@ -447,8 +447,8 @@ def child_key_cmd(
     filename: Optional[str] = ctx.obj.get("filename", None)
 
     sk = None
-    if fingerprint is None and filename is not None:
-        sk = resolve_derivation_master_key(filename)
+    if non_observer_derivation:
+        sk = resolve_derivation_master_key(filename if filename is not None else fingerprint)
 
     derive_child_key(
         fingerprint,

--- a/chia/cmds/keys.py
+++ b/chia/cmds/keys.py
@@ -370,7 +370,7 @@ def search_cmd(
 def wallet_address_cmd(
     ctx: click.Context, index: int, count: int, prefix: Optional[str], non_observer_derivation: bool, show_hd_path: bool
 ) -> None:
-    from .keys_funcs import derive_wallet_address, resolve_derivation_master_key
+    from .keys_funcs import derive_wallet_address, prompt_for_fingerprint, resolve_derivation_master_key
 
     fingerprint: Optional[int] = ctx.obj.get("fingerprint", None)
     filename: Optional[str] = ctx.obj.get("filename", None)
@@ -378,6 +378,12 @@ def wallet_address_cmd(
     sk = None
     if non_observer_derivation:
         sk = resolve_derivation_master_key(filename if filename is not None else fingerprint)
+
+    if fingerprint is None and sk is None:
+        fingerprint = prompt_for_fingerprint()
+        if fingerprint is None:
+            print("A fingerprint of a root key to derive from is required")
+            return
 
     derive_wallet_address(
         ctx.obj["root_path"], fingerprint, index, count, prefix, non_observer_derivation, show_hd_path, sk
@@ -438,7 +444,7 @@ def child_key_cmd(
     show_private_keys: bool,
     show_hd_path: bool,
 ) -> None:
-    from .keys_funcs import derive_child_key, resolve_derivation_master_key
+    from .keys_funcs import derive_child_key, prompt_for_fingerprint, resolve_derivation_master_key
 
     if key_type is None and derive_from_hd_path is None:
         ctx.fail("--type or --derive-from-hd-path is required")
@@ -449,6 +455,12 @@ def child_key_cmd(
     sk = None
     if non_observer_derivation:
         sk = resolve_derivation_master_key(filename if filename is not None else fingerprint)
+
+    if fingerprint is None and sk is None:
+        fingerprint = prompt_for_fingerprint()
+        if fingerprint is None:
+            print("A fingerprint of a root key to derive from is required")
+            return
 
     derive_child_key(
         fingerprint,

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -797,16 +797,7 @@ def private_key_for_fingerprint(fingerprint: int) -> Optional[PrivateKey]:
     return None
 
 
-def get_private_key_with_fingerprint_or_prompt(fingerprint: Optional[int]) -> Optional[PrivateKey]:
-    """
-    Get a private key with the specified fingerprint. If fingerprint is not
-    specified, prompt the user to select a key.
-    """
-
-    # Return the private key matching the specified fingerprint
-    if fingerprint is not None:
-        return private_key_for_fingerprint(fingerprint)
-
+def prompt_for_fingerprint() -> Optional[int]:
     fingerprints: List[int] = [pk.get_fingerprint() for pk in Keychain().get_all_public_keys()]
     while True:
         print("Choose key:")
@@ -826,7 +817,21 @@ def get_private_key_with_fingerprint_or_prompt(fingerprint: Optional[int]) -> Op
                     val = None
                     continue
                 else:
-                    return private_key_for_fingerprint(fingerprints[index])
+                    return fingerprints[index]
+
+
+def get_private_key_with_fingerprint_or_prompt(fingerprint: Optional[int]) -> Optional[PrivateKey]:
+    """
+    Get a private key with the specified fingerprint. If fingerprint is not
+    specified, prompt the user to select a key.
+    """
+
+    # Return the private key matching the specified fingerprint
+    if fingerprint is not None:
+        return private_key_for_fingerprint(fingerprint)
+
+    fingerprint_prompt = prompt_for_fingerprint()
+    return None if fingerprint_prompt is None else private_key_for_fingerprint(fingerprint_prompt)
 
 
 def private_key_from_mnemonic_seed_file(filename: Path) -> PrivateKey:

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -648,10 +648,7 @@ def derive_wallet_address(
     """
     if fingerprint is not None:
         key_data: KeyData = Keychain().get_key(fingerprint, include_secrets=non_observer_derivation)
-        if non_observer_derivation and key_data.secrets is None:
-            print("Need a private key for non observer derivation of wallet addresses")
-            return
-        elif non_observer_derivation:
+        if non_observer_derivation:
             sk = key_data.private_key
         else:
             sk = None
@@ -718,9 +715,6 @@ def derive_child_key(
         assert private_key is not None
         current_pk = private_key.get_g1()
         current_sk = private_key
-
-    if non_observer_derivation and current_sk is None:
-        raise ValueError("Cannot perform non-observer derivation on an observer-only key")
 
     # Key type was specified
     if key_type is not None:


### PR DESCRIPTION
In #16903 I made a bad change to the behavior of key functions in which I removed the resolution of a root secret key when no mnemonic file was provided.  I wrongly assumed that the user would have to specify one of the two options but it's actually possible to not specify either.  This PR makes sure to always resolve a secret key whenever we intend to do non_observer_derivation.