### PR TITLE
CHIA-1472 Augment get_mirror_info to accept both types of programs

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -808,9 +808,7 @@ class DataLayerWallet:
             )[0]
             parent_spend = await fetch_coin_spend(height, parent_state.coin, peer)
             assert parent_spend is not None
-            launcher_id, urls = get_mirror_info(
-                parent_spend.puzzle_reveal.to_program(), parent_spend.solution.to_program()
-            )
+            launcher_id, urls = get_mirror_info(parent_spend.puzzle_reveal, parent_spend.solution)
             # Don't track mirrors with empty url list.
             if not urls:
                 return

--- a/chia/wallet/db_wallet/db_wallet_puzzles.py
+++ b/chia/wallet/db_wallet/db_wallet_puzzles.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Iterator, List, Tuple, Union
 
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import INFINITE_COST, Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
@@ -94,8 +94,11 @@ def create_mirror_puzzle() -> Program:
 MIRROR_PUZZLE_HASH = create_mirror_puzzle().get_tree_hash()
 
 
-def get_mirror_info(parent_puzzle: Program, parent_solution: Program) -> Tuple[bytes32, List[bytes]]:
-    conditions = parent_puzzle.run(parent_solution)
+def get_mirror_info(
+    parent_puzzle: Union[Program, SerializedProgram], parent_solution: Union[Program, SerializedProgram]
+) -> Tuple[bytes32, List[bytes]]:
+    assert type(parent_puzzle) is type(parent_solution)
+    _, conditions = parent_puzzle.run_with_cost(INFINITE_COST, parent_solution)
     for condition in conditions.as_iter():
         if (
             condition.first().as_python() == ConditionOpcode.CREATE_COIN


### PR DESCRIPTION
### Purpose:

This allows us to use serialized programs without the need to convert them into programs.

### Current Behavior:

We would need to convert serialized programs to programs before using the function.

### New Behavior:

We no longer need to convert serialized programs into programs before using the function.