### PR TITLE
Require fewer arguments for `chia wallet coins split`  in the CLI

### DIFF
--- a/chia/_tests/cmds/wallet/test_coins.py
+++ b/chia/_tests/cmds/wallet/test_coins.py
@@ -7,9 +7,9 @@ from typing import List, Optional, Tuple
 from chia._tests.cmds.cmd_test_utils import TestRpcClients, TestWalletRpcClient, logType, run_cli_command_and_assert
 from chia._tests.cmds.wallet.test_consts import FINGERPRINT, FINGERPRINT_ARG, STD_TX, STD_UTX, get_bytes32
 from chia.rpc.wallet_request_types import CombineCoins, CombineCoinsResponse, SplitCoins, SplitCoinsResponse
+from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
-from chia.types.blockchain_format.coin import Coin
 from chia.types.coin_record import CoinRecord
 from chia.util.ints import uint16, uint32, uint64
 from chia.wallet.conditions import ConditionValidTimes

--- a/chia/_tests/cmds/wallet/test_coins.py
+++ b/chia/_tests/cmds/wallet/test_coins.py
@@ -144,7 +144,7 @@ def test_coins_split(capsys: object, get_test_cli_clients: Tuple[TestRpcClients,
         ) -> SplitCoinsResponse:
             self.add_to_log("split_coins", (args, tx_config, timelock_info))
             return SplitCoinsResponse([STD_UTX], [STD_TX])
-        
+
         async def get_coin_records_by_names(
             self,
             names: List[bytes32],
@@ -152,17 +152,13 @@ def test_coins_split(capsys: object, get_test_cli_clients: Tuple[TestRpcClients,
             start_height: Optional[int] = None,
             end_height: Optional[int] = None,
         ) -> List[CoinRecord]:
-            coin = Coin(
-                Program.to(0).get_tree_hash(),
-                Program.to(1).get_tree_hash(),
-                10_000_000_000_000
-            )
+            coin = Coin(Program.to(0).get_tree_hash(), Program.to(1).get_tree_hash(), uint64(10_000_000_000_000))
             cr = CoinRecord(
                 coin,
-                10,
-                0,
+                uint32(10),
+                uint32(0),
                 False,
-                0,
+                uint64(0),
             )
             return [cr]
 
@@ -210,11 +206,6 @@ def test_coins_split(capsys: object, get_test_cli_clients: Tuple[TestRpcClients,
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
 
-    target_coin_id = Coin(
-        Program.to(0).get_tree_hash(),
-        Program.to(1).get_tree_hash(),
-        10_000_000_000_000
-    ).name()
     command_args = [
         "wallet",
         "coins",
@@ -232,14 +223,16 @@ def test_coins_split(capsys: object, get_test_cli_clients: Tuple[TestRpcClients,
     # these are various things that should be in the output
     assert_list = []
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
-    expected_calls: logType = {
+    expected_calls = {
         "get_wallets": [(None,)],
         "get_sync_status": [()],
         "split_coins": [
             (
                 SplitCoins(
                     wallet_id=uint32(1),
-                    number_of_coins=uint16(20),  # this transaction should be equivalent to specifying 20 x  0.5xch coins 
+                    number_of_coins=uint16(
+                        20
+                    ),  # this transaction should be equivalent to specifying 20 x  0.5xch coins
                     amount_per_coin=uint64(500_000_000_000),
                     target_coin_id=target_coin_id,
                     fee=uint64(1_000_000_000),
@@ -276,7 +269,9 @@ def test_coins_split(capsys: object, get_test_cli_clients: Tuple[TestRpcClients,
             (
                 SplitCoins(
                     wallet_id=uint32(1),
-                    number_of_coins=uint16(20),  # this transaction should be equivalent to specifying 20 x  0.5xch coins 
+                    number_of_coins=uint16(
+                        20
+                    ),  # this transaction should be equivalent to specifying 20 x  0.5xch coins
                     amount_per_coin=uint64(500_000_000_000),
                     target_coin_id=target_coin_id,
                     fee=uint64(1_000_000_000),

--- a/chia/_tests/cmds/wallet/test_coins.py
+++ b/chia/_tests/cmds/wallet/test_coins.py
@@ -220,7 +220,6 @@ def test_coins_split(capsys: object, get_test_cli_clients: Tuple[TestRpcClients,
         "--expires-at",
         "150",
     ]
-    # these are various things that should be in the output
     assert_list = []
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     expected_calls = {
@@ -244,7 +243,7 @@ def test_coins_split(capsys: object, get_test_cli_clients: Tuple[TestRpcClients,
         ],
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
-
+    # try the split the other way around
     command_args = [
         "wallet",
         "coins",
@@ -259,27 +258,5 @@ def test_coins_split(capsys: object, get_test_cli_clients: Tuple[TestRpcClients,
         "--expires-at",
         "150",
     ]
-    # these are various things that should be in the output
-    assert_list = []
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
-    expected_calls: logType = {
-        "get_wallets": [(None,)],
-        "get_sync_status": [()],
-        "split_coins": [
-            (
-                SplitCoins(
-                    wallet_id=uint32(1),
-                    number_of_coins=uint16(
-                        20
-                    ),  # this transaction should be equivalent to specifying 20 x  0.5xch coins
-                    amount_per_coin=uint64(500_000_000_000),
-                    target_coin_id=target_coin_id,
-                    fee=uint64(1_000_000_000),
-                    push=True,
-                ),
-                DEFAULT_TX_CONFIG,
-                test_condition_valid_times,
-            )
-        ],
-    }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -216,11 +216,17 @@ async def async_split(
 
         if number_of_coins is None:
             coins = await wallet_client.get_coin_records_by_names([target_coin_id])
+            if len(coins) == 0:
+                print("Could not find target coin.") 
+                return []
             assert coins is not None
             assert amount_per_coin is not None
             number_of_coins = uint64(coins[0].coin.amount // amount_per_coin.convert_amount(mojo_per_unit))
         elif amount_per_coin is None:
             coins = await wallet_client.get_coin_records_by_names([target_coin_id])
+            if len(coins) == 0:
+                print("Could not find target coin.") 
+                return []
             assert coins is not None
             assert number_of_coins is not None
             amount_per_coin = CliAmount(True, uint64(coins[0].coin.amount // number_of_coins))

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -216,9 +216,13 @@ async def async_split(
 
         if number_of_coins is None:
             coins = await wallet_client.get_coin_records_by_names([target_coin_id])
+            assert coins is not None
+            assert amount_per_coin is not None
             number_of_coins = uint64(coins[0].coin.amount // amount_per_coin.convert_amount(mojo_per_unit))
         elif amount_per_coin is None:
             coins = await wallet_client.get_coin_records_by_names([target_coin_id])
+            assert coins is not None
+            assert number_of_coins is not None
             amount_per_coin = CliAmount(True, uint64(coins[0].coin.amount // number_of_coins))
 
         final_amount_per_coin = amount_per_coin.convert_amount(mojo_per_unit)

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -217,7 +217,7 @@ async def async_split(
         if number_of_coins is None:
             coins = await wallet_client.get_coin_records_by_names([target_coin_id])
             if len(coins) == 0:
-                print("Could not find target coin.") 
+                print("Could not find target coin.")
                 return []
             assert coins is not None
             assert amount_per_coin is not None
@@ -225,7 +225,7 @@ async def async_split(
         elif amount_per_coin is None:
             coins = await wallet_client.get_coin_records_by_names([target_coin_id])
             if len(coins) == 0:
-                print("Could not find target coin.") 
+                print("Could not find target coin.")
                 return []
             assert coins is not None
             assert number_of_coins is not None

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -219,7 +219,6 @@ async def async_split(
             if len(coins) == 0:
                 print("Could not find target coin.")
                 return []
-            assert coins is not None
             assert amount_per_coin is not None
             number_of_coins = int(coins[0].coin.amount // amount_per_coin.convert_amount(mojo_per_unit))
         elif amount_per_coin is None:
@@ -227,7 +226,6 @@ async def async_split(
             if len(coins) == 0:
                 print("Could not find target coin.")
                 return []
-            assert coins is not None
             assert number_of_coins is not None
             amount_per_coin = CliAmount(True, uint64(coins[0].coin.amount // number_of_coins))
 

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -221,7 +221,7 @@ async def async_split(
                 return []
             assert coins is not None
             assert amount_per_coin is not None
-            number_of_coins = uint64(coins[0].coin.amount // amount_per_coin.convert_amount(mojo_per_unit))
+            number_of_coins = int(coins[0].coin.amount // amount_per_coin.convert_amount(mojo_per_unit))
         elif amount_per_coin is None:
             coins = await wallet_client.get_coin_records_by_names([target_coin_id])
             if len(coins) == 0:

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -188,8 +188,8 @@ async def async_split(
     fingerprint: Optional[int],
     wallet_id: int,
     fee: uint64,
-    number_of_coins: int,
-    amount_per_coin: CliAmount,
+    number_of_coins: Optional[int],
+    amount_per_coin: Optional[CliAmount],
     target_coin_id: bytes32,
     max_coin_amount: CliAmount,
     min_coin_amount: CliAmount,
@@ -209,6 +209,17 @@ async def async_split(
         if not (await wallet_client.get_sync_status()).synced:
             print("Wallet not synced. Please wait.")
             return []
+
+        if number_of_coins is None and amount_per_coin is None:
+            print("Must use either -a or -n. For more information run --help.")
+            return []
+
+        if number_of_coins is None:
+            coins = await wallet_client.get_coin_records_by_names([target_coin_id])
+            number_of_coins = uint64(coins[0].coin.amount // amount_per_coin.convert_amount(mojo_per_unit))
+        elif amount_per_coin is None:
+            coins = await wallet_client.get_coin_records_by_names([target_coin_id])
+            amount_per_coin = CliAmount(True, uint64(coins[0].coin.amount // number_of_coins))
 
         final_amount_per_coin = amount_per_coin.convert_amount(mojo_per_unit)
 

--- a/chia/cmds/coins.py
+++ b/chia/cmds/coins.py
@@ -164,7 +164,7 @@ def combine_cmd(
     "--number-of-coins",
     type=int,
     help="The number of coins we are creating.",
-    required=True,
+    default=None,
 )
 @options.create_fee()
 @click.option(
@@ -172,7 +172,7 @@ def combine_cmd(
     "--amount-per-coin",
     help="The amount of each newly created coin, in XCH or CAT units",
     type=AmountParamType(),
-    required=True,
+    default=None,
 )
 @click.option(
     "-t", "--target-coin-id", type=Bytes32ParamType(), required=True, help="The coin id of the coin we are splitting."


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
Currently we require both `--number-of-coins` and `--amount-per-coin` when really we can derive one from the other if we know the target coin's amount.
As target coin is a required parameter, we simply lookup that coin and do some mojo maths.

### Current Behavior:
Require both `--number-of-coins` and `--amount-per-coin`.

### New Behavior:
Require at least one of `--number-of-coins` and `--amount-per-coin`. If both are present, then behaviour is unchanged.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

`chia/_tests/cmds/wallet/test_coins.py` has been expanded to include tests for this new coin splitting maths.
