### PR TITLE
[CHIA-621] Add a configurable limit to the amount of DIDs that can be automatically added to the users wallet from transfer

### DIFF
--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -1342,9 +1342,10 @@ class TestDIDWallet:
                 await wallet_node_1.wallet_state_manager.get_all_wallet_info_entries(),
             )
         )
-        did_wallet_2 = wallet_node_1.wallet_state_manager.wallets[did_wallets[0].id]
-        assert isinstance(did_wallet_2, DIDWallet)  # mypy
-        assert len(wallet_node_0.wallet_state_manager.wallets) == 1
+        did_wallet_2: DIDWallet = wallet_node.wallet_state_manager.get_wallet(
+            id=uint32(did_wallets[0].id), required_type=DIDWallet
+        )
+        assert len(wallet_node.wallet_state_manager.wallets) == 1
         assert did_wallet_1.did_info.origin_coin == did_wallet_2.did_info.origin_coin
         if with_recovery:
             assert did_wallet_1.did_info.backup_ids[0] == did_wallet_2.did_info.backup_ids[0]

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -783,7 +783,7 @@ class TestDIDWallet:
                 await did_wallet.recovery_spend(
                     coin,
                     ph,
-                    info,  # type: ignore
+                    info,
                     pubkey,
                     WalletSpendBundle([], AugSchemeMPL.aggregate([])),
                     action_scope,

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -971,6 +971,8 @@ class TestDIDWallet:
             ]
         )
 
+        await time_out_assert(15, did_wallet.get_confirmed_balance, 101)
+        await time_out_assert(15, did_wallet.get_unconfirmed_balance, 101)
         recovery_list = [bytes32.from_hexstr(did_wallet.get_my_DID())]
 
         async with wallet_1.wallet_state_manager.new_action_scope(

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -1344,7 +1344,7 @@ class TestDIDWallet:
                 await wallet_node_1.wallet_state_manager.get_all_wallet_info_entries(),
             )
         )
-        did_wallet_2: DIDWallet = wallet_node.wallet_state_manager.get_wallet(
+        did_wallet_2: DIDWallet = wallet_node_2.wallet_state_manager.get_wallet(
             id=uint32(did_wallets[0].id), required_type=DIDWallet
         )
         assert len(wallet_node.wallet_state_manager.wallets) == 1

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -774,7 +774,7 @@ class TestDIDWallet:
             ]
         )
         coin = await did_wallet.get_coin()
-        info = []
+        info: List[Tuple[bytes, bytes, int]] = []
         pubkey = (await did_wallet.wallet_state_manager.get_unused_derivation_record(did_wallet.wallet_info.id)).pubkey
         with pytest.raises(Exception):  # We expect a CLVM 80 error for this test
             async with did_wallet.wallet_state_manager.new_action_scope(

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -1344,10 +1344,9 @@ class TestDIDWallet:
                 await wallet_node_1.wallet_state_manager.get_all_wallet_info_entries(),
             )
         )
-        did_wallet_2: DIDWallet = wallet_node_2.wallet_state_manager.get_wallet(
-            id=uint32(did_wallets[0].id), required_type=DIDWallet
-        )
-        assert len(wallet_node.wallet_state_manager.wallets) == 1
+        did_wallet_2 = wallet_node_1.wallet_state_manager.wallets[did_wallets[0].id]
+        assert isinstance(did_wallet_2, DIDWallet)  # mypy
+        assert len(wallet_node_0.wallet_state_manager.wallets) == 1
         assert did_wallet_1.did_info.origin_coin == did_wallet_2.did_info.origin_coin
         if with_recovery:
             assert did_wallet_1.did_info.backup_ids[0] == did_wallet_2.did_info.backup_ids[0]

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -2553,16 +2553,17 @@ class WalletRpcApi:
             if hinted_coin.coin.amount % 2 == 1 and hinted_coin.hint is not None:
                 hint = hinted_coin.hint
                 break
-        if hint is None:
+        derivation_record = None
+        if hint is not None:
+            derivation_record = (
+                await self.service.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(hint)
+            )
+        if derivation_record is None:
             # This is an invalid DID, check if we are owner
             derivation_record = (
                 await self.service.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(
                     p2_puzzle.get_tree_hash()
                 )
-            )
-        else:
-            derivation_record = (
-                await self.service.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(hint)
             )
 
         launcher_id = bytes32(singleton_struct.rest().first().as_atom())

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -564,6 +564,9 @@ wallet:
   # the user accepts the risk/responsibility of verifying the authenticity and origin of unknown CATs
   automatically_add_unknown_cats: False
 
+  # if an unknown DID is sent to us, a wallet will be automatically created
+  did_auto_add_limit: 10
+
   # Interval to resend unconfirmed transactions, even if previously accepted into Mempool
   tx_resend_timeout_secs: 1800
 

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -1445,7 +1445,11 @@ class DIDWallet:
         if num_of_backup_ids_needed > len(backup_ids):
             raise Exception
         innerpuz: Program = Program.from_bytes(bytes.fromhex(details[4]))
-        metadata: str = details[6]
+        metadata: str = ""
+        for d in details[6:]:
+            metadata = metadata + d + ":"
+        if len(metadata) > 0:
+            metadata = metadata[:-1]
         did_info = DIDInfo(
             origin_coin=origin,
             backup_ids=backup_ids,

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1334,7 +1334,8 @@ class WalletStateManager:
                 # This means the wallet is in a resync process, skip the coin
                 return None
             # check we aren't above the auto-add wallet limit
-            if did_wallet_count < self.config.get("did_auto_add_limit", 10):
+            limit = self.config.get("did_auto_add_limit", 10)
+            if did_wallet_count < limit:
                 did_wallet = await DIDWallet.create_new_did_wallet_from_coin_spend(
                     self,
                     self.main_wallet,
@@ -1347,6 +1348,7 @@ class WalletStateManager:
                 self.state_changed("wallet_created", wallet_identifier.id, {"did_id": did_wallet.get_my_DID()})
                 return wallet_identifier
             # we are over the limit
+            self.log.warning(f"You are at the max configured limit of {limit} DIDs. Ignoring received DID {launch_id.hex()}")
             return None
 
     async def get_minter_did(self, launcher_coin: Coin, peer: WSChiaConnection) -> Optional[bytes32]:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1334,7 +1334,7 @@ class WalletStateManager:
                 # This means the wallet is in a resync process, skip the coin
                 return None
             # check we aren't above the auto-add wallet limit
-            if did_wallet_count < self.config.get("did_auto_add_limit"):
+            if did_wallet_count < self.config.get("did_auto_add_limit", 10):
                 did_wallet = await DIDWallet.create_new_did_wallet_from_coin_spend(
                     self,
                     self.main_wallet,

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1348,7 +1348,9 @@ class WalletStateManager:
                 self.state_changed("wallet_created", wallet_identifier.id, {"did_id": did_wallet.get_my_DID()})
                 return wallet_identifier
             # we are over the limit
-            self.log.warning(f"You are at the max configured limit of {limit} DIDs. Ignoring received DID {launch_id.hex()}")
+            self.log.warning(
+                f"You are at the max configured limit of {limit} DIDs. Ignoring received DID {launch_id.hex()}"
+            )
             return None
 
     async def get_minter_did(self, launcher_coin: Coin, peer: WSChiaConnection) -> Optional[bytes32]:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1321,27 +1321,33 @@ class WalletStateManager:
             launch_coin: CoinState = response[0]
             origin_coin = launch_coin.coin
 
+            did_wallet_count = 0
             for wallet in self.wallets.values():
                 if wallet.type() == WalletType.DECENTRALIZED_ID:
                     assert isinstance(wallet, DIDWallet)
                     assert wallet.did_info.origin_coin is not None
                     if origin_coin.name() == wallet.did_info.origin_coin.name():
                         return WalletIdentifier.create(wallet)
+                    did_wallet_count += 1
             if coin_state.spent_height is not None:
                 # The first coin we received for DID wallet is spent.
                 # This means the wallet is in a resync process, skip the coin
                 return None
-            did_wallet = await DIDWallet.create_new_did_wallet_from_coin_spend(
-                self,
-                self.main_wallet,
-                launch_coin.coin,
-                did_puzzle,
-                coin_spend,
-                f"DID {encode_puzzle_hash(launch_id, AddressType.DID.hrp(self.config))}",
-            )
-            wallet_identifier = WalletIdentifier.create(did_wallet)
-            self.state_changed("wallet_created", wallet_identifier.id, {"did_id": did_wallet.get_my_DID()})
-            return wallet_identifier
+            # check we aren't above the auto-add wallet limit
+            if did_wallet_count < self.config.get("did_auto_add_limit"):
+                did_wallet = await DIDWallet.create_new_did_wallet_from_coin_spend(
+                    self,
+                    self.main_wallet,
+                    launch_coin.coin,
+                    did_puzzle,
+                    coin_spend,
+                    f"DID {encode_puzzle_hash(launch_id, AddressType.DID.hrp(self.config))}",
+                )
+                wallet_identifier = WalletIdentifier.create(did_wallet)
+                self.state_changed("wallet_created", wallet_identifier.id, {"did_id": did_wallet.get_my_DID()})
+                return wallet_identifier
+            # we are over the limit
+            return None
 
     async def get_minter_did(self, launcher_coin: Coin, peer: WSChiaConnection) -> Optional[bytes32]:
         # Get minter DID


### PR DESCRIPTION

### Purpose:

This PR prevents an attack where users are sent high numbers of new DIDs requiring a large CPU load while new paths are derived.

### Current Behavior:

There is currently no limit to the number of DIDs that can be sent to a user.

### New Behavior:

This adds in a configurable limit in the `initial-config.yaml` which is then checked when we receive a DID via transfer.
Discarded DID's can be recovered through the API, and new DIDs can be manually created above the limit.

This PR also adds in a new test to `test_did.py` which tests this functionality.
