### PR TITLE
CHIA-1568: fix object has no attribute code errors

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -8,7 +8,7 @@ import traceback
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple, Union
 
-from aiohttp import ClientSession, WSCloseCode, WSMessage, WSMsgType
+from aiohttp import ClientSession, WebSocketError, WSCloseCode, WSMessage, WSMsgType
 from aiohttp.client import ClientWebSocketResponse
 from aiohttp.web import WebSocketResponse
 from packaging.version import Version

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -708,7 +708,7 @@ class WSChiaConnection:
             return full_message_loaded
         elif message.type == WSMsgType.ERROR:
             self.log.error(f"WebSocket Error: {message}")
-            if message.data.code == WSCloseCode.MESSAGE_TOO_BIG:
+            if isinstance(message.data, WebSocketError) and message.data.code == WSCloseCode.MESSAGE_TOO_BIG:
                 asyncio.create_task(self.close(300))
             else:
                 asyncio.create_task(self.close())


### PR DESCRIPTION
### Purpose:

Special case code checks for WebSocketErrors

### Current Behavior:

Always accesses code element even when it doesn't exist

### New Behavior:

Only do it for wserror

### Testing Notes:

None