### PR TITLE
CHIA-1362 Deduct block overhead from the mempool's maximum block clvm cost limit

### DIFF
--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -18,6 +18,8 @@ from chia.full_node.mempool import MAX_SKIPPED_ITEMS, PRIORITY_TX_THRESHOLD
 from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, mempool_check_time_locks
 from chia.full_node.mempool_manager import (
     MEMPOOL_MIN_FEE_INCREASE,
+    QUOTE_BYTES,
+    QUOTE_EXECUTION_COST,
     MempoolManager,
     TimelockConditions,
     can_replace,
@@ -1943,8 +1945,8 @@ async def test_mempool_timelocks(cond1: List[object], cond2: List[object], expec
 
 
 TEST_FILL_RATE_ITEM_COST = 144_720_020
-QUOTE_BYTE_COST = 2 * DEFAULT_CONSTANTS.COST_PER_BYTE
-QUOTE_EXECUTION_COST = 20
+TEST_COST_PER_BYTE = 12_000
+TEST_BLOCK_OVERHEAD = QUOTE_BYTES * TEST_COST_PER_BYTE + QUOTE_EXECUTION_COST
 
 
 @pytest.mark.anyio
@@ -1962,8 +1964,8 @@ QUOTE_EXECUTION_COST = 20
         # Here we set the block cost limit to twice the test items' cost - 1,
         # so we expect only one of the two test items to get included in the block.
         # NOTE: The cost difference here is because get_conditions_from_spendbundle
-        # does not include the overhead to make a block (quote byte cost  + quote runtime cost).
-        (TEST_FILL_RATE_ITEM_COST * 2 - 1, 1, TEST_FILL_RATE_ITEM_COST + QUOTE_BYTE_COST + QUOTE_EXECUTION_COST),
+        # does not include the block overhead.
+        (TEST_FILL_RATE_ITEM_COST * 2 - 1, 1, TEST_FILL_RATE_ITEM_COST + TEST_BLOCK_OVERHEAD),
     ],
 )
 async def test_fill_rate_block_validation(

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -119,6 +119,11 @@ class NewPeakItem:
     conds: SpendBundleConditions
 
 
+# For block overhead cost calculation
+QUOTE_BYTES = 2
+QUOTE_EXECUTION_COST = 20
+
+
 class MempoolManager:
     pool: Executor
     constants: ConsensusConstants
@@ -158,7 +163,11 @@ class MempoolManager:
         self.nonzero_fee_minimum_fpc = 5
 
         BLOCK_SIZE_LIMIT_FACTOR = 0.7
-        self.max_block_clvm_cost = uint64(self.constants.MAX_BLOCK_COST_CLVM * BLOCK_SIZE_LIMIT_FACTOR)
+        # We need to deduct the block overhead, which consists of the wrapping
+        # quote opcode's bytes cost as well as its execution cost.
+        BLOCK_OVERHEAD = QUOTE_BYTES * self.constants.COST_PER_BYTE + QUOTE_EXECUTION_COST
+
+        self.max_block_clvm_cost = uint64(self.constants.MAX_BLOCK_COST_CLVM * BLOCK_SIZE_LIMIT_FACTOR - BLOCK_OVERHEAD)
         self.max_tx_clvm_cost = (
             max_tx_clvm_cost if max_tx_clvm_cost is not None else uint64(self.constants.MAX_BLOCK_COST_CLVM // 2)
         )


### PR DESCRIPTION
### Purpose:

Account for the block overhead when creating a mempool bundle for the purpose of block creation, to ensure we never exceed the block maximum clvm cost limit.

### Current Behavior:

We use maximum block clvm cost as the limit when creating the mempool bundle without regard for block overhead.

### New Behavior:

We deduct the block overhead from the maximum block clvm cost limit itself.