### PR TITLE
[CHIA-1486] Update to macOS 13 for build and test

### DIFF
--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         os:
-          - runs-on: macos-12
+          - runs-on: macos-13
             name: intel
             bladebit-suffix: macos-x86-64.tar.gz
             arch-artifact-name: intel
@@ -83,7 +83,7 @@ jobs:
         uses: Chia-Network/actions/setjobenv@main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MACOSX_DEPLOYMENT_TARGET: 12
+          MACOSX_DEPLOYMENT_TARGET: 13
 
       - name: Test for secrets access
         id: check_secrets
@@ -296,10 +296,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - name: 12
-            matrix: 12
-            runs-on:
-              intel: macos-12
           - name: 13
             matrix: 13
             runs-on:

--- a/.github/workflows/check_wheel_availability.yaml
+++ b/.github/workflows/check_wheel_availability.yaml
@@ -32,7 +32,7 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              intel: macos-12
+              intel: macos-13
               arm: macos-13-arm64
           - name: Windows
             matrix: windows

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,7 +29,7 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              intel: macos-12
+              intel: macos-13
               arm: macos-13-arm64
           - name: Windows
             matrix: windows

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -32,7 +32,7 @@ jobs:
         os:
           - runs-on: macos-latest
             matrix: macos-arm
-          - runs-on: macos-12
+          - runs-on: macos-13
             matrix: macos-intel
           - runs-on: ubuntu-latest
             matrix: linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
       concurrency-name: macos-intel
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
-      runs-on: macos-12
+      runs-on: macos-13
       arch: intel
   macos-arm:
     if: github.event_name != 'workflow_dispatch' || inputs.run-macos-arm

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -43,7 +43,7 @@ jobs:
             matrix: macos
             emoji: 🍎
             runs-on:
-              intel: macos-12
+              intel: macos-13
               arm: macos-13-arm64
           - name: Windows
             matrix: windows


### PR DESCRIPTION
Update to macOS 13 for build and testing per deprecation plans for macOS 12.

We announced that 2.4.2 was the last release to support macOS 12 (see Changelog)