### PR TITLE
CHIA-1525 Make PreValidationResult take SpendBundleConditions instead of NPCResult

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -2641,7 +2641,10 @@ class TestBodyValidation:
         diff = b.constants.DIFFICULTY_STARTING
         err = (
             await b.add_block(
-                blocks[-1], PreValidationResult(None, uint64(1), npc_result, True, uint32(0)), None, sub_slot_iters=ssi
+                blocks[-1],
+                PreValidationResult(None, uint64(1), npc_result.conds, True, uint32(0)),
+                None,
+                sub_slot_iters=ssi,
             )
         )[1]
         assert err in [Err.BLOCK_COST_EXCEEDS_MAX]
@@ -2717,7 +2720,7 @@ class TestBodyValidation:
         )
         ssi = b.constants.SUB_SLOT_ITERS_STARTING
         _, err, _ = await b.add_block(
-            block_2, PreValidationResult(None, uint64(1), npc_result, False, uint32(0)), None, sub_slot_iters=ssi
+            block_2, PreValidationResult(None, uint64(1), npc_result.conds, False, uint32(0)), None, sub_slot_iters=ssi
         )
         assert err == Err.INVALID_BLOCK_COST
 
@@ -2746,7 +2749,7 @@ class TestBodyValidation:
             constants=bt.constants,
         )
         _, err, _ = await b.add_block(
-            block_2, PreValidationResult(None, uint64(1), npc_result, False, uint32(0)), None, sub_slot_iters=ssi
+            block_2, PreValidationResult(None, uint64(1), npc_result.conds, False, uint32(0)), None, sub_slot_iters=ssi
         )
         assert err == Err.INVALID_BLOCK_COST
 
@@ -2777,7 +2780,7 @@ class TestBodyValidation:
         )
 
         result, err, _ = await b.add_block(
-            block_2, PreValidationResult(None, uint64(1), npc_result, False, uint32(0)), None, sub_slot_iters=ssi
+            block_2, PreValidationResult(None, uint64(1), npc_result.conds, False, uint32(0)), None, sub_slot_iters=ssi
         )
         assert err == Err.INVALID_BLOCK_COST
 

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -741,9 +741,8 @@ class TestFullNodeProtocol:
         assert entry is not None
         result = entry.result
         assert result is not None
-        assert result.npc_result is not None
-        assert result.npc_result.conds is not None
-        assert result.npc_result.conds.cost > 0
+        assert result.conds is not None
+        assert result.conds.cost > 0
 
         assert not full_node_1.full_node.blockchain.contains_block(block.header_hash)
         assert block.transactions_generator is not None

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -14,7 +14,6 @@ from chia.consensus.block_root_validation import validate_block_merkle_roots
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
 from chia.consensus.constants import ConsensusConstants
-from chia.consensus.cost_calculator import NPCResult
 from chia.full_node.mempool_check_conditions import mempool_check_time_locks
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -125,19 +124,22 @@ async def validate_block_body(
     get_coin_records: Callable[[Collection[bytes32]], Awaitable[List[CoinRecord]]],
     block: Union[FullBlock, UnfinishedBlock],
     height: uint32,
-    npc_result: Optional[NPCResult],
+    conds: Optional[SpendBundleConditions],
     fork_info: ForkInfo,
     bls_cache: Optional[BLSCache],
     *,
     validate_signature: bool = True,
-) -> Tuple[Optional[Err], Optional[NPCResult]]:
+) -> Tuple[Optional[Err], Optional[SpendBundleConditions]]:
     """
     This assumes the header block has been completely validated.
-    Validates the transactions and body of the block. Returns None for the first value if everything
-    validates correctly, or an Err if something does not validate. For the second value, returns a CostResult
-    only if validation succeeded, and there are transactions. In other cases it returns None. The NPC result is
-    the result of running the generator with the previous generators refs. It is only present for transaction
-    blocks which have spent coins.
+    Validates the transactions and body of the block.
+    Returns None for the first value if everything validates correctly, or an
+        Err if something does not validate.
+    For the second value, returns a SpendBundleConditions only if validation
+        succeeded, and there are transactions. In other cases it returns None.
+    conds is the result of running the generator with the previous generators
+        refs. It must be set for transaction blocks and must be None for
+        non-transaction blocks.
     fork_info specifies the fork context of this block. In case the block
         extends the main chain, it can be empty, but if the block extends a fork
         of the main chain, the fork info is mandatory in order to validate the block.
@@ -291,8 +293,7 @@ async def validate_block_body(
     if block.transactions_generator is not None:
         # Get List of names removed, puzzles hashes for removed coins and conditions created
 
-        assert npc_result is not None
-        cost = uint64(0 if npc_result.conds is None else npc_result.conds.cost)
+        cost = uint64(0 if conds is None else conds.cost)
 
         # 7. Check that cost <= MAX_BLOCK_COST_CLVM
         log.debug(
@@ -303,19 +304,16 @@ async def validate_block_body(
             return Err.BLOCK_COST_EXCEEDS_MAX, None
 
         # 8. The CLVM program must not return any errors
-        if npc_result.error is not None:
-            return Err(npc_result.error), None
+        assert conds is not None
 
-        assert npc_result.conds is not None
-
-        for spend in npc_result.conds.spends:
+        for spend in conds.spends:
             removals.append(bytes32(spend.coin_id))
             removals_puzzle_dic[bytes32(spend.coin_id)] = bytes32(spend.puzzle_hash)
             for puzzle_hash, amount, _ in spend.create_coin:
                 c = Coin(bytes32(spend.coin_id), bytes32(puzzle_hash), uint64(amount))
                 additions.append((c, c.name()))
     else:
-        assert npc_result is None
+        assert conds is None
 
     # 9. Check that the correct cost is in the transactions info
     if block.transactions_info.cost != cost:
@@ -459,10 +457,7 @@ async def validate_block_body(
 
     # reserve fee cannot be greater than UINT64_MAX per consensus rule.
     # run_generator() would fail
-    assert_fee_sum: uint64 = uint64(0)
-    if npc_result:
-        assert npc_result.conds is not None
-        assert_fee_sum = uint64(npc_result.conds.reserve_fee)
+    assert_fee_sum = uint64(0 if conds is None else conds.reserve_fee)
 
     # 17. Check that the assert fee sum <= fees, and that each reserved fee is non-negative
     if fees < assert_fee_sum:
@@ -483,24 +478,21 @@ async def validate_block_body(
 
     # 21. Verify conditions
     # verify absolute/relative height/time conditions
-    if npc_result is not None:
-        assert npc_result.conds is not None
-
+    if conds is not None:
         error = mempool_check_time_locks(
             removal_coin_records,
-            npc_result.conds,
+            conds,
             prev_transaction_block_height,
             prev_transaction_block_timestamp,
         )
-        if error:
+        if error is not None:
             return error, None
 
     # create hash_key list for aggsig check
     pairs_pks: List[G1Element] = []
     pairs_msgs: List[bytes] = []
-    if npc_result:
-        assert npc_result.conds is not None
-        pairs_pks, pairs_msgs = pkm_pairs(npc_result.conds, constants.AGG_SIG_ME_ADDITIONAL_DATA)
+    if conds is not None:
+        pairs_pks, pairs_msgs = pkm_pairs(conds, constants.AGG_SIG_ME_ADDITIONAL_DATA)
 
     # 22. Verify aggregated signature
     # TODO: move this to pre_validate_blocks_multiprocessing so we can sync faster
@@ -520,4 +512,4 @@ async def validate_block_body(
             if not bls_cache.aggregate_verify(pairs_pks, pairs_msgs, block.transactions_info.aggregated_signature):
                 return Err.BAD_AGGREGATE_SIGNATURE, None
 
-    return None, npc_result
+    return None, conds

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1846,9 +1846,9 @@ class FullNode:
                 return None
             validation_start = time.monotonic()
             # Tries to add the block to the blockchain, if we already validated transactions, don't do it again
-            npc_results = {}
-            if pre_validation_result is not None and pre_validation_result.npc_result is not None:
-                npc_results[block.height] = pre_validation_result.npc_result
+            block_height_conds_map = {}
+            if pre_validation_result is not None and pre_validation_result.conds is not None:
+                block_height_conds_map[block.height] = pre_validation_result.conds
 
             # Don't validate signatures because we want to validate them in the main thread later, since we have a
             # cache available
@@ -1868,7 +1868,7 @@ class FullNode:
                 self.blockchain,
                 [block],
                 self.blockchain.pool,
-                npc_results,
+                block_height_conds_map,
                 sub_slot_iters=ssi,
                 difficulty=diff,
                 prev_ses_block=prev_ses_block,


### PR DESCRIPTION
### Purpose:

`PreValidationResult` currently uses `NPCResult` without error possibility in this context, so it's simpler to use `SpendBundleConditions` directly here.

### Current Behavior:

`PreValidationResult` holds `NPCResult` and its users have logic to get to `SpendBundleConditions` from there.

### New Behavior:

`PreValidationResult` holds `SpendBundleConditions` and its users simply leverage that without needing extra logic.