### PR TITLE
Add `TypeAlias` hint to external rust types

### DIFF
--- a/chia/consensus/block_record.py
+++ b/chia/consensus/block_record.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, TypeAlias
 
 import chia_rs
 from typing_extensions import Protocol
@@ -8,7 +8,7 @@ from typing_extensions import Protocol
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint32, uint64
 
-BlockRecord = chia_rs.BlockRecord
+BlockRecord: TypeAlias = chia_rs.BlockRecord
 
 
 class BlockRecordProtocol(Protocol):

--- a/chia/protocols/wallet_protocol.py
+++ b/chia/protocols/wallet_protocol.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, TypeAlias
 
 import chia_rs
 
@@ -21,8 +21,8 @@ Note: When changing this file, also change protocol_message_types.py, and the pr
 """
 
 
-CoinState = chia_rs.CoinState
-RespondToPhUpdates = chia_rs.RespondToPhUpdates
+CoinState: TypeAlias = chia_rs.CoinState
+RespondToPhUpdates: TypeAlias = chia_rs.RespondToPhUpdates
 
 
 @streamable

--- a/chia/types/blockchain_format/foliage.py
+++ b/chia/types/blockchain_format/foliage.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import chia_rs
+from typing_extensions import TypeAlias
 
-TransactionsInfo = chia_rs.TransactionsInfo
-FoliageTransactionBlock = chia_rs.FoliageTransactionBlock
-FoliageBlockData = chia_rs.FoliageBlockData
-Foliage = chia_rs.Foliage
+TransactionsInfo: TypeAlias = chia_rs.TransactionsInfo
+FoliageTransactionBlock: TypeAlias = chia_rs.FoliageTransactionBlock
+FoliageBlockData: TypeAlias = chia_rs.FoliageBlockData
+Foliage: TypeAlias = chia_rs.Foliage

--- a/chia/types/blockchain_format/pool_target.py
+++ b/chia/types/blockchain_format/pool_target.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import chia_rs
 
-PoolTarget = chia_rs.PoolTarget
+PoolTarget: TypeAlias = chia_rs.PoolTarget

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional, cast
+from typing import Optional, TypeAlias, cast
 
 import chia_rs
 from bitstring import BitArray
@@ -13,7 +13,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.hash import std_hash
 from chia.util.ints import uint32
 
-ProofOfSpace = chia_rs.ProofOfSpace
+ProofOfSpace: TypeAlias = chia_rs.ProofOfSpace
 
 log = logging.getLogger(__name__)
 

--- a/chia/types/blockchain_format/reward_chain_block.py
+++ b/chia/types/blockchain_format/reward_chain_block.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import chia_rs
 
-RewardChainBlock = chia_rs.RewardChainBlock
-RewardChainBlockUnfinished = chia_rs.RewardChainBlockUnfinished
+RewardChainBlock: TypeAlias = chia_rs.RewardChainBlock
+RewardChainBlockUnfinished: TypeAlias = chia_rs.RewardChainBlockUnfinished

--- a/chia/types/blockchain_format/serialized_program.py
+++ b/chia/types/blockchain_format/serialized_program.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import chia_rs
 
-SerializedProgram = chia_rs.Program
+SerializedProgram: TypeAlias = chia_rs.Program

--- a/chia/types/blockchain_format/sized_bytes.py
+++ b/chia/types/blockchain_format/sized_bytes.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import chia_rs.sized_bytes
 
-bytes4 = chia_rs.sized_bytes.bytes4
-bytes8 = chia_rs.sized_bytes.bytes8
-bytes32 = chia_rs.sized_bytes.bytes32
-bytes48 = chia_rs.sized_bytes.bytes48
-bytes96 = chia_rs.sized_bytes.bytes96
-bytes100 = chia_rs.sized_bytes.bytes100
-bytes480 = chia_rs.sized_bytes.bytes480
+bytes4: TypeAlias = chia_rs.sized_bytes.bytes4
+bytes8: TypeAlias = chia_rs.sized_bytes.bytes8
+bytes32: TypeAlias = chia_rs.sized_bytes.bytes32
+bytes48: TypeAlias = chia_rs.sized_bytes.bytes48
+bytes96: TypeAlias = chia_rs.sized_bytes.bytes96
+bytes100: TypeAlias = chia_rs.sized_bytes.bytes100
+bytes480: TypeAlias = chia_rs.sized_bytes.bytes480

--- a/chia/types/blockchain_format/slots.py
+++ b/chia/types/blockchain_format/slots.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import chia_rs
 
-ChallengeBlockInfo = chia_rs.ChallengeBlockInfo
-ChallengeChainSubSlot = chia_rs.ChallengeChainSubSlot
-InfusedChallengeChainSubSlot = chia_rs.InfusedChallengeChainSubSlot
-RewardChainSubSlot = chia_rs.RewardChainSubSlot
-SubSlotProofs = chia_rs.SubSlotProofs
+ChallengeBlockInfo: TypeAlias = chia_rs.ChallengeBlockInfo
+ChallengeChainSubSlot: TypeAlias = chia_rs.ChallengeChainSubSlot
+InfusedChallengeChainSubSlot: TypeAlias = chia_rs.InfusedChallengeChainSubSlot
+RewardChainSubSlot: TypeAlias = chia_rs.RewardChainSubSlot
+SubSlotProofs: TypeAlias = chia_rs.SubSlotProofs

--- a/chia/types/blockchain_format/sub_epoch_summary.py
+++ b/chia/types/blockchain_format/sub_epoch_summary.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import chia_rs
 
-SubEpochSummary = chia_rs.SubEpochSummary
+SubEpochSummary: TypeAlias = chia_rs.SubEpochSummary

--- a/chia/types/coin_spend.py
+++ b/chia/types/coin_spend.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, TypeAlias, Union
 
 import chia_rs
 
@@ -16,7 +16,7 @@ from chia.util.errors import Err, ValidationError
 from chia.util.ints import uint64
 from chia.util.streamable import Streamable, streamable
 
-CoinSpend = chia_rs.CoinSpend
+CoinSpend: TypeAlias = chia_rs.CoinSpend
 
 
 def make_spend(

--- a/chia/types/end_of_slot_bundle.py
+++ b/chia/types/end_of_slot_bundle.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import chia_rs
 
-EndOfSubSlotBundle = chia_rs.EndOfSubSlotBundle
+EndOfSubSlotBundle: TypeAlias = chia_rs.EndOfSubSlotBundle

--- a/chia/types/full_block.py
+++ b/chia/types/full_block.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import chia_rs
 
-FullBlock = chia_rs.FullBlock
+FullBlock: TypeAlias = chia_rs.FullBlock

--- a/chia/types/header_block.py
+++ b/chia/types/header_block.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import chia_rs
 
-HeaderBlock = chia_rs.HeaderBlock
+HeaderBlock: TypeAlias = chia_rs.HeaderBlock

--- a/chia/types/spend_bundle.py
+++ b/chia/types/spend_bundle.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TypeVar
+from typing import TypeAlias, TypeVar
 
 import chia_rs
 
@@ -9,7 +9,7 @@ from chia.util.errors import Err, ValidationError
 
 from .coin_spend import compute_additions_with_cost
 
-SpendBundle = chia_rs.SpendBundle
+SpendBundle: TypeAlias = chia_rs.SpendBundle
 T_SpendBundle = TypeVar("T_SpendBundle", bound="SpendBundle")
 
 

--- a/chia/types/spend_bundle_conditions.py
+++ b/chia/types/spend_bundle_conditions.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import chia_rs
 
 ELIGIBLE_FOR_DEDUP = chia_rs.ELIGIBLE_FOR_DEDUP
-SpendConditions = chia_rs.SpendConditions
-SpendBundleConditions = chia_rs.SpendBundleConditions
+SpendConditions: TypeAlias = chia_rs.SpendConditions
+SpendBundleConditions: TypeAlias = chia_rs.SpendBundleConditions

--- a/chia/types/unfinished_block.py
+++ b/chia/types/unfinished_block.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import chia_rs
 
-UnfinishedBlock = chia_rs.UnfinishedBlock
+UnfinishedBlock: TypeAlias = chia_rs.UnfinishedBlock

--- a/chia/types/weight_proof.py
+++ b/chia/types/weight_proof.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, TypeAlias
 
 import chia_rs
 
@@ -10,7 +10,7 @@ from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.header_block import HeaderBlock
 from chia.util.streamable import Streamable, streamable
 
-SubEpochData = chia_rs.SubEpochData
+SubEpochData: TypeAlias = chia_rs.SubEpochData
 
 # number of challenge blocks
 # Average iters for challenge blocks
@@ -23,9 +23,9 @@ SubEpochData = chia_rs.SubEpochData
 # total number of challenge blocks == total number of reward chain blocks
 
 
-SubEpochChallengeSegment = chia_rs.SubEpochChallengeSegment
-SubEpochSegments = chia_rs.SubEpochSegments
-SubSlotData = chia_rs.SubSlotData
+SubEpochChallengeSegment: TypeAlias = chia_rs.SubEpochChallengeSegment
+SubEpochSegments: TypeAlias = chia_rs.SubEpochSegments
+SubSlotData: TypeAlias = chia_rs.SubSlotData
 
 
 @streamable

--- a/chia/util/ints.py
+++ b/chia/util/ints.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
+from typing import TypeAlias
+
 import chia_rs.sized_ints
 
-int8 = chia_rs.sized_ints.int8
-uint8 = chia_rs.sized_ints.uint8
+int8: TypeAlias = chia_rs.sized_ints.int8
+uint8: TypeAlias = chia_rs.sized_ints.uint8
 
-int16 = chia_rs.sized_ints.int16
-uint16 = chia_rs.sized_ints.uint16
+int16: TypeAlias = chia_rs.sized_ints.int16
+uint16: TypeAlias = chia_rs.sized_ints.uint16
 
-int32 = chia_rs.sized_ints.int32
-uint32 = chia_rs.sized_ints.uint32
+int32: TypeAlias = chia_rs.sized_ints.int32
+uint32: TypeAlias = chia_rs.sized_ints.uint32
 
-int64 = chia_rs.sized_ints.int64
-uint64 = chia_rs.sized_ints.uint64
+int64: TypeAlias = chia_rs.sized_ints.int64
+uint64: TypeAlias = chia_rs.sized_ints.uint64
 
-uint128 = chia_rs.sized_ints.uint128
+uint128: TypeAlias = chia_rs.sized_ints.uint128
 
-int512 = chia_rs.sized_ints.int512
+int512: TypeAlias = chia_rs.sized_ints.int512


### PR DESCRIPTION
My editor gives me warnings about rust types being used in type expressions: `"variable not allowed in type expression"`.  It does not give me this error if the types are explicitly hinted as aliases.