### PR TITLE
[CHIA-1175] Add TXConfig args to coin commands

### DIFF
--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -120,6 +120,8 @@ async def async_combine(
     max_coin_amount: CliAmount,
     min_coin_amount: CliAmount,
     excluded_amounts: Sequence[CliAmount],
+    coins_to_exclude: Sequence[bytes32],
+    reuse_puzhash: bool,
     number_of_coins: int,
     target_coin_amount: Optional[CliAmount],
     target_coin_ids: Sequence[bytes32],
@@ -142,7 +144,8 @@ async def async_combine(
             max_coin_amount=max_coin_amount,
             min_coin_amount=min_coin_amount,
             excluded_coin_amounts=list(excluded_amounts),
-            # TODO: [add TXConfig args] add excluded_coin_ids
+            excluded_coin_ids=list(coins_to_exclude),
+            reuse_puzhash=reuse_puzhash,
         ).to_tx_config(mojo_per_unit, config, fingerprint)
 
         final_target_coin_amount = (
@@ -188,7 +191,11 @@ async def async_split(
     number_of_coins: int,
     amount_per_coin: CliAmount,
     target_coin_id: bytes32,
-    # TODO: [add TXConfig args]
+    max_coin_amount: CliAmount,
+    min_coin_amount: CliAmount,
+    excluded_amounts: Sequence[CliAmount],
+    coins_to_exclude: Sequence[bytes32],
+    reuse_puzhash: bool,
     push: bool,
     condition_valid_times: ConditionValidTimes,
 ) -> List[TransactionRecord]:
@@ -206,7 +213,11 @@ async def async_split(
         final_amount_per_coin = amount_per_coin.convert_amount(mojo_per_unit)
 
         tx_config = CMDTXConfigLoader(
-            # TODO: [add TXConfig args]
+            max_coin_amount=max_coin_amount,
+            min_coin_amount=min_coin_amount,
+            excluded_coin_amounts=list(excluded_amounts),
+            excluded_coin_ids=list(coins_to_exclude),
+            reuse_puzhash=reuse_puzhash,
         ).to_tx_config(mojo_per_unit, config, fingerprint)
 
         transactions: List[TransactionRecord] = (

--- a/chia/cmds/coins.py
+++ b/chia/cmds/coins.py
@@ -6,8 +6,8 @@ from typing import List, Optional, Sequence
 import click
 
 from chia.cmds import options
-from chia.cmds.cmds_util import tx_out_cmd
-from chia.cmds.param_types import AmountParamType, Bytes32ParamType, CliAmount, cli_amount_none
+from chia.cmds.cmds_util import coin_selection_args, tx_config_args, tx_out_cmd
+from chia.cmds.param_types import AmountParamType, Bytes32ParamType, CliAmount
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint64
 from chia.wallet.conditions import ConditionValidTimes
@@ -31,32 +31,7 @@ def coins_cmd(ctx: click.Context) -> None:
 @options.create_fingerprint()
 @click.option("-i", "--id", help="Id of the wallet to use", type=int, default=1, show_default=True, required=True)
 @click.option("-u", "--show-unconfirmed", help="Separately display unconfirmed coins.", is_flag=True)
-@click.option(
-    "--min-amount",
-    help="Ignore coins worth less then this much XCH or CAT units",
-    type=AmountParamType(),
-    default=cli_amount_none,
-)
-@click.option(
-    "--max-amount",
-    help="Ignore coins worth more then this much XCH or CAT units",
-    type=AmountParamType(),
-    default=cli_amount_none,
-)
-@click.option(
-    "--exclude-coin",
-    "coins_to_exclude",
-    multiple=True,
-    help="prevent this coin from being included.",
-    type=Bytes32ParamType(),
-)
-@click.option(
-    "--exclude-amount",
-    "amounts_to_exclude",
-    multiple=True,
-    type=AmountParamType(),
-    help="Exclude any coins with this XCH or CAT amount from being included.",
-)
+@coin_selection_args
 @click.option(
     "--paginate/--no-paginate",
     default=None,
@@ -69,8 +44,8 @@ def list_cmd(
     fingerprint: int,
     id: int,
     show_unconfirmed: bool,
-    min_amount: CliAmount,
-    max_amount: CliAmount,
+    min_coin_amount: CliAmount,
+    max_coin_amount: CliAmount,
     coins_to_exclude: Sequence[bytes32],
     amounts_to_exclude: Sequence[CliAmount],
     paginate: Optional[bool],
@@ -82,8 +57,8 @@ def list_cmd(
             wallet_rpc_port=wallet_rpc_port,
             fingerprint=fingerprint,
             wallet_id=id,
-            max_coin_amount=max_amount,
-            min_coin_amount=min_amount,
+            max_coin_amount=max_coin_amount,
+            min_coin_amount=min_coin_amount,
             excluded_amounts=amounts_to_exclude,
             excluded_coin_ids=coins_to_exclude,
             show_unconfirmed=show_unconfirmed,
@@ -111,19 +86,6 @@ def list_cmd(
     default=None,
 )
 @click.option(
-    "--min-amount",
-    help="Ignore coins worth less then this much XCH or CAT units",
-    type=AmountParamType(),
-    default=cli_amount_none,
-)
-@click.option(
-    "--exclude-amount",
-    "amounts_to_exclude",
-    multiple=True,
-    type=AmountParamType(),
-    help="Exclude any coins with this XCH or CAT amount from being included.",
-)
-@click.option(
     "-n",
     "--number-of-coins",
     type=int,
@@ -131,12 +93,7 @@ def list_cmd(
     show_default=True,
     help="The number of coins we are combining.",
 )
-@click.option(
-    "--max-amount",
-    help="Ignore coins worth more then this much XCH or CAT units",
-    type=AmountParamType(),
-    default=cli_amount_none,
-)
+@tx_config_args
 @options.create_fee()
 @click.option(
     "--input-coin",
@@ -157,13 +114,15 @@ def combine_cmd(
     fingerprint: int,
     id: int,
     target_amount: Optional[CliAmount],
-    min_amount: CliAmount,
+    min_coin_amount: CliAmount,
     amounts_to_exclude: Sequence[CliAmount],
+    coins_to_exclude: Sequence[bytes32],
     number_of_coins: int,
-    max_amount: CliAmount,
+    max_coin_amount: CliAmount,
     fee: uint64,
     input_coins: Sequence[bytes32],
     largest_first: bool,
+    reuse: bool,
     push: bool,
     condition_valid_times: ConditionValidTimes,
 ) -> List[TransactionRecord]:
@@ -175,9 +134,11 @@ def combine_cmd(
             fingerprint=fingerprint,
             wallet_id=id,
             fee=fee,
-            max_coin_amount=max_amount,
-            min_coin_amount=min_amount,
+            max_coin_amount=max_coin_amount,
+            min_coin_amount=min_coin_amount,
             excluded_amounts=amounts_to_exclude,
+            coins_to_exclude=coins_to_exclude,
+            reuse_puzhash=reuse,
             number_of_coins=number_of_coins,
             target_coin_amount=target_amount,
             target_coin_ids=input_coins,
@@ -216,6 +177,7 @@ def combine_cmd(
 @click.option(
     "-t", "--target-coin-id", type=Bytes32ParamType(), required=True, help="The coin id of the coin we are splitting."
 )
+@tx_config_args
 @tx_out_cmd()
 def split_cmd(
     wallet_rpc_port: Optional[int],
@@ -225,6 +187,11 @@ def split_cmd(
     fee: uint64,
     amount_per_coin: CliAmount,
     target_coin_id: bytes32,
+    min_coin_amount: CliAmount,
+    max_coin_amount: CliAmount,
+    amounts_to_exclude: Sequence[CliAmount],
+    coins_to_exclude: Sequence[bytes32],
+    reuse: bool,
     push: bool,
     condition_valid_times: ConditionValidTimes,
 ) -> List[TransactionRecord]:
@@ -236,6 +203,11 @@ def split_cmd(
             fingerprint=fingerprint,
             wallet_id=id,
             fee=fee,
+            max_coin_amount=max_coin_amount,
+            min_coin_amount=min_coin_amount,
+            excluded_amounts=amounts_to_exclude,
+            coins_to_exclude=coins_to_exclude,
+            reuse_puzhash=reuse,
             number_of_coins=number_of_coins,
             amount_per_coin=amount_per_coin,
             target_coin_id=target_coin_id,


### PR DESCRIPTION
Addressing some code `TODO`s and making sure all of our coin commands have a consistent API w/ the full set of options.