### PR TITLE
[CHIA-4224] Added `offer_only` option to `create_offer_for_ids`

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -1588,6 +1588,17 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
     all_offers = (await env_1.rpc_client.get_all_offers(GetAllOffers())).trade_records
     assert len(all_offers) == 0
 
+    offer_only_res = await env_1.rpc_client.fetch(
+        "create_offer_for_ids",
+        CreateOfferForIDs(
+            offer={str(1): "-5", cat_asset_id.hex(): "1"},
+            validate_only=True,
+            offer_only=True,
+        ).json_serialize_for_transport(wallet_environments.tx_config, tuple(), ConditionValidTimes()),
+    )
+    assert "offer" in offer_only_res
+    assert "trade_record" not in offer_only_res
+
     driver_dict = {
         cat_asset_id: PuzzleInfo(
             {

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -1588,16 +1588,16 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
     all_offers = (await env_1.rpc_client.get_all_offers(GetAllOffers())).trade_records
     assert len(all_offers) == 0
 
-    offer_only_res = await env_1.rpc_client.fetch(
-        "create_offer_for_ids",
+    offer_only_res = await env_1.rpc_client.create_offer_for_ids(
         CreateOfferForIDs(
             offer={str(1): "-5", cat_asset_id.hex(): "1"},
             validate_only=True,
             offer_only=True,
-        ).json_serialize_for_transport(wallet_environments.tx_config, tuple(), ConditionValidTimes()),
+        ),
+        tx_config=wallet_environments.tx_config,
     )
-    assert "offer" in offer_only_res
-    assert "trade_record" not in offer_only_res
+    assert offer_only_res.offer is not None
+    assert not hasattr(offer_only_res, "trade_record")
 
     driver_dict = {
         cat_asset_id: PuzzleInfo(

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -114,6 +114,7 @@ from chia.wallet.wallet_request_types import (
     CreateNewWallet,
     CreateNewWalletType,
     CreateOfferForIDs,
+    CreateOfferForIDsResponse,
     CreateSignedTransaction,
     DefaultCAT,
     DeleteKey,
@@ -1687,6 +1688,7 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
         CreateOfferForIDs(offer={str(1): "-5", str(cat_wallet_id): "1"}, fee=uint64(1)),
         tx_config=wallet_environments.tx_config,
     )
+    assert isinstance(create_res, CreateOfferForIDsResponse)
     all_offers = (await env_1.rpc_client.get_all_offers(GetAllOffers())).trade_records
     assert len(all_offers) == 2
     offer_count = await env_1.rpc_client.get_offers_count()

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -1599,6 +1599,7 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
     )
     assert offer_only_res.offer is not None
     assert not hasattr(offer_only_res, "trade_record")
+    assert offer_only_res.to_json_dict() == {"offer": offer_only_res.offer.to_bech32()}
 
     driver_dict = {
         cat_asset_id: PuzzleInfo(

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -57,6 +57,7 @@ from chia.wallet.wallet_request_types import (
     CreateNewWallet,
     CreateNewWalletType,
     CreateOfferForIDs,
+    CreateOfferForIDsResponse,
     DeleteNotifications,
     DeleteUnconfirmedTransactions,
     DIDFindLostDID,
@@ -686,6 +687,7 @@ async def make_offer(
                         ).to_tx_config(units["chia"], config, fingerprint),
                         timelock_info=condition_valid_times,
                     )
+                    assert isinstance(res, CreateOfferForIDsResponse)
                     if res.offer is not None:
                         file.write(res.offer.to_bech32())
                         print(f"Created offer with ID {res.trade_record.trade_id}")

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -70,6 +70,7 @@ from chia.wallet.wallet_request_types import (
     CancelOffer,
     CreateNewDL,
     CreateOfferForIDs,
+    CreateOfferForIDsResponse,
     DLDeleteMirror,
     DLGetMirrors,
     DLHistory,
@@ -1213,6 +1214,7 @@ class DataLayer:
                 # This is not a change in behavior, the default was already implicit.
                 tx_config=DEFAULT_TX_CONFIG,
             )
+            assert isinstance(res, CreateOfferForIDsResponse)
 
             offer = Offer(
                 trade_id=res.trade_record.trade_id,

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -2166,6 +2166,7 @@ class CreateOfferForIDs(TransactionEndpointRequest):
     driver_dict: dict[bytes32, PuzzleInfo] | None = None
     solver: Solver | None = None
     validate_only: bool = False
+    offer_only: bool = False
 
     @property
     def offer_spec(self) -> dict[int | bytes32, int]:

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -2188,6 +2188,19 @@ class CreateOfferForIDsResponse(_OfferEndpointResponse):
 
 @streamable
 @dataclass(kw_only=True, frozen=True)
+class CreateOfferForIDsOfferOnlyResponse(Streamable):
+    offer: Offer
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {"offer": self.offer.to_bech32()}
+
+    @classmethod
+    def from_json_dict(cls, json_dict: dict[str, Any]) -> Self:
+        return cls(offer=Offer.from_bech32(json_dict["offer"]))
+
+
+@streamable
+@dataclass(kw_only=True, frozen=True)
 class TakeOffer(TransactionEndpointRequest):
     offer: str
     solver: Solver | None = None

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -416,6 +416,10 @@ def tx_endpoint(
                 # unfortunately, this API isn't solely a tx endpoint
                 return response
 
+            if func.__name__ == "create_offer_for_ids" and request.get("offer_only", False):
+                response.pop("trade_record", None)
+                return response
+
             if "action_scope_override" in kwargs:
                 # deferring to parent action scope
                 return response

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -416,10 +416,6 @@ def tx_endpoint(
                 # unfortunately, this API isn't solely a tx endpoint
                 return response
 
-            if func.__name__ == "create_offer_for_ids" and request.get("offer_only", False):
-                response.pop("trade_record", None)
-                return response
-
             if "action_scope_override" in kwargs:
                 # deferring to parent action scope
                 return response
@@ -533,6 +529,12 @@ def tx_endpoint(
                     await self.service.wallet_state_manager.tx_store.add_transaction_record(
                         dataclasses.replace(tx, trade_id=new_trade.trade_id)
                     )
+
+            if func.__name__ == "create_offer_for_ids" and request.get("offer_only", False):
+                response.pop("trade_record", None)
+                response.pop("transactions", None)
+                response.pop("unsigned_transactions", None)
+                return response
 
             return response
 

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -42,6 +42,7 @@ from chia.wallet.wallet_request_types import (
     CreateNewWallet,
     CreateNewWalletResponse,
     CreateOfferForIDs,
+    CreateOfferForIDsOfferOnlyResponse,
     CreateOfferForIDsResponse,
     CreateSignedTransaction,
     CreateSignedTransactionsResponse,
@@ -587,12 +588,13 @@ class WalletRpcClient(RpcClient):
         tx_config: TXConfig,
         extra_conditions: tuple[Condition, ...] = tuple(),
         timelock_info: ConditionValidTimes = ConditionValidTimes(),
-    ) -> CreateOfferForIDsResponse:
-        return CreateOfferForIDsResponse.from_json_dict(
-            await self.fetch(
-                "create_offer_for_ids", request.json_serialize_for_transport(tx_config, extra_conditions, timelock_info)
-            )
+    ) -> CreateOfferForIDsResponse | CreateOfferForIDsOfferOnlyResponse:
+        response = await self.fetch(
+            "create_offer_for_ids", request.json_serialize_for_transport(tx_config, extra_conditions, timelock_info)
         )
+        if request.offer_only:
+            return CreateOfferForIDsOfferOnlyResponse.from_json_dict(response)
+        return CreateOfferForIDsResponse.from_json_dict(response)
 
     async def get_offer_summary(self, request: GetOfferSummary) -> GetOfferSummaryResponse:
         return GetOfferSummaryResponse.from_json_dict(await self.fetch("get_offer_summary", request.to_json_dict()))


### PR DESCRIPTION
There is a case where response payload size of `create_offer_for_ids` hits the limit of websocket connection.
I've added an `offer_only` flag for `create_offer_for_ids` which lets the API respond only `offer_data` and `trade_record` properties to reduce response payload size.

Corresponding GUI PR: https://github.com/Chia-Network/chia-blockchain-gui/pull/2506


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wallet offer RPC response shaping and client typing; default behavior is unchanged, but callers using offer_only get a different response shape and no trade_record in the payload.
> 
> **Overview**
> Adds an **`offer_only`** flag to **`create_offer_for_ids`** so callers can shrink WebSocket payloads when full offer creation responses exceed size limits.
> 
> When **`offer_only=True`**, the wallet RPC still runs the normal offer flow but **strips** `trade_record`, `transactions`, and `unsigned_transactions` from the JSON response, leaving essentially the bech32 **`offer`**. The RPC client maps that to a new **`CreateOfferForIDsOfferOnlyResponse`** type; the default path still returns **`CreateOfferForIDsResponse`** unchanged.
> 
> Tests cover validate-only **`offer_only`** behavior; CLI and data-layer call sites add **`isinstance`** checks for the full response type where they still need **`trade_record`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36704a9b8713e1578f47abe819e716bb4b08e90f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->