### PR TITLE
Add version number to every log line

### DIFF
--- a/chia/util/chia_logging.py
+++ b/chia/util/chia_logging.py
@@ -53,11 +53,8 @@ def initialize_logging(
     file_name_length = 33 - len(service_name)
     log_date_format = "%Y-%m-%dT%H:%M:%S"
     file_log_formatter = logging.Formatter(
-        fmt=(
-            "%(asctime)s.%(msecs)03d "
-            f"{__version__} {service_name} "
-            "%(name)-{file_name_length}s: %(levelname)-8s %(message)s"
-        ),
+        fmt=f"%(asctime)s.%(msecs)03d {__version__} {service_name} %(name)-{file_name_length}s: "
+            f"%(levelname)-8s %(message)s",
         datefmt=log_date_format,
     )
     handlers: List[logging.Handler] = []
@@ -65,7 +62,7 @@ def initialize_logging(
         stdout_handler = colorlog.StreamHandler()
         stdout_handler.setFormatter(
             colorlog.ColoredFormatter(
-                f"%(asctime)s.%(msecs)03d {service_name} %(name)-{file_name_length}s: "
+                f"%(asctime)s.%(msecs)03d {__version__} {service_name} %(name)-{file_name_length}s: "
                 f"%(log_color)s%(levelname)-8s%(reset)s %(message)s",
                 datefmt=log_date_format,
                 reset=True,

--- a/chia/util/chia_logging.py
+++ b/chia/util/chia_logging.py
@@ -53,7 +53,11 @@ def initialize_logging(
     file_name_length = 33 - len(service_name)
     log_date_format = "%Y-%m-%dT%H:%M:%S"
     file_log_formatter = logging.Formatter(
-        fmt=f"%(asctime)s.%(msecs)03d {__version__} {service_name} %(name)-{file_name_length}s: %(levelname)-8s %(message)s",
+        fmt=(
+            "%(asctime)s.%(msecs)03d "
+            f"{__version__} {service_name} "
+            "%(name)-{file_name_length}s: %(levelname)-8s %(message)s"
+        ),
         datefmt=log_date_format,
     )
     handlers: List[logging.Handler] = []

--- a/chia/util/chia_logging.py
+++ b/chia/util/chia_logging.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, cast
 import colorlog
 from concurrent_log_handler import ConcurrentRotatingFileHandler
 
+from chia import __version__
 from chia.util.chia_version import chia_short_version
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.path import path_from_root
@@ -52,7 +53,7 @@ def initialize_logging(
     file_name_length = 33 - len(service_name)
     log_date_format = "%Y-%m-%dT%H:%M:%S"
     file_log_formatter = logging.Formatter(
-        fmt=f"%(asctime)s.%(msecs)03d {chia_short_version()} {service_name} %(name)-{file_name_length}s: %(levelname)-8s %(message)s",
+        fmt=f"%(asctime)s.%(msecs)03d {__version__} {service_name} %(name)-{file_name_length}s: %(levelname)-8s %(message)s",
         datefmt=log_date_format,
     )
     handlers: List[logging.Handler] = []

--- a/chia/util/chia_logging.py
+++ b/chia/util/chia_logging.py
@@ -52,7 +52,7 @@ def initialize_logging(
     file_name_length = 33 - len(service_name)
     log_date_format = "%Y-%m-%dT%H:%M:%S"
     file_log_formatter = logging.Formatter(
-        fmt=f"%(asctime)s.%(msecs)03d {service_name} %(name)-{file_name_length}s: %(levelname)-8s %(message)s",
+        fmt=f"%(asctime)s.%(msecs)03d {chia_short_version()} {service_name} %(name)-{file_name_length}s: %(levelname)-8s %(message)s",
         datefmt=log_date_format,
     )
     handlers: List[logging.Handler] = []

--- a/chia/util/chia_logging.py
+++ b/chia/util/chia_logging.py
@@ -54,7 +54,7 @@ def initialize_logging(
     log_date_format = "%Y-%m-%dT%H:%M:%S"
     file_log_formatter = logging.Formatter(
         fmt=f"%(asctime)s.%(msecs)03d {__version__} {service_name} %(name)-{file_name_length}s: "
-            f"%(levelname)-8s %(message)s",
+        f"%(levelname)-8s %(message)s",
         datefmt=log_date_format,
     )
     handlers: List[logging.Handler] = []


### PR DESCRIPTION
### Purpose:

This PR adds the Chia version to every line of log output when logging to a file.  This is helpful in a few ways:

1. When users submit a log file or copy and paste a snippet of a log when reporting an issue, it is clear at a glance what version of Chia we are working with.  This would eliminate the need to ask the user to provide this information, which is often forgotten when reporting an issue and save everyone time and effort.
2. I've run into a number of occasions where I've updated Chia, but not restarted the running process, so when I run `chia version` I get a different version than what is actually running.  This causes confusion when troubleshooting as there's no good way to tell what version of Chia is actually running.  If the version is reported on every line in the logs, there's no confusion as to the currently running version. 

### Current Behavior:

Example log lines in version 2.4.3:

```
2024-09-18T15:12:09.824 wallet chia.wallet.wallet_state_manager: INFO     set_sync_mode syncing - range: 1882000-1882001
2024-09-18T15:12:09.825 wallet chia.wallet.wallet_blockchain: INFO     Peak set to: 1882001 timestamp: 1726697501
2024-09-18T15:12:12.034 wallet chia.wallet.wallet_state_manager: INFO     set_sync_mode syncing - range: 1882001-1882002
2024-09-18T15:12:12.035 wallet chia.wallet.wallet_blockchain: INFO     Peak set to: 1882002 timestamp: 1726697501
```

### New Behavior:

Example log lines with version number added:

```
2024-09-18T15:12:09.824 2.4.3 wallet chia.wallet.wallet_state_manager: INFO     set_sync_mode syncing - range: 1882000-1882001
2024-09-18T15:12:09.825 2.4.3 wallet chia.wallet.wallet_blockchain: INFO     Peak set to: 1882001 timestamp: 1726697501
2024-09-18T15:12:12.034 2.4.3 wallet chia.wallet.wallet_state_manager: INFO     set_sync_mode syncing - range: 1882001-1882002
2024-09-18T15:12:12.035 2.4.3 wallet chia.wallet.wallet_blockchain: INFO     Peak set to: 1882002 timestamp: 1726697501
```
