### PR TITLE
[CHIA-1346] Add a full node RPC client to `WalletTestFramework`

### DIFF
--- a/chia/_tests/environments/wallet.py
+++ b/chia/_tests/environments/wallet.py
@@ -6,6 +6,7 @@ from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Tuple, Union, cast
 
 from chia._tests.environments.common import ServiceEnvironment
+from chia.rpc.full_node_rpc_client import FullNodeRpcClient
 from chia.rpc.rpc_server import RpcServer
 from chia.rpc.wallet_rpc_api import WalletRpcApi
 from chia.rpc.wallet_rpc_client import WalletRpcClient
@@ -266,6 +267,7 @@ class WalletEnvironment:
 @dataclass
 class WalletTestFramework:
     full_node: FullNodeSimulator
+    full_node_rpc_client: FullNodeRpcClient
     trusted_full_node: bool
     environments: List[WalletEnvironment]
     tx_config: TXConfig = DEFAULT_TX_CONFIG

--- a/chia/_tests/wallet/test_wallet_test_framework.py
+++ b/chia/_tests/wallet/test_wallet_test_framework.py
@@ -8,6 +8,7 @@ from chia._tests.environments.wallet import (
     WalletStateTransition,
     WalletTestFramework,
 )
+from chia.consensus.block_record import BlockRecord
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
 
 
@@ -43,6 +44,8 @@ async def test_basic_functionality(wallet_environments: WalletTestFramework) -> 
     assert env_0.node.config["min_mainnet_k_size"] == 2
     assert env_0.wallet_state_manager.config["min_mainnet_k_size"] == 2
     assert wallet_environments.full_node.full_node.config["min_mainnet_k_size"] == 2
+
+    assert isinstance(await wallet_environments.full_node_rpc_client.get_block_record_by_height(1), BlockRecord)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
On occasion, a test would like to both interact with a wallet and a full node.  Currently, the `WalletTestFramework` has no method for getting an RPC client for a full node.  This PR adds that.