### PR TITLE
[CHIA-1164] Port `test_nft_wallet.py` to `WalletTestFramework`

### DIFF
--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List
 
 import pytest
 from chia_rs import AugSchemeMPL, G1Element, G2Element
@@ -10,10 +10,9 @@ from clvm_tools.binutils import disassemble
 
 from chia._tests.conftest import ConsensusMode
 from chia._tests.environments.wallet import WalletStateTransition, WalletTestFramework
-from chia._tests.util.time_out_assert import time_out_assert, time_out_assert_not_none
+from chia._tests.util.time_out_assert import time_out_assert
 from chia.rpc.rpc_client import ResponseFailureError
-from chia.simulator.full_node_simulator import FullNodeSimulator
-from chia.simulator.simulator_protocol import FarmNewBlockProtocol, ReorgProtocol
+from chia.simulator.simulator_protocol import ReorgProtocol
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX
@@ -27,7 +26,6 @@ from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.wallet_types import WalletType
-from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 from chia.wallet.wallet_state_manager import WalletStateManager
 
@@ -67,19 +65,6 @@ async def wait_rpc_state_condition(
             )
 
         await asyncio.sleep(0.3)
-
-
-async def make_new_block_with(
-    resp: Dict[str, Any], full_node_api: FullNodeSimulator, ph: bytes32, node_to_sync: Optional[WalletNode] = None
-) -> WalletSpendBundle:
-    assert resp.get("success")
-    sb = resp["spend_bundle"]
-    assert isinstance(sb, WalletSpendBundle)
-    await time_out_assert_not_none(30, full_node_api.full_node.mempool_manager.get_spendbundle, sb.name())
-    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-    if node_to_sync is not None:
-        await full_node_api.wait_for_wallet_synced(wallet_node=node_to_sync, timeout=30)
-    return sb
 
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="irrelevant")

--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1349,9 +1349,9 @@ async def test_nft_transfer_nft_with_did(wallet_environments: WalletTestFramewor
 
     res = await env_1.rpc_client.fetch("nft_get_by_did", {"did_id": hmr_did_id})
     assert res.get("success")
-    assert env_1.wallet_aliases["nft"] == res["wallet_id"]
+    assert env_1.wallet_aliases["nft_w_did"] == res["wallet_id"]
     # Check NFT DID is set now
-    coins = (await env_1.rpc_client.list_nfts(env_1.wallet_aliases["nft"], start_index=0, num=1))["nft_list"]
+    coins = (await env_1.rpc_client.list_nfts(env_1.wallet_aliases["nft_w_did"], start_index=0, num=1))["nft_list"]
     assert len(coins) == 1
     coin = NFTInfo.from_json_dict(coins[0])
     assert coin.owner_did is not None

--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -618,7 +618,7 @@ async def test_nft_wallet_rpc_creation_and_list(wallet_environments: WalletTestF
     assert resp["count"] == 2
     resp = await wait_rpc_state_condition(10, env.rpc_client.fetch, ["nft_count_nfts", {}], lambda x: x["success"])
     assert resp["count"] == 2
-    with pytest.raises(ResponseFailureError, match="not found"):
+    with pytest.raises(ResponseFailureError, match="Wallet 50 not found."):
         resp = await wait_rpc_state_condition(
             10, env.rpc_client.fetch, ["nft_count_nfts", {"wallet_id": 50}], lambda x: x["success"] is False
         )

--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -720,7 +720,6 @@ async def test_nft_wallet_rpc_update_metadata(wallet_environments: WalletTestFra
                     "nft": {"pending_coin_removal_count": -1},
                 },
             ),
-            WalletStateTransition(),
         ]
     )
 
@@ -759,7 +758,6 @@ async def test_nft_wallet_rpc_update_metadata(wallet_environments: WalletTestFra
                     "nft": {"pending_coin_removal_count": -1},
                 },
             ),
-            WalletStateTransition(),
         ]
     )
 
@@ -1386,7 +1384,6 @@ async def test_update_metadata_for_nft_did(wallet_environments: WalletTestFramew
                     "did": {"set_remainder": True},
                 },
             ),
-            WalletStateTransition(),
         ]
     )
 
@@ -1409,7 +1406,6 @@ async def test_update_metadata_for_nft_did(wallet_environments: WalletTestFramew
                 },
                 post_block_balance_updates={},
             ),
-            WalletStateTransition(),
         ]
     )
 
@@ -1462,7 +1458,6 @@ async def test_update_metadata_for_nft_did(wallet_environments: WalletTestFramew
                     "nft": {"pending_coin_removal_count": -1, "unspent_coin_count": 1},
                 },
             ),
-            WalletStateTransition(),
         ]
     )
 
@@ -1515,7 +1510,6 @@ async def test_update_metadata_for_nft_did(wallet_environments: WalletTestFramew
                     "nft": {"pending_coin_removal_count": -1},
                 },
             ),
-            WalletStateTransition(),
         ]
     )
 
@@ -1563,7 +1557,6 @@ async def test_nft_bulk_set_did(wallet_environments: WalletTestFramework) -> Non
                     "did": {"set_remainder": True},
                 },
             ),
-            WalletStateTransition(),
         ]
     )
 
@@ -1589,7 +1582,6 @@ async def test_nft_bulk_set_did(wallet_environments: WalletTestFramework) -> Non
                 },
                 post_block_balance_updates={},
             ),
-            WalletStateTransition(),
         ]
     )
 

--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1791,7 +1791,7 @@ async def test_nft_bulk_set_did(wallet_environments: WalletTestFramework) -> Non
     assert len(coins) == 3
     nft1 = NFTInfo.from_json_dict(coins[0])
     nft12 = NFTInfo.from_json_dict(coins[1])
-    nft13 = NFTInfo.from_json_dict(coins[1])
+    nft13 = NFTInfo.from_json_dict(coins[2])
     nft_wallet_to_check = env.wallet_state_manager.wallets[uint32(env.wallet_aliases["nft_w_did"])]
     assert isinstance(nft_wallet_to_check, NFTWallet)
     assert await nft_wallet_to_check.get_nft_count() == 3

--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1522,7 +1522,7 @@ async def test_update_metadata_for_nft_did(wallet_environments: WalletTestFramew
     uris = coins[0]["data_uris"]
     assert len(uris) == 1
     assert "https://www.chia.net/img/branding/chia-logo.svg" in uris
-    assert len(coins[0]["metadata_uris"]) == 1
+    assert len(coins[0]["metadata_uris"]) == 2
     assert "http://metadata" == coins[0]["metadata_uris"][0]
     assert len(coins[0]["license_uris"]) == 0
 

--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -26,7 +26,6 @@ from chia.wallet.nft_wallet.nft_info import NFTInfo
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.compute_memos import compute_memos
-from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
@@ -110,7 +109,9 @@ async def test_nft_wallet_creation_automatically(wallet_environments: WalletTest
         [("u", ["https://www.chia.net/img/branding/chia-logo.svg"]), ("h", "0xD4584AD463139FA8C0D9F68F4B59F185")]
     )
 
-    async with nft_wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with nft_wallet_0.wallet_state_manager.new_action_scope(
+        wallet_environments.tx_config, push=True
+    ) as action_scope:
         await nft_wallet_0.generate_new_nft(metadata, action_scope)
 
     await wallet_environments.process_pending_states(
@@ -161,10 +162,12 @@ async def test_nft_wallet_creation_automatically(wallet_environments: WalletTest
     coins = await nft_wallet_0.get_current_nfts()
     assert len(coins) == 1, "nft not generated"
 
-    async with nft_wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with nft_wallet_0.wallet_state_manager.new_action_scope(
+        wallet_environments.tx_config, push=True
+    ) as action_scope:
         await nft_wallet_0.generate_signed_transaction(
             [uint64(coins[0].coin.amount)],
-            [await wallet_1.get_puzzle_hash(new=not wallet_environments.tx_config.reuse_puzhash)],
+            [await wallet_1.get_puzzle_hash(new=False)],
             action_scope,
             coins={coins[0].coin},
         )
@@ -244,7 +247,9 @@ async def test_nft_wallet_creation_and_transfer(wallet_environments: WalletTestF
     metadata = Program.to(
         [("u", ["https://www.chia.net/img/branding/chia-logo.svg"]), ("h", "0xD4584AD463139FA8C0D9F68F4B59F185")]
     )
-    async with nft_wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with nft_wallet_0.wallet_state_manager.new_action_scope(
+        wallet_environments.tx_config, push=True
+    ) as action_scope:
         await nft_wallet_0.generate_new_nft(metadata, action_scope)
     for tx in action_scope.side_effects.transactions:
         if tx.spend_bundle is not None:
@@ -324,7 +329,9 @@ async def test_nft_wallet_creation_and_transfer(wallet_environments: WalletTestF
 
     new_metadata = Program.to([("u", ["https://www.test.net/logo.svg"]), ("h", "0xD4584AD463139FA8C0D9F68F4B59F181")])
 
-    async with nft_wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with nft_wallet_0.wallet_state_manager.new_action_scope(
+        wallet_environments.tx_config, push=True
+    ) as action_scope:
         await nft_wallet_0.generate_new_nft(new_metadata, action_scope)
     for tx in action_scope.side_effects.transactions:
         if tx.spend_bundle is not None:
@@ -375,7 +382,9 @@ async def test_nft_wallet_creation_and_transfer(wallet_environments: WalletTestF
     nft_wallet_1 = await NFTWallet.create_new_nft_wallet(
         wallet_node_1.wallet_state_manager, wallet_1, name="NFT WALLET 2"
     )
-    async with nft_wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with nft_wallet_0.wallet_state_manager.new_action_scope(
+        wallet_environments.tx_config, push=True
+    ) as action_scope:
         await nft_wallet_0.generate_signed_transaction(
             [uint64(coins[1].coin.amount)],
             [await wallet_1.get_puzzle_hash(False)],
@@ -430,7 +439,9 @@ async def test_nft_wallet_creation_and_transfer(wallet_environments: WalletTestF
     assert len(coins) == 1
 
     # Send it back to original owner
-    async with nft_wallet_1.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with nft_wallet_1.wallet_state_manager.new_action_scope(
+        wallet_environments.tx_config, push=True
+    ) as action_scope:
         await nft_wallet_1.generate_signed_transaction(
             [uint64(coins[0].coin.amount)],
             [await wallet_0.get_puzzle_hash(False)],
@@ -1536,7 +1547,7 @@ async def test_nft_bulk_set_did(wallet_environments: WalletTestFramework) -> Non
         "nft_no_did": 4,
     }
 
-    async with env.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with env.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         did_wallet = await DIDWallet.create_new_did_wallet(env.wallet_state_manager, wallet, uint64(1), action_scope)
 
     # use "set_remainder" here because this is more of a DID test issue

--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -2084,7 +2084,7 @@ async def test_nft_bulk_transfer(wallet_environments: WalletTestFramework) -> No
     assert len(coins) == 3
     nft0 = NFTInfo.from_json_dict(coins[0])
     nft02 = NFTInfo.from_json_dict(coins[1])
-    nft03 = NFTInfo.from_json_dict(coins[1])
+    nft03 = NFTInfo.from_json_dict(coins[2])
     nft_set = {nft1.launcher_id, nft12.launcher_id, nft2.launcher_id}
     assert nft0.launcher_id in nft_set
     assert nft02.launcher_id in nft_set

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -1057,21 +1057,19 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("nft_get_nfts", request)
         return response
 
-    # TODO: add a test for this
     async def set_nft_did(
         self,
         wallet_id: int,
-        did_id: str,
+        did_id: Optional[str],
         nft_coin_id: str,
         fee: int,
         tx_config: TXConfig,
         extra_conditions: Tuple[Condition, ...] = tuple(),
         timelock_info: ConditionValidTimes = ConditionValidTimes(),
         push: bool = True,
-    ) -> NFTSetNFTDIDResponse:  # pragma: no cover
+    ) -> NFTSetNFTDIDResponse:
         request = {
             "wallet_id": wallet_id,
-            "did_id": did_id,
             "nft_coin_id": nft_coin_id,
             "fee": fee,
             "extra_conditions": conditions_to_json_dicts(extra_conditions),
@@ -1079,6 +1077,8 @@ class WalletRpcClient(RpcClient):
             **tx_config.to_json_dict(),
             **timelock_info.to_json_dict(),
         }
+        if did_id is not None:
+            request["did_id"] = did_id
         response = await self.fetch("nft_set_nft_did", request)
         return json_deserialize_with_clvm_streamable(response, NFTSetNFTDIDResponse)
 

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -976,7 +976,6 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("nft_mint_nft", request)
         return json_deserialize_with_clvm_streamable(response, NFTMintNFTResponse)
 
-    # TODO: add a test for this
     async def add_uri_to_nft(
         self,
         wallet_id: int,
@@ -988,7 +987,7 @@ class WalletRpcClient(RpcClient):
         extra_conditions: Tuple[Condition, ...] = tuple(),
         timelock_info: ConditionValidTimes = ConditionValidTimes(),
         push: bool = True,
-    ) -> NFTAddURIResponse:  # pragma: no cover
+    ) -> NFTAddURIResponse:
         request = {
             "wallet_id": wallet_id,
             "nft_coin_id": nft_coin_id,

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -1317,8 +1317,12 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("sign_message_by_address", {"address": address, "message": message})
         return response["pubkey"], response["signature"], response["signing_mode"]
 
-    async def sign_message_by_id(self, id: str, message: str) -> Tuple[str, str, str]:
-        response = await self.fetch("sign_message_by_id", {"id": id, "message": message})
+    async def sign_message_by_id(
+        self, id: str, message: str, is_hex: bool = False, safe_mode: bool = True
+    ) -> Tuple[str, str, str]:
+        response = await self.fetch(
+            "sign_message_by_id", {"id": id, "message": message, "is_hex": is_hex, "safe_mode": safe_mode}
+        )
         return response["pubkey"], response["signature"], response["signing_mode"]
 
     # DAOs

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -459,8 +459,8 @@ class DIDWallet:
         # full_puz = did_wallet_puzzles.create_fullpuz(innerpuz, origin.name())
         # All additions in this block here:
 
-        new_pubkey = (await self.wallet_state_manager.get_unused_derivation_record(self.wallet_info.id)).pubkey
-        new_puzhash = puzzle_for_pk(new_pubkey).get_tree_hash()
+        new_puzhash = await self.wallet_state_manager.main_wallet.get_puzzle_hash(new=False)
+        new_pubkey = await self.wallet_state_manager.get_public_key(new_puzhash)
         parent_info = None
         assert did_info.origin_coin is not None
         assert did_info.current_inner is not None

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1365,6 +1365,10 @@ class WalletStateManager:
                 and len(launcher_parent) == 1
                 and launcher_parent[0].spent_height is not None
             )
+            if self.constants.GENESIS_CHALLENGE[:16] in bytes(
+                launcher_parent[0].coin.parent_coin_info
+            ) or self.constants.GENESIS_CHALLENGE[16:] in bytes(launcher_parent[0].coin.parent_coin_info):
+                return None
             did_coin: List[CoinState] = await self.wallet_node.get_coin_state(
                 [launcher_parent[0].coin.parent_coin_info], peer=peer
             )

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1365,6 +1365,7 @@ class WalletStateManager:
                 and len(launcher_parent) == 1
                 and launcher_parent[0].spent_height is not None
             )
+            # NFTs minted out of coinbase coins would not have minter DIDs
             if self.constants.GENESIS_CHALLENGE[:16] in bytes(
                 launcher_parent[0].coin.parent_coin_info
             ) or self.constants.GENESIS_CHALLENGE[16:] in bytes(launcher_parent[0].coin.parent_coin_info):


### PR DESCRIPTION
This ports the existing NFT tests to the current most paradigmatic framework.  The following issues were found as a result of the new framework:
- Small puzzle hash bleed in DID wallet
- Line ~1528 `assert len(coins[0]["metadata_uris"]) == 2` used to be `==1` which was a bad check (upheld by another error of forgetting to farm a block)
- Some missing parameters for existing RPC client endpoints
- Bad assumption that NFTs were never minted out of coinbase coins

I also imagine this will result in a non-trivial speedup since most tests were spinning up two environments for no reason and the consensus mode parametrizations have been restricted so we've gone from about 230ish to 49 test runs