### PR TITLE
Port `test_trades.py` to `WalletTestFramework`

### DIFF
--- a/chia/_tests/environments/wallet.py
+++ b/chia/_tests/environments/wallet.py
@@ -272,7 +272,9 @@ class WalletTestFramework:
     environments: List[WalletEnvironment]
     tx_config: TXConfig = DEFAULT_TX_CONFIG
 
-    async def process_pending_states(self, state_transitions: List[WalletStateTransition]) -> None:
+    async def process_pending_states(
+        self, state_transitions: List[WalletStateTransition], invalid_transactions: List[bytes32] = []
+    ) -> None:
         """
         This is the main entry point for processing state in wallet tests. It does the following things:
 
@@ -302,7 +304,11 @@ class WalletTestFramework:
             for i, env in enumerate(self.environments):
                 await self.full_node.wait_for_wallet_synced(wallet_node=env.node, timeout=20)
                 try:
-                    pending_txs.append(await env.wait_for_transactions_to_settle(self.full_node))
+                    pending_txs.append(
+                        await env.wait_for_transactions_to_settle(
+                            self.full_node, _exclude_from_mempool_check=invalid_transactions
+                        )
+                    )
                 except TimeoutError:  # pragma: no cover
                     raise TimeoutError(f"All TXs for env-{i} were not found in mempool or marked as in mempool")
             for i, (env, transition) in enumerate(zip(self.environments, state_transitions)):
@@ -328,7 +334,8 @@ class WalletTestFramework:
                 )
                 try:
                     await env.wait_for_transactions_to_settle(
-                        self.full_node, _exclude_from_mempool_check=[tx.name for tx in local_pending_txs]
+                        self.full_node,
+                        _exclude_from_mempool_check=[*invalid_transactions, *(tx.name for tx in local_pending_txs)],
                     )
                 except TimeoutError:  # pragma: no cover
                     raise TimeoutError(f"All TXs for env-{i} were not found in mempool or marked as in mempool")

--- a/chia/_tests/environments/wallet.py
+++ b/chia/_tests/environments/wallet.py
@@ -335,7 +335,7 @@ class WalletTestFramework:
                 try:
                     await env.wait_for_transactions_to_settle(
                         self.full_node,
-                        _exclude_from_mempool_check=[*invalid_transactions, *(tx.name for tx in local_pending_txs)],
+                        _exclude_from_mempool_check=invalid_transactions + [tx.name for tx in local_pending_txs],
                     )
                 except TimeoutError:  # pragma: no cover
                     raise TimeoutError(f"All TXs for env-{i} were not found in mempool or marked as in mempool")

--- a/chia/_tests/wallet/cat_wallet/test_trades.py
+++ b/chia/_tests/wallet/cat_wallet/test_trades.py
@@ -2255,54 +2255,149 @@ async def test_trade_bad_spend(wallet_environments: WalletTestFramework) -> None
     await time_out_assert(30, get_trade_and_status, TradeStatus.FAILED, trade_manager_taker, tr1)
 
 
-@pytest.mark.parametrize("trusted", [True, False])
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [
+        {
+            "num_environments": 2,
+            "blocks_needed": [1, 1],
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
 @pytest.mark.anyio
-async def test_trade_high_fee(
-    wallets_prefarm: Tuple[Tuple[WalletNode, int], Tuple[WalletNode, int], FullNodeSimulator]
-) -> None:
-    (wallet_node_maker, maker_funds), (wallet_node_taker, _), full_node = wallets_prefarm
-    wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
+async def test_trade_high_fee(wallet_environments: WalletTestFramework) -> None:
+    env_maker = wallet_environments.environments[0]
+    env_taker = wallet_environments.environments[1]
+
+    env_maker.wallet_aliases = {
+        "xch": 1,
+        "cat": 2,
+    }
+    env_taker.wallet_aliases = {
+        "xch": 1,
+        "cat": 2,
+    }
+
     xch_to_cat_amount = uint64(100)
 
-    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        cat_wallet_maker = await CATWallet.create_new_cat_wallet(
-            wallet_node_maker.wallet_state_manager,
-            wallet_maker,
+    async with env_maker.wallet_state_manager.new_action_scope(
+        wallet_environments.tx_config, push=True
+    ) as action_scope:
+        await CATWallet.create_new_cat_wallet(
+            env_maker.wallet_state_manager,
+            env_maker.xch_wallet,
             {"identifier": "genesis_by_id"},
             xch_to_cat_amount,
             action_scope,
         )
 
-    await full_node.process_transaction_records(records=action_scope.side_effects.transactions)
+    await wallet_environments.process_pending_states(
+        [
+            # tests in test_cat_wallet.py
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "xch": {"set_remainder": True},
+                    "cat": {"init": True, "set_remainder": True},
+                },
+                post_block_balance_updates={
+                    "xch": {"set_remainder": True},
+                    "cat": {"set_remainder": True},
+                },
+            ),
+            WalletStateTransition(),
+        ]
+    )
 
-    await time_out_assert(15, cat_wallet_maker.get_confirmed_balance, xch_to_cat_amount)
-    await time_out_assert(15, cat_wallet_maker.get_unconfirmed_balance, xch_to_cat_amount)
-    maker_funds -= xch_to_cat_amount
-    await time_out_assert(15, wallet_maker.get_confirmed_balance, maker_funds)
-
-    chia_for_cat: OfferSummary = {
-        wallet_maker.id(): 1000,
-        cat_wallet_maker.id(): -4,
+    cat_for_chia: OfferSummary = {
+        env_maker.wallet_aliases["xch"]: 1000,
+        env_maker.wallet_aliases["cat"]: -4,
     }
 
-    trade_manager_maker = wallet_node_maker.wallet_state_manager.trade_manager
-    trade_manager_taker = wallet_node_taker.wallet_state_manager.trade_manager
+    trade_manager_maker = env_maker.wallet_state_manager.trade_manager
+    trade_manager_taker = env_taker.wallet_state_manager.trade_manager
 
-    async with trade_manager_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=False) as action_scope:
-        success, trade_make, error = await trade_manager_maker.create_offer_for_ids(chia_for_cat, action_scope)
+    async with env_maker.wallet_state_manager.new_action_scope(
+        wallet_environments.tx_config, push=False
+    ) as action_scope:
+        success, trade_make, error = await trade_manager_maker.create_offer_for_ids(cat_for_chia, action_scope)
     await time_out_assert(10, get_trade_and_status, TradeStatus.PENDING_ACCEPT, trade_manager_maker, trade_make)
     assert error is None
     assert success is True
     assert trade_make is not None
-    peer = wallet_node_taker.get_full_node_peer()
-    [offer], signing_response = await wallet_node_maker.wallet_state_manager.sign_offers(
-        [Offer.from_bytes(trade_make.offer)]
-    )
+    peer = env_taker.node.get_full_node_peer()
+    [offer], signing_response = await env_maker.wallet_state_manager.sign_offers([Offer.from_bytes(trade_make.offer)])
+    fee = uint64(1000000000000)
     async with trade_manager_taker.wallet_state_manager.new_action_scope(
-        DEFAULT_TX_CONFIG, push=True, additional_signing_responses=signing_response
+        wallet_environments.tx_config, push=True, additional_signing_responses=signing_response
     ) as action_scope:
         tr1 = await trade_manager_taker.respond_to_offer(offer, peer, action_scope, fee=uint64(1000000000000))
-    await full_node.process_transaction_records(records=action_scope.side_effects.transactions)
+
+    await wallet_environments.process_pending_states(
+        [
+            # tests in test_cat_wallet.py
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "cat": {
+                        "<=#spendable_balance": cat_for_chia[env_maker.wallet_aliases["cat"]],
+                        "<=#max_send_amount": cat_for_chia[env_maker.wallet_aliases["cat"]],
+                        "pending_change": 0,
+                        "pending_coin_removal_count": 1,
+                    }
+                },
+                post_block_balance_updates={
+                    "xch": {
+                        "unconfirmed_wallet_balance": cat_for_chia[env_maker.wallet_aliases["xch"]],
+                        "confirmed_wallet_balance": cat_for_chia[env_maker.wallet_aliases["xch"]],
+                        ">=#spendable_balance": 1,
+                        ">=#max_send_amount": 1,
+                        "pending_change": 0,
+                        "unspent_coin_count": 1,
+                    },
+                    "cat": {
+                        "unconfirmed_wallet_balance": cat_for_chia[env_maker.wallet_aliases["cat"]],
+                        "confirmed_wallet_balance": cat_for_chia[env_maker.wallet_aliases["cat"]],
+                        ">=#spendable_balance": 1,
+                        ">=#max_send_amount": 1,
+                        "pending_change": 0,
+                        "pending_coin_removal_count": -1,
+                    },
+                },
+            ),
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "xch": {
+                        "unconfirmed_wallet_balance": -cat_for_chia[env_maker.wallet_aliases["xch"]] - fee,
+                        "<=#spendable_balance": -cat_for_chia[env_maker.wallet_aliases["xch"]] - fee,
+                        "<=#max_send_amount": -cat_for_chia[env_maker.wallet_aliases["xch"]] - fee,
+                        ">=#pending_change": 1,
+                        "pending_coin_removal_count": 1,
+                    },
+                    "cat": {
+                        "init": True,
+                        "unconfirmed_wallet_balance": -1 * cat_for_chia[env_maker.wallet_aliases["cat"]],
+                    },
+                },
+                post_block_balance_updates={
+                    "xch": {
+                        "confirmed_wallet_balance": -cat_for_chia[env_maker.wallet_aliases["xch"]] - fee,
+                        ">=#spendable_balance": 1,
+                        ">=#max_send_amount": 1,
+                        "<=#pending_change": -1,
+                        "pending_coin_removal_count": -1,
+                    },
+                    "cat": {
+                        "confirmed_wallet_balance": -1 * cat_for_chia[env_maker.wallet_aliases["cat"]],
+                        "spendable_balance": -1 * cat_for_chia[env_maker.wallet_aliases["cat"]],
+                        "max_send_amount": -1 * cat_for_chia[env_maker.wallet_aliases["cat"]],
+                        "unspent_coin_count": 1,
+                    },
+                },
+            ),
+        ]
+    )
+
     await time_out_assert(15, get_trade_and_status, TradeStatus.CONFIRMED, trade_manager_taker, tr1)
 
 

--- a/chia/_tests/wallet/cat_wallet/test_trades.py
+++ b/chia/_tests/wallet/cat_wallet/test_trades.py
@@ -1896,7 +1896,6 @@ async def test_trade_cancellation(wallet_environments: WalletTestFramework) -> N
 
     await wallet_environments.process_pending_states(
         [
-            # tests in test_cat_wallet.py
             WalletStateTransition(
                 pre_block_balance_updates={
                     "xch": {
@@ -2039,7 +2038,6 @@ async def test_trade_conflict(wallet_environments: WalletTestFramework) -> None:
     assert await trade_manager_trader.get_coins_of_interest()
     await wallet_environments.process_pending_states(
         [
-            # tests in test_cat_wallet.py
             WalletStateTransition(
                 pre_block_balance_updates={
                     "cat": {
@@ -2334,7 +2332,6 @@ async def test_trade_high_fee(wallet_environments: WalletTestFramework) -> None:
 
     await wallet_environments.process_pending_states(
         [
-            # tests in test_cat_wallet.py
             WalletStateTransition(
                 pre_block_balance_updates={
                     "cat": {

--- a/chia/_tests/wallet/cat_wallet/test_trades.py
+++ b/chia/_tests/wallet/cat_wallet/test_trades.py
@@ -30,7 +30,6 @@ from chia.wallet.trading.offer import Offer
 from chia.wallet.trading.trade_status import TradeStatus
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
-from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.vc_wallet.cr_cat_drivers import ProofsChecker
 from chia.wallet.vc_wallet.cr_cat_wallet import CRCATWallet
 from chia.wallet.vc_wallet.vc_store import VCProofs
@@ -618,7 +617,7 @@ async def test_cat_trades(
         await client_maker.crcat_approve_pending(
             new_cat_wallet_maker.id(),
             uint64(2),
-            DEFAULT_TX_CONFIG,
+            wallet_environments.tx_config,
         )
 
         await wallet_environments.process_pending_states(
@@ -958,7 +957,7 @@ async def test_cat_trades(
         await client_maker.crcat_approve_pending(
             new_cat_wallet_maker.id(),
             uint64(6),
-            DEFAULT_TX_CONFIG,
+            wallet_environments.tx_config,
         )
 
         await wallet_environments.process_pending_states(
@@ -1196,7 +1195,7 @@ async def test_cat_trades(
         await client_maker.crcat_approve_pending(
             cat_wallet_maker.id(),
             uint64(8),
-            DEFAULT_TX_CONFIG,
+            wallet_environments.tx_config,
         )
 
         await wallet_environments.process_pending_states(
@@ -1243,7 +1242,7 @@ async def test_cat_trades(
         await client_maker.crcat_approve_pending(
             new_cat_wallet_maker.id(),
             uint64(9),
-            DEFAULT_TX_CONFIG,
+            wallet_environments.tx_config,
         )
 
         await wallet_environments.process_pending_states(
@@ -1566,7 +1565,7 @@ async def test_cat_trades(
         await client_maker.crcat_approve_pending(
             new_cat_wallet_maker.id(),
             uint64(15),
-            DEFAULT_TX_CONFIG,
+            wallet_environments.tx_config,
         )
 
         await wallet_environments.process_pending_states(

--- a/chia/_tests/wallet/cat_wallet/test_trades.py
+++ b/chia/_tests/wallet/cat_wallet/test_trades.py
@@ -2324,11 +2324,11 @@ async def test_trade_high_fee(wallet_environments: WalletTestFramework) -> None:
     assert trade_make is not None
     peer = env_taker.node.get_full_node_peer()
     [offer], signing_response = await env_maker.wallet_state_manager.sign_offers([Offer.from_bytes(trade_make.offer)])
-    fee = uint64(1000000000000)
+    fee = uint64(1_000_000_000_000)
     async with trade_manager_taker.wallet_state_manager.new_action_scope(
         wallet_environments.tx_config, push=True, additional_signing_responses=signing_response
     ) as action_scope:
-        tr1 = await trade_manager_taker.respond_to_offer(offer, peer, action_scope, fee=uint64(1000000000000))
+        tr1 = await trade_manager_taker.respond_to_offer(offer, peer, action_scope, fee=fee)
 
     await wallet_environments.process_pending_states(
         [

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -379,7 +379,7 @@ class TradeManager:
                     confirmed=False,
                     sent=uint32(10),
                     spend_bundle=None,
-                    additions=cancellation_additions,
+                    additions=[],
                     removals=[coin],
                     wallet_id=wallet.id(),
                     sent_to=[],


### PR DESCRIPTION
This ports the remaining trade tests to the `WalletTestFramework`.  A small balance error was found in the trade manager related to cancellations and an inflexibility in the framework itself was also solved for (the ability to specify transactions that we expect to fail when submitted). Also, a test that specifically tested balances for trade cancellations was deleted because that's implicit in the test framework.