### PR TITLE
add test targets just for pre-generating the test chains

### DIFF
--- a/chia/_tests/blockchain/test_build_chains.py
+++ b/chia/_tests/blockchain/test_build_chains.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from chia.types.full_block import FullBlock
+
+# These test targets are used to trigger a build of the test chains.
+# On CI we clone the test-cache repository to load the chains from, so they
+# don't need to be re-generated.
+
+# When running tests in parallel (with pytest-xdist) it's faster to first
+# generate all the chains, so the same chains aren't being created in parallel.
+
+# The cached test chains are stored in ~/.chia/blocks
+
+# To generate the chains, run:
+
+# pytest -m build_test_chains
+
+
+@pytest.mark.build_test_chains
+def test_trigger_default_400(default_400_blocks: List[FullBlock]) -> None:
+    pass
+
+
+@pytest.mark.build_test_chains
+def test_trigger_default_1000(default_1000_blocks: List[FullBlock]) -> None:
+    pass
+
+
+@pytest.mark.build_test_chains
+def test_trigger_pre_genesis_empty_1000(pre_genesis_empty_slots_1000_blocks: List[FullBlock]) -> None:
+    pass
+
+
+@pytest.mark.build_test_chains
+def test_trigger_default_1500(default_1500_blocks: List[FullBlock]) -> None:
+    pass
+
+
+@pytest.mark.build_test_chains
+def test_trigger_default_10000(
+    default_10000_blocks: List[FullBlock],
+    test_long_reorg_blocks: List[FullBlock],
+    test_long_reorg_blocks_light: List[FullBlock],
+    test_long_reorg_1500_blocks: List[FullBlock],
+    test_long_reorg_1500_blocks_light: List[FullBlock],
+) -> None:
+    pass
+
+
+@pytest.mark.build_test_chains
+def test_trigger_default_2000_compact(default_2000_blocks_compact: List[FullBlock]) -> None:
+    pass
+
+
+@pytest.mark.build_test_chains
+def test_trigger_default_10000_compact(default_10000_blocks_compact: List[FullBlock]) -> None:
+    pass

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ log_level = WARNING
 console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
 markers =
+    build_test_chains
     limit_consensus_modes
     standard_block_tools
     data_layer: Mark as a data layer related test.


### PR DESCRIPTION
### Purpose:

Make it easier to work with our test chains (cached in the `test-cache` repo).
Specifically, when running tests in parallel (with `pytest-xdist`) these fixtures are instantiated in parallel, in different processes. This means we are likely to generate the chains multiple times concurrently. This adds dummy test targets with the sole purpose of triggering each fixture once. So you can still generate all test chains concurrently.

~~I also added a tool to compare two test blockchains to aid investigations into discrepancies.~~

### Current Behavior:

running `pytest` with multiple processes on a clean install (not using the `test-cache` repo) will generate the test chains multiple times, redundantly.

### New Behavior:

The test chains can be generated as a separate step, before running the tests, by running:

```
pytest -m build_test_chains
```