### PR TITLE
CHIA-1564 Simplify WalletSpendBundle class by leveraging some parent class methods

### DIFF
--- a/chia/wallet/wallet_spend_bundle.py
+++ b/chia/wallet/wallet_spend_bundle.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple
+from typing import List
 
 from chia_rs import AugSchemeMPL, G2Element
 
@@ -11,21 +11,6 @@ from chia.wallet.util.debug_spend_bundle import debug_spend_bundle
 
 
 class WalletSpendBundle(SpendBundle):
-
-    @classmethod
-    def from_bytes(cls, bytes: bytes) -> WalletSpendBundle:
-        sb = SpendBundle.from_bytes(bytes)
-        return cls(sb.coin_spends, sb.aggregated_signature)
-
-    @classmethod
-    def parse_rust(cls, blob: bytes, flag: bool = False) -> Tuple[WalletSpendBundle, int]:
-        bundle, advance = super(WalletSpendBundle, WalletSpendBundle).parse_rust(blob)
-        return cls(bundle.coin_spends, bundle.aggregated_signature), advance
-
-    @classmethod
-    def from_json_dict(cls, json_dict: Dict[str, Any]) -> WalletSpendBundle:
-        sb = SpendBundle.from_json_dict(json_dict)
-        return cls(sb.coin_spends, sb.aggregated_signature)
 
     @classmethod
     def aggregate(cls, spend_bundles: List[T_SpendBundle]) -> WalletSpendBundle:


### PR DESCRIPTION
### Purpose:

Simplify `WalletSpendBundle` class by leveraging parent `from_bytes`,  `parse_rust`  and `from_json_dict` class methods.

### Current Behavior:

We override these class methods in `WalletSpendBundle`.

### New Behavior:

We no longer override these class methods in `WalletSpendBundle`.