### PR TITLE
tests as its own subproject

### DIFF
--- a/chia/util/virtual_project_analysis.py
+++ b/chia/util/virtual_project_analysis.py
@@ -47,6 +47,12 @@ class ChiaFile:
 
     @classmethod
     def parse(cls, file_path: Path) -> ChiaFile:
+        # everything under chia/_tests belong to the "tests" subproject. It
+        # (obviously) depends on everything, but no production code is allowed
+        # to depend back on the tests.
+        if list(file_path.parts[0:2]) == ["chia", "_tests"]:
+            return cls(file_path, Annotation("tests", True))
+
         with open(file_path, encoding="utf-8", errors="ignore") as f:
             file_string = f.read().strip()
             return cls(file_path, Annotation.parse(file_string))


### PR DESCRIPTION
extend virtual_project_analysis to treat all files under chia/_tests as its own subproject. Since the tests depend on the production code,this will prevent production code from depending on tests

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

Prevent future mistakes where production code depends on test code. This is not a problem today, but it has been in the past.

### Current Behavior:

It's hard to detect if production code gains a dependency on test code

### New Behavior:

If production code gains a dependency on test code, CI will be red

### Testing Notes:

I tested this by importing a test class into production code, and observe the virtual project tool failing