### PR TITLE
[CHIA-1638] Pace block requests

### DIFF
--- a/chia/_tests/plot_sync/test_sender.py
+++ b/chia/_tests/plot_sync/test_sender.py
@@ -45,7 +45,7 @@ def test_set_connection_values(bt: BlockTools, seeded_random: random.Random) -> 
     # Test setting a valid connection works
     sender.set_connection(farmer_connection)  # type:ignore[arg-type]
     assert sender._connection is not None
-    assert sender._connection == farmer_connection
+    assert id(sender._connection) == id(farmer_connection)
 
 
 @pytest.mark.anyio

--- a/chia/_tests/plot_sync/test_sender.py
+++ b/chia/_tests/plot_sync/test_sender.py
@@ -45,7 +45,7 @@ def test_set_connection_values(bt: BlockTools, seeded_random: random.Random) -> 
     # Test setting a valid connection works
     sender.set_connection(farmer_connection)  # type:ignore[arg-type]
     assert sender._connection is not None
-    assert sender._connection == farmer_connection  # type: ignore[comparison-overlap]
+    assert sender._connection == farmer_connection
 
 
 @pytest.mark.anyio

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -754,3 +754,21 @@ class WSChiaConnection:
 
     def has_capability(self, capability: Capability) -> bool:
         return capability in self.peer_capabilities
+
+    def __hash__(self) -> int:
+        return hash(self.peer_node_id)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(object, WSChiaConnection):
+            return False
+        return self.peer_node_id == other.peer_node_id
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(object, WSChiaConnection):
+            return False
+        return self.peer_node_id < other.peer_node_id
+
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(object, WSChiaConnection):
+            return False
+        return self.peer_node_id > other.peer_node_id

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -754,11 +754,3 @@ class WSChiaConnection:
 
     def has_capability(self, capability: Capability) -> bool:
         return capability in self.peer_capabilities
-
-    def __hash__(self) -> int:
-        return hash(id(self))
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(object, WSChiaConnection):
-            return False
-        return id(self) == id(other)

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -756,19 +756,9 @@ class WSChiaConnection:
         return capability in self.peer_capabilities
 
     def __hash__(self) -> int:
-        return hash(self.peer_node_id)
+        return hash(id(self))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(object, WSChiaConnection):
             return False
-        return self.peer_node_id == other.peer_node_id
-
-    def __lt__(self, other: object) -> bool:
-        if not isinstance(object, WSChiaConnection):
-            return False
-        return self.peer_node_id < other.peer_node_id
-
-    def __gt__(self, other: object) -> bool:
-        if not isinstance(object, WSChiaConnection):
-            return False
-        return self.peer_node_id > other.peer_node_id
+        return id(self) == id(other)


### PR DESCRIPTION
### Purpose:

This patch addresses a problem during long-sync, where the syncing node may send `request_blocks` at a rate exceeding the peer's *outbound* rate limit for `respond_blocks`. The result of which is the peer not responding and the syncing node closing the connection. Over time, all peers may get disconnected and syncing stalls. It takes at least 30 seconds + weight proof validation to restart syncing.

The root of this problem is that the rate limits for `request_blocks` is not aligned with the rate limit for `respond_blocks`. They are 500 msgs/minute and 100 msgs/minute respectively (but then scaled to 30%). It never makes sense to send more requests that the peer is willing to respond to, so these limits should really be the same.

This patch hard-codes the expected outbound rate limit of the peer and *paces* requests to never exceed that limit. Thus, maintaining a steady sync (albeit, slow). The rate is at most one request every 2 seconds.

We already send requests to multiple peers, if we have more than one. This patch keeps track of the timestamp, per peer, when it's OK to send the next request. Sometimes, this timestamp can be in the past. This happens if one peer stalls for a long time and we "miss" the time to send a request to another peer (or the same peer for that matter).

The rate limit is enforced at 60 seconds at a time, so we allow "catching up" by only incrementing the timestamp by the rate limit minimum (2 seconds). However, if a peer takes too long to respond, we penalize it by bumping the time stamp to the current time. This creates a weak affinity to request more from faster peers.

There are still issues with our concept of rate limits. For instance, there is a configuration option to scale the rate limits. But the effective limits are never communicated over the protocol, so there's no way of knowing whether a peer has tweaked its limits.

### Current Behavior:

During long sync, we request blocks as fast as we can (with a single request outstanding at a time). Risking pushing peers over the limit, stalling and having to restart the sync.

### New Behavior:

During long sync, we pace the block requests to peers to never exceed the (presumed) rate limit for block requests.

### Testing Notes:

Manually tested on my node. I sync about 3x faster.