### PR TITLE
[CHIA-1359] Fix action scope callbacks across multiple `.use` calls

### DIFF
--- a/chia/_tests/util/test_action_scope.py
+++ b/chia/_tests/util/test_action_scope.py
@@ -90,6 +90,9 @@ async def test_callbacks() -> None:
 
             interface.set_callback(callback)
 
+        async with action_scope.use():
+            pass  # Testing that callback stays put even through another .use()
+
     assert action_scope.side_effects.buf == b"bar"
 
 

--- a/chia/util/action_scope.py
+++ b/chia/util/action_scope.py
@@ -143,7 +143,7 @@ class ActionScope(Generic[_T_SideEffects, _T_Config]):
     async def use(self, _callbacks_allowed: bool = True) -> AsyncIterator[StateInterface[_T_SideEffects]]:
         async with self._resource_manager.use():
             side_effects = await self._resource_manager.get_resource(self._side_effects_format)
-            interface = StateInterface(side_effects, _callbacks_allowed)
+            interface = StateInterface(side_effects, _callbacks_allowed, self._callback)
 
             yield interface
 


### PR DESCRIPTION
A bug was noticed where action scope callbacks were not preserved across multiple calls to `.use()`. This PR fixes that bug and adds a test for it.