### PR TITLE
Catch assertion error in height_to_hash()

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -1072,7 +1072,7 @@ class Blockchain:
         try:
             height_hash = self.height_to_hash(peak_block.height)
         except Exception:
-            log.info(f"No header hash found for heigh {peak_block.height}. We must be on a fork.")
+            log.info(f"No header hash found for height {peak_block.height}. We must be on a fork.")
         if height_hash != header_hash:  # we are on a fork
             peak: Optional[BlockRecord] = self.get_peak()
             assert peak is not None

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -1068,7 +1068,12 @@ class Blockchain:
         # need to find the fork point
         peak_block = await self.get_block_record_from_db(header_hash)
         assert peak_block is not None
-        if self.height_to_hash(peak_block.height) != header_hash:
+        height_hash = None
+        try:
+            height_hash = self.height_to_hash(peak_block.height)
+        except Exception:
+            log.info(f"No header hash found for heigh {peak_block.height}. We must be on a fork.")
+        if height_hash != header_hash:
             peak: Optional[BlockRecord] = self.get_peak()
             assert peak is not None
             reorg_chain: Dict[uint32, bytes32]

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -1068,12 +1068,12 @@ class Blockchain:
         # need to find the fork point
         peak_block = await self.get_block_record_from_db(header_hash)
         assert peak_block is not None
-        height_hash = None
+        height_hash: Optional[bytes32] = None
         try:
             height_hash = self.height_to_hash(peak_block.height)
         except Exception:
             log.info(f"No header hash found for heigh {peak_block.height}. We must be on a fork.")
-        if height_hash != header_hash:
+        if height_hash != header_hash:  # we are on a fork
             peak: Optional[BlockRecord] = self.get_peak()
             assert peak is not None
             reorg_chain: Dict[uint32, bytes32]


### PR DESCRIPTION

### Purpose:
Currently get_hash() in block_height_map.py has an assert which can fail and is not caught in the calling height_to_hash() function in blockchain.py.
In this case we should treat it as though we are on a fork that is further ahead than us.

This PR adds in try except condition, a default value, and a log for when this case is hit.

### Current Behavior:
Raises the exception.

### New Behavior:
Catches, logs and proceeds
