### PR TITLE
comment out test code that's not executed

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -307,7 +307,10 @@ class TestBlockHeaderValidation:
             [],
         )
         npc_result = None
-        if unf.transactions_generator is not None:
+        # if this assert fires, remove it along with the pragma for the block
+        # below
+        assert unf.transactions_generator is None
+        if unf.transactions_generator is not None:  # pragma: no cover
             block_generator = await blockchain.get_block_generator(unf)
             assert block_generator is not None
             block_bytes = bytes(unf)
@@ -332,7 +335,10 @@ class TestBlockHeaderValidation:
             [],
         )
         npc_result = None
-        if unf.transactions_generator is not None:
+        # if this assert fires, remove it along with the pragma for the block
+        # below
+        assert unf.transactions_generator is None
+        if unf.transactions_generator is not None:  # pragma: no cover
             block_generator = await blockchain.get_block_generator(unf)
             assert block_generator is not None
             block_bytes = bytes(unf)
@@ -420,7 +426,10 @@ class TestBlockHeaderValidation:
                     [],
                 )
                 npc_result = None
-                if block.transactions_generator is not None:
+                # if this assert fires, remove it along with the pragma for the block
+                # below
+                assert block.transactions_generator is None
+                if block.transactions_generator is not None:  # pragma: no cover
                     block_generator = await blockchain.get_block_generator(unf)
                     assert block_generator is not None
                     block_bytes = bytes(unf)


### PR DESCRIPTION
### Purpose:

Address missing test coverage in `test_blockchain.py`. There are parts of the tests that are not executed. This change comments-out the unused test code, and asserts that it's not needed, in case it's needed at some point in the future, the asserts will fail and it's clear what needs to be done.

### Current Behavior:

Some conditions are always false in `test_blockchain.py`, and the block of code is never executed.

### New Behavior:

The unused code is commented out and asserts are added to ensure it would still remain unused in the future.