### PR TITLE
CHIA-1465 Simplify double spend validation in validate_block_body

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -367,8 +367,8 @@ async def validate_block_body(
 
     # 14. Check for duplicate spends inside block
     removal_counter = collections.Counter(removals)
-    for k, v in removal_counter.items():
-        if v > 1:
+    for count in removal_counter.values():
+        if count > 1:
             return Err.DOUBLE_SPEND, None
 
     # 15. Check if removals exist and were not previously spent. (unspent_db + diff_store + this_block)


### PR DESCRIPTION
### Purpose:

We only need to check the values. The keys are not needed.

### Current Behavior:

We iterate through key value pairs in order to check for duplicate spends inside a block. 

### New Behavior:

We iterate through values in order to do that duplicate spends check.