### PR TITLE
CHIA-1291 Switch mempool TX prevalidation to the Rust version

### DIFF
--- a/benchmarks/mempool-long-lived.py
+++ b/benchmarks/mempool-long-lived.py
@@ -114,7 +114,7 @@ async def run_mempool_benchmark() -> None:
                 coin.name(): CoinRecord(coin, uint32(height // 2), uint32(0), False, uint64(timestamp // 2))
             }
             spend_bundle_id = sb.name()
-            sbc = await mempool.pre_validate_spendbundle(sb, None, spend_bundle_id)
+            sbc = await mempool.pre_validate_spendbundle(sb, spend_bundle_id)
             assert sbc is not None
             await mempool.add_spend_bundle(sb, sbc, spend_bundle_id, uint32(height))
 

--- a/benchmarks/mempool.py
+++ b/benchmarks/mempool.py
@@ -173,7 +173,7 @@ async def run_mempool_benchmark() -> None:
         async def add_spend_bundles(spend_bundles: List[SpendBundle]) -> None:
             for tx in spend_bundles:
                 spend_bundle_id = tx.name()
-                npc = await mempool.pre_validate_spendbundle(tx, None, spend_bundle_id)
+                npc = await mempool.pre_validate_spendbundle(tx, spend_bundle_id)
                 assert npc is not None
                 info = await mempool.add_spend_bundle(tx, npc, spend_bundle_id, height)
                 assert info.status == MempoolInclusionStatus.SUCCESS

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -387,7 +387,7 @@ def spend_bundle_from_conditions(
 async def add_spendbundle(
     mempool_manager: MempoolManager, sb: SpendBundle, sb_name: bytes32
 ) -> Tuple[Optional[uint64], MempoolInclusionStatus, Optional[Err]]:
-    sbc = await mempool_manager.pre_validate_spendbundle(sb, None, sb_name)
+    sbc = await mempool_manager.pre_validate_spendbundle(sb, sb_name)
     ret = await mempool_manager.add_spend_bundle(sb, sbc, sb_name, TEST_HEIGHT)
     invariant_check_mempool(mempool_manager.mempool)
     return ret.cost, ret.status, ret.error
@@ -461,7 +461,7 @@ async def test_empty_spend_bundle() -> None:
     mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_records)
     sb = SpendBundle([], G2Element())
     with pytest.raises(ValidationError, match="INVALID_SPEND_BUNDLE"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -470,7 +470,7 @@ async def test_negative_addition_amount() -> None:
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, -1]]
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="COIN_AMOUNT_NEGATIVE"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -481,7 +481,7 @@ async def test_valid_addition_amount() -> None:
     coin = Coin(IDENTITY_PUZZLE_HASH, IDENTITY_PUZZLE_HASH, max_amount)
     sb = spend_bundle_from_conditions(conditions, coin)
     # ensure this does not throw
-    _ = await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+    _ = await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -491,7 +491,7 @@ async def test_too_big_addition_amount() -> None:
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, max_amount + 1]]
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="COIN_AMOUNT_EXCEEDS_MAXIMUM"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -503,7 +503,7 @@ async def test_duplicate_output() -> None:
     ]
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="DUPLICATE_OUTPUT"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -514,7 +514,7 @@ async def test_block_cost_exceeds_max() -> None:
         conditions.append([ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, i])
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="BLOCK_COST_EXCEEDS_MAX"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -524,7 +524,7 @@ async def test_double_spend_prevalidation() -> None:
     sb = spend_bundle_from_conditions(conditions)
     sb_twice: SpendBundle = SpendBundle.aggregate([sb, sb])
     with pytest.raises(ValidationError, match="DOUBLE_SPEND"):
-        await mempool_manager.pre_validate_spendbundle(sb_twice, None, sb_twice.name())
+        await mempool_manager.pre_validate_spendbundle(sb_twice, sb_twice.name())
 
 
 @pytest.mark.anyio
@@ -532,11 +532,11 @@ async def test_minting_coin() -> None:
     mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_records)
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, TEST_COIN_AMOUNT]]
     sb = spend_bundle_from_conditions(conditions)
-    _ = await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+    _ = await mempool_manager.pre_validate_spendbundle(sb, sb.name())
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, TEST_COIN_AMOUNT + 1]]
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="MINTING_COIN"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -544,11 +544,11 @@ async def test_reserve_fee_condition() -> None:
     mempool_manager = await instantiate_mempool_manager(zero_calls_get_coin_records)
     conditions = [[ConditionOpcode.RESERVE_FEE, TEST_COIN_AMOUNT]]
     sb = spend_bundle_from_conditions(conditions)
-    _ = await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+    _ = await mempool_manager.pre_validate_spendbundle(sb, sb.name())
     conditions = [[ConditionOpcode.RESERVE_FEE, TEST_COIN_AMOUNT + 1]]
     sb = spend_bundle_from_conditions(conditions)
     with pytest.raises(ValidationError, match="RESERVE_FEE_CONDITION_FAILED"):
-        await mempool_manager.pre_validate_spendbundle(sb, None, sb.name())
+        await mempool_manager.pre_validate_spendbundle(sb, sb.name())
 
 
 @pytest.mark.anyio
@@ -581,7 +581,7 @@ async def test_same_sb_twice_with_eligible_coin() -> None:
     sb = SpendBundle.aggregate([sb1, sb2])
     sb_name = sb.name()
     result = await add_spendbundle(mempool_manager, sb, sb_name)
-    expected_cost = uint64(10268283)
+    expected_cost = uint64(10_236_088)
     assert result == (expected_cost, MempoolInclusionStatus.SUCCESS, None)
     assert mempool_manager.get_spendbundle(sb_name) == sb
     result = await add_spendbundle(mempool_manager, sb, sb_name)
@@ -614,7 +614,7 @@ async def test_sb_twice_with_eligible_coin_and_different_spends_order() -> None:
     assert mempool_manager.get_spendbundle(sb_name) is None
     assert mempool_manager.get_spendbundle(reordered_sb_name) is None
     result = await add_spendbundle(mempool_manager, sb, sb_name)
-    expected_cost = uint64(13091510)
+    expected_cost = uint64(13_056_132)
     assert result == (expected_cost, MempoolInclusionStatus.SUCCESS, None)
     assert mempool_manager.get_spendbundle(sb_name) == sb
     assert mempool_manager.get_spendbundle(reordered_sb_name) is None
@@ -1942,7 +1942,9 @@ async def test_mempool_timelocks(cond1: List[object], cond2: List[object], expec
         assert e.code == expected
 
 
-TEST_FILL_RATE_ITEM_COST = 144_744_040
+TEST_FILL_RATE_ITEM_COST = 144_720_020
+QUOTE_BYTE_COST = 2 * DEFAULT_CONSTANTS.COST_PER_BYTE
+QUOTE_EXECUTION_COST = 20
 
 
 @pytest.mark.anyio
@@ -1956,10 +1958,12 @@ TEST_FILL_RATE_ITEM_COST = 144_744_040
         # because of the spend bundle aggregation that creates the block
         # bundle, in addition to a small block compression effect that we
         # can't completely avoid.
-        (TEST_FILL_RATE_ITEM_COST * 2, 2, TEST_FILL_RATE_ITEM_COST * 2 - 156_020),
+        (TEST_FILL_RATE_ITEM_COST * 2, 2, TEST_FILL_RATE_ITEM_COST * 2 - 107_980),
         # Here we set the block cost limit to twice the test items' cost - 1,
         # so we expect only one of the two test items to get included in the block.
-        (TEST_FILL_RATE_ITEM_COST * 2 - 1, 1, TEST_FILL_RATE_ITEM_COST),
+        # NOTE: The cost difference here is because get_conditions_from_spendbundle
+        # does not include the overhead to make a block (quote byte cost  + quote runtime cost).
+        (TEST_FILL_RATE_ITEM_COST * 2 - 1, 1, TEST_FILL_RATE_ITEM_COST + QUOTE_BYTE_COST + QUOTE_EXECUTION_COST),
     ],
 )
 async def test_fill_rate_block_validation(

--- a/chia/clvm/spend_sim.py
+++ b/chia/clvm/spend_sim.py
@@ -337,7 +337,7 @@ class SimClient:
     async def push_tx(self, spend_bundle: SpendBundle) -> Tuple[MempoolInclusionStatus, Optional[Err]]:
         try:
             spend_bundle_id = spend_bundle.name()
-            sbc = await self.service.mempool_manager.pre_validate_spendbundle(spend_bundle, None, spend_bundle_id)
+            sbc = await self.service.mempool_manager.pre_validate_spendbundle(spend_bundle, spend_bundle_id)
         except ValidationError as e:
             return MempoolInclusionStatus.FAILED, e.code
         assert self.service.mempool_manager.peak is not None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -279,7 +279,6 @@ class FullNode:
             self._mempool_manager = MempoolManager(
                 get_coin_records=self.coin_store.get_coin_records,
                 consensus_constants=self.constants,
-                multiprocessing_context=self.multiprocessing_context,
                 single_threaded=single_threaded,
             )
 
@@ -2356,7 +2355,7 @@ class FullNode:
         else:
             try:
                 cost_result = await self.mempool_manager.pre_validate_spendbundle(
-                    transaction, tx_bytes, spend_name, self._bls_cache
+                    transaction, spend_name, self._bls_cache
                 )
             except ValidationError as e:
                 self.mempool_manager.remove_seen(spend_name)

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -868,7 +868,7 @@ class FullNodeRpcApi:
             spend_bundle: SpendBundle = SpendBundle.from_json_dict(request["spend_bundle"])
             spend_name = spend_bundle.name()
             conds: SpendBundleConditions = await self.service.mempool_manager.pre_validate_spendbundle(
-                spend_bundle, None, spend_name
+                spend_bundle, spend_name
             )
             cost = conds.cost
         elif "cost" in request:

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import dataclasses
 from typing import Awaitable, Callable, Dict, List, Optional, Tuple
 
-from chia_rs import fast_forward_singleton
+from chia_rs import fast_forward_singleton, get_conditions_from_spendbundle
 
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.constants import ConsensusConstants
-from chia.full_node.bundle_tools import simple_solution_generator
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -16,6 +14,7 @@ from chia.types.coin_spend import CoinSpend
 from chia.types.internal_mempool_item import InternalMempoolItem
 from chia.types.mempool_item import BundleCoinSpend
 from chia.types.spend_bundle import SpendBundle
+from chia.util.errors import Err
 from chia.util.ints import uint32, uint64
 
 
@@ -332,17 +331,25 @@ class EligibleCoinSpends:
             coin_spends=new_coin_spends, aggregated_signature=mempool_item.spend_bundle.aggregated_signature
         )
         # We need to run the new spend bundle to make sure it remains valid
-        generator = simple_solution_generator(new_sb)
-        new_npc_result = get_name_puzzle_conditions(
-            generator=generator,
-            max_cost=mempool_item.conds.cost,
-            mempool_mode=True,
-            height=height,
-            constants=constants,
-        )
-        if new_npc_result.error is not None:
-            raise ValueError("Mempool item became invalid after singleton fast forward.")
-        assert new_npc_result.conds is not None
+        assert mempool_item.conds is not None
+        try:
+            new_conditions = get_conditions_from_spendbundle(
+                new_sb,
+                mempool_item.conds.cost,
+                constants,
+                height,
+            )
+        # validate_clvm_and_signature raises a TypeError with an error code
+        except TypeError as e:
+            # Convert that to a ValidationError
+            if len(e.args) > 0:
+                error = Err(e.args[0])
+                raise ValueError(f"Mempool item became invalid after singleton fast forward with error {error}.")
+            else:
+                raise ValueError(
+                    "Mempool item became invalid after singleton fast forward with an unspecified error."
+                )  # pragma: no cover
+
         # Update bundle_coin_spends using the collected data
         for coin_id in replaced_coin_ids:
             mempool_item.bundle_coin_spends.pop(coin_id, None)
@@ -354,4 +361,4 @@ class EligibleCoinSpends:
         # change. Still, it's good form to update the spend bundle with the
         # new coin spends
         mempool_item.spend_bundle = new_sb
-        mempool_item.conds = new_npc_result.conds
+        mempool_item.conds = new_conditions


### PR DESCRIPTION
### Purpose:
Leverage the Rust version of `validate_clvm_and_signature` with the added benefit of being able to use `ThreadPools` instead of `ProcessPools`.

### Current Behavior:
Mempool item prevalidation currently happens with a Python version of `validate_clvm_and_signature` through `ProcessPools`.

### New Behavior:
Mempool item prevalidation happens with a Rust version of `validate_clvm_and_signature` through `ThreadPools`.