### PR TITLE
update long-reorg tests along with the reorg test chains

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
         python-version: ["3.10"]
     env:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
-      BLOCKS_AND_PLOTS_VERSION: 0.38.0
+      BLOCKS_AND_PLOTS_VERSION: 0.40.0
 
     steps:
       - name: Clean workspace

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -133,7 +133,7 @@ jobs:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
       CHIA_SIMULATOR_ROOT: ${{ github.workspace }}/.chia/simulator
       JOB_FILE_NAME: tests_${{ matrix.os.file_name }}_python-${{ matrix.python.file_name }}_${{ matrix.configuration.module_import_path }}${{ matrix.configuration.file_name_index }}
-      BLOCKS_AND_PLOTS_VERSION: 0.38.0
+      BLOCKS_AND_PLOTS_VERSION: 0.40.0
 
     steps:
       - name: Configure git

--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -369,6 +369,26 @@ def test_long_reorg_blocks(bt, consensus_mode, default_10000_blocks):
     )
 
 
+@pytest.fixture(scope="session")
+def test_long_reorg_1500_blocks(bt, consensus_mode, default_10000_blocks):
+    version = ""
+    if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
+        version = "_hardfork"
+
+    from chia._tests.util.blockchain import persistent_blocks
+
+    return persistent_blocks(
+        4500,
+        f"test_blocks_long_reorg_{saved_blocks_version}{version}-2.db",
+        bt,
+        block_list_input=default_10000_blocks[:1500],
+        seed=b"reorg_blocks",
+        time_per_block=8,
+        dummy_block_references=True,
+        include_transactions=True,
+    )
+
+
 # this long reorg chain shares the first 500 blocks with "default_10000_blocks"
 # and has the same weight blocks
 @pytest.fixture(scope="session")
@@ -384,6 +404,25 @@ def test_long_reorg_blocks_light(bt, consensus_mode, default_10000_blocks):
         f"test_blocks_long_reorg_light_{saved_blocks_version}{version}.db",
         bt,
         block_list_input=default_10000_blocks[:500],
+        seed=b"reorg_blocks2",
+        dummy_block_references=True,
+        include_transactions=True,
+    )
+
+
+@pytest.fixture(scope="session")
+def test_long_reorg_1500_blocks_light(bt, consensus_mode, default_10000_blocks):
+    version = ""
+    if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
+        version = "_hardfork"
+
+    from chia._tests.util.blockchain import persistent_blocks
+
+    return persistent_blocks(
+        4500,
+        f"test_blocks_long_reorg_light_{saved_blocks_version}{version}-2.db",
+        bt,
+        block_list_input=default_10000_blocks[:1500],
         seed=b"reorg_blocks2",
         dummy_block_references=True,
         include_transactions=True,

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2256,21 +2256,21 @@ async def test_long_reorg(
     light_blocks: bool,
     one_node_one_block,
     default_10000_blocks: List[FullBlock],
-    test_long_reorg_blocks: List[FullBlock],
-    test_long_reorg_blocks_light: List[FullBlock],
+    test_long_reorg_1500_blocks: List[FullBlock],
+    test_long_reorg_1500_blocks_light: List[FullBlock],
     seeded_random: random.Random,
 ):
     node, server, bt = one_node_one_block
 
-    fork_point = 499
-    blocks = default_10000_blocks[:1600]
+    fork_point = 1499
+    blocks = default_10000_blocks[:3000]
 
     if light_blocks:
         # if the blocks have lighter weight, we need more height to compensate,
         # to force a reorg
-        reorg_blocks = test_long_reorg_blocks_light[:1650]
+        reorg_blocks = test_long_reorg_1500_blocks_light[:3050]
     else:
-        reorg_blocks = test_long_reorg_blocks[:1200]
+        reorg_blocks = test_long_reorg_1500_blocks[:2700]
 
     for block_batch in to_batches(blocks, 64):
         b = block_batch.entries[0]
@@ -2325,9 +2325,9 @@ async def test_long_reorg(
     # when using add_block manualy we must warmup the cache
     await node.full_node.blockchain.warmup(fork_point - 100)
     if light_blocks:
-        blocks = default_10000_blocks[fork_point - 100 : 1800]
+        blocks = default_10000_blocks[fork_point - 100 : 3200]
     else:
-        blocks = default_10000_blocks[fork_point - 100 : 2600]
+        blocks = default_10000_blocks[fork_point - 100 : 5500]
 
     fork_block = blocks[0]
     fork_info = ForkInfo(fork_block.height - 1, fork_block.height - 1, fork_block.prev_header_hash)
@@ -2346,25 +2346,43 @@ async def test_long_reorg(
 @pytest.mark.anyio
 @pytest.mark.parametrize("light_blocks", [True, False])
 @pytest.mark.parametrize("chain_length", [0, 100])
-@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
+@pytest.mark.parametrize("fork_point", [500, 1500])
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="save time")
 async def test_long_reorg_nodes(
     light_blocks: bool,
     chain_length: int,
+    fork_point: int,
     three_nodes,
     default_10000_blocks: List[FullBlock],
     test_long_reorg_blocks: List[FullBlock],
     test_long_reorg_blocks_light: List[FullBlock],
+    test_long_reorg_1500_blocks: List[FullBlock],
+    test_long_reorg_1500_blocks_light: List[FullBlock],
     self_hostname: str,
     seeded_random: random.Random,
 ):
     full_node_1, full_node_2, full_node_3 = three_nodes
 
-    blocks = default_10000_blocks[: 1600 - chain_length]
+    if fork_point == 1500:
+        blocks = default_10000_blocks[: 3600 - chain_length]
+    else:
+        blocks = default_10000_blocks[: 1600 - chain_length]
 
     if light_blocks:
-        reorg_blocks = test_long_reorg_blocks_light[: 1600 - chain_length]
+        if fork_point == 1500:
+            reorg_blocks = test_long_reorg_1500_blocks_light[: 3600 - chain_length]
+            reorg_height = 4000
+        else:
+            reorg_blocks = test_long_reorg_blocks_light[: 1600 - chain_length]
+            reorg_height = 4000
     else:
-        reorg_blocks = test_long_reorg_blocks[: 1200 - chain_length]
+        if fork_point == 1500:
+            reorg_blocks = test_long_reorg_1500_blocks[: 3100 - chain_length]
+            reorg_height = 10000
+        else:
+            reorg_blocks = test_long_reorg_blocks[: 1200 - chain_length]
+            reorg_height = 4000
+            pytest.skip("We rely on the light-blocks test for a 0 forkpoint")
 
     # full node 1 has the original chain
     for block_batch in to_batches(blocks, 64):
@@ -2414,7 +2432,11 @@ async def test_long_reorg_nodes(
     assert p1.header_hash == reorg_blocks[-1].header_hash
     assert p2.header_hash == reorg_blocks[-1].header_hash
 
-    blocks = default_10000_blocks[:4000]
+    blocks = default_10000_blocks[:reorg_height]
+
+    # this is a pre-requisite for a reorg to happen
+    assert blocks[-1].weight > p1.weight
+    assert blocks[-1].weight > p2.weight
 
     # full node 3 has the original chain, but even longer
     for block_batch in to_batches(blocks, 64):


### PR DESCRIPTION
### Purpose:

Increase test coverage by making the fork point be > 0

### Current Behavior:

The long reorg tests all reorg to height 0

### New Behavior:

Some long reorg tests reorg to height 0 and some to height 1500, thus exercising Almogs recent warm-up code.