### PR TITLE
Set AGG_SIG_ME_ADDITIONAL_DATA in config.yaml for simulator

### DIFF
--- a/chia/cmds/sim_funcs.py
+++ b/chia/cmds/sim_funcs.py
@@ -76,6 +76,7 @@ def create_chia_directory(
         config["network_overrides"]["config"]["simulator0"] = config["network_overrides"]["config"]["testnet0"].copy()
         sim_genesis = "eb8c4d20b322be8d9fddbf9412016bdffe9a2901d7edb0e364e94266d0e095f7"
         config["network_overrides"]["constants"]["simulator0"]["GENESIS_CHALLENGE"] = sim_genesis
+        config["network_overrides"]["constants"]["simulator0"]["AGG_SIG_ME_ADDITIONAL_DATA"] = sim_genesis
         # tell services to use simulator0
         config["selected_network"] = "simulator0"
         config["wallet"]["selected_network"] = "simulator0"


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

We currently generate a `config.yaml` for the simulator which sets `GENESIS_CHALLENGE` but not `AGG_SIG_ME_ADDITIONAL_DATA`. This results in the simulator defaulting to using the mainnet genesis challenge as the agg sig me additional data.

### Current Behavior:

Mainnet genesis challenge used as agg sig me additional data on the simulator.

### New Behavior:

Simulator genesis challenge used as agg sig me additional data on the simulator.
