### PR TITLE
CHIA-1565 Pass a ValidationState to validate_finished_header_block

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -171,13 +171,9 @@ class TestBlockHeaderValidation:
                 # TODO: Inspect these block values as they are currently None
                 expected_difficulty = block.finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
                 expected_sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
+                vs = ValidationState(expected_sub_slot_iters, expected_difficulty, None)
                 _, error = validate_finished_header_block(
-                    empty_blockchain.constants,
-                    empty_blockchain,
-                    header_block_bad,
-                    False,
-                    expected_difficulty,
-                    expected_sub_slot_iters,
+                    empty_blockchain.constants, empty_blockchain, header_block_bad, False, vs
                 )
                 assert error is not None
                 assert error.code == Err.INVALID_NEW_SUB_SLOT_ITERS
@@ -198,13 +194,9 @@ class TestBlockHeaderValidation:
                 # TODO: Inspect these block values as they are currently None
                 expected_difficulty = block.finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
                 expected_sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
+                vs = ValidationState(expected_sub_slot_iters, expected_difficulty, None)
                 _, error = validate_finished_header_block(
-                    empty_blockchain.constants,
-                    empty_blockchain,
-                    header_block_bad_2,
-                    False,
-                    expected_difficulty,
-                    expected_sub_slot_iters,
+                    empty_blockchain.constants, empty_blockchain, header_block_bad_2, False, vs
                 )
                 assert error is not None
                 assert error.code == Err.INVALID_NEW_DIFFICULTY
@@ -232,13 +224,9 @@ class TestBlockHeaderValidation:
                 # TODO: Inspect these block values as they are currently None
                 expected_difficulty = block.finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
                 expected_sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
+                vs = ValidationState(expected_sub_slot_iters, expected_difficulty, None)
                 _, error = validate_finished_header_block(
-                    empty_blockchain.constants,
-                    empty_blockchain,
-                    header_block_bad_3,
-                    False,
-                    expected_difficulty,
-                    expected_sub_slot_iters,
+                    empty_blockchain.constants, empty_blockchain, header_block_bad_3, False, vs
                 )
                 assert error is not None
                 assert error.code == Err.INVALID_SUB_EPOCH_SUMMARY
@@ -265,13 +253,9 @@ class TestBlockHeaderValidation:
                 # TODO: Inspect these block values as they are currently None
                 expected_difficulty = block.finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
                 expected_sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
+                vs = ValidationState(expected_sub_slot_iters, expected_difficulty, None)
                 _, error = validate_finished_header_block(
-                    empty_blockchain.constants,
-                    empty_blockchain,
-                    header_block_bad_4,
-                    False,
-                    expected_difficulty,
-                    expected_sub_slot_iters,
+                    empty_blockchain.constants, empty_blockchain, header_block_bad_4, False, vs
                 )
                 assert error is not None
                 assert error.code == Err.INVALID_SUB_EPOCH_SUMMARY
@@ -522,13 +506,11 @@ class TestBlockHeaderValidation:
         )
 
         header_block_bad = get_block_header(block_0_bad, [], [])
+        vs = ValidationState(
+            empty_blockchain.constants.SUB_SLOT_ITERS_STARTING, empty_blockchain.constants.DIFFICULTY_STARTING, None
+        )
         _, error = validate_finished_header_block(
-            empty_blockchain.constants,
-            empty_blockchain,
-            header_block_bad,
-            False,
-            empty_blockchain.constants.DIFFICULTY_STARTING,
-            empty_blockchain.constants.SUB_SLOT_ITERS_STARTING,
+            empty_blockchain.constants, empty_blockchain, header_block_bad, False, vs
         )
 
         assert error is not None
@@ -556,13 +538,9 @@ class TestBlockHeaderValidation:
         # TODO: Inspect these block values as they are currently None
         expected_difficulty = blocks[1].finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
         expected_sub_slot_iters = blocks[1].finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
+        vs = ValidationState(expected_sub_slot_iters, expected_difficulty, None)
         _, error = validate_finished_header_block(
-            empty_blockchain.constants,
-            empty_blockchain,
-            header_block_bad,
-            False,
-            expected_difficulty,
-            expected_sub_slot_iters,
+            empty_blockchain.constants, empty_blockchain, header_block_bad, False, vs
         )
         assert error is not None
         assert error.code == Err.INVALID_PREV_CHALLENGE_SLOT_HASH
@@ -587,13 +565,9 @@ class TestBlockHeaderValidation:
         # TODO: Inspect these block values as they are currently None
         expected_difficulty = blocks[1].finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
         expected_sub_slot_iters = blocks[1].finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
+        vs = ValidationState(expected_sub_slot_iters, expected_difficulty, None)
         _, error = validate_finished_header_block(
-            empty_blockchain.constants,
-            empty_blockchain,
-            header_block_bad,
-            False,
-            expected_difficulty,
-            expected_sub_slot_iters,
+            empty_blockchain.constants, empty_blockchain, header_block_bad, False, vs
         )
         assert error is not None
         assert error.code == Err.INVALID_PREV_CHALLENGE_SLOT_HASH
@@ -746,13 +720,9 @@ class TestBlockHeaderValidation:
                 # TODO: Inspect these block values as they are currently None
                 expected_difficulty = block.finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
                 expected_sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
+                vs = ValidationState(expected_sub_slot_iters, expected_difficulty, None)
                 _, error = validate_finished_header_block(
-                    empty_blockchain.constants,
-                    empty_blockchain,
-                    header_block_bad,
-                    False,
-                    expected_difficulty,
-                    expected_sub_slot_iters,
+                    empty_blockchain.constants, empty_blockchain, header_block_bad, False, vs
                 )
                 assert error is not None
                 assert error.code == Err.INVALID_ICC_HASH_CC
@@ -818,13 +788,11 @@ class TestBlockHeaderValidation:
         )
 
         header_block_bad = get_block_header(block_bad, [], [])
+        vs = ValidationState(
+            empty_blockchain.constants.SUB_SLOT_ITERS_STARTING, empty_blockchain.constants.DIFFICULTY_STARTING, None
+        )
         _, error = validate_finished_header_block(
-            empty_blockchain.constants,
-            empty_blockchain,
-            header_block_bad,
-            False,
-            empty_blockchain.constants.DIFFICULTY_STARTING,
-            empty_blockchain.constants.SUB_SLOT_ITERS_STARTING,
+            empty_blockchain.constants, empty_blockchain, header_block_bad, False, vs
         )
         assert error is not None
         assert error.code == Err.INVALID_SUB_EPOCH_SUMMARY_HASH

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -29,6 +29,7 @@ from chia.types.blockchain_format.vdf import VDFInfo, VDFProof, validate_vdf
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.header_block import HeaderBlock
 from chia.types.unfinished_header_block import UnfinishedHeaderBlock
+from chia.types.validation_state import ValidationState
 from chia.util.errors import Err, ValidationError
 from chia.util.hash import std_hash
 from chia.util.ints import uint8, uint32, uint64, uint128
@@ -834,10 +835,8 @@ def validate_finished_header_block(
     blocks: BlockRecordsProtocol,
     header_block: HeaderBlock,
     check_filter: bool,
-    expected_difficulty: uint64,
-    expected_sub_slot_iters: uint64,
+    vs: ValidationState,
     check_sub_epoch_summary: bool = True,
-    prev_ses_block: Optional[BlockRecord] = None,
 ) -> tuple[Optional[uint64], Optional[ValidationError]]:
     """
     Fully validates the header of a block. A header block is the same  as a full block, but
@@ -858,11 +857,11 @@ def validate_finished_header_block(
         blocks,
         unfinished_header_block,
         check_filter,
-        expected_difficulty,
-        expected_sub_slot_iters,
+        vs.current_difficulty,
+        vs.current_ssi,
         False,
         check_sub_epoch_summary=check_sub_epoch_summary,
-        prev_ses_block=prev_ses_block,
+        prev_ses_block=vs.prev_ses_block,
     )
 
     genesis_block = False
@@ -880,7 +879,7 @@ def validate_finished_header_block(
 
     ip_iters: uint64 = calculate_ip_iters(
         constants,
-        expected_sub_slot_iters,
+        vs.current_ssi,
         header_block.reward_chain_block.signage_point_index,
         required_iters,
     )
@@ -891,8 +890,8 @@ def validate_finished_header_block(
             return None, ValidationError(Err.INVALID_HEIGHT)
 
         # 28. Check weight
-        if header_block.weight != prev_b.weight + expected_difficulty:
-            log.error(f"INVALID WEIGHT: {header_block} {prev_b} {expected_difficulty}")
+        if header_block.weight != prev_b.weight + vs.current_difficulty:
+            log.error(f"INVALID WEIGHT: {header_block} {prev_b} {vs.current_difficulty}")
             return None, ValidationError(Err.INVALID_WEIGHT)
     else:
         # 27b. Check genesis block height, weight, and prev block hash

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -96,9 +96,7 @@ def pre_validate_block(
             blockchain,
             header_block,
             True,  # check_filter
-            vs.current_difficulty,
-            vs.current_ssi,
-            prev_ses_block=vs.prev_ses_block,
+            vs,
         )
         error_int: Optional[uint16] = None
         if error is not None:

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -31,6 +31,7 @@ from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
 from chia.types.blockchain_format.vdf import VDFInfo, VDFProof, validate_vdf
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.header_block import HeaderBlock
+from chia.types.validation_state import ValidationState
 from chia.types.weight_proof import (
     RecentChainData,
     SubEpochChallengeSegment,
@@ -1253,8 +1254,9 @@ def validate_recent_blocks(
                 adjusted = True
             deficit = get_deficit(constants, deficit, prev_block_record, overflow, len(block.finished_sub_slots))
             if sub_slots > 2 and transaction_blocks > 11 and (tip_height - block.height < last_blocks_to_validate):
+                vs = ValidationState(ssi, diff, None)
                 caluclated_required_iters, error = validate_finished_header_block(
-                    constants, sub_blocks, block, False, diff, ssi, ses_blocks > 2
+                    constants, sub_blocks, block, False, vs, ses_blocks > 2
                 )
                 if error is not None:
                     log.error(f"block {block.header_hash} failed validation {error}")

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -11,6 +11,7 @@ from chia.consensus.find_fork_point import find_fork_point_in_chain
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.header_block import HeaderBlock
+from chia.types.validation_state import ValidationState
 from chia.types.weight_proof import WeightProof
 from chia.util.errors import Err
 from chia.util.ints import uint32, uint64
@@ -110,9 +111,8 @@ class WalletBlockchain:
             difficulty = self._difficulty
 
         # Validation requires a block cache (self) that goes back to a subepoch barrier
-        required_iters, error = validate_finished_header_block(
-            self.constants, self, block, False, difficulty, sub_slot_iters, False
-        )
+        vs = ValidationState(sub_slot_iters, difficulty, None)
+        required_iters, error = validate_finished_header_block(self.constants, self, block, False, vs, False)
         if error is not None:
             return AddBlockResult.INVALID_BLOCK, error.code
         if required_iters is None:


### PR DESCRIPTION
### Purpose:

`validate_finished_header_block` takes `expected_difficulty`, `expected_sub_slot_iters` and `prev_ses_block` as separate parameters. Now that we have `ValidationState`, we can pass that directly.

### Current Behavior:

`validate_finished_header_block` takes `expected_difficulty`, `expected_sub_slot_iters` and `prev_ses_block` as separate parameters.

### New Behavior:

`validate_finished_header_block` takes a `ValidationState` instead.