### PR TITLE
CHIA-1451 Remove no longer needed TestWalletInterestedStore class

### DIFF
--- a/chia/_tests/wallet/test_wallet_interested_store.py
+++ b/chia/_tests/wallet/test_wallet_interested_store.py
@@ -11,34 +11,33 @@ from chia.util.ints import uint64
 from chia.wallet.wallet_interested_store import WalletInterestedStore
 
 
-class TestWalletInterestedStore:
-    @pytest.mark.anyio
-    async def test_store(self, seeded_random: random.Random):
-        async with DBConnection(1) as db_wrapper:
-            store = await WalletInterestedStore.create(db_wrapper)
-            coin_1 = Coin(bytes32.random(seeded_random), bytes32.random(seeded_random), uint64(12312))
-            coin_2 = Coin(bytes32.random(seeded_random), bytes32.random(seeded_random), uint64(12312))
-            assert (await store.get_interested_coin_ids()) == []
-            await store.add_interested_coin_id(coin_1.name())
-            assert (await store.get_interested_coin_ids()) == [coin_1.name()]
-            await store.add_interested_coin_id(coin_1.name())
-            assert (await store.get_interested_coin_ids()) == [coin_1.name()]
-            await store.add_interested_coin_id(coin_2.name())
-            assert set(await store.get_interested_coin_ids()) == {coin_1.name(), coin_2.name()}
-            await store.remove_interested_coin_id(coin_1.name())
-            assert set(await store.get_interested_coin_ids()) == {coin_2.name()}
-            puzzle_hash = bytes32.random(seeded_random)
-            assert len(await store.get_interested_puzzle_hashes()) == 0
+@pytest.mark.anyio
+async def test_store(seeded_random: random.Random):
+    async with DBConnection(1) as db_wrapper:
+        store = await WalletInterestedStore.create(db_wrapper)
+        coin_1 = Coin(bytes32.random(seeded_random), bytes32.random(seeded_random), uint64(12312))
+        coin_2 = Coin(bytes32.random(seeded_random), bytes32.random(seeded_random), uint64(12312))
+        assert (await store.get_interested_coin_ids()) == []
+        await store.add_interested_coin_id(coin_1.name())
+        assert (await store.get_interested_coin_ids()) == [coin_1.name()]
+        await store.add_interested_coin_id(coin_1.name())
+        assert (await store.get_interested_coin_ids()) == [coin_1.name()]
+        await store.add_interested_coin_id(coin_2.name())
+        assert set(await store.get_interested_coin_ids()) == {coin_1.name(), coin_2.name()}
+        await store.remove_interested_coin_id(coin_1.name())
+        assert set(await store.get_interested_coin_ids()) == {coin_2.name()}
+        puzzle_hash = bytes32.random(seeded_random)
+        assert len(await store.get_interested_puzzle_hashes()) == 0
 
-            await store.add_interested_puzzle_hash(puzzle_hash, 2)
-            assert len(await store.get_interested_puzzle_hashes()) == 1
-            await store.add_interested_puzzle_hash(puzzle_hash, 2)
-            assert len(await store.get_interested_puzzle_hashes()) == 1
-            assert (await store.get_interested_puzzle_hash_wallet_id(puzzle_hash)) == 2
-            await store.add_interested_puzzle_hash(puzzle_hash, 3)
-            assert len(await store.get_interested_puzzle_hashes()) == 1
+        await store.add_interested_puzzle_hash(puzzle_hash, 2)
+        assert len(await store.get_interested_puzzle_hashes()) == 1
+        await store.add_interested_puzzle_hash(puzzle_hash, 2)
+        assert len(await store.get_interested_puzzle_hashes()) == 1
+        assert (await store.get_interested_puzzle_hash_wallet_id(puzzle_hash)) == 2
+        await store.add_interested_puzzle_hash(puzzle_hash, 3)
+        assert len(await store.get_interested_puzzle_hashes()) == 1
 
-            assert (await store.get_interested_puzzle_hash_wallet_id(puzzle_hash)) == 3
-            await store.remove_interested_puzzle_hash(puzzle_hash)
-            assert (await store.get_interested_puzzle_hash_wallet_id(puzzle_hash)) is None
-            assert len(await store.get_interested_puzzle_hashes()) == 0
+        assert (await store.get_interested_puzzle_hash_wallet_id(puzzle_hash)) == 3
+        await store.remove_interested_puzzle_hash(puzzle_hash)
+        assert (await store.get_interested_puzzle_hash_wallet_id(puzzle_hash)) is None
+        assert len(await store.get_interested_puzzle_hashes()) == 0


### PR DESCRIPTION
### Purpose:

As we're using pytest instead of unittest, this class isn't needed anymore.

### Current Behavior:

Tests are grouped into a `TestWalletInterestedStore` class.

### New Behavior:

Tests are no longer grouped into a `TestWalletInterestedStore` class.