### PR TITLE
simplify passing around difficulty, sub slot iterators and prev_ses_block

### DIFF
--- a/chia/_tests/blockchain/blockchain_test_utils.py
+++ b/chia/_tests/blockchain/blockchain_test_utils.py
@@ -8,8 +8,8 @@ from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.blockchain import AddBlockResult, Blockchain
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
 from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_blocks_multiprocessing
-from chia.types.chain_state import ChainState
 from chia.types.full_block import FullBlock
+from chia.types.validation_state import ValidationState
 from chia.util.errors import Err
 from chia.util.ints import uint32, uint64
 
@@ -82,7 +82,7 @@ async def _validate_and_add_block(
             [block],
             blockchain.pool,
             {},
-            ChainState(ssi, diff, prev_ses_block),
+            ValidationState(ssi, diff, prev_ses_block),
             validate_signatures=False,
         )
         assert pre_validation_results is not None

--- a/chia/_tests/blockchain/blockchain_test_utils.py
+++ b/chia/_tests/blockchain/blockchain_test_utils.py
@@ -8,6 +8,7 @@ from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.blockchain import AddBlockResult, Blockchain
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
 from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_blocks_multiprocessing
+from chia.types.chain_state import ChainState
 from chia.types.full_block import FullBlock
 from chia.util.errors import Err
 from chia.util.ints import uint32, uint64
@@ -81,9 +82,7 @@ async def _validate_and_add_block(
             [block],
             blockchain.pool,
             {},
-            sub_slot_iters=ssi,
-            difficulty=diff,
-            prev_ses_block=prev_ses_block,
+            ChainState(ssi, diff, prev_ses_block),
             validate_signatures=False,
         )
         assert pre_validation_results is not None

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -42,7 +42,6 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import InfusedChallengeChainSubSlot
 from chia.types.blockchain_format.vdf import VDFInfo, VDFProof, validate_vdf
-from chia.types.chain_state import ChainState
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
@@ -50,6 +49,7 @@ from chia.types.full_block import FullBlock
 from chia.types.generator_types import BlockGenerator
 from chia.types.spend_bundle import SpendBundle
 from chia.types.unfinished_block import UnfinishedBlock
+from chia.types.validation_state import ValidationState
 from chia.util.cpu import available_logical_cores
 from chia.util.errors import Err
 from chia.util.generator_tools import get_block_header
@@ -1826,7 +1826,7 @@ class TestPreValidation:
             [blocks[0], block_bad],
             empty_blockchain.pool,
             {},
-            ChainState(ssi, difficulty, None),
+            ValidationState(ssi, difficulty, None),
             validate_signatures=True,
         )
         assert res[0].error is None
@@ -1853,7 +1853,7 @@ class TestPreValidation:
                 blocks_to_validate,
                 empty_blockchain.pool,
                 {},
-                ChainState(ssi, difficulty, None),
+                ValidationState(ssi, difficulty, None),
                 validate_signatures=True,
             )
             end_pv = time.time()
@@ -1959,7 +1959,7 @@ class TestBodyValidation:
             [blocks[-1]],
             b.pool,
             {},
-            ChainState(ssi, diff, None),
+            ValidationState(ssi, diff, None),
             validate_signatures=False,
         )
         # Ignore errors from pre-validation, we are testing block_body_validation
@@ -2081,7 +2081,7 @@ class TestBodyValidation:
                 [blocks[-1]],
                 b.pool,
                 {},
-                ChainState(ssi, diff, None),
+                ValidationState(ssi, diff, None),
                 validate_signatures=True,
             )
             assert pre_validation_results is not None
@@ -2160,7 +2160,7 @@ class TestBodyValidation:
             [blocks[-1]],
             b.pool,
             {},
-            ChainState(ssi, diff, None),
+            ValidationState(ssi, diff, None),
             validate_signatures=False,
         )
         # Ignore errors from pre-validation, we are testing block_body_validation
@@ -2284,7 +2284,7 @@ class TestBodyValidation:
                 [blocks[-1]],
                 b.pool,
                 {},
-                ChainState(ssi, diff, None),
+                ValidationState(ssi, diff, None),
                 validate_signatures=True,
             )
             assert pre_validation_results is not None
@@ -2643,7 +2643,7 @@ class TestBodyValidation:
             [blocks[-1]],
             b.pool,
             {},
-            ChainState(ssi, diff, None),
+            ValidationState(ssi, diff, None),
             validate_signatures=False,
         )
         assert results is not None
@@ -3220,7 +3220,7 @@ class TestBodyValidation:
             [last_block],
             b.pool,
             {},
-            ChainState(ssi, diff, None),
+            ValidationState(ssi, diff, None),
             validate_signatures=True,
         )
         assert preval_results is not None
@@ -3336,7 +3336,7 @@ class TestReorgs:
             blocks,
             b.pool,
             {},
-            ChainState(ssi, diff, None),
+            ValidationState(ssi, diff, None),
             validate_signatures=False,
         )
         for i, block in enumerate(blocks):
@@ -3895,7 +3895,7 @@ async def test_reorg_flip_flop(empty_blockchain: Blockchain, bt: BlockTools) -> 
             [block1],
             b.pool,
             {},
-            ChainState(ssi, diff, None),
+            ValidationState(ssi, diff, None),
             validate_signatures=False,
         )
         _, err, _ = await b.add_block(block1, preval[0], None, sub_slot_iters=ssi)
@@ -3906,7 +3906,7 @@ async def test_reorg_flip_flop(empty_blockchain: Blockchain, bt: BlockTools) -> 
             [block2],
             b.pool,
             {},
-            ChainState(ssi, diff, None),
+            ValidationState(ssi, diff, None),
             validate_signatures=False,
         )
         _, err, _ = await b.add_block(block2, preval[0], None, sub_slot_iters=ssi)
@@ -3939,7 +3939,7 @@ async def test_get_tx_peak(default_400_blocks: List[FullBlock], empty_blockchain
         test_blocks,
         bc.pool,
         {},
-        ChainState(ssi, diff, None),
+        ValidationState(ssi, diff, None),
         validate_signatures=False,
     )
 

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -42,6 +42,7 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import InfusedChallengeChainSubSlot
 from chia.types.blockchain_format.vdf import VDFInfo, VDFProof, validate_vdf
+from chia.types.chain_state import ChainState
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
@@ -1825,9 +1826,7 @@ class TestPreValidation:
             [blocks[0], block_bad],
             empty_blockchain.pool,
             {},
-            sub_slot_iters=ssi,
-            difficulty=difficulty,
-            prev_ses_block=None,
+            ChainState(ssi, difficulty, None),
             validate_signatures=True,
         )
         assert res[0].error is None
@@ -1854,9 +1853,7 @@ class TestPreValidation:
                 blocks_to_validate,
                 empty_blockchain.pool,
                 {},
-                sub_slot_iters=ssi,
-                difficulty=difficulty,
-                prev_ses_block=None,
+                ChainState(ssi, difficulty, None),
                 validate_signatures=True,
             )
             end_pv = time.time()
@@ -1962,9 +1959,7 @@ class TestBodyValidation:
             [blocks[-1]],
             b.pool,
             {},
-            sub_slot_iters=ssi,
-            difficulty=diff,
-            prev_ses_block=None,
+            ChainState(ssi, diff, None),
             validate_signatures=False,
         )
         # Ignore errors from pre-validation, we are testing block_body_validation
@@ -2086,9 +2081,7 @@ class TestBodyValidation:
                 [blocks[-1]],
                 b.pool,
                 {},
-                sub_slot_iters=ssi,
-                difficulty=diff,
-                prev_ses_block=None,
+                ChainState(ssi, diff, None),
                 validate_signatures=True,
             )
             assert pre_validation_results is not None
@@ -2167,9 +2160,7 @@ class TestBodyValidation:
             [blocks[-1]],
             b.pool,
             {},
-            sub_slot_iters=ssi,
-            difficulty=diff,
-            prev_ses_block=None,
+            ChainState(ssi, diff, None),
             validate_signatures=False,
         )
         # Ignore errors from pre-validation, we are testing block_body_validation
@@ -2293,9 +2284,7 @@ class TestBodyValidation:
                 [blocks[-1]],
                 b.pool,
                 {},
-                sub_slot_iters=ssi,
-                difficulty=diff,
-                prev_ses_block=None,
+                ChainState(ssi, diff, None),
                 validate_signatures=True,
             )
             assert pre_validation_results is not None
@@ -2654,9 +2643,7 @@ class TestBodyValidation:
             [blocks[-1]],
             b.pool,
             {},
-            sub_slot_iters=ssi,
-            difficulty=diff,
-            prev_ses_block=None,
+            ChainState(ssi, diff, None),
             validate_signatures=False,
         )
         assert results is not None
@@ -3233,9 +3220,7 @@ class TestBodyValidation:
             [last_block],
             b.pool,
             {},
-            sub_slot_iters=ssi,
-            difficulty=diff,
-            prev_ses_block=None,
+            ChainState(ssi, diff, None),
             validate_signatures=True,
         )
         assert preval_results is not None
@@ -3351,9 +3336,7 @@ class TestReorgs:
             blocks,
             b.pool,
             {},
-            sub_slot_iters=ssi,
-            difficulty=diff,
-            prev_ses_block=None,
+            ChainState(ssi, diff, None),
             validate_signatures=False,
         )
         for i, block in enumerate(blocks):
@@ -3912,9 +3895,7 @@ async def test_reorg_flip_flop(empty_blockchain: Blockchain, bt: BlockTools) -> 
             [block1],
             b.pool,
             {},
-            sub_slot_iters=ssi,
-            difficulty=diff,
-            prev_ses_block=None,
+            ChainState(ssi, diff, None),
             validate_signatures=False,
         )
         _, err, _ = await b.add_block(block1, preval[0], None, sub_slot_iters=ssi)
@@ -3925,9 +3906,7 @@ async def test_reorg_flip_flop(empty_blockchain: Blockchain, bt: BlockTools) -> 
             [block2],
             b.pool,
             {},
-            sub_slot_iters=ssi,
-            difficulty=diff,
-            prev_ses_block=None,
+            ChainState(ssi, diff, None),
             validate_signatures=False,
         )
         _, err, _ = await b.add_block(block2, preval[0], None, sub_slot_iters=ssi)
@@ -3960,9 +3939,7 @@ async def test_get_tx_peak(default_400_blocks: List[FullBlock], empty_blockchain
         test_blocks,
         bc.pool,
         {},
-        sub_slot_iters=ssi,
-        difficulty=diff,
-        prev_ses_block=None,
+        ChainState(ssi, diff, None),
         validate_signatures=False,
     )
 

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -52,7 +52,6 @@ from chia.types.blockchain_format.reward_chain_block import RewardChainBlockUnfi
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFProof
-from chia.types.chain_state import ChainState
 from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
@@ -61,6 +60,7 @@ from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.peer_info import PeerInfo, TimestampedPeerInfo
 from chia.types.spend_bundle import SpendBundle, estimate_fees
 from chia.types.unfinished_block import UnfinishedBlock
+from chia.types.validation_state import ValidationState
 from chia.util.errors import ConsensusError, Err
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64, uint128
@@ -433,7 +433,7 @@ class TestFullNodeBlockCompression:
                         all_blocks[:i],
                         blockchain.pool,
                         {},
-                        ChainState(ssi, diff, None),
+                        ValidationState(ssi, diff, None),
                         validate_signatures=False,
                     )
                     assert results is not None
@@ -450,7 +450,7 @@ class TestFullNodeBlockCompression:
                         all_blocks[:i],
                         blockchain.pool,
                         {},
-                        ChainState(ssi, diff, None),
+                        ValidationState(ssi, diff, None),
                         validate_signatures=False,
                     )
                     assert results is not None

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -52,6 +52,7 @@ from chia.types.blockchain_format.reward_chain_block import RewardChainBlockUnfi
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFProof
+from chia.types.chain_state import ChainState
 from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
@@ -432,9 +433,7 @@ class TestFullNodeBlockCompression:
                         all_blocks[:i],
                         blockchain.pool,
                         {},
-                        sub_slot_iters=ssi,
-                        difficulty=diff,
-                        prev_ses_block=None,
+                        ChainState(ssi, diff, None),
                         validate_signatures=False,
                     )
                     assert results is not None
@@ -451,9 +450,7 @@ class TestFullNodeBlockCompression:
                         all_blocks[:i],
                         blockchain.pool,
                         {},
-                        sub_slot_iters=ssi,
-                        difficulty=diff,
-                        prev_ses_block=None,
+                        ChainState(ssi, diff, None),
                         validate_signatures=False,
                     )
                     assert results is not None

--- a/chia/_tests/farmer_harvester/test_third_party_harvesters.py
+++ b/chia/_tests/farmer_harvester/test_third_party_harvesters.py
@@ -37,9 +37,9 @@ from chia.types.blockchain_format.foliage import FoliageBlockData, FoliageTransa
 from chia.types.blockchain_format.proof_of_space import ProofOfSpace
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import ChallengeChainSubSlot, RewardChainSubSlot
-from chia.types.chain_state import ChainState
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import UnresolvedPeerInfo
+from chia.types.validation_state import ValidationState
 from chia.util.bech32m import decode_puzzle_hash
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64
@@ -442,7 +442,7 @@ async def add_test_blocks_into_full_node(blocks: List[FullBlock], full_node: Ful
         blocks,
         full_node.blockchain.pool,
         {},
-        ChainState(ssi, diff, prev_ses_block),
+        ValidationState(ssi, diff, prev_ses_block),
         validate_signatures=True,
     )
     assert pre_validation_results is not None and len(pre_validation_results) == len(blocks)

--- a/chia/_tests/farmer_harvester/test_third_party_harvesters.py
+++ b/chia/_tests/farmer_harvester/test_third_party_harvesters.py
@@ -37,6 +37,7 @@ from chia.types.blockchain_format.foliage import FoliageBlockData, FoliageTransa
 from chia.types.blockchain_format.proof_of_space import ProofOfSpace
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.slots import ChallengeChainSubSlot, RewardChainSubSlot
+from chia.types.chain_state import ChainState
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import UnresolvedPeerInfo
 from chia.util.bech32m import decode_puzzle_hash
@@ -441,9 +442,7 @@ async def add_test_blocks_into_full_node(blocks: List[FullBlock], full_node: Ful
         blocks,
         full_node.blockchain.pool,
         {},
-        sub_slot_iters=ssi,
-        difficulty=diff,
-        prev_ses_block=prev_ses_block,
+        ChainState(ssi, diff, prev_ses_block),
         validate_signatures=True,
     )
     assert pre_validation_results is not None and len(pre_validation_results) == len(blocks)

--- a/chia/_tests/util/full_sync.py
+++ b/chia/_tests/util/full_sync.py
@@ -23,9 +23,9 @@ from chia.server.server import ChiaServer
 from chia.server.ws_connection import ConnectionCallback, WSChiaConnection
 from chia.simulator.block_tools import make_unfinished_block
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.chain_state import ChainState
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
+from chia.types.validation_state import ValidationState
 from chia.util.config import load_config
 from chia.util.ints import uint16
 
@@ -208,7 +208,7 @@ async def run_sync_test(
                                 full_node.constants, True, block_record, full_node.blockchain
                             )
                             success, summary, err = await full_node.add_block_batch(
-                                block_batch, peer_info, None, ChainState(ssi, diff, None)
+                                block_batch, peer_info, None, ValidationState(ssi, diff, None)
                             )
                             end_height = block_batch[-1].height
                             full_node.blockchain.clean_block_record(end_height - full_node.constants.BLOCKS_CACHE_SIZE)

--- a/chia/_tests/util/full_sync.py
+++ b/chia/_tests/util/full_sync.py
@@ -214,7 +214,7 @@ async def run_sync_test(
                             full_node.blockchain.clean_block_record(end_height - full_node.constants.BLOCKS_CACHE_SIZE)
 
                             if not success:
-                                raise RuntimeError(f"failed to ingest block batch: {err}")
+                                raise RuntimeError("failed to ingest block batch")
 
                             assert summary is not None
 

--- a/chia/_tests/util/full_sync.py
+++ b/chia/_tests/util/full_sync.py
@@ -23,6 +23,7 @@ from chia.server.server import ChiaServer
 from chia.server.ws_connection import ConnectionCallback, WSChiaConnection
 from chia.simulator.block_tools import make_unfinished_block
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.chain_state import ChainState
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
 from chia.util.config import load_config
@@ -206,14 +207,14 @@ async def run_sync_test(
                             ssi, diff = get_next_sub_slot_iters_and_difficulty(
                                 full_node.constants, True, block_record, full_node.blockchain
                             )
-                            success, summary, _, _, _, _ = await full_node.add_block_batch(
-                                block_batch, peer_info, None, current_ssi=ssi, current_difficulty=diff
+                            success, summary, err = await full_node.add_block_batch(
+                                block_batch, peer_info, None, ChainState(ssi, diff, None)
                             )
                             end_height = block_batch[-1].height
                             full_node.blockchain.clean_block_record(end_height - full_node.constants.BLOCKS_CACHE_SIZE)
 
                             if not success:
-                                raise RuntimeError("failed to ingest block batch")
+                                raise RuntimeError(f"failed to ingest block batch: {err}")
 
                             assert summary is not None
 

--- a/chia/_tests/util/misc.py
+++ b/chia/_tests/util/misc.py
@@ -59,10 +59,10 @@ from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_dif
 from chia.full_node.full_node import FullNode
 from chia.full_node.mempool import Mempool
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.chain_state import ChainState
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
+from chia.types.validation_state import ValidationState
 from chia.util.batches import to_batches
 from chia.util.hash import std_hash
 from chia.util.ints import uint16, uint32, uint64
@@ -706,16 +706,17 @@ async def add_blocks_in_batches(
         ssi, diff = get_next_sub_slot_iters_and_difficulty(
             full_node.constants, True, block_record, full_node.blockchain
         )
-    cs = ChainState(ssi, diff, None)
+    vs = ValidationState(ssi, diff, None)
     for block_batch in to_batches(blocks, 64):
         b = block_batch.entries[0]
         if (b.height % 128) == 0:
             print(f"main chain: {b.height:4} weight: {b.weight}")
+        # vs is updated by the call to add_block_batch()
         success, _, err = await full_node.add_block_batch(
             block_batch.entries,
             PeerInfo("0.0.0.0", 0),
             None,
-            cs,
+            vs,
         )
         assert err is None
         assert success is True

--- a/chia/_tests/util/misc.py
+++ b/chia/_tests/util/misc.py
@@ -59,6 +59,7 @@ from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_dif
 from chia.full_node.full_node import FullNode
 from chia.full_node.mempool import Mempool
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.chain_state import ChainState
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
@@ -705,18 +706,16 @@ async def add_blocks_in_batches(
         ssi, diff = get_next_sub_slot_iters_and_difficulty(
             full_node.constants, True, block_record, full_node.blockchain
         )
-    prev_ses_block = None
+    cs = ChainState(ssi, diff, None)
     for block_batch in to_batches(blocks, 64):
         b = block_batch.entries[0]
         if (b.height % 128) == 0:
             print(f"main chain: {b.height:4} weight: {b.weight}")
-        success, _, ssi, diff, prev_ses_block, err = await full_node.add_block_batch(
+        success, _, err = await full_node.add_block_batch(
             block_batch.entries,
             PeerInfo("0.0.0.0", 0),
             None,
-            current_ssi=ssi,
-            current_difficulty=diff,
-            prev_ses_block=prev_ses_block,
+            cs,
         )
         assert err is None
         assert success is True

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -38,9 +38,9 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.chain_state import ChainState
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
+from chia.types.validation_state import ValidationState
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64, uint128
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
@@ -363,7 +363,7 @@ async def test_long_sync_wallet(
         blocks_reorg[-num_blocks - 10 : -1],
         PeerInfo("0.0.0.0", 0),
         None,
-        ChainState(sub_slot_iters, difficulty, None),
+        ValidationState(sub_slot_iters, difficulty, None),
     )
     await full_node.add_block(blocks_reorg[-1])
 
@@ -482,7 +482,7 @@ async def test_wallet_reorg_get_coinbase(
         blocks_reorg_2[-44:],
         PeerInfo("0.0.0.0", 0),
         None,
-        ChainState(sub_slot_iters, difficulty, None),
+        ValidationState(sub_slot_iters, difficulty, None),
     )
 
     for wallet_node, wallet_server in wallets:

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -38,6 +38,7 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.chain_state import ChainState
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
 from chia.util.hash import std_hash
@@ -362,8 +363,7 @@ async def test_long_sync_wallet(
         blocks_reorg[-num_blocks - 10 : -1],
         PeerInfo("0.0.0.0", 0),
         None,
-        current_ssi=sub_slot_iters,
-        current_difficulty=difficulty,
+        ChainState(sub_slot_iters, difficulty, None),
     )
     await full_node.add_block(blocks_reorg[-1])
 
@@ -482,8 +482,7 @@ async def test_wallet_reorg_get_coinbase(
         blocks_reorg_2[-44:],
         PeerInfo("0.0.0.0", 0),
         None,
-        current_ssi=sub_slot_iters,
-        current_difficulty=difficulty,
+        ChainState(sub_slot_iters, difficulty, None),
     )
 
     for wallet_node, wallet_server in wallets:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -74,7 +74,6 @@ from chia.types.blockchain_format.pool_target import PoolTarget
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFInfo, VDFProof, validate_vdf
-from chia.types.chain_state import ChainState
 from chia.types.coin_record import CoinRecord
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.full_block import FullBlock
@@ -86,6 +85,7 @@ from chia.types.peer_info import PeerInfo
 from chia.types.spend_bundle import SpendBundle
 from chia.types.transaction_queue_entry import TransactionQueueEntry
 from chia.types.unfinished_block import UnfinishedBlock
+from chia.types.validation_state import ValidationState
 from chia.types.weight_proof import WeightProof
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.check_fork_next_block import check_fork_next_block
@@ -609,9 +609,9 @@ class FullNode:
                     ssi, diff = get_next_sub_slot_iters_and_difficulty(
                         self.constants, new_slot, prev_b, self.blockchain
                     )
-                    cs = ChainState(ssi, diff, None)
+                    vs = ValidationState(ssi, diff, None)
                     success, state_change_summary, err = await self.add_block_batch(
-                        response.blocks, peer_info, None, cs
+                        response.blocks, peer_info, None, vs
                     )
                     if not success:
                         raise ValueError(f"Error short batch syncing, failed to validate blocks {height}-{end_height}")
@@ -1099,7 +1099,7 @@ class FullNode:
             prev_b = await self.blockchain.get_full_block(prev_b_hash)
             assert prev_b is not None
             ssi, diff, prev_ses_block = await self.get_sub_slot_iters_difficulty_ses_block(prev_b, None, None)
-        cs = ChainState(ssi, diff, prev_ses_block)
+        vs = ValidationState(ssi, diff, prev_ses_block)
 
         async def fetch_block_batches(
             batch_queue: asyncio.Queue[Optional[Tuple[WSChiaConnection, List[FullBlock]]]]
@@ -1177,13 +1177,13 @@ class FullNode:
                             assert fork_hash is not None
                             fork_info = ForkInfo(fork_point_height - 1, fork_point_height - 1, fork_hash)
 
-                # The ChainState object (cs) is an in-out parameter. the add_block_batch()
+                # The ValidationState object (vs) is an in-out parameter. the add_block_batch()
                 # call will update it
                 success, state_change_summary, err = await self.add_block_batch(
                     blocks,
                     peer.get_peer_logging(),
                     fork_info,
-                    cs,
+                    vs,
                     summaries,
                 )
                 if success is False:
@@ -1284,7 +1284,7 @@ class FullNode:
         all_blocks: List[FullBlock],
         peer_info: PeerInfo,
         fork_info: Optional[ForkInfo],
-        cs: ChainState,  # in-out parameter
+        vs: ValidationState,  # in-out parameter
         wp_summaries: Optional[List[SubEpochSummary]] = None,
     ) -> Tuple[bool, Optional[StateChangeSummary], Optional[Err]]:
         # Precondition: All blocks must be contiguous blocks, index i+1 must be the parent of index i
@@ -1301,11 +1301,11 @@ class FullNode:
                 self.blockchain.add_block_record(block_rec)
                 if block_rec.sub_epoch_summary_included:
                     # already validated block, update sub slot iters, difficulty and prev sub epoch summary
-                    cs.prev_ses_block = block_rec
+                    vs.prev_ses_block = block_rec
                     if block_rec.sub_epoch_summary_included.new_sub_slot_iters is not None:
-                        cs.current_ssi = block_rec.sub_epoch_summary_included.new_sub_slot_iters
+                        vs.current_ssi = block_rec.sub_epoch_summary_included.new_sub_slot_iters
                     if block_rec.sub_epoch_summary_included.new_difficulty is not None:
-                        cs.current_difficulty = block_rec.sub_epoch_summary_included.new_difficulty
+                        vs.current_difficulty = block_rec.sub_epoch_summary_included.new_difficulty
 
             if fork_info is None:
                 continue
@@ -1335,6 +1335,9 @@ class FullNode:
 
         # Validates signatures in multiprocessing since they take a while, and we don't have cached transactions
         # for these blocks (unlike during normal operation where we validate one at a time)
+        # We have to copy the ValidationState object to preserve it for the add_block()
+        # call below. pre_validate_blocks_multiprocessing() will update the
+        # object we pass in.
         pre_validate_start = time.monotonic()
         pre_validation_results: List[PreValidationResult] = await pre_validate_blocks_multiprocessing(
             self.blockchain.constants,
@@ -1342,7 +1345,7 @@ class FullNode:
             blocks_to_validate,
             self.blockchain.pool,
             {},
-            copy.copy(cs),
+            copy.copy(vs),
             wp_summaries=wp_summaries,
             validate_signatures=True,
         )
@@ -1370,7 +1373,7 @@ class FullNode:
         agg_state_change_summary: Optional[StateChangeSummary] = None
         block_record = await self.blockchain.get_block_record_from_db(blocks_to_validate[0].prev_header_hash)
         for i, block in enumerate(blocks_to_validate):
-            assert cs.prev_ses_block is None or cs.prev_ses_block.height < block.height
+            assert vs.prev_ses_block is None or vs.prev_ses_block.height < block.height
             assert pre_validation_results[i].required_iters is not None
             state_change_summary: Optional[StateChangeSummary]
             # when adding blocks in batches, we won't have any overlapping
@@ -1384,13 +1387,13 @@ class FullNode:
                         self.constants, True, block_record, self.blockchain
                     )
                     assert cc_sub_slot.new_sub_slot_iters is not None
-                    cs.current_ssi = cc_sub_slot.new_sub_slot_iters
+                    vs.current_ssi = cc_sub_slot.new_sub_slot_iters
                     assert cc_sub_slot.new_difficulty is not None
-                    cs.current_difficulty = cc_sub_slot.new_difficulty
-                    assert expected_sub_slot_iters == cs.current_ssi
-                    assert expected_difficulty == cs.current_difficulty
+                    vs.current_difficulty = cc_sub_slot.new_difficulty
+                    assert expected_sub_slot_iters == vs.current_ssi
+                    assert expected_difficulty == vs.current_difficulty
             result, error, state_change_summary = await self.blockchain.add_block(
-                block, pre_validation_results[i], None, cs.current_ssi, fork_info, prev_ses_block=cs.prev_ses_block
+                block, pre_validation_results[i], None, vs.current_ssi, fork_info, prev_ses_block=vs.prev_ses_block
             )
 
             if result == AddBlockResult.NEW_PEAK:
@@ -1420,7 +1423,7 @@ class FullNode:
             block_record = self.blockchain.block_record(block.header_hash)
             assert block_record is not None
             if block_record.sub_epoch_summary_included is not None:
-                cs.prev_ses_block = block_record
+                vs.prev_ses_block = block_record
                 if self.weight_proof_handler is not None:
                     await self.weight_proof_handler.create_prev_sub_epoch_segments()
         if agg_state_change_summary is not None:
@@ -1868,7 +1871,7 @@ class FullNode:
                 [block],
                 self.blockchain.pool,
                 block_height_conds_map,
-                ChainState(ssi, diff, prev_ses_block),
+                ValidationState(ssi, diff, prev_ses_block),
                 validate_signatures=False,
             )
             added: Optional[AddBlockResult] = None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -614,9 +614,7 @@ class FullNode:
                         response.blocks, peer_info, None, cs
                     )
                     if not success:
-                        raise ValueError(
-                            f"Error short batch syncing, failed to validate blocks {height}-{end_height}: {err}"
-                        )
+                        raise ValueError(f"Error short batch syncing, failed to validate blocks {height}-{end_height}")
                     if state_change_summary is not None:
                         try:
                             peak_fb: Optional[FullBlock] = await self.blockchain.get_full_peak()
@@ -1179,6 +1177,8 @@ class FullNode:
                             assert fork_hash is not None
                             fork_info = ForkInfo(fork_point_height - 1, fork_point_height - 1, fork_hash)
 
+                # The ChainState object (cs) is an in-out parameter. the add_block_batch()
+                # call will update it
                 success, state_change_summary, err = await self.add_block_batch(
                     blocks,
                     peer.get_peer_logging(),
@@ -1342,7 +1342,7 @@ class FullNode:
             blocks_to_validate,
             self.blockchain.pool,
             {},
-            copy.deepcopy(cs),
+            copy.copy(cs),
             wp_summaries=wp_summaries,
             validate_signatures=True,
         )

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import copy
 import dataclasses
 import logging
 import multiprocessing
@@ -73,6 +74,7 @@ from chia.types.blockchain_format.pool_target import PoolTarget
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFInfo, VDFProof, validate_vdf
+from chia.types.chain_state import ChainState
 from chia.types.coin_record import CoinRecord
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.full_block import FullBlock
@@ -607,11 +609,14 @@ class FullNode:
                     ssi, diff = get_next_sub_slot_iters_and_difficulty(
                         self.constants, new_slot, prev_b, self.blockchain
                     )
-                    success, state_change_summary, ssi, diff, _, _ = await self.add_block_batch(
-                        response.blocks, peer_info, None, ssi, diff
+                    cs = ChainState(ssi, diff, None)
+                    success, state_change_summary, err = await self.add_block_batch(
+                        response.blocks, peer_info, None, cs
                     )
                     if not success:
-                        raise ValueError(f"Error short batch syncing, failed to validate blocks {height}-{end_height}")
+                        raise ValueError(
+                            f"Error short batch syncing, failed to validate blocks {height}-{end_height}: {err}"
+                        )
                     if state_change_summary is not None:
                         try:
                             peak_fb: Optional[FullBlock] = await self.blockchain.get_full_peak()
@@ -1085,6 +1090,18 @@ class FullNode:
         # normally "fork_point" or "fork_height" refers to the first common
         # block between the main chain and the fork. Here "fork_point_height"
         # seems to refer to the first diverging block
+        fork_info: Optional[ForkInfo] = None
+        if fork_point_height == 0:
+            ssi = self.constants.SUB_SLOT_ITERS_STARTING
+            diff = self.constants.DIFFICULTY_STARTING
+            prev_ses_block = None
+        else:
+            prev_b_hash = self.blockchain.height_to_hash(fork_point_height)
+            assert prev_b_hash is not None
+            prev_b = await self.blockchain.get_full_block(prev_b_hash)
+            assert prev_b is not None
+            ssi, diff, prev_ses_block = await self.get_sub_slot_iters_difficulty_ses_block(prev_b, None, None)
+        cs = ChainState(ssi, diff, prev_ses_block)
 
         async def fetch_block_batches(
             batch_queue: asyncio.Queue[Optional[Tuple[WSChiaConnection, List[FullBlock]]]]
@@ -1124,17 +1141,7 @@ class FullNode:
         async def validate_block_batches(
             inner_batch_queue: asyncio.Queue[Optional[Tuple[WSChiaConnection, List[FullBlock]]]]
         ) -> None:
-            fork_info: Optional[ForkInfo] = None
-            if fork_point_height == 0:
-                ssi = self.constants.SUB_SLOT_ITERS_STARTING
-                diff = self.constants.DIFFICULTY_STARTING
-                prev_ses_block = None
-            else:
-                prev_b_hash = self.blockchain.height_to_hash(fork_point_height)
-                assert prev_b_hash is not None
-                prev_b = await self.blockchain.get_full_block(prev_b_hash)
-                assert prev_b is not None
-                ssi, diff, prev_ses_block = await self.get_sub_slot_iters_difficulty_ses_block(prev_b, None, None)
+            nonlocal fork_info
             block_rate = 0
             block_rate_time = time.monotonic()
             block_rate_height = -1
@@ -1172,13 +1179,11 @@ class FullNode:
                             assert fork_hash is not None
                             fork_info = ForkInfo(fork_point_height - 1, fork_point_height - 1, fork_hash)
 
-                success, state_change_summary, ssi, diff, prev_ses_block, err = await self.add_block_batch(
+                success, state_change_summary, err = await self.add_block_batch(
                     blocks,
                     peer.get_peer_logging(),
                     fork_info,
-                    ssi,
-                    diff,
-                    prev_ses_block,
+                    cs,
                     summaries,
                 )
                 if success is False:
@@ -1279,11 +1284,9 @@ class FullNode:
         all_blocks: List[FullBlock],
         peer_info: PeerInfo,
         fork_info: Optional[ForkInfo],
-        current_ssi: uint64,
-        current_difficulty: uint64,
-        prev_ses_block: Optional[BlockRecord] = None,
+        cs: ChainState,  # in-out parameter
         wp_summaries: Optional[List[SubEpochSummary]] = None,
-    ) -> Tuple[bool, Optional[StateChangeSummary], uint64, uint64, Optional[BlockRecord], Optional[Err]]:
+    ) -> Tuple[bool, Optional[StateChangeSummary], Optional[Err]]:
         # Precondition: All blocks must be contiguous blocks, index i+1 must be the parent of index i
         # Returns a bool for success, as well as a StateChangeSummary if the peak was advanced
 
@@ -1298,11 +1301,11 @@ class FullNode:
                 self.blockchain.add_block_record(block_rec)
                 if block_rec.sub_epoch_summary_included:
                     # already validated block, update sub slot iters, difficulty and prev sub epoch summary
-                    prev_ses_block = block_rec
+                    cs.prev_ses_block = block_rec
                     if block_rec.sub_epoch_summary_included.new_sub_slot_iters is not None:
-                        current_ssi = block_rec.sub_epoch_summary_included.new_sub_slot_iters
+                        cs.current_ssi = block_rec.sub_epoch_summary_included.new_sub_slot_iters
                     if block_rec.sub_epoch_summary_included.new_difficulty is not None:
-                        current_difficulty = block_rec.sub_epoch_summary_included.new_difficulty
+                        cs.current_difficulty = block_rec.sub_epoch_summary_included.new_difficulty
 
             if fork_info is None:
                 continue
@@ -1328,7 +1331,7 @@ class FullNode:
                 await self.blockchain.run_single_block(block, fork_info)
 
         if len(blocks_to_validate) == 0:
-            return True, None, current_ssi, current_difficulty, prev_ses_block, None
+            return True, None, None
 
         # Validates signatures in multiprocessing since they take a while, and we don't have cached transactions
         # for these blocks (unlike during normal operation where we validate one at a time)
@@ -1339,9 +1342,7 @@ class FullNode:
             blocks_to_validate,
             self.blockchain.pool,
             {},
-            sub_slot_iters=current_ssi,
-            difficulty=current_difficulty,
-            prev_ses_block=prev_ses_block,
+            copy.deepcopy(cs),
             wp_summaries=wp_summaries,
             validate_signatures=True,
         )
@@ -1363,15 +1364,13 @@ class FullNode:
                 return (
                     False,
                     None,
-                    current_ssi,
-                    current_difficulty,
-                    prev_ses_block,
                     Err(pre_validation_results[i].error),
                 )
 
         agg_state_change_summary: Optional[StateChangeSummary] = None
         block_record = await self.blockchain.get_block_record_from_db(blocks_to_validate[0].prev_header_hash)
         for i, block in enumerate(blocks_to_validate):
+            assert cs.prev_ses_block is None or cs.prev_ses_block.height < block.height
             assert pre_validation_results[i].required_iters is not None
             state_change_summary: Optional[StateChangeSummary]
             # when adding blocks in batches, we won't have any overlapping
@@ -1385,13 +1384,13 @@ class FullNode:
                         self.constants, True, block_record, self.blockchain
                     )
                     assert cc_sub_slot.new_sub_slot_iters is not None
-                    current_ssi = cc_sub_slot.new_sub_slot_iters
+                    cs.current_ssi = cc_sub_slot.new_sub_slot_iters
                     assert cc_sub_slot.new_difficulty is not None
-                    current_difficulty = cc_sub_slot.new_difficulty
-                    assert expected_sub_slot_iters == current_ssi
-                    assert expected_difficulty == current_difficulty
+                    cs.current_difficulty = cc_sub_slot.new_difficulty
+                    assert expected_sub_slot_iters == cs.current_ssi
+                    assert expected_difficulty == cs.current_difficulty
             result, error, state_change_summary = await self.blockchain.add_block(
-                block, pre_validation_results[i], None, current_ssi, fork_info, prev_ses_block=prev_ses_block
+                block, pre_validation_results[i], None, cs.current_ssi, fork_info, prev_ses_block=cs.prev_ses_block
             )
 
             if result == AddBlockResult.NEW_PEAK:
@@ -1417,11 +1416,11 @@ class FullNode:
             elif result == AddBlockResult.INVALID_BLOCK or result == AddBlockResult.DISCONNECTED_BLOCK:
                 if error is not None:
                     self.log.error(f"Error: {error}, Invalid block from peer: {peer_info} ")
-                return False, agg_state_change_summary, current_ssi, current_difficulty, prev_ses_block, error
+                return False, agg_state_change_summary, error
             block_record = self.blockchain.block_record(block.header_hash)
             assert block_record is not None
             if block_record.sub_epoch_summary_included is not None:
-                prev_ses_block = block_record
+                cs.prev_ses_block = block_record
                 if self.weight_proof_handler is not None:
                     await self.weight_proof_handler.create_prev_sub_epoch_segments()
         if agg_state_change_summary is not None:
@@ -1430,7 +1429,7 @@ class FullNode:
                 f"Total time for {len(blocks_to_validate)} blocks: {time.monotonic() - pre_validate_start}, "
                 f"advanced: True"
             )
-        return True, agg_state_change_summary, current_ssi, current_difficulty, prev_ses_block, None
+        return True, agg_state_change_summary, None
 
     async def get_sub_slot_iters_difficulty_ses_block(
         self, block: FullBlock, ssi: Optional[uint64], diff: Optional[uint64]
@@ -1869,9 +1868,7 @@ class FullNode:
                 [block],
                 self.blockchain.pool,
                 block_height_conds_map,
-                sub_slot_iters=ssi,
-                difficulty=diff,
-                prev_ses_block=prev_ses_block,
+                ChainState(ssi, diff, prev_ses_block),
                 validate_signatures=False,
             )
             added: Optional[AddBlockResult] = None

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -19,10 +19,10 @@ from chia.simulator.block_tools import BlockTools
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, GetAllCoinsProtocol, ReorgProtocol
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.chain_state import ChainState
 from chia.types.coin_record import CoinRecord
 from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
+from chia.types.validation_state import ValidationState
 from chia.util.config import lock_and_load_config, save_config
 from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.timing import adjusted_timeout, backoff_times
@@ -177,7 +177,7 @@ class FullNodeSimulator(FullNodeAPI):
                     [genesis],
                     self.full_node.blockchain.pool,
                     {},
-                    ChainState(ssi, diff, None),
+                    ValidationState(ssi, diff, None),
                     validate_signatures=True,
                 )
                 assert pre_validation_results is not None
@@ -238,7 +238,7 @@ class FullNodeSimulator(FullNodeAPI):
                     [genesis],
                     self.full_node.blockchain.pool,
                     {},
-                    ChainState(ssi, diff, None),
+                    ValidationState(ssi, diff, None),
                     validate_signatures=True,
                 )
                 assert pre_validation_results is not None

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -19,6 +19,7 @@ from chia.simulator.block_tools import BlockTools
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, GetAllCoinsProtocol, ReorgProtocol
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.chain_state import ChainState
 from chia.types.coin_record import CoinRecord
 from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
@@ -176,9 +177,7 @@ class FullNodeSimulator(FullNodeAPI):
                     [genesis],
                     self.full_node.blockchain.pool,
                     {},
-                    sub_slot_iters=ssi,
-                    difficulty=diff,
-                    prev_ses_block=None,
+                    ChainState(ssi, diff, None),
                     validate_signatures=True,
                 )
                 assert pre_validation_results is not None
@@ -227,7 +226,7 @@ class FullNodeSimulator(FullNodeAPI):
 
     async def farm_new_block(self, request: FarmNewBlockProtocol, force_wait_for_timestamp: bool = False):
         ssi = self.full_node.constants.SUB_SLOT_ITERS_STARTING
-        diffculty = self.full_node.constants.DIFFICULTY_STARTING
+        diff = self.full_node.constants.DIFFICULTY_STARTING
         async with self.full_node.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
             self.log.info("Farming new block!")
             current_blocks = await self.get_all_full_blocks()
@@ -239,9 +238,7 @@ class FullNodeSimulator(FullNodeAPI):
                     [genesis],
                     self.full_node.blockchain.pool,
                     {},
-                    sub_slot_iters=ssi,
-                    difficulty=diffculty,
-                    prev_ses_block=None,
+                    ChainState(ssi, diff, None),
                     validate_signatures=True,
                 )
                 assert pre_validation_results is not None

--- a/chia/types/chain_state.py
+++ b/chia/types/chain_state.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Optional
+
+from chia.consensus.block_record import BlockRecord
+from chia.util.ints import uint64
+
+
+@dataclasses.dataclass
+class ChainState:
+    current_ssi: uint64
+    current_difficulty: uint64
+    prev_ses_block: Optional[BlockRecord] = None

--- a/chia/types/validation_state.py
+++ b/chia/types/validation_state.py
@@ -8,7 +8,7 @@ from chia.util.ints import uint64
 
 
 @dataclasses.dataclass
-class ChainState:
+class ValidationState:
     current_ssi: uint64
     current_difficulty: uint64
     prev_ses_block: Optional[BlockRecord] = None

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -18,8 +18,8 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
 from chia.full_node.full_node import FullNode
 from chia.server.ws_connection import WSChiaConnection
-from chia.types.chain_state import ChainState
 from chia.types.full_block import FullBlock
+from chia.types.validation_state import ValidationState
 from chia.util.config import load_config
 
 
@@ -160,7 +160,7 @@ async def run_sync_checkpoint(
                     full_node.constants, True, block_record, full_node.blockchain
                 )
                 success, _, err = await full_node.add_block_batch(
-                    block_batch, peer_info, None, ChainState(ssi, diff, None)
+                    block_batch, peer_info, None, ValidationState(ssi, diff, None)
                 )
                 end_height = block_batch[-1].height
                 full_node.blockchain.clean_block_record(end_height - full_node.constants.BLOCKS_CACHE_SIZE)
@@ -178,7 +178,7 @@ async def run_sync_checkpoint(
                     full_node.constants, True, block_record, full_node.blockchain
                 )
                 success, _, err = await full_node.add_block_batch(
-                    block_batch, peer_info, None, ChainState(ssi, diff, None)
+                    block_batch, peer_info, None, ValidationState(ssi, diff, None)
                 )
                 if not success:
                     raise RuntimeError("failed to ingest block batch")

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -18,6 +18,7 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
 from chia.full_node.full_node import FullNode
 from chia.server.ws_connection import WSChiaConnection
+from chia.types.chain_state import ChainState
 from chia.types.full_block import FullBlock
 from chia.util.config import load_config
 
@@ -158,14 +159,14 @@ async def run_sync_checkpoint(
                 ssi, diff = get_next_sub_slot_iters_and_difficulty(
                     full_node.constants, True, block_record, full_node.blockchain
                 )
-                success, _, _, _, _, _ = await full_node.add_block_batch(
-                    block_batch, peer_info, None, current_ssi=ssi, current_difficulty=diff
+                success, _, err = await full_node.add_block_batch(
+                    block_batch, peer_info, None, ChainState(ssi, diff, None)
                 )
                 end_height = block_batch[-1].height
                 full_node.blockchain.clean_block_record(end_height - full_node.constants.BLOCKS_CACHE_SIZE)
 
                 if not success:
-                    raise RuntimeError("failed to ingest block batch")
+                    raise RuntimeError(f"failed to ingest block batch: {err}")
 
                 height += len(block_batch)
                 print(f"\rheight {height}    ", end="")
@@ -176,11 +177,11 @@ async def run_sync_checkpoint(
                 ssi, diff = get_next_sub_slot_iters_and_difficulty(
                     full_node.constants, True, block_record, full_node.blockchain
                 )
-                success, _, _, _, _, _ = await full_node.add_block_batch(
-                    block_batch, peer_info, None, current_ssi=ssi, current_difficulty=diff
+                success, _, err = await full_node.add_block_batch(
+                    block_batch, peer_info, None, ChainState(ssi, diff, None)
                 )
                 if not success:
-                    raise RuntimeError("failed to ingest block batch")
+                    raise RuntimeError(f"failed to ingest block batch: {err}")
 
 
 main.add_command(run)

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -166,7 +166,7 @@ async def run_sync_checkpoint(
                 full_node.blockchain.clean_block_record(end_height - full_node.constants.BLOCKS_CACHE_SIZE)
 
                 if not success:
-                    raise RuntimeError(f"failed to ingest block batch: {err}")
+                    raise RuntimeError("failed to ingest block batch")
 
                 height += len(block_batch)
                 print(f"\rheight {height}    ", end="")
@@ -181,7 +181,7 @@ async def run_sync_checkpoint(
                     block_batch, peer_info, None, ChainState(ssi, diff, None)
                 )
                 if not success:
-                    raise RuntimeError(f"failed to ingest block batch: {err}")
+                    raise RuntimeError("failed to ingest block batch")
 
 
 main.add_command(run)


### PR DESCRIPTION
### Purpose:

combine current sub slot iterations, current difficulty and previous ses block into `ChainState`, to make it easier to pass around and update.

The call to `add_block_batch()` takes these three variables, and also returns them. With this change, it's simple to pass in a `ChainState` object and `add_block_batch()` can update the fields in-place instead.

### Current Behavior:

`add_block_batch()` and `pre_validate_blocks_multiprocessing()` take `sub_slot_iterations`, `difficulty` and `prev_ses_block` as well as return updated versions.

### New Behavior:

`add_block_batch()` and `pre_validate_blocks_multiprocessing()` take `ChainState` and updates it in place.