### PR TITLE
CHIA-1248 Adapt to fixing get_conditions_from_spendbundle's return value to include the cost of the whole spend

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -935,8 +935,8 @@ class TestFullNodeProtocol:
         # these numbers reflect the capacity of the mempool. In these
         # tests MEMPOOL_BLOCK_BUFFER is 1. The other factors are COST_PER_BYTE
         # and MAX_BLOCK_COST_CLVM
-        assert included_tx == 27
-        assert not_included_tx == 6
+        assert included_tx == 23
+        assert not_included_tx == 10
         assert seen_bigger_transaction_has_high_fee
 
         # Mempool is full

--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -268,6 +268,7 @@ class SpendSim:
                     get_unspent_lineage_info_for_puzzle_hash=self.coin_store.get_unspent_lineage_info_for_puzzle_hash,
                     item_inclusion_filter=item_inclusion_filter,
                 )
+
                 if result is not None:
                     bundle, additions = result
                     generator_bundle = bundle

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -302,9 +302,7 @@ class MempoolManager:
         if ret.error is not None:
             raise ValidationError(Err(ret.error), "pre_validate_spendbundle failed")
         assert ret.conds is not None
-        # TODO: this cost padding is temporary, until we update the mempool's
-        # block creation logic to take the block overhead into account
-        return ret.conds.replace(cost=ret.conds.cost + 10000000)
+        return ret.conds
 
     async def add_spend_bundle(
         self,


### PR DESCRIPTION
### Purpose:

This adapts this effort to https://github.com/Chia-Network/chia_rs/pull/680 which fixes the fundamental issue that caused us to alter some test values.

### Current Behavior:

We needed to alter some test values to get some tests to pass beyond a slight decrease in costs.

### New Behavior:

The code works as it should and we only need to account for the slight cost decrease when needed.