### PR TITLE
validate cached blockchains

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
         python-version: ["3.10"]
     env:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
-      BLOCKS_AND_PLOTS_VERSION: 0.40.0
+      BLOCKS_AND_PLOTS_VERSION: 0.41.0
 
     steps:
       - name: Clean workspace

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -126,7 +126,7 @@ jobs:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
       CHIA_SIMULATOR_ROOT: ${{ github.workspace }}/.chia/simulator
       JOB_FILE_NAME: tests_${{ matrix.os.file_name }}_python-${{ matrix.python.file_name }}_${{ matrix.configuration.module_import_path }}${{ matrix.configuration.file_name_index }}
-      BLOCKS_AND_PLOTS_VERSION: 0.40.0
+      BLOCKS_AND_PLOTS_VERSION: 0.41.0
 
     steps:
       - name: Configure git

--- a/chia/_tests/util/blockchain.py
+++ b/chia/_tests/util/blockchain.py
@@ -95,7 +95,7 @@ def persistent_blocks(
                 # intentional, please also update the test chain cache.
                 # run: pytest -m build_test_chains
                 for i in range(5):
-                    if blocks[i] != expected_blocks[i]:
+                    if blocks[i] != expected_blocks[i]:  # pragma: no cover
                         print(
                             f"Block {i} in the block cache on disk differs "
                             "from what BlockTools generated. Please make sure "

--- a/chia/_tests/util/blockchain.py
+++ b/chia/_tests/util/blockchain.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Optional
 
 from chia_rs import ConsensusConstants
+from chia_rs.sized_ints import uint64
 
 from chia.consensus.blockchain import Blockchain
 from chia.full_node.block_store import BlockStore
@@ -73,6 +74,37 @@ def persistent_blocks(
                 blocks.append(FullBlock.from_bytes_unchecked(block_bytes))
             if len(blocks) == num_of_blocks + len(block_list_input):
                 print(f"\n loaded {file_path} with {len(blocks)} blocks")
+
+                # make sure that the blocks we found on-disk are consistent with
+                # the ones we would have generated
+                expected_blocks: list[FullBlock] = bt.get_consecutive_blocks(
+                    5,
+                    block_list_input=block_list_input,
+                    time_per_block=time_per_block,
+                    seed=seed,
+                    skip_slots=empty_sub_slots,
+                    normalized_to_identity_cc_eos=normalized_to_identity_cc_eos,
+                    normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
+                    normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
+                    normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
+                    dummy_block_references=dummy_block_references,
+                    include_transactions=include_transactions,
+                    genesis_timestamp=uint64(1234567890),
+                )
+                # if this assert fails, and changing the test chains was
+                # intentional, please also update the test chain cache.
+                # run: pytest -m build_test_chains
+                for i in range(5):
+                    if blocks[i] != expected_blocks[i]:
+                        print(
+                            f"Block {i} in the block cache on disk differs "
+                            "from what BlockTools generated. Please make sure "
+                            "your test blocks are up-to-date"
+                        )
+                        print(f"disk:\n{blocks[i]}")
+                        print(f"block-tools:\n{expected_blocks[i]}")
+                    assert blocks[i] == expected_blocks[i]
+
                 return blocks
         except EOFError:
             print("\n error reading db file")
@@ -126,6 +158,7 @@ def new_test_db(
         normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
         dummy_block_references=dummy_block_references,
         include_transactions=include_transactions,
+        genesis_timestamp=uint64(1234567890),
     )
     block_bytes_list: list[bytes] = []
     for block in blocks:


### PR DESCRIPTION
### Purpose:

Prevent `BlockTools` to drift away from the chains stored in `test-cache` (i.e. ensure changes to `BlockTools` are caught by CI so we can update the cache)

When loading the cached test blockchains, check that the first few blocks match what we would have generated if it wasn't cached. This should make CI highlight whenever BlockTools changes some way of how chains are generated that alters the chain output. When this happens, we should also update the test-cache repo.

The test chains in `test-cache` have diverged from what's generated by `BlockTools` today. Probably at least in https://github.com/Chia-Network/chia-blockchain/pull/18209

### Current Behavior:

If we find cached blockchains, we use them and assume they are right.

### New Behavior:

If we find cached blockchains, we check the first 5 blocks to ensure they match what we would have generated, then use them.