### PR TITLE
CHIA-1602 Remove no longer needed TestNetwork class

### DIFF
--- a/chia/_tests/util/test_network.py
+++ b/chia/_tests/util/test_network.py
@@ -10,35 +10,33 @@ import pytest
 from chia.util.network import IPAddress, resolve
 
 
-class TestNetwork:
-    @pytest.mark.anyio
-    async def test_resolve4(self):
-        # Run these tests forcing IPv4 resolution
-        prefer_ipv6 = False
-        assert await resolve("127.0.0.1", prefer_ipv6=prefer_ipv6) == IPAddress.create("127.0.0.1")
-        assert await resolve("10.11.12.13", prefer_ipv6=prefer_ipv6) == IPAddress.create("10.11.12.13")
-        assert await resolve("localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("127.0.0.1")
-        assert await resolve("example.net", prefer_ipv6=prefer_ipv6) == IPAddress.create("93.184.215.14")
+@pytest.mark.anyio
+async def test_resolve4():
+    # Run these tests forcing IPv4 resolution
+    prefer_ipv6 = False
+    assert await resolve("127.0.0.1", prefer_ipv6=prefer_ipv6) == IPAddress.create("127.0.0.1")
+    assert await resolve("10.11.12.13", prefer_ipv6=prefer_ipv6) == IPAddress.create("10.11.12.13")
+    assert await resolve("localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("127.0.0.1")
+    assert await resolve("example.net", prefer_ipv6=prefer_ipv6) == IPAddress.create("93.184.215.14")
 
-    @pytest.mark.anyio
-    @pytest.mark.skipif(
-        condition=("GITHUB_ACTIONS" in os.environ) and (sys.platform in {"darwin", "win32"}),
-        reason="macOS and Windows runners in GitHub Actions do not seem to support IPv6",
+
+@pytest.mark.anyio
+@pytest.mark.skipif(
+    condition=("GITHUB_ACTIONS" in os.environ) and (sys.platform in {"darwin", "win32"}),
+    reason="macOS and Windows runners in GitHub Actions do not seem to support IPv6",
+)
+async def test_resolve6():
+    # Run these tests forcing IPv6 resolution
+    prefer_ipv6 = True
+    assert await resolve("::1", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
+    assert await resolve("2000:1000::1234:abcd", prefer_ipv6=prefer_ipv6) == IPAddress.create("2000:1000::1234:abcd")
+    # ip6-localhost is not always available, and localhost is IPv4 only
+    # on some systems.  Just test neither here.
+    # assert await resolve("ip6-localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
+    # assert await resolve("localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
+    assert await resolve("example.net", prefer_ipv6=prefer_ipv6) == IPAddress.create(
+        "2606:2800:21f:cb07:6820:80da:af6b:8b2c"
     )
-    async def test_resolve6(self):
-        # Run these tests forcing IPv6 resolution
-        prefer_ipv6 = True
-        assert await resolve("::1", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
-        assert await resolve("2000:1000::1234:abcd", prefer_ipv6=prefer_ipv6) == IPAddress.create(
-            "2000:1000::1234:abcd"
-        )
-        # ip6-localhost is not always available, and localhost is IPv4 only
-        # on some systems.  Just test neither here.
-        # assert await resolve("ip6-localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
-        # assert await resolve("localhost", prefer_ipv6=prefer_ipv6) == IPAddress.create("::1")
-        assert await resolve("example.net", prefer_ipv6=prefer_ipv6) == IPAddress.create(
-            "2606:2800:21f:cb07:6820:80da:af6b:8b2c"
-        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Purpose:

As we're using pytest instead of unittest, this class isn't needed anymore.

### Current Behavior:

Tests are grouped into a `TestNetwork` class.

### New Behavior:

Tests are no longer grouped into a `TestNetwork` class.