### PR TITLE
Fix BrokenProcessPool error for Windows installer blueboxing

### DIFF
--- a/chia/server/start_timelord.py
+++ b/chia/server/start_timelord.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
-from multiprocessing import freeze_support
 import pathlib
 import sys
+from multiprocessing import freeze_support
 from typing import Any, Dict, Optional
 
 from chia.consensus.constants import ConsensusConstants, replace_str_to_bytes

--- a/chia/server/start_timelord.py
+++ b/chia/server/start_timelord.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from multiprocessing import freeze_support
 import pathlib
 import sys
 from typing import Any, Dict, Optional
@@ -75,6 +76,7 @@ async def async_main() -> int:
 
 
 def main() -> int:
+    freeze_support()
     return async_run(async_main())
 
 

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -14,7 +14,7 @@ from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncIterator, ClassVar, Dict, List, Optional, Set, Tuple, cast
 
-from chiavdf import create_discriminant
+from chiavdf import create_discriminant, prove
 
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.pot_iterations import calculate_sp_iters, is_overflow_block
@@ -58,8 +58,14 @@ class BlueboxProcessData(Streamable):
 def prove_bluebox_slow(payload: bytes) -> bytes:
     bluebox_process_data = BlueboxProcessData.from_bytes(payload)
     initial_el = b"\x08" + (b"\x00" * 99)
-    return bytes.fromhex(
-        "020083665c591e07f59baea550faeb0f56236db0b47e4d6d6cdb183ba5277c0a1409338dc74d406b8082fdd80fdfdfe82f51d43fce3b4534d19ed26a5204c092ee6f5341a6cb013d1819a9ea66bb786149117ff8990f8e0f399ba639bff8d83c826d010003009dd61b03dae01b275fb492dfe4a4a4782272c4ba1fb5a4ddfd79b5108d095c1aa5d2b7927ffe564964a2a8dd2ef9235ae11bd64bb12df4506787081da9ec916540c9804b6ad612c8d6ec95b183c7ef0b4512c0b994dd77c3767d6b163aba56650100"
+    return cast(
+        bytes,
+        prove(
+            bluebox_process_data.challenge,
+            initial_el,
+            bluebox_process_data.size_bits,
+            bluebox_process_data.iters,
+        ),
     )
 
 
@@ -1166,17 +1172,11 @@ class Timelord:
                         uint16(self.constants.DISCRIMINANT_SIZE_BITS),
                         picked_info.new_proof_of_time.number_of_iterations,
                     )
-
-                    log.info(f"WJB prove_bluebox_slow bluebox_process_data {bytes(bluebox_process_data).hex()}")
-
                     proof = await asyncio.get_running_loop().run_in_executor(
                         pool,
                         prove_bluebox_slow,
                         bytes(bluebox_process_data),
                     )
-
-                    log.info(f"WJB proof {proof.hex()}")
-
                     t2 = time.time()
                     delta = t2 - t1
                     if delta > 0:
@@ -1191,6 +1191,9 @@ class Timelord:
                         return
                     vdf_proof = VDFProof(uint8(0), proof_part, True)
                     initial_form = ClassgroupElement.get_default_element()
+                    if not validate_vdf(vdf_proof, self.constants, initial_form, picked_info.new_proof_of_time):
+                        log.error("Invalid compact proof of time!")
+                        return
                     response = timelord_protocol.RespondCompactProofOfTime(
                         picked_info.new_proof_of_time,
                         vdf_proof,
@@ -1198,6 +1201,9 @@ class Timelord:
                         picked_info.height,
                         picked_info.field_vdf,
                     )
+                    if self._server is not None:
+                        message = make_msg(ProtocolMessageTypes.respond_compact_proof_of_time, response)
+                        await self.server.send_to_all([message], NodeType.FULL_NODE)
                 except Exception as e:
                     log.error(f"Exception manage discriminant queue: {e}")
                     tb = traceback.format_exc()

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -163,9 +163,7 @@ class Timelord:
                 workers = self.config.get("slow_bluebox_process_count", 1)
                 self.bluebox_pool = ProcessPoolExecutor(
                     max_workers=workers,
-                    mp_context=self.multiprocessing_context,
-                    initializer=setproctitle,
-                    initargs=(f"{getproctitle()}_worker",),
+                    mp_context=self.multiprocessing_context),
                 )
                 self.main_loop = asyncio.create_task(
                     self._start_manage_discriminant_queue_sanitizer_slow(self.bluebox_pool, workers)

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -57,6 +57,7 @@ class BlueboxProcessData(Streamable):
 def prove_bluebox_slow(payload: bytes) -> bytes:
     bluebox_process_data = BlueboxProcessData.from_bytes(payload)
     initial_el = b"\x08" + (b"\x00" * 99)
+    return
     return cast(
         bytes,
         prove(
@@ -1169,14 +1170,13 @@ class Timelord:
                         uint16(self.constants.DISCRIMINANT_SIZE_BITS),
                         picked_info.new_proof_of_time.number_of_iterations,
                     )
-                    log.error("WJB!")
-                    return
-
                     proof = await asyncio.get_running_loop().run_in_executor(
                         pool,
                         prove_bluebox_slow,
                         bytes(bluebox_process_data),
                     )
+                    log.error("WJB!")
+                    return
                     t2 = time.time()
                     delta = t2 - t1
                     if delta > 0:

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -58,11 +58,8 @@ class BlueboxProcessData(Streamable):
 def prove_bluebox_slow(payload: bytes) -> bytes:
     bluebox_process_data = BlueboxProcessData.from_bytes(payload)
     initial_el = b"\x08" + (b"\x00" * 99)
-    return cast(
-        bytes,
-        bytes.fromhex(
-            "020083665c591e07f59baea550faeb0f56236db0b47e4d6d6cdb183ba5277c0a1409338dc74d406b8082fdd80fdfdfe82f51d43fce3b4534d19ed26a5204c092ee6f5341a6cb013d1819a9ea66bb786149117ff8990f8e0f399ba639bff8d83c826d010003009dd61b03dae01b275fb492dfe4a4a4782272c4ba1fb5a4ddfd79b5108d095c1aa5d2b7927ffe564964a2a8dd2ef9235ae11bd64bb12df4506787081da9ec916540c9804b6ad612c8d6ec95b183c7ef0b4512c0b994dd77c3767d6b163aba56650100"
-        ),
+    return bytes.fromhex(
+        "020083665c591e07f59baea550faeb0f56236db0b47e4d6d6cdb183ba5277c0a1409338dc74d406b8082fdd80fdfdfe82f51d43fce3b4534d19ed26a5204c092ee6f5341a6cb013d1819a9ea66bb786149117ff8990f8e0f399ba639bff8d83c826d010003009dd61b03dae01b275fb492dfe4a4a4782272c4ba1fb5a4ddfd79b5108d095c1aa5d2b7927ffe564964a2a8dd2ef9235ae11bd64bb12df4506787081da9ec916540c9804b6ad612c8d6ec95b183c7ef0b4512c0b994dd77c3767d6b163aba56650100"
     )
 
 

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -163,7 +163,7 @@ class Timelord:
                 workers = self.config.get("slow_bluebox_process_count", 1)
                 self.bluebox_pool = ProcessPoolExecutor(
                     max_workers=workers,
-                    mp_context=self.multiprocessing_context),
+                    mp_context=self.multiprocessing_context
                 )
                 self.main_loop = asyncio.create_task(
                     self._start_manage_discriminant_queue_sanitizer_slow(self.bluebox_pool, workers)
@@ -1126,7 +1126,7 @@ class Timelord:
                         self.pending_bluebox_info.remove(info)
                         self.free_clients = self.free_clients[1:]
                 except Exception as e:
-                    log.error(f"Exception manage discriminant queue: {e}")
+                    log.error(f"Exception manage discriminant queue: {e}", exc_info=True)
             await asyncio.sleep(0.1)
 
     async def _start_manage_discriminant_queue_sanitizer_slow(self, pool: ProcessPoolExecutor, counter: int) -> None:

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -1169,6 +1169,9 @@ class Timelord:
                         uint16(self.constants.DISCRIMINANT_SIZE_BITS),
                         picked_info.new_proof_of_time.number_of_iterations,
                     )
+                    log.error("WJB!")
+                    return
+
                     proof = await asyncio.get_running_loop().run_in_executor(
                         pool,
                         prove_bluebox_slow,

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -41,7 +41,6 @@ from chia.types.blockchain_format.vdf import VDFInfo, VDFProof, validate_vdf
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.util.config import process_config_start_method
 from chia.util.ints import uint8, uint16, uint32, uint64, uint128
-from chia.util.setproctitle import getproctitle, setproctitle
 from chia.util.streamable import Streamable, streamable
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
### Purpose:

Fix BrokenProcessPool error for Windows installer blueboxing

### Current Behavior:

Multiprocessing errors out when using installer timelord executable

### New Behavior:

Add freeze_support() black magic to allow multiprocessing to work

### Testing Notes:

Blueboxing now works under windows installer
