### PR TITLE
CHIA-1377 Remove no longer needed tx_bytes in add_transaction

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2444,12 +2444,7 @@ class FullNode:
         return None, False
 
     async def add_transaction(
-        self,
-        transaction: SpendBundle,
-        spend_name: bytes32,
-        peer: Optional[WSChiaConnection] = None,
-        test: bool = False,
-        tx_bytes: Optional[bytes] = None,
+        self, transaction: SpendBundle, spend_name: bytes32, peer: Optional[WSChiaConnection] = None, test: bool = False
     ) -> Tuple[MempoolInclusionStatus, Optional[Err]]:
         if self.sync_store.get_sync_mode():
             return MempoolInclusionStatus.FAILED, Err.NO_TRANSACTIONS_WHILE_SYNCING


### PR DESCRIPTION
### Purpose:

This is an addendum to PR #18557. We no longer need/use `tx_bytes` here.

### Current Behavior:

`add_transaction` takes an optional `tx_bytes`.

### New Behavior:

`add_transaction` no longer takes an optional `tx_bytes`.