### PR TITLE
Fix install.sh upgrade issue

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -172,7 +172,18 @@ fi
 .penv/bin/poetry env use "${INSTALL_PYTHON_PATH}"
 # shellcheck disable=SC2086
 .penv/bin/poetry install ${EXTRAS}
-ln -s -f .venv venv
+
+if [ -e venv ]; then
+  if [ -d venv ] && [ ! -L venv ]; then
+    echo "The 'venv' directory already exists. Please delete it before installing."
+    exit 1
+  elif [ -L venv ]; then
+    ln -sfn .venv venv
+  fi
+else
+  ln -s .venv venv
+fi
+
 if [ ! -f "activate" ]; then
   ln -s venv/bin/activate .
 fi


### PR DESCRIPTION
Fixes https://github.com/Chia-Network/chia-blockchain/issues/18672

If a user is upgrading and they already have a `venv` dir, then install.sh will silently fail, resulting in potentially erroneous output during the execution of `chia` commands, since it is using stuff from the old venv dir.

In my case, running `chia` would return:
```python
Traceback (most recent call last):
  File "/home/william/wsrc/chia-blockchain/venv/bin/chia", line 5, in <module>
    from chia.cmds.chia import main
  File "/home/william/wsrc/chia-blockchain/chia/cmds/chia.py", line 9, in <module>
    from chia.cmds.beta import beta_cmd
  File "/home/william/wsrc/chia-blockchain/chia/cmds/beta.py", line 10, in <module>
    from chia.cmds.beta_funcs import (
  File "/home/william/wsrc/chia-blockchain/chia/cmds/beta_funcs.py", line 8, in <module>
    from chia.cmds.cmds_util import format_bytes, prompt_yes_no, validate_directory_writable
  File "/home/william/wsrc/chia-blockchain/chia/cmds/cmds_util.py", line 14, in <module>
    from chia.consensus.default_constants import DEFAULT_CONSTANTS
  File "/home/william/wsrc/chia-blockchain/chia/consensus/default_constants.py", line 13, in <module>
DEFAULT_CONSTANTS = ConsensusConstants(
^^^^^^^^^^^^^^^^^^^
TypeError: ConsensusConstants.__new__() got an unexpected keyword argument 'AGG_SIG_PARENT_ADDITIONAL_DATA'
```