### PR TITLE
Fixed logging for fast bluebox timelord and added Visual Studio (.vs)…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ activate
 # Editors
 .vscode
 .idea
+.vs
 
 # Packaging
 chia-blockchain.tar.gz

--- a/chia/timelord/timelord_launcher.py
+++ b/chia/timelord/timelord_launcher.py
@@ -110,17 +110,25 @@ async def spawn_process(
             continue
 
         async with process_mgr.manage_proc(proc):
-            stdout, stderr = await proc.communicate()
-            if stdout:
-                log.info(f"VDF client {counter}: {stdout.decode().rstrip()}")
-            if stderr:
-                if first_10_seconds:
-                    if time.time() - start_time > 10:
-                        first_10_seconds = False
-                else:
-                    log.error(f"VDF client {counter}: {stderr.decode().rstrip()}")
+            while True:
+                if proc.stdout is None or proc.stderr is None:
+                    break
+                if proc.stdout.at_eof() and proc.stderr.at_eof():
+                    break
+                stdout = (await proc.stdout.readline()).decode().rstrip()
+                if stdout:
+                    log.info(f"VDF client {counter}: {stdout}")
+                stderr = (await proc.stderr.readline()).decode().rstrip()
+                if stderr:
+                    if first_10_seconds:
+                        if time.time() - start_time > 10:
+                            first_10_seconds = False
+                    else:
+                        log.error(f"VDF client {counter}: {stderr}")
 
-        await asyncio.sleep(0.1)
+                await asyncio.sleep(0.1)
+
+            await proc.communicate()
 
 
 async def spawn_all_processes(config: Dict, net_config: Dict, process_mgr: VDFClientProcessMgr):

--- a/chia/timelord/timelord_launcher.py
+++ b/chia/timelord/timelord_launcher.py
@@ -55,9 +55,7 @@ class VDFClientProcessMgr:
             self.active_processes.clear()
 
     @asynccontextmanager
-    async def manage_proc(
-        self, proc: asyncio.subprocess.Process
-    ) -> AsyncIterator[None]:
+    async def manage_proc(self, proc: asyncio.subprocess.Process) -> AsyncIterator[None]:
         await self.add_process(proc)
         try:
             yield
@@ -79,9 +77,7 @@ def find_vdf_client() -> pathlib.Path:
     p = location.joinpath("vdf_client")
     if p.is_file():
         return p
-    raise FileNotFoundError(
-        "Cannot find vdf_client binary. Is Timelord installed? See install-timelord.sh"
-    )
+    raise FileNotFoundError("Cannot find vdf_client binary. Is Timelord installed? See install-timelord.sh")
 
 
 async def spawn_process(
@@ -135,9 +131,7 @@ async def spawn_process(
             await proc.communicate()
 
 
-async def spawn_all_processes(
-    config: Dict, net_config: Dict, process_mgr: VDFClientProcessMgr
-):
+async def spawn_all_processes(config: Dict, net_config: Dict, process_mgr: VDFClientProcessMgr):
     await asyncio.sleep(5)
     hostname = net_config["self_hostname"] if "host" not in config else config["host"]
     port = config["port"]

--- a/chia/timelord/timelord_launcher.py
+++ b/chia/timelord/timelord_launcher.py
@@ -55,7 +55,9 @@ class VDFClientProcessMgr:
             self.active_processes.clear()
 
     @asynccontextmanager
-    async def manage_proc(self, proc: asyncio.subprocess.Process) -> AsyncIterator[None]:
+    async def manage_proc(
+        self, proc: asyncio.subprocess.Process
+    ) -> AsyncIterator[None]:
         await self.add_process(proc)
         try:
             yield
@@ -77,7 +79,9 @@ def find_vdf_client() -> pathlib.Path:
     p = location.joinpath("vdf_client")
     if p.is_file():
         return p
-    raise FileNotFoundError("Cannot find vdf_client binary. Is Timelord installed? See install-timelord.sh")
+    raise FileNotFoundError(
+        "Cannot find vdf_client binary. Is Timelord installed? See install-timelord.sh"
+    )
 
 
 async def spawn_process(
@@ -131,7 +135,9 @@ async def spawn_process(
             await proc.communicate()
 
 
-async def spawn_all_processes(config: Dict, net_config: Dict, process_mgr: VDFClientProcessMgr):
+async def spawn_all_processes(
+    config: Dict, net_config: Dict, process_mgr: VDFClientProcessMgr
+):
     await asyncio.sleep(5)
     hostname = net_config["self_hostname"] if "host" not in config else config["host"]
     port = config["port"]


### PR DESCRIPTION
Resolved an issue with buffered logging for fast bluebox timelords.
Added ".vs" to gitignore for Visual Studio IDEs
Checking for EOF on stdout/stderr to prevent erroneous warnings in the logs when services are shutting down

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
Improve logging around bluebox timelords

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:
Fast bluebox timelord logging is buffered and only written to the log when a proof is successfully compacted (log snippet below)
2024-08-26T08:14:55.180 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 9: VDF Client: Discriminant = -0xf99b672f309a774ed181ee97aadf94e214c2fef363bfbde60f87c017ae16b2b6775bdd302bde0a37f45dd16715db661dad738cfd7305f944266281cb2d3c4b8ef1368cc1abc75540b6cd600f98b10cd24df580bcf6c67406f5b9291112a4f5b4083607469ac66817e36dbf97a909f4d450d1bb20f68c94042cb5422dd59c9667
Got simple weso proof: 0200b624f10e8099d189fe442311a6ce4607f4228eab3a3737a930ae2ae0d88a000320d6d02ee3838ec56e218e7189db49416d6619a9cf76ff5ad6378d401a0a1769d70f59b4fb21716623eadaf911c837b7e067a504a078967deb9effdce4507f010100010060513b9aa88cd5104c5d4a8fc53b5a8953052553339cacb06ffd87c72e6cf52038f2e763abc64788da79620cc7690b932960be3215f938516df04cbb1a3051137fc5da8f0075c22afc41d68330697875ef1d89f67fe26862a1d60095542bb70a0502
VDF Client: Sending proof
VDF Client: Sent proof
VDF loop finished. Total iters: 46011276
VDF Client: Stopped everything! Ready for the next challenge.

### New Behavior:
Logging is written out as events occur, allowing for better monitoring of progression (log snippet below)
2024-08-25T20:36:54.005 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 6: VDF Client: Discriminant = -0x81b0a38b20f2bdea6767bd7da72a21ecd5874f997a3207324cea4fc8e7d4ae2378e4f22e43f1fe39a01f49682d907cf898abd3488dfa04ca913ae1114a07ad0da050f4a7beba52d7dcc40c3529e4d656dc309ce1d38f0636bdd635d5258a95a5f2f793271e1daef657f1c92117639fd69fc674e0d1337f429e4cf58600b23687
2024-08-25T20:36:54.007 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 7: VDF Client: Discriminant = -0x9fda95a677c43fc2c753f6d3fc934a84f9112d3c11856f14b27b6420d7ac31444ddd3b6cde266e2ba64c20f0b6db4f6ed9cffafc3ffeced40dffa73c38193696896a00fbdd68e9c20827744d67865a16bdbed7ed3dbba4f0aeeb2e3e57085e595a3a580c1c8d036667306afb4880b60d8b1f891b7c95e6334fab724f94893faf
2024-08-25T20:36:54.036 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 2: VDF Client: Discriminant = -0x81b0a38b20f2bdea6767bd7da72a21ecd5874f997a3207324cea4fc8e7d4ae2378e4f22e43f1fe39a01f49682d907cf898abd3488dfa04ca913ae1114a07ad0da050f4a7beba52d7dcc40c3529e4d656dc309ce1d38f0636bdd635d5258a95a5f2f793271e1daef657f1c92117639fd69fc674e0d1337f429e4cf58600b23687
2024-08-25T20:36:54.061 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 0: VDF Client: Discriminant = -0xe7f9a2eb77e6e363812698d3adb3c7b0f62010abc66884d9834e427366ecd00e62cdc2bed5612cc9ba94a84ee2141d16dfcdeadb4c584e889d9cc31a7a38fe73e391a51b3d82137470ffdac3b168bbe4f9077203dbd7b69b5b837645303e6411aa8704c99b9c26664811670c9cab9b1d346817e5cd782ab77e67cc995c84b737
2024-08-25T20:36:54.069 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 4: VDF Client: Discriminant = -0xb3b9fe030a2fe442dd6ec170c1efbfd412834add0130e93f94349d93656521f5047e88457b55cf35e47dd23ed66628580db257b8553ebd8a9a076e7d87efee2167aedaaceac7a9d0dc49ec01649ef76270be3dcd4708bb4efa87a191495e39b28ff3ceda76a05464eb14f0bd956a00eef2c9632f46d90ae662be7ecedaed97b7
2024-08-25T20:36:54.077 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 3: VDF Client: Discriminant = -0xb3b9fe030a2fe442dd6ec170c1efbfd412834add0130e93f94349d93656521f5047e88457b55cf35e47dd23ed66628580db257b8553ebd8a9a076e7d87efee2167aedaaceac7a9d0dc49ec01649ef76270be3dcd4708bb4efa87a191495e39b28ff3ceda76a05464eb14f0bd956a00eef2c9632f46d90ae662be7ecedaed97b7
2024-08-25T20:36:54.087 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 1: VDF Client: Discriminant = -0x8bc076d4793b907fdda8346bf834cfa808126ef3ef13a3533ab7dcabeb1fb2afcbd5a7a6b8eab67ffeabd980a8b8aecc07e943b730539093c0a9de0d2e45cf0cf91373676c00aa9850ac5ea8f5fb33dcbee6c1641bb5df1f5120f029b151549841151bb46a50ac4159af3d900e49813d58adbb611671b38f2002cbeee74c2f1f
2024-08-25T20:36:54.160 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 8: VDF Client: Discriminant = -0xe52bc4e846fe1f6e247db832f4edb64e2fcad47fecbc090785cdc771a11dfb16a074f76748aad3b2c2a541de23dfc0678beca69d34bda5880db026158d99ff130bfc84ac82cdf911c282fbe9245369751fc1602e1b3d313de4e8e4e3dd33cf5d0cde24e380ef78cb2a592413b463312e5394deef11ec2851b0dfac4edd0e7bc7
2024-08-25T20:36:54.236 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 5: VDF Client: Discriminant = -0xe52bc4e846fe1f6e247db832f4edb64e2fcad47fecbc090785cdc771a11dfb16a074f76748aad3b2c2a541de23dfc0678beca69d34bda5880db026158d99ff130bfc84ac82cdf911c282fbe9245369751fc1602e1b3d313de4e8e4e3dd33cf5d0cde24e380ef78cb2a592413b463312e5394deef11ec2851b0dfac4edd0e7bc7
2024-08-25T20:36:54.254 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 9: VDF Client: Discriminant = -0xb3246bd83477c2cbae8f1a2f5029437d36b5fcf3804d2d4769551120a455f742e2c1ecde3ba76b62984983ad39fb797290085f72fcaa36fa79a509d728ed1ad86a65d31f2208aa7b836a5c0d77f77c9e13ccf08016a8ba1818b2b6515878c260f8a8faee5b4ba5c1793cd24948d799cb3a62cc57edee581b35bb887fb85f802f
2024-08-25T20:39:16.747 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 1: Got simple weso proof: 03007ac5be14559b0e620aa9ec32be2075008da19fa3397ce001b0b9a5748b8b82d25cb054eb8963c6a2ff00d4a13d04a6c957376e937809c2588402c90342b50a2043e359e8b354ba92dde16f2066738504a78733001f2390d2ec2b82cf21bff10901000100a29bf85061ff4831112437066e11cd1cb8ab6534f5196ef7aa6724d58b85b01fabf1a8da94f24198c3f21d3ac492c519a8fc98684c933b7c690709d08bfda6295d1750bfeeacee02a68257ac8714595acb5b7b62ff3827d57daced92dfbe6f390100
2024-08-25T20:39:16.847 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 1: VDF Client: Sending proof
2024-08-25T20:39:16.948 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 1: VDF Client: Sent proof
2024-08-25T20:39:17.050 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 1: VDF loop finished. Total iters: 16624962
2024-08-25T20:39:17.151 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 1: VDF Client: Stopped everything! Ready for the next challenge.
2024-08-25T20:39:17.311 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 1: VDF Client: Discriminant = -0xc8bd3aadec6512e0a1668d13091137f25517a060cc03354372de2ea0f89276e8b493e323a4bdf36c87717c8ca3351d16fdf2bd7ee901b9356d823dc9c82d720bdaf08bffb21119c1ed3c6898bb3fc83598c01c0cb145999810cdace0b74ec92f46e48b539f9d4d4464e715df42473735031d0c9abf6de1c2138c7fef4c9fed0f
2024-08-25T20:40:43.372 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 9: Got simple weso proof: 0300b73cd2c8c43a3065bcd331a08006c9ee989b35edf435185add0c9c1358c5572b471c2973e9b3c97d44f3d6aeba70d588eb3b27290cf7d6caa35feee534133d4da580f4afa2ddd3939f4aa26821353f2fd1dbd4ac9984dedb29f45fa3ab1fa484010000004a3b748923a54195301c7e830ba3175495a9cf47089b5976326dadd7e6ac2bd4e74030f272daf23f92cd917ea9554fcbde1181176f95fd2b6a84cb72b7b555664bfab9d27aec42b66e22f9ac396b93d3127cde4baad79f7b4be6daa63a0805700100
2024-08-25T20:40:43.473 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 9: VDF Client: Sending proof
2024-08-25T20:40:43.573 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 9: VDF Client: Sent proof
2024-08-25T20:40:43.674 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 9: VDF loop finished. Total iters: 26634284
2024-08-25T20:40:43.775 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 9: VDF Client: Stopped everything! Ready for the next challenge.
2024-08-25T20:40:43.938 TLauncher chia.timelord.timelord_launcher: INFO     VDF client 9: VDF Client: Discriminant = -0x8f117ba1d99bcf43be9dd6161667b9a56b1c643ad22d1bb77f5d2475150c9f8affded490a522060c4372c098e1d23eca3d8e81a9f5726cc80b4f39dedd7d821d5d50b4bb64778d8eeb2f8f34f20225495c53b52ea098952a064aab57f4b457f9d258d9258339ffb2b3e2f415985f3eee42434e29aaa337111695f9d4f8e7ee77


<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
