### PR TITLE
use TaskGroup for the long sync validation pipeline

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1211,14 +1211,11 @@ class FullNode:
         batch_queue_input: asyncio.Queue[Optional[Tuple[WSChiaConnection, List[FullBlock]]]] = asyncio.Queue(
             maxsize=buffer_size
         )
-        fetch_task = asyncio.Task(fetch_block_batches(batch_queue_input))
-        validate_task = asyncio.Task(validate_block_batches(batch_queue_input))
-        try:
-            with log_exceptions(log=self.log, message="sync from fork point failed"):
-                await asyncio.gather(fetch_task, validate_task)
-        except Exception:
-            assert validate_task.done()
-            fetch_task.cancel()  # no need to cancel validate_task, if we end up here validate_task is already done
+
+        with log_exceptions(log=self.log, message="sync from fork point failed"):
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(fetch_block_batches(batch_queue_input))
+                tg.create_task(validate_block_batches(batch_queue_input))
 
     def get_peers_with_peak(self, peak_hash: bytes32) -> List[WSChiaConnection]:
         peer_ids: Set[bytes32] = self.sync_store.get_peers_that_have_peak([peak_hash])


### PR DESCRIPTION
### Purpose:

Simplify code by using `asyncio.TaskGroup` rather than manually cancel tasks when one fails.

### Current Behavior:

We "manually" keeps track of tasks in order to cancel them if one fails.

### New Behavior:

We use the (newer) facility `TaskGroup` to group tasks to cancel all tasks if one fails.

### Testing Notes:

I `chia stop all -d` during long sync to ensure the daemon did not have to `kill -9` the node process.