### PR TITLE
multiprocess_validation refactor

### DIFF
--- a/chia/_tests/blockchain/blockchain_test_utils.py
+++ b/chia/_tests/blockchain/blockchain_test_utils.py
@@ -7,7 +7,7 @@ from chia_rs import BLSCache
 from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.blockchain import AddBlockResult, Blockchain
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
-from chia.consensus.multiprocess_validation import PreValidationResult
+from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_blocks_multiprocessing
 from chia.types.full_block import FullBlock
 from chia.util.errors import Err
 from chia.util.ints import uint32, uint64
@@ -75,8 +75,16 @@ async def _validate_and_add_block(
     else:
         # validate_signatures must be False in order to trigger add_block() to
         # validate the signature.
-        pre_validation_results: List[PreValidationResult] = await blockchain.pre_validate_blocks_multiprocessing(
-            [block], {}, sub_slot_iters=ssi, difficulty=diff, prev_ses_block=prev_ses_block, validate_signatures=False
+        pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+            blockchain.constants,
+            blockchain,
+            [block],
+            blockchain.pool,
+            {},
+            sub_slot_iters=ssi,
+            difficulty=diff,
+            prev_ses_block=prev_ses_block,
+            validate_signatures=False,
         )
         assert pre_validation_results is not None
         results = pre_validation_results[0]

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -29,7 +29,7 @@ from chia.consensus.coinbase import create_farmer_coin
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.get_block_generator import get_block_generator
-from chia.consensus.multiprocess_validation import PreValidationResult
+from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_blocks_multiprocessing
 from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.simulator.block_tools import BlockTools, create_block_tools_async
@@ -1819,8 +1819,11 @@ class TestPreValidation:
         block_bad = recursive_replace(
             blocks[-1], "reward_chain_block.total_iters", blocks[-1].reward_chain_block.total_iters + 1
         )
-        res = await empty_blockchain.pre_validate_blocks_multiprocessing(
+        res = await pre_validate_blocks_multiprocessing(
+            bt.constants,
+            empty_blockchain,
             [blocks[0], block_bad],
+            empty_blockchain.pool,
             {},
             sub_slot_iters=ssi,
             difficulty=difficulty,
@@ -1845,8 +1848,11 @@ class TestPreValidation:
             end_i = min(i + n_at_a_time, len(blocks))
             blocks_to_validate = blocks[i:end_i]
             start_pv = time.time()
-            res = await empty_blockchain.pre_validate_blocks_multiprocessing(
+            res = await pre_validate_blocks_multiprocessing(
+                bt.constants,
+                empty_blockchain,
                 blocks_to_validate,
+                empty_blockchain.pool,
                 {},
                 sub_slot_iters=ssi,
                 difficulty=difficulty,
@@ -1950,8 +1956,16 @@ class TestBodyValidation:
         )
         ssi = b.constants.SUB_SLOT_ITERS_STARTING
         diff = b.constants.DIFFICULTY_STARTING
-        pre_validation_results: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
-            [blocks[-1]], {}, sub_slot_iters=ssi, difficulty=diff, prev_ses_block=None, validate_signatures=False
+        pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+            bt.constants,
+            b,
+            [blocks[-1]],
+            b.pool,
+            {},
+            sub_slot_iters=ssi,
+            difficulty=diff,
+            prev_ses_block=None,
+            validate_signatures=False,
         )
         # Ignore errors from pre-validation, we are testing block_body_validation
         repl_preval_results = replace(pre_validation_results[0], error=None, required_iters=uint64(1))
@@ -2066,8 +2080,16 @@ class TestBodyValidation:
             )
             ssi = b.constants.SUB_SLOT_ITERS_STARTING
             diff = b.constants.DIFFICULTY_STARTING
-            pre_validation_results: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
-                [blocks[-1]], {}, sub_slot_iters=ssi, difficulty=diff, prev_ses_block=None, validate_signatures=True
+            pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+                bt.constants,
+                b,
+                [blocks[-1]],
+                b.pool,
+                {},
+                sub_slot_iters=ssi,
+                difficulty=diff,
+                prev_ses_block=None,
+                validate_signatures=True,
             )
             assert pre_validation_results is not None
             assert (await b.add_block(blocks[-1], pre_validation_results[0], None, sub_slot_iters=ssi))[0] == expected
@@ -2139,8 +2161,16 @@ class TestBodyValidation:
         )
         ssi = b.constants.SUB_SLOT_ITERS_STARTING
         diff = b.constants.DIFFICULTY_STARTING
-        pre_validation_results: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
-            [blocks[-1]], {}, sub_slot_iters=ssi, difficulty=diff, prev_ses_block=None, validate_signatures=False
+        pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+            bt.constants,
+            b,
+            [blocks[-1]],
+            empty_blockchain.pool,
+            {},
+            sub_slot_iters=ssi,
+            difficulty=diff,
+            prev_ses_block=None,
+            validate_signatures=False,
         )
         # Ignore errors from pre-validation, we are testing block_body_validation
         repl_preval_results = replace(pre_validation_results[0], error=None, required_iters=uint64(1))
@@ -2257,8 +2287,16 @@ class TestBodyValidation:
             )
             ssi = b.constants.SUB_SLOT_ITERS_STARTING
             diff = b.constants.DIFFICULTY_STARTING
-            pre_validation_results: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
-                [blocks[-1]], {}, sub_slot_iters=ssi, difficulty=diff, prev_ses_block=None, validate_signatures=True
+            pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+                bt.constants,
+                b,
+                [blocks[-1]],
+                b.pool,
+                {},
+                sub_slot_iters=ssi,
+                difficulty=diff,
+                prev_ses_block=None,
+                validate_signatures=True,
             )
             assert pre_validation_results is not None
             assert (await b.add_block(blocks[-1], pre_validation_results[0], None, sub_slot_iters=ssi))[0] == expected
@@ -2607,8 +2645,16 @@ class TestBodyValidation:
             )
         )[1]
         assert err in [Err.BLOCK_COST_EXCEEDS_MAX]
-        results: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
-            [blocks[-1]], {}, sub_slot_iters=ssi, difficulty=diff, prev_ses_block=None, validate_signatures=False
+        results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+            bt.constants,
+            b,
+            [blocks[-1]],
+            b.pool,
+            {},
+            sub_slot_iters=ssi,
+            difficulty=diff,
+            prev_ses_block=None,
+            validate_signatures=False,
         )
         assert results is not None
         assert Err(results[0].error) == Err.BLOCK_COST_EXCEEDS_MAX
@@ -3178,8 +3224,16 @@ class TestBodyValidation:
         # Bad signature also fails in prevalidation
         ssi = b.constants.SUB_SLOT_ITERS_STARTING
         diff = b.constants.DIFFICULTY_STARTING
-        preval_results = await b.pre_validate_blocks_multiprocessing(
-            [last_block], {}, sub_slot_iters=ssi, difficulty=diff, prev_ses_block=None, validate_signatures=True
+        preval_results = await pre_validate_blocks_multiprocessing(
+            bt.constants,
+            b,
+            [last_block],
+            empty_blockchain.pool,
+            {},
+            sub_slot_iters=ssi,
+            difficulty=diff,
+            prev_ses_block=None,
+            validate_signatures=True,
         )
         assert preval_results is not None
         assert preval_results[0].error == Err.BAD_AGGREGATE_SIGNATURE.value
@@ -3288,8 +3342,16 @@ class TestReorgs:
         print(f"pre-validating {len(blocks)} blocks")
         ssi = b.constants.SUB_SLOT_ITERS_STARTING
         diff = b.constants.DIFFICULTY_STARTING
-        pre_validation_results: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
-            blocks, {}, sub_slot_iters=ssi, difficulty=diff, prev_ses_block=None, validate_signatures=False
+        pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+            b.constants,
+            b,
+            blocks,
+            b.pool,
+            {},
+            sub_slot_iters=ssi,
+            difficulty=diff,
+            prev_ses_block=None,
+            validate_signatures=False,
         )
         for i, block in enumerate(blocks):
             if block.height != 0 and len(block.finished_sub_slots) > 0:
@@ -3841,13 +3903,29 @@ async def test_reorg_flip_flop(empty_blockchain: Blockchain, bt: BlockTools) -> 
             block1, block2 = b1, b2
         counter += 1
 
-        preval: List[PreValidationResult] = await b.pre_validate_blocks_multiprocessing(
-            [block1], {}, sub_slot_iters=ssi, difficulty=diff, prev_ses_block=None, validate_signatures=False
+        preval: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+            bt.constants,
+            b,
+            [block1],
+            b.pool,
+            {},
+            sub_slot_iters=ssi,
+            difficulty=diff,
+            prev_ses_block=None,
+            validate_signatures=False,
         )
         _, err, _ = await b.add_block(block1, preval[0], None, sub_slot_iters=ssi)
         assert err is None
-        preval = await b.pre_validate_blocks_multiprocessing(
-            [block2], {}, sub_slot_iters=ssi, difficulty=diff, prev_ses_block=None, validate_signatures=False
+        preval = await pre_validate_blocks_multiprocessing(
+            bt.constants,
+            b,
+            [block2],
+            b.pool,
+            {},
+            sub_slot_iters=ssi,
+            difficulty=diff,
+            prev_ses_block=None,
+            validate_signatures=False,
         )
         _, err, _ = await b.add_block(block2, preval[0], None, sub_slot_iters=ssi)
         assert err is None
@@ -3873,8 +3951,16 @@ async def test_get_tx_peak(default_400_blocks: List[FullBlock], empty_blockchain
     test_blocks = default_400_blocks[:100]
     ssi = empty_blockchain.constants.SUB_SLOT_ITERS_STARTING
     diff = empty_blockchain.constants.DIFFICULTY_STARTING
-    res = await bc.pre_validate_blocks_multiprocessing(
-        test_blocks, {}, sub_slot_iters=ssi, difficulty=diff, prev_ses_block=None, validate_signatures=False
+    res = await pre_validate_blocks_multiprocessing(
+        bc.constants,
+        bc,
+        test_blocks,
+        bc.pool,
+        {},
+        sub_slot_iters=ssi,
+        difficulty=diff,
+        prev_ses_block=None,
+        validate_signatures=False,
     )
 
     last_tx_block_record = None

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -1820,7 +1820,7 @@ class TestPreValidation:
             blocks[-1], "reward_chain_block.total_iters", blocks[-1].reward_chain_block.total_iters + 1
         )
         res = await pre_validate_blocks_multiprocessing(
-            bt.constants,
+            empty_blockchain.constants,
             empty_blockchain,
             [blocks[0], block_bad],
             empty_blockchain.pool,
@@ -1849,7 +1849,7 @@ class TestPreValidation:
             blocks_to_validate = blocks[i:end_i]
             start_pv = time.time()
             res = await pre_validate_blocks_multiprocessing(
-                bt.constants,
+                empty_blockchain.constants,
                 empty_blockchain,
                 blocks_to_validate,
                 empty_blockchain.pool,
@@ -1957,7 +1957,7 @@ class TestBodyValidation:
         ssi = b.constants.SUB_SLOT_ITERS_STARTING
         diff = b.constants.DIFFICULTY_STARTING
         pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
-            bt.constants,
+            b.constants,
             b,
             [blocks[-1]],
             b.pool,
@@ -2081,7 +2081,7 @@ class TestBodyValidation:
             ssi = b.constants.SUB_SLOT_ITERS_STARTING
             diff = b.constants.DIFFICULTY_STARTING
             pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
-                bt.constants,
+                b.constants,
                 b,
                 [blocks[-1]],
                 b.pool,
@@ -2162,10 +2162,10 @@ class TestBodyValidation:
         ssi = b.constants.SUB_SLOT_ITERS_STARTING
         diff = b.constants.DIFFICULTY_STARTING
         pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
-            bt.constants,
+            b.constants,
             b,
             [blocks[-1]],
-            empty_blockchain.pool,
+            b.pool,
             {},
             sub_slot_iters=ssi,
             difficulty=diff,
@@ -2288,7 +2288,7 @@ class TestBodyValidation:
             ssi = b.constants.SUB_SLOT_ITERS_STARTING
             diff = b.constants.DIFFICULTY_STARTING
             pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
-                bt.constants,
+                b.constants,
                 b,
                 [blocks[-1]],
                 b.pool,
@@ -2646,7 +2646,7 @@ class TestBodyValidation:
         )[1]
         assert err in [Err.BLOCK_COST_EXCEEDS_MAX]
         results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
-            bt.constants,
+            b.constants,
             b,
             [blocks[-1]],
             b.pool,
@@ -3225,10 +3225,10 @@ class TestBodyValidation:
         ssi = b.constants.SUB_SLOT_ITERS_STARTING
         diff = b.constants.DIFFICULTY_STARTING
         preval_results = await pre_validate_blocks_multiprocessing(
-            bt.constants,
+            b.constants,
             b,
             [last_block],
-            empty_blockchain.pool,
+            b.pool,
             {},
             sub_slot_iters=ssi,
             difficulty=diff,
@@ -3904,7 +3904,7 @@ async def test_reorg_flip_flop(empty_blockchain: Blockchain, bt: BlockTools) -> 
         counter += 1
 
         preval: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
-            bt.constants,
+            b.constants,
             b,
             [block1],
             b.pool,
@@ -3917,7 +3917,7 @@ async def test_reorg_flip_flop(empty_blockchain: Blockchain, bt: BlockTools) -> 
         _, err, _ = await b.add_block(block1, preval[0], None, sub_slot_iters=ssi)
         assert err is None
         preval = await pre_validate_blocks_multiprocessing(
-            bt.constants,
+            b.constants,
             b,
             [block2],
             b.pool,

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -3949,8 +3949,8 @@ async def test_reorg_flip_flop(empty_blockchain: Blockchain, bt: BlockTools) -> 
 async def test_get_tx_peak(default_400_blocks: List[FullBlock], empty_blockchain: Blockchain) -> None:
     bc = empty_blockchain
     test_blocks = default_400_blocks[:100]
-    ssi = empty_blockchain.constants.SUB_SLOT_ITERS_STARTING
-    diff = empty_blockchain.constants.DIFFICULTY_STARTING
+    ssi = bc.constants.SUB_SLOT_ITERS_STARTING
+    diff = bc.constants.DIFFICULTY_STARTING
     res = await pre_validate_blocks_multiprocessing(
         bc.constants,
         bc,

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -427,7 +427,7 @@ class TestFullNodeBlockCompression:
                     await _validate_and_add_block_no_error(blockchain, reorg_block)
                 for i in range(1, height):
                     results = await pre_validate_blocks_multiprocessing(
-                        bt.constants,
+                        blockchain.constants,
                         blockchain,
                         all_blocks[:i],
                         blockchain.pool,
@@ -446,7 +446,7 @@ class TestFullNodeBlockCompression:
                     await _validate_and_add_block_no_error(blockchain, block)
                 for i in range(1, height):
                     results = await pre_validate_blocks_multiprocessing(
-                        bt.constants,
+                        blockchain.constants,
                         blockchain,
                         all_blocks[:i],
                         blockchain.pool,

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -23,6 +23,7 @@ from chia._tests.util.misc import add_blocks_in_batches, wallet_height_at_least
 from chia._tests.util.setup_nodes import SimulatorsAndWalletsServices
 from chia._tests.util.time_out_assert import time_out_assert, time_out_assert_custom_interval, time_out_messages
 from chia.consensus.block_body_validation import ForkInfo
+from chia.consensus.multiprocess_validation import pre_validate_blocks_multiprocessing
 from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.full_node import WalletUpdate
 from chia.full_node.full_node_api import FullNodeAPI
@@ -425,37 +426,39 @@ class TestFullNodeBlockCompression:
                 for reorg_block in reog_blocks[:r]:
                     await _validate_and_add_block_no_error(blockchain, reorg_block)
                 for i in range(1, height):
-                    for batch_size in range(1, height, 3):
-                        results = await blockchain.pre_validate_blocks_multiprocessing(
-                            all_blocks[:i],
-                            {},
-                            sub_slot_iters=ssi,
-                            difficulty=diff,
-                            prev_ses_block=None,
-                            batch_size=batch_size,
-                            validate_signatures=False,
-                        )
-                        assert results is not None
-                        for result in results:
-                            assert result.error is None
+                    results = await pre_validate_blocks_multiprocessing(
+                        bt.constants,
+                        blockchain,
+                        all_blocks[:i],
+                        blockchain.pool,
+                        {},
+                        sub_slot_iters=ssi,
+                        difficulty=diff,
+                        prev_ses_block=None,
+                        validate_signatures=False,
+                    )
+                    assert results is not None
+                    for result in results:
+                        assert result.error is None
 
             for r in range(0, len(all_blocks), 3):
                 for block in all_blocks[:r]:
                     await _validate_and_add_block_no_error(blockchain, block)
                 for i in range(1, height):
-                    for batch_size in range(1, height, 3):
-                        results = await blockchain.pre_validate_blocks_multiprocessing(
-                            all_blocks[:i],
-                            {},
-                            sub_slot_iters=ssi,
-                            difficulty=diff,
-                            prev_ses_block=None,
-                            batch_size=batch_size,
-                            validate_signatures=False,
-                        )
-                        assert results is not None
-                        for result in results:
-                            assert result.error is None
+                    results = await pre_validate_blocks_multiprocessing(
+                        bt.constants,
+                        blockchain,
+                        all_blocks[:i],
+                        blockchain.pool,
+                        {},
+                        sub_slot_iters=ssi,
+                        difficulty=diff,
+                        prev_ses_block=None,
+                        validate_signatures=False,
+                    )
+                    assert results is not None
+                    for result in results:
+                        assert result.error is None
 
 
 class TestFullNodeProtocol:

--- a/chia/_tests/farmer_harvester/test_third_party_harvesters.py
+++ b/chia/_tests/farmer_harvester/test_third_party_harvesters.py
@@ -435,14 +435,11 @@ async def add_test_blocks_into_full_node(blocks: List[FullBlock], full_node: Ful
         prev_ses_block = curr
     new_slot = len(block.finished_sub_slots) > 0
     ssi, diff = get_next_sub_slot_iters_and_difficulty(full_node.constants, new_slot, prev_b, full_node.blockchain)
-
-    constants = full_node.blockchain.constants
-    pool = full_node.blockchain.pool
     pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
-        constants,
+        full_node.blockchain.constants,
         full_node.blockchain,
         blocks,
-        pool,
+        full_node.blockchain.pool,
         {},
         sub_slot_iters=ssi,
         difficulty=diff,

--- a/chia/_tests/farmer_harvester/test_third_party_harvesters.py
+++ b/chia/_tests/farmer_harvester/test_third_party_harvesters.py
@@ -15,7 +15,7 @@ from pytest_mock import MockerFixture
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.blockchain import AddBlockResult
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
-from chia.consensus.multiprocess_validation import PreValidationResult
+from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_blocks_multiprocessing
 from chia.farmer.farmer import Farmer, calculate_harvester_fee_quality
 from chia.farmer.farmer_api import FarmerAPI
 from chia.full_node.full_node import FullNode
@@ -435,8 +435,19 @@ async def add_test_blocks_into_full_node(blocks: List[FullBlock], full_node: Ful
         prev_ses_block = curr
     new_slot = len(block.finished_sub_slots) > 0
     ssi, diff = get_next_sub_slot_iters_and_difficulty(full_node.constants, new_slot, prev_b, full_node.blockchain)
-    pre_validation_results: List[PreValidationResult] = await full_node.blockchain.pre_validate_blocks_multiprocessing(
-        blocks, {}, sub_slot_iters=ssi, difficulty=diff, prev_ses_block=prev_ses_block, validate_signatures=True
+
+    constants = full_node.blockchain.constants
+    pool = full_node.blockchain.pool
+    pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+        constants,
+        full_node.blockchain,
+        blocks,
+        pool,
+        {},
+        sub_slot_iters=ssi,
+        difficulty=diff,
+        prev_ses_block=prev_ses_block,
+        validate_signatures=True,
     )
     assert pre_validation_results is not None and len(pre_validation_results) == len(blocks)
     for i in range(len(blocks)):

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -24,11 +24,7 @@ from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_dif
 from chia.consensus.find_fork_point import lookup_fork_chain
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.get_block_generator import get_block_generator
-from chia.consensus.multiprocess_validation import (
-    PreValidationResult,
-    _run_generator,
-    pre_validate_blocks_multiprocessing,
-)
+from chia.consensus.multiprocess_validation import PreValidationResult, _run_generator
 from chia.full_node.block_height_map import BlockHeightMap
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
@@ -795,33 +791,6 @@ class Blockchain:
             return PreValidationResult(uint16(error_code.value), None, None, False, uint32(0))
 
         return PreValidationResult(None, required_iters, cost_result, False, uint32(0))
-
-    async def pre_validate_blocks_multiprocessing(
-        self,
-        blocks: List[FullBlock],
-        npc_results: Dict[uint32, NPCResult],  # A cache of the result of running CLVM, optional (you can use {})
-        sub_slot_iters: uint64,
-        difficulty: uint64,
-        prev_ses_block: Optional[BlockRecord],
-        batch_size: int = 4,
-        wp_summaries: Optional[List[SubEpochSummary]] = None,
-        *,
-        validate_signatures: bool,
-    ) -> List[PreValidationResult]:
-        return await pre_validate_blocks_multiprocessing(
-            self.constants,
-            self,
-            blocks,
-            self.pool,
-            True,
-            npc_results,
-            batch_size,
-            sub_slot_iters,
-            difficulty,
-            prev_ses_block,
-            wp_summaries,
-            validate_signatures=validate_signatures,
-        )
 
     async def run_generator(self, unfinished_block: bytes, generator: BlockGenerator, height: uint32) -> NPCResult:
         task = asyncio.get_running_loop().run_in_executor(

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -42,7 +42,7 @@ from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
 from chia.consensus.get_block_generator import get_block_generator
 from chia.consensus.make_sub_epoch_summary import next_sub_epoch_summary
-from chia.consensus.multiprocess_validation import PreValidationResult
+from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_blocks_multiprocessing
 from chia.consensus.pot_iterations import calculate_sp_iters
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
@@ -1333,8 +1333,12 @@ class FullNode:
         # Validates signatures in multiprocessing since they take a while, and we don't have cached transactions
         # for these blocks (unlike during normal operation where we validate one at a time)
         pre_validate_start = time.monotonic()
-        pre_validation_results: List[PreValidationResult] = await self.blockchain.pre_validate_blocks_multiprocessing(
+        pool = self.blockchain.pool
+        pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+            self.constants,
+            self.blockchain,
             blocks_to_validate,
+            pool,
             {},
             sub_slot_iters=current_ssi,
             difficulty=current_difficulty,
@@ -1860,8 +1864,12 @@ class FullNode:
                 prev_ses_block = curr
             new_slot = len(block.finished_sub_slots) > 0
             ssi, diff = get_next_sub_slot_iters_and_difficulty(self.constants, new_slot, prev_b, self.blockchain)
-            pre_validation_results = await self.blockchain.pre_validate_blocks_multiprocessing(
+            pool = self.blockchain.pool
+            pre_validation_results = await pre_validate_blocks_multiprocessing(
+                self.constants,
+                self.blockchain,
                 [block],
+                pool,
                 npc_results,
                 sub_slot_iters=ssi,
                 difficulty=diff,

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1333,12 +1333,11 @@ class FullNode:
         # Validates signatures in multiprocessing since they take a while, and we don't have cached transactions
         # for these blocks (unlike during normal operation where we validate one at a time)
         pre_validate_start = time.monotonic()
-        pool = self.blockchain.pool
         pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
-            self.constants,
+            self.blockchain.constants,
             self.blockchain,
             blocks_to_validate,
-            pool,
+            self.blockchain.pool,
             {},
             sub_slot_iters=current_ssi,
             difficulty=current_difficulty,
@@ -1864,12 +1863,11 @@ class FullNode:
                 prev_ses_block = curr
             new_slot = len(block.finished_sub_slots) > 0
             ssi, diff = get_next_sub_slot_iters_and_difficulty(self.constants, new_slot, prev_b, self.blockchain)
-            pool = self.blockchain.pool
             pre_validation_results = await pre_validate_blocks_multiprocessing(
-                self.constants,
+                self.blockchain.constants,
                 self.blockchain,
                 [block],
-                pool,
+                self.blockchain.pool,
                 npc_results,
                 sub_slot_iters=ssi,
                 difficulty=diff,

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -10,7 +10,7 @@ import anyio
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.blockchain import BlockchainMutexPriority
-from chia.consensus.multiprocess_validation import PreValidationResult
+from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_blocks_multiprocessing
 from chia.full_node.full_node import FullNode
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.rpc.rpc_server import default_get_connections
@@ -170,15 +170,17 @@ class FullNodeSimulator(FullNodeAPI):
             current_blocks = await self.get_all_full_blocks()
             if len(current_blocks) == 0:
                 genesis = self.bt.get_consecutive_blocks(uint8(1))[0]
-                pre_validation_results: List[PreValidationResult] = (
-                    await self.full_node.blockchain.pre_validate_blocks_multiprocessing(
-                        [genesis],
-                        {},
-                        sub_slot_iters=ssi,
-                        difficulty=diff,
-                        prev_ses_block=None,
-                        validate_signatures=True,
-                    )
+                pool = self.full_node.blockchain.pool
+                pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+                    self.bt.constants,
+                    self.full_node.blockchain,
+                    [genesis],
+                    pool,
+                    {},
+                    sub_slot_iters=ssi,
+                    difficulty=diff,
+                    prev_ses_block=None,
+                    validate_signatures=True,
                 )
                 assert pre_validation_results is not None
                 await self.full_node.blockchain.add_block(
@@ -232,15 +234,17 @@ class FullNodeSimulator(FullNodeAPI):
             current_blocks = await self.get_all_full_blocks()
             if len(current_blocks) == 0:
                 genesis = self.bt.get_consecutive_blocks(uint8(1))[0]
-                pre_validation_results: List[PreValidationResult] = (
-                    await self.full_node.blockchain.pre_validate_blocks_multiprocessing(
-                        [genesis],
-                        {},
-                        sub_slot_iters=ssi,
-                        difficulty=diffculty,
-                        prev_ses_block=None,
-                        validate_signatures=True,
-                    )
+                pool = self.full_node.blockchain.pool
+                pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+                    self.bt.constants,
+                    self.full_node.blockchain,
+                    [genesis],
+                    pool,
+                    {},
+                    sub_slot_iters=ssi,
+                    difficulty=diffculty,
+                    prev_ses_block=None,
+                    validate_signatures=True,
                 )
                 assert pre_validation_results is not None
                 await self.full_node.blockchain.add_block(

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -170,12 +170,11 @@ class FullNodeSimulator(FullNodeAPI):
             current_blocks = await self.get_all_full_blocks()
             if len(current_blocks) == 0:
                 genesis = self.bt.get_consecutive_blocks(uint8(1))[0]
-                pool = self.full_node.blockchain.pool
                 pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
-                    self.bt.constants,
+                    self.full_node.blockchain.constants,
                     self.full_node.blockchain,
                     [genesis],
-                    pool,
+                    self.full_node.blockchain.pool,
                     {},
                     sub_slot_iters=ssi,
                     difficulty=diff,
@@ -234,12 +233,11 @@ class FullNodeSimulator(FullNodeAPI):
             current_blocks = await self.get_all_full_blocks()
             if len(current_blocks) == 0:
                 genesis = self.bt.get_consecutive_blocks(uint8(1))[0]
-                pool = self.full_node.blockchain.pool
                 pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
-                    self.bt.constants,
+                    self.full_node.blockchain.constants,
                     self.full_node.blockchain,
                     [genesis],
-                    pool,
+                    self.full_node.blockchain.pool,
                     {},
                     sub_slot_iters=ssi,
                     difficulty=diffculty,


### PR DESCRIPTION
### Purpose:

This patch removes the thin wrapper `pre_validate_blocks_multiprocess()` method from the `Blockchain` class.
Specifically, this part of the patch: https://github.com/Chia-Network/chia-blockchain/pull/18541/files#diff-40409ea13958d9e8cec2be388c12e68da7c3179de55f01879713c5abdb1fed38L799-L825

The purpose of this wrapper is to pass the constants, self (as the `BlocksProtocol`) and ProcessPoolExecutor (also a member of `Blockchain`) into the underlying call to the free function`pre_validate_blocks_multiprocessing()`.

The reason to remove it is to prepare call sites for passing in other classes implementing the `BlocksProtocol`, such as `AugmentedBlockchain`, to support pipelining block validation during long sync.

The underlying free function takes more parameters, specifically, `ConsensusConstants`, `BlocksProtocol` and `ProcessPoolExecutor`. To reduce the impact of these additional parameters, two other parameters are removed; `check_filter` and `batch_size`. In all calls these are always set to `True` and `4`, respectively. In fact, the `batch_size` can probably be removed (along with the batching itself) once validation is run in threads.

### Current Behavior:

Many calls to `pre_validate_blocks_multiprocessing()` are made via the wrapper in `Blockchain`, passing in the blockchain object itself.

`pre_validate_blocks_multiprocessing()` takes parameters `check_filter` and `batch_size`.

### New Behavior:

All calls to `pre_validate_blocks_multiprocessing()` explicitly pass in the object implementing the `BlocksProtocol` (e.g. `Blockchain`).

`pre_validate_blocks_multiprocessing()` no longer takes parameters `check_filter` and `batch_size`, but hard code those to `True` and `4`.