### PR TITLE
[CHIA-1306] Tweak `TransactionEndpointRequest` to require TX args

### DIFF
--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1734,7 +1734,8 @@ async def test_nft_bulk_set_did(wallet_environments: WalletTestFramework) -> Non
     ]
     fee = uint64(1000)
     set_did_bulk_resp = await env.rpc_client.set_nft_did_bulk(
-        NFTSetDIDBulk(did_id=hmr_did_id, nft_coin_list=nft_coin_list, fee=fee, push=True)
+        NFTSetDIDBulk(did_id=hmr_did_id, nft_coin_list=nft_coin_list, fee=fee, push=True),
+        wallet_environments.tx_config,
     )
     assert len(set_did_bulk_resp.spend_bundle.coin_spends) == 5
     assert set_did_bulk_resp.tx_num == 5  # 1 for each NFT being spent (3), 1 for fee tx, 1 for did tx
@@ -2031,7 +2032,8 @@ async def test_nft_bulk_transfer(wallet_environments: WalletTestFramework) -> No
     fee = uint64(1000)
     address = encode_puzzle_hash(await wallet_1.get_puzzle_hash(new=False), AddressType.XCH.hrp(env_1.node.config))
     bulk_transfer_resp = await env_0.rpc_client.transfer_nft_bulk(
-        NFTTransferBulk(target_address=address, nft_coin_list=nft_coin_list, fee=fee, push=True)
+        NFTTransferBulk(target_address=address, nft_coin_list=nft_coin_list, fee=fee, push=True),
+        wallet_environments.tx_config,
     )
     assert len(bulk_transfer_resp.spend_bundle.coin_spends) == 4
     assert bulk_transfer_resp.tx_num == 4

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -283,10 +283,13 @@ class TransactionEndpointRequest(Streamable):
     fee: uint64 = uint64(0)
     push: Optional[bool] = None
 
-    def to_json_dict(self) -> Dict[str, Any]:
-        raise NotImplementedError(
-            "to_json_dict is banned on TransactionEndpointRequest, please use .json_serialize_for_transport"
-        )
+    def to_json_dict(self, _avoid_ban: bool = False) -> Dict[str, Any]:
+        if not _avoid_ban:
+            raise NotImplementedError(
+                "to_json_dict is banned on TransactionEndpointRequest, please use .json_serialize_for_transport"
+            )
+        else:
+            return super().to_json_dict()
 
     def json_serialize_for_transport(
         self, tx_config: TXConfig, extra_conditions: Tuple[Condition, ...], timelock_info: ConditionValidTimes
@@ -295,7 +298,7 @@ class TransactionEndpointRequest(Streamable):
             **tx_config.to_json_dict(),
             **timelock_info.to_json_dict(),
             "extra_conditions": [condition.to_json_dict() for condition in extra_conditions],
-            **self.to_json_dict(),
+            **self.to_json_dict(_avoid_ban=True),
         }
 
 

--- a/chia/rpc/wallet_request_types.py
+++ b/chia/rpc/wallet_request_types.py
@@ -12,7 +12,7 @@ from typing_extensions import dataclass_transform
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint16, uint32, uint64
 from chia.util.streamable import Streamable, streamable
-from chia.wallet.conditions import Condition
+from chia.wallet.conditions import Condition, ConditionValidTimes
 from chia.wallet.notification_store import Notification
 from chia.wallet.signer_protocol import (
     SignedTransaction,
@@ -25,10 +25,9 @@ from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.offer import Offer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.clvm_streamable import json_deserialize_with_clvm_streamable
+from chia.wallet.util.tx_config import TXConfig
 from chia.wallet.vc_wallet.vc_store import VCRecord
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
-from dabakala.chia.wallet.conditions import ConditionValidTimes
-from dabakala.chia.wallet.util.tx_config import TXConfig
 
 _T_OfferEndpointResponse = TypeVar("_T_OfferEndpointResponse", bound="_OfferEndpointResponse")
 

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -1193,11 +1193,31 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("nft_mint_bulk", request)
         return json_deserialize_with_clvm_streamable(response, NFTMintBulkResponse)
 
-    async def set_nft_did_bulk(self, request: NFTSetDIDBulk) -> NFTSetDIDBulkResponse:
-        return NFTSetDIDBulkResponse.from_json_dict(await self.fetch("nft_set_did_bulk", request.to_json_dict()))
+    async def set_nft_did_bulk(
+        self,
+        request: NFTSetDIDBulk,
+        tx_config: TXConfig,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+        timelock_info: ConditionValidTimes = ConditionValidTimes(),
+    ) -> NFTSetDIDBulkResponse:
+        return NFTSetDIDBulkResponse.from_json_dict(
+            await self.fetch(
+                "nft_set_did_bulk", request.json_serialize_for_transport(tx_config, extra_conditions, timelock_info)
+            )
+        )
 
-    async def transfer_nft_bulk(self, request: NFTTransferBulk) -> NFTTransferBulkResponse:
-        return NFTTransferBulkResponse.from_json_dict(await self.fetch("nft_transfer_bulk", request.to_json_dict()))
+    async def transfer_nft_bulk(
+        self,
+        request: NFTTransferBulk,
+        tx_config: TXConfig,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
+        timelock_info: ConditionValidTimes = ConditionValidTimes(),
+    ) -> NFTTransferBulkResponse:
+        return NFTTransferBulkResponse.from_json_dict(
+            await self.fetch(
+                "nft_transfer_bulk", request.json_serialize_for_transport(tx_config, extra_conditions, timelock_info)
+            )
+        )
 
     # DataLayer
     async def create_new_dl(
@@ -1804,11 +1824,12 @@ class WalletRpcClient(RpcClient):
         self,
         args: SplitCoins,
         tx_config: TXConfig,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
         timelock_info: ConditionValidTimes = ConditionValidTimes(),
     ) -> SplitCoinsResponse:
         return SplitCoinsResponse.from_json_dict(
             await self.fetch(
-                "split_coins", {**args.to_json_dict(), **tx_config.to_json_dict(), **timelock_info.to_json_dict()}
+                "split_coins", args.json_serialize_for_transport(tx_config, extra_conditions, timelock_info)
             )
         )
 
@@ -1816,10 +1837,11 @@ class WalletRpcClient(RpcClient):
         self,
         args: CombineCoins,
         tx_config: TXConfig,
+        extra_conditions: Tuple[Condition, ...] = tuple(),
         timelock_info: ConditionValidTimes = ConditionValidTimes(),
     ) -> CombineCoinsResponse:
         return CombineCoinsResponse.from_json_dict(
             await self.fetch(
-                "combine_coins", {**args.to_json_dict(), **tx_config.to_json_dict(), **timelock_info.to_json_dict()}
+                "combine_coins", args.json_serialize_for_transport(tx_config, extra_conditions, timelock_info)
             )
         )


### PR DESCRIPTION
This PR bans the previous standard way to serialize `TransactionEndpointRequest`s in favor of one that requires attention to the common args that all of them should have.  This is utilized instead of just including those onto the dataclass because streamable/clvm streamable/tx config makes this a hard ask.  This should prevent any attempts on sending the request to the RPC  without adequately taking into account the arguments that a user should have the chance to specify.