### PR TITLE
[CHIA-1566] pipeline block validation in sync_from_fork_point()

### DIFF
--- a/chia/_tests/blockchain/blockchain_test_utils.py
+++ b/chia/_tests/blockchain/blockchain_test_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Optional
 
 from chia_rs import BLSCache
@@ -76,7 +77,7 @@ async def _validate_and_add_block(
     else:
         # validate_signatures must be False in order to trigger add_block() to
         # validate the signature.
-        pre_validation_results: list[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+        futures = await pre_validate_blocks_multiprocessing(
             blockchain.constants,
             blockchain,
             [block],
@@ -85,6 +86,7 @@ async def _validate_and_add_block(
             ValidationState(ssi, diff, prev_ses_block),
             validate_signatures=False,
         )
+        pre_validation_results: list[PreValidationResult] = list(await asyncio.gather(*futures))
         assert pre_validation_results is not None
         results = pre_validation_results[0]
     if results.error is not None:

--- a/chia/_tests/blockchain/blockchain_test_utils.py
+++ b/chia/_tests/blockchain/blockchain_test_utils.py
@@ -11,6 +11,7 @@ from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_dif
 from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_blocks_multiprocessing
 from chia.types.full_block import FullBlock
 from chia.types.validation_state import ValidationState
+from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.errors import Err
 from chia.util.ints import uint32, uint64
 
@@ -79,7 +80,7 @@ async def _validate_and_add_block(
         # validate the signature.
         futures = await pre_validate_blocks_multiprocessing(
             blockchain.constants,
-            blockchain,
+            AugmentedBlockchain(blockchain),
             [block],
             blockchain.pool,
             {},

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -53,6 +53,7 @@ from chia.types.generator_types import BlockGenerator
 from chia.types.spend_bundle import SpendBundle
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.types.validation_state import ValidationState
+from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.cpu import available_logical_cores
 from chia.util.errors import Err
 from chia.util.generator_tools import get_block_header
@@ -1793,7 +1794,7 @@ class TestPreValidation:
         )
         futures = await pre_validate_blocks_multiprocessing(
             empty_blockchain.constants,
-            empty_blockchain,
+            AugmentedBlockchain(empty_blockchain),
             [blocks[0], block_bad],
             empty_blockchain.pool,
             {},
@@ -1821,7 +1822,7 @@ class TestPreValidation:
             start_pv = time.time()
             futures = await pre_validate_blocks_multiprocessing(
                 empty_blockchain.constants,
-                empty_blockchain,
+                AugmentedBlockchain(empty_blockchain),
                 blocks_to_validate,
                 empty_blockchain.pool,
                 {},
@@ -1929,7 +1930,7 @@ class TestBodyValidation:
         diff = b.constants.DIFFICULTY_STARTING
         futures = await pre_validate_blocks_multiprocessing(
             b.constants,
-            b,
+            AugmentedBlockchain(b),
             [blocks[-1]],
             b.pool,
             {},
@@ -2056,7 +2057,7 @@ class TestBodyValidation:
             diff = b.constants.DIFFICULTY_STARTING
             futures = await pre_validate_blocks_multiprocessing(
                 b.constants,
-                b,
+                AugmentedBlockchain(b),
                 [blocks[-1]],
                 b.pool,
                 {},
@@ -2140,7 +2141,7 @@ class TestBodyValidation:
         diff = b.constants.DIFFICULTY_STARTING
         futures = await pre_validate_blocks_multiprocessing(
             b.constants,
-            b,
+            AugmentedBlockchain(b),
             [blocks[-1]],
             b.pool,
             {},
@@ -2269,7 +2270,7 @@ class TestBodyValidation:
             diff = b.constants.DIFFICULTY_STARTING
             futures = await pre_validate_blocks_multiprocessing(
                 b.constants,
-                b,
+                AugmentedBlockchain(b),
                 [blocks[-1]],
                 b.pool,
                 {},
@@ -2636,7 +2637,7 @@ class TestBodyValidation:
         assert err in [Err.BLOCK_COST_EXCEEDS_MAX]
         futures = await pre_validate_blocks_multiprocessing(
             b.constants,
-            b,
+            AugmentedBlockchain(b),
             [blocks[-1]],
             b.pool,
             {},
@@ -3243,7 +3244,7 @@ class TestBodyValidation:
         diff = b.constants.DIFFICULTY_STARTING
         futures = await pre_validate_blocks_multiprocessing(
             b.constants,
-            b,
+            AugmentedBlockchain(b),
             [last_block],
             b.pool,
             {},
@@ -3363,7 +3364,7 @@ class TestReorgs:
         diff = b.constants.DIFFICULTY_STARTING
         futures = await pre_validate_blocks_multiprocessing(
             b.constants,
-            b,
+            AugmentedBlockchain(b),
             blocks,
             b.pool,
             {},
@@ -3931,7 +3932,7 @@ async def test_reorg_flip_flop(empty_blockchain: Blockchain, bt: BlockTools) -> 
 
         futures = await pre_validate_blocks_multiprocessing(
             b.constants,
-            b,
+            AugmentedBlockchain(b),
             [block1],
             b.pool,
             {},
@@ -3944,7 +3945,7 @@ async def test_reorg_flip_flop(empty_blockchain: Blockchain, bt: BlockTools) -> 
         assert err is None
         futures = await pre_validate_blocks_multiprocessing(
             b.constants,
-            b,
+            AugmentedBlockchain(b),
             [block2],
             b.pool,
             {},
@@ -3979,7 +3980,7 @@ async def test_get_tx_peak(default_400_blocks: list[FullBlock], empty_blockchain
     diff = bc.constants.DIFFICULTY_STARTING
     futures = await pre_validate_blocks_multiprocessing(
         bc.constants,
-        bc,
+        AugmentedBlockchain(bc),
         test_blocks,
         bc.pool,
         {},

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -63,6 +63,7 @@ from chia.types.peer_info import PeerInfo, TimestampedPeerInfo
 from chia.types.spend_bundle import SpendBundle, estimate_fees
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.types.validation_state import ValidationState
+from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.errors import ConsensusError, Err
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint16, uint32, uint64, uint128
@@ -432,7 +433,7 @@ class TestFullNodeBlockCompression:
                 for i in range(1, height):
                     futures = await pre_validate_blocks_multiprocessing(
                         blockchain.constants,
-                        blockchain,
+                        AugmentedBlockchain(blockchain),
                         all_blocks[:i],
                         blockchain.pool,
                         {},
@@ -451,7 +452,7 @@ class TestFullNodeBlockCompression:
                 for i in range(1, height):
                     futures = await pre_validate_blocks_multiprocessing(
                         blockchain.constants,
-                        blockchain,
+                        AugmentedBlockchain(blockchain),
                         all_blocks[:i],
                         blockchain.pool,
                         {},

--- a/chia/_tests/farmer_harvester/test_third_party_harvesters.py
+++ b/chia/_tests/farmer_harvester/test_third_party_harvesters.py
@@ -41,6 +41,7 @@ from chia.types.blockchain_format.slots import ChallengeChainSubSlot, RewardChai
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import UnresolvedPeerInfo
 from chia.types.validation_state import ValidationState
+from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.bech32m import decode_puzzle_hash
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64
@@ -439,7 +440,7 @@ async def add_test_blocks_into_full_node(blocks: list[FullBlock], full_node: Ful
     ssi, diff = get_next_sub_slot_iters_and_difficulty(full_node.constants, new_slot, prev_b, full_node.blockchain)
     futures = await pre_validate_blocks_multiprocessing(
         full_node.blockchain.constants,
-        full_node.blockchain,
+        AugmentedBlockchain(full_node.blockchain),
         blocks,
         full_node.blockchain.pool,
         {},

--- a/chia/_tests/farmer_harvester/test_third_party_harvesters.py
+++ b/chia/_tests/farmer_harvester/test_third_party_harvesters.py
@@ -437,7 +437,7 @@ async def add_test_blocks_into_full_node(blocks: list[FullBlock], full_node: Ful
         prev_ses_block = curr
     new_slot = len(block.finished_sub_slots) > 0
     ssi, diff = get_next_sub_slot_iters_and_difficulty(full_node.constants, new_slot, prev_b, full_node.blockchain)
-    pre_validation_results: list[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+    futures = await pre_validate_blocks_multiprocessing(
         full_node.blockchain.constants,
         full_node.blockchain,
         blocks,
@@ -446,6 +446,7 @@ async def add_test_blocks_into_full_node(blocks: list[FullBlock], full_node: Ful
         ValidationState(ssi, diff, prev_ses_block),
         validate_signatures=True,
     )
+    pre_validation_results: list[PreValidationResult] = list(await asyncio.gather(*futures))
     assert pre_validation_results is not None and len(pre_validation_results) == len(blocks)
     for i in range(len(blocks)):
         block = blocks[i]

--- a/chia/_tests/util/full_sync.py
+++ b/chia/_tests/util/full_sync.py
@@ -28,6 +28,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
 from chia.types.validation_state import ValidationState
+from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.config import load_config
 from chia.util.ints import uint16
 
@@ -212,6 +213,7 @@ async def run_sync_test(
                             fork_height = block_batch[0].height - 1
                             header_hash = block_batch[0].prev_header_hash
                             success, summary, err = await full_node.add_block_batch(
+                                AugmentedBlockchain(full_node.blockchain),
                                 block_batch,
                                 peer_info,
                                 ForkInfo(fork_height, fork_height, header_hash),

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -44,6 +44,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
 from chia.types.validation_state import ValidationState
+from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64, uint128
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
@@ -364,6 +365,7 @@ async def test_long_sync_wallet(
     )
     fork_height = blocks_reorg[-num_blocks - 10].height - 1
     await full_node.add_block_batch(
+        AugmentedBlockchain(full_node.blockchain),
         blocks_reorg[-num_blocks - 10 : -1],
         PeerInfo("0.0.0.0", 0),
         ForkInfo(fork_height, fork_height, blocks_reorg[-num_blocks - 10].prev_header_hash),
@@ -481,6 +483,7 @@ async def test_wallet_reorg_get_coinbase(
         full_node.constants, True, block_record, full_node.blockchain
     )
     await full_node.add_block_batch(
+        AugmentedBlockchain(full_node.blockchain),
         blocks_reorg_2[-44:],
         PeerInfo("0.0.0.0", 0),
         ForkInfo(blocks_reorg_2[-45].height, blocks_reorg_2[-45].height, blocks_reorg_2[-45].header_hash),

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -487,6 +487,8 @@ class Blockchain:
 
         if genesis:
             records_to_add = [block_record]
+        elif fork_info.block_hashes == [block_record.header_hash]:
+            records_to_add = [block_record]
         else:
             records_to_add = await self.block_store.get_block_records_by_hash(fork_info.block_hashes)
 

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -488,6 +488,8 @@ class Blockchain:
         if genesis:
             records_to_add = [block_record]
         elif fork_info.block_hashes == [block_record.header_hash]:
+            # in the common case, we just add a block on top of the chain. Check
+            # for that here to avoid an unnecessary database lookup.
             records_to_add = [block_record]
         else:
             records_to_add = await self.block_store.get_block_records_by_hash(fork_info.block_hashes)

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -143,16 +143,25 @@ async def pre_validate_blocks_multiprocessing(
 ) -> Sequence[Awaitable[PreValidationResult]]:
     """
     This method must be called under the blockchain lock
-    If all the full blocks pass pre-validation, (only validates header), returns the list of required iters.
-    if any validation issue occurs, returns False.
+    The blocks passed to this function are submitted to be validated in the
+    executor passed in as "pool". The futures for those jobs are then returned.
+    When awaited, the return value is the PreValidationResult for each block.
+    The PreValidationResult indicates whether the block was valid or not.
 
     Args:
         constants:
-        pool:
-        constants:
-        blockchain:
+        blockchain: The blockchain object to validate these blocks with respect to.
+            It's an AugmentedBlockchain to allow for previous batches of blocks to
+            be included, even if they haven't been added to the underlying blockchain
+            database yet. The blocks passed in will be added/augmented onto this blockchain.
+        pool: The executor to submit the validation jobs to
         blocks: list of full blocks to validate (must be connected to current chain)
-        npc_results
+        vs: The ValidationState refers to the state for the first block in the batch.
+            This is an in-out parameter that will be updated to the validation state
+            for the next batch of blocks. It includes subslot iterators, difficulty and
+            the previous sub epoch summary (ses) block.
+        wp_summaries:
+        validate_signatures:
     """
     prev_b: Optional[BlockRecord] = None
 
@@ -245,5 +254,4 @@ async def pre_validate_blocks_multiprocessing(
         if block_rec.sub_epoch_summary_included is not None:
             vs.prev_ses_block = block_rec
 
-    # Collect all results into one flat list
     return futures

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1441,6 +1441,18 @@ class FullNode:
         vs: ValidationState,
         wp_summaries: Optional[list[SubEpochSummary]] = None,
     ) -> Sequence[Awaitable[PreValidationResult]]:
+        """
+        This is a thin wrapper over pre_validate_blocks_multiprocessing().
+
+        Args:
+            blockchain:
+            blocks_to_validate:
+            peer_info:
+            vs: The ValidationState for the first block in the batch. This is an in-out
+                parameter. It will be updated to be the validation state for the next
+                batch of blocks.
+            wp_summaries:
+        """
         # Validates signatures in multiprocessing since they take a while, and we don't have cached transactions
         # for these blocks (unlike during normal operation where we validate one at a time)
         # We have to copy the ValidationState object to preserve it for the add_block()
@@ -1518,7 +1530,7 @@ class FullNode:
                 if error is not None:
                     self.log.error(f"Error: {error}, Invalid block from peer: {peer_info} ")
                 return agg_state_change_summary, error
-            block_record = blockchain.block_record(block.header_hash)
+            block_record = blockchain.block_record(header_hash)
             assert block_record is not None
             if block_record.sub_epoch_summary_included is not None:
                 vs.prev_ses_block = block_record

--- a/chia/simulator/add_blocks_in_batches.py
+++ b/chia/simulator/add_blocks_in_batches.py
@@ -9,6 +9,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
 from chia.types.validation_state import ValidationState
+from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.batches import to_batches
 
 
@@ -39,6 +40,7 @@ async def add_blocks_in_batches(
             print(f"main chain: {b.height:4} weight: {b.weight}")
         # vs is updated by the call to add_block_batch()
         success, state_change_summary, err = await full_node.add_block_batch(
+            AugmentedBlockchain(full_node.blockchain),
             block_batch.entries,
             PeerInfo("0.0.0.0", 0),
             fork_info,

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -174,7 +174,7 @@ class FullNodeSimulator(FullNodeAPI):
             current_blocks = await self.get_all_full_blocks()
             if len(current_blocks) == 0:
                 genesis = self.bt.get_consecutive_blocks(uint8(1))[0]
-                pre_validation_results: list[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+                futures = await pre_validate_blocks_multiprocessing(
                     self.full_node.blockchain.constants,
                     self.full_node.blockchain,
                     [genesis],
@@ -183,6 +183,7 @@ class FullNodeSimulator(FullNodeAPI):
                     ValidationState(ssi, diff, None),
                     validate_signatures=True,
                 )
+                pre_validation_results: list[PreValidationResult] = list(await asyncio.gather(*futures))
                 assert pre_validation_results is not None
                 fork_info = ForkInfo(-1, -1, self.full_node.constants.GENESIS_CHALLENGE)
                 await self.full_node.blockchain.add_block(
@@ -237,7 +238,7 @@ class FullNodeSimulator(FullNodeAPI):
             current_blocks = await self.get_all_full_blocks()
             if len(current_blocks) == 0:
                 genesis = self.bt.get_consecutive_blocks(uint8(1))[0]
-                pre_validation_results: list[PreValidationResult] = await pre_validate_blocks_multiprocessing(
+                futures = await pre_validate_blocks_multiprocessing(
                     self.full_node.blockchain.constants,
                     self.full_node.blockchain,
                     [genesis],
@@ -246,6 +247,7 @@ class FullNodeSimulator(FullNodeAPI):
                     ValidationState(ssi, diff, None),
                     validate_signatures=True,
                 )
+                pre_validation_results: list[PreValidationResult] = list(await asyncio.gather(*futures))
                 assert pre_validation_results is not None
                 fork_info = ForkInfo(-1, -1, self.full_node.constants.GENESIS_CHALLENGE)
                 await self.full_node.blockchain.add_block(

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -26,6 +26,7 @@ from chia.types.coin_record import CoinRecord
 from chia.types.full_block import FullBlock
 from chia.types.spend_bundle import SpendBundle
 from chia.types.validation_state import ValidationState
+from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.config import lock_and_load_config, save_config
 from chia.util.ints import uint8, uint32, uint64, uint128
 from chia.util.timing import adjusted_timeout, backoff_times
@@ -176,7 +177,7 @@ class FullNodeSimulator(FullNodeAPI):
                 genesis = self.bt.get_consecutive_blocks(uint8(1))[0]
                 futures = await pre_validate_blocks_multiprocessing(
                     self.full_node.blockchain.constants,
-                    self.full_node.blockchain,
+                    AugmentedBlockchain(self.full_node.blockchain),
                     [genesis],
                     self.full_node.blockchain.pool,
                     {},
@@ -240,7 +241,7 @@ class FullNodeSimulator(FullNodeAPI):
                 genesis = self.bt.get_consecutive_blocks(uint8(1))[0]
                 futures = await pre_validate_blocks_multiprocessing(
                     self.full_node.blockchain.constants,
-                    self.full_node.blockchain,
+                    AugmentedBlockchain(self.full_node.blockchain),
                     [genesis],
                     self.full_node.blockchain.pool,
                     {},

--- a/chia/util/augmented_chain.py
+++ b/chia/util/augmented_chain.py
@@ -45,6 +45,11 @@ class AugmentedBlockchain:
         self._extra_blocks[block_record.header_hash] = (block, block_record)
         self._height_to_hash[block_record.height] = block_record.header_hash
 
+    def remove_extra_block(self, hh: bytes32) -> None:
+        if hh in self._extra_blocks:
+            block_record = self._extra_blocks.pop(hh)[1]
+            del self._height_to_hash[block_record.height]
+
     # BlocksProtocol
     async def lookup_block_generators(self, header_hash: bytes32, generator_refs: set[uint32]) -> dict[uint32, bytes]:
 

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -21,6 +21,7 @@ from chia.full_node.full_node import FullNode
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.full_block import FullBlock
 from chia.types.validation_state import ValidationState
+from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.config import load_config
 
 
@@ -165,6 +166,7 @@ async def run_sync_checkpoint(
                 header_hash = block_batch[0].prev_header_hash
 
                 success, _, err = await full_node.add_block_batch(
+                    AugmentedBlockchain(full_node.blockchain),
                     block_batch,
                     peer_info,
                     ForkInfo(fork_height, fork_height, header_hash),
@@ -188,6 +190,7 @@ async def run_sync_checkpoint(
                 fork_height = block_batch[0].height - 1
                 fork_header_hash = block_batch[0].prev_header_hash
                 success, _, err = await full_node.add_block_batch(
+                    AugmentedBlockchain(full_node.blockchain),
                     block_batch,
                     peer_info,
                     ForkInfo(fork_height, fork_height, fork_header_hash),


### PR DESCRIPTION
This PR is large and is best reviewed one commit at a time.

### Purpose:

The main purpose of this PR is to remove one of the main bottlenecks of long sync.

This builds on https://github.com/Chia-Network/chia-blockchain/pull/18681, which transitioned block validation to a thread pool, from a process pool.

By far the most expensive step in syncing is to add the block to the blockchain database. To increase our throughput, this change lets us fetch blocks and pre-validate them concurrently with adding blocks to the database. This makes the bottleneck never have to wait for the pre-validation step, but it can work non-stop on adding blocks.

The step that adds the block to the database also validates the VDFs and proofs-of-space, which are also somewhat expensive.

We currently have a shallow sync pipeline:
1. fetch blocks from peers
2. validate blocks and then add them to the database

This PR extends this pipeline, breaking out block validation into its own step:
1. fetch blocks from peers
2. validate blocks
3. add blocks to the database (and validate VDFs and PoS)

### main improvements

This patch speeds up the long sync in two ways.

#### more efficient pipeline

The database never have to wait for the next batch of blocks to be validated before adding blocks to the chain. Put differently, we can start validating the next batch of blocks while waiting for the first one to be added to the database.

For this, we use the `AugmentedBlockchain` class introduced earlier. This provides an interface that looks like the blockchain, but with additional blocks appear as-if they've been added to the chain. This is crucial for pre-validating the next batch of blocks, before the previous one is done being added to the database.

The `AugmentedBlockchain` was previously used to simplify the batch validation, but is now moved up one layer, to the sync tasks themselves. This allows augmented blocks to remain across batches of validations.

VDFs and PoS are still validated in the last pipeline step, serially. Moving more of this work into the pre-validation step is not part of this PR but a possible future improvement. 

#### more than 8 cores

If you have more than 8 CPU cores, you can now use them for block validation. The original behavior was to validate blocks in batches of 32. This batch was, in turn, split into batches of 4, where each batch was scheduled on a worker process. Since blocks are validated in threads now, there's virtually no overhead to submit jobs. This patch submits all blocks as individual work items to the thread pool. The pipeline queue depth is 128 blocks, meaning it should be easy to keep at least 64 cores busy validating blocks.

### review

These are the commits in this PR, with explanation.

1. change `pre_validate_multiprocessing()` to return *futures* rather than the results directly. The results are computed in the thread pool and will be available later. Returning a future makes it easier to perform work concurrently with the validation. This is taken advantage of in a later commit where the sync pipeline is extended to kick off the validation, but then post the futures to the next pipeline step to pick up the results.
2. split up `Add_blocks_batch()` into 3 separate functions, to allow the work be split up across pipeline steps. The original `add_block_batch()` is preserved since it's still used in short-sync. Currently, `add_block_batch()` filters blocks that we already have in the chain, validates the blocks and then adds them to the database. Splitting this up is a prerequisite for splitting up validation from database ingestion, in a later commit.
3. change `pre_validate_multiprocessing()` to take an `AugmentedBlockchain` directly, instead of creating that wrapper itself. This allows augmented blocks to be preserved across batches of validation. i.e. a deeper pipeline.
4. add additional pipeline step to `sync_from_forkpoint(). This is the main change, made possible by the previous commits.
5. This is a small optimization to avoid an unnecessary database lookup in the common case

### Current Behavior:

The bottleneck step of long sync ping-pongs between block validation and database ingestion.

### New Behavior:

The bottleneck step of long sync is adding blocks to the database, and block validation is done concurrently with this. Leaving more wall-clock time to database ingestion.

### Testing Notes:

There's successful sync test [here](https://grafana.sin.chiatechlab.com/d/oBgwkDI7z/blockchain-sync-tests?orgId=1&var-ref=pace-block-requests&var-ref=2.4.4&var-repo=All&from=now-7d&to=now&var-network=mainnet), which also has another commit to throttle block requests (to not exceed the rate limit of the other peer).