### PR TITLE
Remove chia-seeder.h9.com

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -425,7 +425,6 @@ full_node:
     - "dns-introducer.chia.net"
     - "chia.ctrlaltdel.ch"
     - "seeder.dexie.space"
-    - "chia-seeder.h9.com"
     - "chia.hoffmang.com"
     - "seeder.xchpool.org"
   introducer_peer:


### PR DESCRIPTION
Remove chia-seeder.h9.com - has been offline for months and we have received no response about it being down