### PR TITLE
[CHIA-1645] - Replace any unicode decoding errors during daemon startup

### DIFF
--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -51,7 +51,7 @@ async def create_start_daemon_connection(
         process = launch_start_daemon(root_path)
         # give the daemon a chance to start up
         if process.stdout:
-            process.stdout.readline()
+            process.stdout.readline().decode("utf-8", errors="replace")
         await asyncio.sleep(1)
         # it prints "daemon: listening"
         connection = await connect_to_daemon_and_validate(root_path, config)


### PR DESCRIPTION
Attempt to resolve strange UnicodeDecodeError as reported here: https://github.com/Chia-Network/chia-blockchain/issues/18677

Unknown if there are other issues hiding

```Traceback (most recent call last):
File "chia\cmds\chia.py", line 143, in
File "chia\cmds\chia.py", line 139, in main
File "click\core.py", line 1157, in call
File "click\core.py", line 1078, in main
File "click\core.py", line 1688, in invoke
File "click\core.py", line 1434, in invoke
File "click\core.py", line 783, in invoke
File "click\decorators.py", line 33, in new_func
File "chia\cmds\start.py", line 24, in start_cmd
File "asyncio\runners.py", line 44, in run
File "asyncio\base_events.py", line 649, in run_until_complete
File "chia\cmds\start_funcs.py", line 81, in async_start
File "chia\cmds\start_funcs.py", line 54, in create_start_daemon_connection
File "codecs.py", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf8 in position 31: invalid start byte
[23908] Failed to execute script 'chia' due to unhandled exception!
```


Putting some information here:

When daemon starts it calls `sys.stdout.write` with a JSON string that includes path components (see `async_run_daemon` in `daemon/server.py` - I believe by default this will output in local code page on Windows - this is probably correct as then the console will show it correctly

When starting the daemon, we call `subprocess.Popen` using `encoding="utf-8"`; this line was added in PR #9697 with comment "gbk platform encoding issue on stdio pipe". The code then tries to read from stdout using `process.stdout.readline()` which is the call that is raising in the above stack trace.

I don't want to change sys.stdout.write to output UTF-8 as that will likely not print corrrectly in the actual console if launching the daemon directly from the console. I suspect removing the `encoding="utf-8"` line from the `Popen` call would work, but I am reticent to remove this as it was added for some specific reason. Unfortunately that rationale isn't entirely understood.

Probably the quickest fix is to wrap the `readline` with a `try/except` handler since we aren't actually trying to process the output here.

Other issues with the code: The code is using the presence of text/bytes on stdout as a trigger that the daemon has started in `create_start_daemon_connection` - however, the daemon start code write out on stdout right at the beginning, well before even running the webserver we are trying to connect to. So the code that is using `readline` as a trigger mechanism doesn't seem to be very useful - I'm not sure it does much in the current codebase.

Options for fixing include
- remove `encoding="utf-8"` in `Popen`
- remove `readline` 
- wrap `readline` in `try/except`
- remove `readline` and add in back-off retry handler if connection fails to connect