### PR TITLE
CHIA-1626 Move some modules to the utils virtual project

### DIFF
--- a/chia/util/batches.py
+++ b/chia/util/batches.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 from collections.abc import Collection, Iterator

--- a/chia/util/bech32m.py
+++ b/chia/util/bech32m.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 # Copyright (c) 2017 Pieter Wuille
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -23,7 +25,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Optional
 
-from chia.types.blockchain_format.sized_bytes import bytes32
+from chia_rs.sized_bytes import bytes32
 
 # Based on this specification from Pieter Wuille:
 # https://github.com/sipa/bips/blob/bip-bech32m/bip-bech32m.mediawiki

--- a/chia/util/byte_types.py
+++ b/chia/util/byte_types.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 

--- a/chia/util/collection.py
+++ b/chia/util/collection.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 # Utility Functions for Collections & Sequences

--- a/chia/util/cpu.py
+++ b/chia/util/cpu.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import os

--- a/chia/util/db_synchronous.py
+++ b/chia/util/db_synchronous.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 

--- a/chia/util/db_version.py
+++ b/chia/util/db_version.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import sqlite3

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import asyncio

--- a/chia/util/default_root.py
+++ b/chia/util/default_root.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import os

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 from enum import Enum

--- a/chia/util/file_keyring.py
+++ b/chia/util/file_keyring.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import base64

--- a/chia/util/files.py
+++ b/chia/util/files.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import asyncio

--- a/chia/util/hash.py
+++ b/chia/util/hash.py
@@ -1,9 +1,11 @@
+# Package: utils
+
 from __future__ import annotations
 
 from hashlib import sha256
 from typing import Literal, SupportsBytes, Union, cast, overload
 
-from chia.types.blockchain_format.sized_bytes import bytes32
+from chia_rs.sized_bytes import bytes32
 
 
 @overload

--- a/chia/util/inline_executor.py
+++ b/chia/util/inline_executor.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 from concurrent.futures import Executor, Future

--- a/chia/util/keychain.py
+++ b/chia/util/keychain.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import sys
@@ -11,9 +13,10 @@ from typing import Any, Literal, Optional, Union, overload
 import importlib_resources
 from bitstring import BitArray  # pyright: reportMissingImports=false
 from chia_rs import AugSchemeMPL, G1Element, PrivateKey  # pyright: reportMissingImports=false
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint32
 from typing_extensions import final
 
-from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.bech32m import bech32_decode, convertbits
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.errors import (
@@ -27,7 +30,6 @@ from chia.util.errors import (
 )
 from chia.util.file_keyring import Key
 from chia.util.hash import std_hash
-from chia.util.ints import uint32
 from chia.util.keyring_wrapper import KeyringWrapper
 from chia.util.streamable import Streamable, streamable
 

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/chia/util/limited_semaphore.py
+++ b/chia/util/limited_semaphore.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import asyncio

--- a/chia/util/lock.py
+++ b/chia/util/lock.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/chia/util/log_exceptions.py
+++ b/chia/util/log_exceptions.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import logging

--- a/chia/util/logging.py
+++ b/chia/util/logging.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import logging

--- a/chia/util/lru_cache.py
+++ b/chia/util/lru_cache.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 from collections import OrderedDict

--- a/chia/util/math.py
+++ b/chia/util/math.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 

--- a/chia/util/paginator.py
+++ b/chia/util/paginator.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import dataclasses

--- a/chia/util/path.py
+++ b/chia/util/path.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import os

--- a/chia/util/permissions.py
+++ b/chia/util/permissions.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import os

--- a/chia/util/priority_mutex.py
+++ b/chia/util/priority_mutex.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import asyncio

--- a/chia/util/profiler.py
+++ b/chia/util/profiler.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import asyncio

--- a/chia/util/recursive_replace.py
+++ b/chia/util/recursive_replace.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 from dataclasses import replace

--- a/chia/util/setproctitle.py
+++ b/chia/util/setproctitle.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 try:

--- a/chia/util/significant_bits.py
+++ b/chia/util/significant_bits.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import dataclasses
@@ -9,12 +11,12 @@ from collections.abc import Collection
 from enum import Enum
 from typing import TYPE_CHECKING, Any, BinaryIO, Callable, ClassVar, Optional, TypeVar, Union, get_type_hints
 
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint16, uint32, uint64
 from typing_extensions import Literal, get_args, get_origin
 
-from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.hash import std_hash
-from chia.util.ints import uint16, uint32, uint64
 
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance

--- a/chia/util/task_timing.py
+++ b/chia/util/task_timing.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import asyncio

--- a/chia/util/timing.py
+++ b/chia/util/timing.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import os

--- a/chia/util/virtual_project_analysis.py
+++ b/chia/util/virtual_project_analysis.py
@@ -1,3 +1,5 @@
+# Package: utils
+
 from __future__ import annotations
 
 import ast


### PR DESCRIPTION
### Purpose:

Mark some modules as belonging to the `utils` virtual project. This seems like a good temporary package to allow us to explore further actionable items to untangle our deps. For starters, it will allow us to extract `streamable` as a virtual project.

The end goal here is to separate `wallet` from `full_node`.

### Current Behavior:

The modules in question are currently marked as belonging to the `chia-blockchain` project.

### New Behavior:

They're now marked as belonging to the `utils` project.