### PR TITLE
Fix new pool url detection

### DIFF
--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -351,8 +351,13 @@ class Farmer:
                         response: Dict[str, Any] = json.loads(await resp.text())
                         self.log.info(f"GET /pool_info response: {response}")
                         new_pool_url: Optional[str] = None
-                        if resp.url != url and all(r.status in {301, 308} for r in resp.history):
-                            new_pool_url = f"{resp.url}".replace("/pool_info", "")
+                        response_url_str = f"{resp.url}"
+                        if (
+                            response_url_str != url
+                            and len(resp.history) > 0
+                            and all(r.status in {301, 308} for r in resp.history)
+                        ):
+                            new_pool_url = response_url_str.replace("/pool_info", "")
 
                         return GetPoolInfoResult(pool_info=response, new_pool_url=new_pool_url)
                     else:

--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -96,13 +96,13 @@ def update_pool_config_entry(
                     if update_closure(pool_config_dict):
                         updated = True
             except Exception as e:
-                log.error(f"Exception updating config: {pool_config_dict} {e}")
+                log.error(
+                    f"Exception updating pool config {pool_config_dict} for launcher_id {pool_wallet_config.launcher_id}: {e}"
+                )
     if updated:
         log.info(update_log_message)
         config["pool"]["pool_list"] = pool_list
         save_config(root_path, "config.yaml", config)
-    else:
-        log.error(f"Failed to update pool config entry for launcher_id {pool_wallet_config.launcher_id}")
 
 
 async def update_pool_config(root_path: Path, pool_config_list: List[PoolWalletConfig]) -> None:

--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -91,13 +91,14 @@ def update_pool_config_entry(
             return
         updated = False
         for pool_config_dict in pool_list:
+            launcher_id = pool_wallet_config.launcher_id
             try:
-                if hexstr_to_bytes(pool_config_dict["launcher_id"]) == bytes(pool_wallet_config.launcher_id):
+                if hexstr_to_bytes(pool_config_dict["launcher_id"]) == bytes(launcher_id):
                     if update_closure(pool_config_dict):
                         updated = True
             except Exception as e:
                 log.error(
-                    f"Exception updating pool config {pool_config_dict} for launcher_id {pool_wallet_config.launcher_id}: {e}"
+                    f"Exception updating pool config {pool_config_dict} for launcher_id {launcher_id}: {e}"
                 )
     if updated:
         log.info(update_log_message)

--- a/chia/pools/pool_config.py
+++ b/chia/pools/pool_config.py
@@ -97,9 +97,7 @@ def update_pool_config_entry(
                     if update_closure(pool_config_dict):
                         updated = True
             except Exception as e:
-                log.error(
-                    f"Exception updating pool config {pool_config_dict} for launcher_id {launcher_id}: {e}"
-                )
+                log.error(f"Exception updating pool config {pool_config_dict} for launcher_id {launcher_id}: {e}")
     if updated:
         log.info(update_log_message)
         config["pool"]["pool_list"] = pool_list


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/pull/17384 introduced a new feature which updates the pool url in the config file, if a change is detected. This however always triggered (bug), but only updated the config if the url actually differed.

With the addition of https://github.com/Chia-Network/chia-blockchain/pull/18341 an error log line was (incorrectly) added, which made this bug visible, as currently the only use of the function should always produce a config update (but that does not need to be the case).

This PR fixes the bug and removes the incorrect error log line, any errors in the closure are caught by the try/except block. If we want to log whether the config entry was found we need another variable to keep track of that, as `updated` is not suitable for that.