### PR TITLE
CHIA-1387 Simplify fetching TX data in create_bundle_from_mempool_items

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -494,8 +494,7 @@ class Mempool:
         sigs: List[G2Element] = []
         log.info(f"Starting to make block, max cost: {self.mempool_info.max_block_clvm_cost}")
         bundle_creation_start = monotonic()
-        with self._db_conn:
-            cursor = self._db_conn.execute("SELECT name, fee FROM tx ORDER BY fee_per_cost DESC, seq ASC")
+        cursor = self._db_conn.execute("SELECT name, fee FROM tx ORDER BY fee_per_cost DESC, seq ASC")
         skipped_items = 0
         for row in cursor:
             name = bytes32(row[0])


### PR DESCRIPTION
### Purpose:

We don't need a transaction as we're only fetching TX data here.

### Current Behavior:

We're fetching TX data in a transaction, despite having nothing to commit or rollback.

### New Behavior:

We simply fetch the TX data we need.