### PR TITLE
[CHIA-1357] Correctly set `start_index` in `create_more_puzzle_hashes`

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -431,7 +431,6 @@ class WalletStateManager:
 
         # iterate all wallets that need derived keys and establish the start
         # index for all of them
-        start_index: int = 0
         start_index_by_wallet: Dict[uint32, int] = {}
         last_index = unused + to_generate
         for wallet_id in targets:
@@ -445,9 +444,8 @@ class WalletStateManager:
             last: Optional[uint32] = await self.puzzle_store.get_last_derivation_path_for_wallet(wallet_id)
             if last is not None:
                 if last + 1 >= last_index:
-                    self.log.debug(f"Nothing to create for for wallet_id: {wallet_id}, index: {start_index}")
+                    self.log.debug(f"Nothing to create for for wallet_id: {wallet_id}, index: {last_index}")
                     continue
-                start_index = min(start_index, last + 1)
                 start_index_by_wallet[wallet_id] = last + 1
             else:
                 start_index_by_wallet[wallet_id] = 0
@@ -455,7 +453,9 @@ class WalletStateManager:
         if len(start_index_by_wallet) == 0:
             return
 
-        # now derive the keysfrom start_index to last_index
+        lowest_start_index = min(start_index_by_wallet.values())
+
+        # now derive the keysfrom lowest_start_index to last_index
         # these maps derivation index to public key
         hardened_keys: Dict[int, G1Element] = {}
         unhardened_keys: Dict[int, G1Element] = {}
@@ -463,12 +463,12 @@ class WalletStateManager:
         if self.private_key is not None:
             # Hardened
             intermediate_sk = master_sk_to_wallet_sk_intermediate(self.private_key)
-            for index in range(start_index, last_index):
+            for index in range(lowest_start_index, last_index):
                 hardened_keys[index] = _derive_path(intermediate_sk, [index]).get_g1()
 
         # Unhardened
         intermediate_pk_un = master_pk_to_wallet_pk_unhardened_intermediate(self.root_pubkey)
-        for index in range(start_index, last_index):
+        for index in range(lowest_start_index, last_index):
             unhardened_keys[index] = _derive_pk_unhardened(intermediate_pk_un, [index])
 
         for wallet_id, start_index in start_index_by_wallet.items():


### PR DESCRIPTION
Due to a logic error, `start_index` in the `create_more_puzzle_hashes` function would always be set to 0 resulting in the re-derivation of potentially many pubkeys that were not necessary.  This PR correctly creates the intended variable of `lowest_start_index`.