### PR TITLE
[CHIA-1234] Add bech32m options to some key functions

### DIFF
--- a/chia/_tests/core/cmds/test_keys.py
+++ b/chia/_tests/core/cmds/test_keys.py
@@ -22,6 +22,7 @@ TEST_MNEMONIC_SEED = (
     "tomato remind jaguar original blur embody project can"
 )
 TEST_PUBLIC_KEY = "8a37cad4c5edf0a7544cbdb9f9383f7c5e82567d0236dc4f5b0547137afff9a5ce33aece3358d0202cafb9a12607ab53"
+TEST_BECH32_PUBKEY = "bls123814rygqxr4ryyadg0tx9cprt55vzpamcumr34v3ys66cynl6qx43emhm35nlz8clfxnujzkhpvkvqf5n2fxpd"
 TEST_PK_FINGERPRINT = 2167729070
 TEST_FINGERPRINT = 2877570395
 
@@ -339,6 +340,10 @@ class TestKeysCommands:
         assert result.output.find(f"Fingerprint: {TEST_FINGERPRINT}") != -1
         assert result.output.find(f"Fingerprint: {TEST_PK_FINGERPRINT}") != -1
         assert result.output.find("First wallet address (non-observer): N/A") != -1
+
+        # Try with bech32 formatting
+        result = runner.invoke(cli, [*base_params, *cmd_params, "--bech32m-prefix", "bls1238"])
+        assert result.output.find(TEST_BECH32_PUBKEY) != -1
 
     def test_show_fingerprint(self, keyring_with_one_public_one_private_key, tmp_path):
         """
@@ -1643,6 +1648,8 @@ class TestKeysCommands:
                 "--count",
                 "1",
                 "--show-hd-path",
+                "--bech32m-prefix",
+                "bls1238",
             ],
         )
 
@@ -1650,7 +1657,7 @@ class TestKeysCommands:
         assert (
             result.output.find(
                 "Wallet public key 9 (m/12381/8444/2/9): "
-                "a272d5aaa6046e64bd7fd69bae288b9f9e5622c13058ec7d1b85e3d4d1acfa5d63d6542336c7b24d2fceab991919e989"
+                "bls123815fedt24xq3hxf0tl66d6u2ytn709vgkpxpvwclgmsh3af5dvlfwk84j5yvmv0vjd9l82hxger85cjly2r27"
             )
             != -1
         )

--- a/chia/cmds/keys.py
+++ b/chia/cmds/keys.py
@@ -59,6 +59,11 @@ def generate_cmd(ctx: click.Context, label: Optional[str]) -> None:
     show_default=True,
     is_flag=True,
 )
+@click.option(
+    "--bech32m-prefix",
+    help=("Encode public keys in bech32m with a specified prefix"),
+    default=None,
+)
 @options.create_fingerprint()
 @click.pass_context
 def show_cmd(
@@ -67,10 +72,11 @@ def show_cmd(
     non_observer_derivation: bool,
     json: bool,
     fingerprint: Optional[int],
+    bech32m_prefix: Optional[str],
 ) -> None:
     from .keys_funcs import show_keys
 
-    show_keys(ctx.obj["root_path"], show_mnemonic_seed, non_observer_derivation, json, fingerprint)
+    show_keys(ctx.obj["root_path"], show_mnemonic_seed, non_observer_derivation, json, fingerprint, bech32m_prefix)
 
 
 @keys_cmd.command("add", help="Add a private key by mnemonic or public key as hex")
@@ -427,6 +433,11 @@ def wallet_address_cmd(
     show_default=True,
     is_flag=True,
 )
+@click.option(
+    "--bech32m-prefix",
+    help=("Encode public keys in bech32m with a specified prefix"),
+    default=None,
+)
 @click.pass_context
 def child_key_cmd(
     ctx: click.Context,
@@ -437,6 +448,7 @@ def child_key_cmd(
     non_observer_derivation: bool,
     show_private_keys: bool,
     show_hd_path: bool,
+    bech32m_prefix: Optional[str],
 ) -> None:
     from .keys_funcs import derive_child_key, resolve_derivation_master_key
 
@@ -460,4 +472,5 @@ def child_key_cmd(
         show_private_keys,
         show_hd_path,
         sk,
+        bech32m_prefix,
     )

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -12,7 +12,7 @@ from chia_rs import AugSchemeMPL, G1Element, G2Element, PrivateKey
 from chia.cmds.passphrase_funcs import obtain_current_passphrase
 from chia.consensus.coinbase import create_puzzlehash_for_pk
 from chia.types.signing_mode import SigningMode
-from chia.util.bech32m import encode_puzzle_hash
+from chia.util.bech32m import bech32_encode, convertbits, encode_puzzle_hash
 from chia.util.config import load_config
 from chia.util.errors import KeychainException
 from chia.util.file_keyring import MAX_LABEL_LENGTH
@@ -137,8 +137,17 @@ def delete_key_label(fingerprint: int) -> None:
         sys.exit(f"Error: {e}")
 
 
+def format_pk_bech32_maybe(prefix: Optional[str], pubkey: str) -> str:
+    return pubkey if prefix is None else bech32_encode(prefix, convertbits(list(bytes.fromhex(pubkey)), 8, 5))
+
+
 def show_keys(
-    root_path: Path, show_mnemonic: bool, non_observer_derivation: bool, json_output: bool, fingerprint: Optional[int]
+    root_path: Path,
+    show_mnemonic: bool,
+    non_observer_derivation: bool,
+    json_output: bool,
+    fingerprint: Optional[int],
+    bech32m_prefix: Optional[str],
 ) -> None:
     """
     Prints all keys and mnemonics (if available).
@@ -220,9 +229,9 @@ def show_keys(
             if "label" in key:
                 print("Label:", key["label"])
             print("Fingerprint:", key["fingerprint"])
-            print("Master public key (m):", key["master_pk"])
-            print("Farmer public key (m/12381/8444/0/0):", key["farmer_pk"])
-            print("Pool public key (m/12381/8444/1/0):", key["pool_pk"])
+            print("Master public key (m):", format_pk_bech32_maybe(bech32m_prefix, key["master_pk"]))
+            print("Farmer public key (m/12381/8444/0/0):", format_pk_bech32_maybe(bech32m_prefix, key["farmer_pk"]))
+            print("Pool public key (m/12381/8444/1/0):", format_pk_bech32_maybe(bech32m_prefix, key["pool_pk"]))
             print(f"First wallet address{' (non-observer)' if key['non_observer'] else ''}: {key['wallet_address']}")
             if show_mnemonic:
                 print("Master private key (m):", key["master_sk"])
@@ -704,6 +713,7 @@ def derive_child_key(
     show_private_keys: bool,
     show_hd_path: bool,
     private_key: Optional[PrivateKey],
+    bech32m_prefix: Optional[str],
 ) -> None:
     """
     Derive child keys from the provided master key.
@@ -782,7 +792,7 @@ def derive_child_key(
         else:
             key_type_str = "Non-Observer" if non_observer_derivation else "Observer"
 
-        print(f"{key_type_str} public key {i}{hd_path}: {pk}")
+        print(f"{key_type_str} public key {i}{hd_path}: {format_pk_bech32_maybe(bech32m_prefix, bytes(pk).hex())}")
         if show_private_keys and sk is not None:
             print(f"{key_type_str} private key {i}{hd_path}: {private_key_string_repr(sk)}")
 


### PR DESCRIPTION
This PR adds the ability to specify a bech32m prefix with which to display your pubkeys in the `show` and `derive` commands 