### PR TITLE
[CHIA-1218] Raise on too much decimal precision in CLI

### DIFF
--- a/chia/_tests/cmds/test_click_types.py
+++ b/chia/_tests/cmds/test_click_types.py
@@ -110,6 +110,8 @@ def test_click_amount_type() -> None:
         CliAmount(mojos=False, amount=uint64(100000)).convert_amount(units["chia"])
     with pytest.raises(ValueError):  # overflow
         large_decimal_amount.convert_amount(units["chia"])
+    with pytest.raises(ValueError, match="Too much decimal precision"):
+        CliAmount(mojos=False, amount=Decimal("1.01")).convert_amount(10)
 
 
 def test_click_address_type() -> None:

--- a/chia/_tests/cmds/wallet/test_vcs.py
+++ b/chia/_tests/cmds/wallet/test_vcs.py
@@ -299,7 +299,7 @@ def test_vcs_approve_r_cats(capsys: object, get_test_cli_clients: Tuple[TestRpcC
         "-a1",
         "-m0.5",
         "--min-coin-amount",
-        "0.000000001",
+        "0.001",
         "--max-coin-amount",
         "10",
         "--reuse",
@@ -313,7 +313,7 @@ def test_vcs_approve_r_cats(capsys: object, get_test_cli_clients: Tuple[TestRpcC
                 wallet_id,
                 uint64(1000),
                 TXConfig(
-                    min_coin_amount=uint64(0),
+                    min_coin_amount=uint64(1),
                     max_coin_amount=uint64(10000),
                     excluded_coin_amounts=[],
                     excluded_coin_ids=[],

--- a/chia/cmds/param_types.py
+++ b/chia/cmds/param_types.py
@@ -104,7 +104,14 @@ class CliAmount:
             return self.amount
         if not isinstance(self.amount, Decimal):
             raise ValueError("Amount must be a Decimal if mojos flag is not set.")
-        return uint64(self.amount * mojo_per_unit)
+        converted_amount = self.amount * mojo_per_unit
+        uint64_amount = uint64(converted_amount)
+        if uint64_amount != converted_amount:
+            raise ValueError(
+                "Too much decimal precision specified."
+                "Please use the units of the balance numbers from `chia wallet show`"
+            )
+        return uint64_amount
 
 
 class AmountParamType(click.ParamType):


### PR DESCRIPTION
Previously this would round:
```
uint64(0.00001) == uint64(0)
```
which led to users unexpectedly specifying zero as an amount when they were in fact making a mistake specifying the wrong units.  This PR changes that case to be an error so that unexpected inputs don't result in unintentional actions.