### PR TITLE
Update timelord_launcher.py - Fix buffered stdout/stderr from VDF Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ activate
 # Editors
 .vscode
 .idea
+.vs
 
 # Packaging
 chia-blockchain.tar.gz


### PR DESCRIPTION
This change reads stdout and stderr from the VDF Client process in real-time and writes it to the log. The previous method using proc.communicate() was buffering this output until the process ended before writing it - resulting in malformed lines and preventing users from monitoring timelord activity in real-time via the log. Before/After log samples below.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

Allow for better monitoring of timelords via the debug.log file and make the log output easier to import into parsing tools.

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:
Old Log output:
2024-08-22T16:57:57.853 TLauncher chia.timelord.timelord_launcher: INFO VDF client 2: VDF Client: Discriminant = -0xd6c8fe7aa65d1fbbbafd01204d0ddf2260e56684cc4128162d82a407b882f7333c5ba3bc1cb2a6f02262b5b100539d894c297288f01754fe1f770b58272bbd3b70ce101188543cc660aa08bba5fec34c529a993b4aadb5f46fb329cf97e3137ea384fef02488a5849674c090fd253ef012905b2097c310428960c4e66f5f12d7
Got simple weso proof: 02000e8e091430df853132c5d69da2348903970c83bd1f970ee850857b1dcf73357f33dc95ab53985ebf208f9f856ecd98a8f504e393317c73d02fbd674cb3f4031525918b1006882728d2de0c421c3e4e033e25dfdc4ff6341412d074df7b223930010003007cdc93bbb9d241708e33a050522b03952e9d8371dc35bdaeeda0f14760770096e36df41e6182b45e7ed42e03573cc9395e514a74abc0a97fb0fb8942e8e7f345a1ec8578bba52bc9f7069c9361d909a7fab696ca7af66171db4018bf553a5a0b0100
VDF Client: Sending proof
VDF Client: Sent proof
VDF loop finished. Total iters: 102650976
VDF Client: Stopped everything! Ready for the next challenge.
2024-08-22T16:59:03.863 TLauncher chia.timelord.timelord_launcher: INFO VDF client 0: VDF Client: Discriminant = -0xd6c8fe7aa65d1fbbbafd01204d0ddf2260e56684cc4128162d82a407b882f7333c5ba3bc1cb2a6f02262b5b100539d894c297288f01754fe1f770b58272bbd3b70ce101188543cc660aa08bba5fec34c529a993b4aadb5f46fb329cf97e3137ea384fef02488a5849674c090fd253ef012905b2097c310428960c4e66f5f12d7
Got simple weso proof: 01009c8ff8ab81fa7fbc2501cc4a1914023461bffc6a2de130cef9bc1a3d1e6ae41138137769107e2bbba836a197d483dd7838633114ec8ffe019bd7eed4dc423b77653d31ee1b2fc67a977cc97f3e3d4c3d4afd917411005eebe73f9f2dfdd25e1f01000100e10c62a51679b9a4fb5d8d22f4b46fa6bef65ba6a75bf9feec091ef169103aa848eb7af9236e72b162b867ffc68aaa79b5372ac094b3ddfa84540367ea8d4b550f05eb2c11fe6144f45f5d9d2e0033e8d522a122c3e30806c73913a924f3c3070100
VDF Client: Sending proof
VDF Client: Sent proof
VDF loop finished. Total iters: 111796803
VDF Client: Stopped everything! Ready for the next challenge.

### New Behavior:

New Log Output:

2024-08-24T05:17:04.432 TLauncher chia.timelord.timelord_launcher: INFO VDF client 0: Got simple weso proof: 0100a262d41e0e6548645fdb3fed02d2467752235ee9be84065185429764f561ce4bd93bafa4d2fee2e5bf09f974e8a315bcc959d0ccd515d509b3d2955ccd77e300a5b5eba6f1bbd9f5f2121189fe9974b719c32ad713f3a2d3566e5bf856971600181302007ee2792129e292f0116b008febcade7d445d7e78a7eb74f53ad2d5c455d6b740ea4ad5e6359f4eaef86e64203acfc1636c8d8fbcfa60aeb2419c2cfd302f5e42b90b5034c773b16bf4503f070b7ff3ca57e3747d9e996ff83e3169dee688882c0100
2024-08-24T05:17:04.533 TLauncher chia.timelord.timelord_launcher: INFO VDF client 0: VDF Client: Sending proof
2024-08-24T05:17:04.633 TLauncher chia.timelord.timelord_launcher: INFO VDF client 0: VDF Client: Sent proof
2024-08-24T05:17:04.734 TLauncher chia.timelord.timelord_launcher: INFO VDF client 0: VDF loop finished. Total iters: 49473707
2024-08-24T05:17:04.835 TLauncher chia.timelord.timelord_launcher: INFO VDF client 0: VDF Client: Stopped everything! Ready for the next challenge.
2024-08-24T05:17:04.986 TLauncher chia.timelord.timelord_launcher: INFO VDF client 0: VDF Client: Discriminant = -0x95bafb45e4694594b57e5673d5a9663aa73e59289f8d6fbf0fc52af6cd09b96430fe79cb020959757f4fb2b2fc389ac3fda2f7e5a93a6a7f3b88e68cf8f078385ff6920d5fff7420e819e679faf79c54894551ff0ab6372c9be8c76a45f1b0c91cc4149b1bd86902127be818fb620ed694e280bd868111e80ea83e612b975617
2024-08-24T05:18:09.563 TLauncher chia.timelord.timelord_launcher: INFO VDF client 1: Got simple weso proof: 00007e2e97f4b20590e71b7935ac271ebc86c1ecad6d12e7392489ec8c4dce6f2edee97998bb7e7ad8dce0dfcba7d329e5e9952c0326e94bcd178fdbc9c8efd2a22fdf92aafdc8e7ab0fac4d0c1a2adf844047cdddd29faf1fab893430e8fb935433010001001c757a8ee6113c9ea57d7873c8f779371ef898e9846d0b168394bf15f46d991c604137f651892a4d937f678ee2ab2c9ff1612ad6d61990114ef8460bd0e8400fa15c9a953214f70ff399e9a85cbea97bfa4df3a5429a4e8d577ba11a4c5b74060400
2024-08-24T05:18:09.664 TLauncher chia.timelord.timelord_launcher: INFO VDF client 1: VDF Client: Sending proof
2024-08-24T05:18:09.764 TLauncher chia.timelord.timelord_launcher: INFO VDF client 1: VDF Client: Sent proof
2024-08-24T05:18:09.865 TLauncher chia.timelord.timelord_launcher: INFO VDF client 1: VDF loop finished. Total iters: 58846227
2024-08-24T05:18:09.966 TLauncher chia.timelord.timelord_launcher: INFO VDF client 1: VDF Client: Stopped everything! Ready for the next challenge.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
