### PR TITLE
CHIA-1388 Check the cat list values from get_cat_list against the default cats in test_cat_endpoints

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -48,6 +48,7 @@ from chia.rpc.rpc_client import ResponseFailureError
 from chia.rpc.rpc_server import RpcServer
 from chia.rpc.wallet_request_types import (
     CombineCoins,
+    DefaultCAT,
     DIDGetPubkey,
     GetNotifications,
     SplitCoins,
@@ -1166,7 +1167,13 @@ async def test_cat_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment):
     assert len(selected_coins) > 0
 
     # Test get_cat_list
-    assert len(DEFAULT_CATS) == len((await client.get_cat_list()).cat_list)
+    cat_list = (await client.get_cat_list()).cat_list
+    assert len(DEFAULT_CATS) == len(cat_list)
+    default_cats_set = {
+        DefaultCAT(asset_id=bytes32.from_hexstr(cat["asset_id"]), name=cat["name"], symbol=cat["symbol"])
+        for cat in DEFAULT_CATS.values()
+    }
+    assert default_cats_set == set(cat_list)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Purpose:

This covers not only the length of the returned list, but the contents as well.

### Current Behavior:

We check if `get_cat_list` returns a list with the expected length against default CATs.

### New Behavior:

We check both the length and the contents returned by `get_cat_list` against default CATs.