### PR TITLE
[CHIA-1561] validate UnfinishedBlocks and signature in thread pool

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -22,7 +22,7 @@ from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_dif
 from chia.consensus.find_fork_point import lookup_fork_chain
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.get_block_generator import get_block_generator
-from chia.consensus.multiprocess_validation import PreValidationResult, _run_generator
+from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.full_node.block_height_map import BlockHeightMap
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
@@ -40,7 +40,7 @@ from chia.types.unfinished_block import UnfinishedBlock
 from chia.types.unfinished_header_block import UnfinishedHeaderBlock
 from chia.types.weight_proof import SubEpochChallengeSegment
 from chia.util.cpu import available_logical_cores
-from chia.util.errors import ConsensusError, Err
+from chia.util.errors import Err
 from chia.util.generator_tools import get_block_header
 from chia.util.hash import std_hash
 from chia.util.inline_executor import InlineExecutor
@@ -783,23 +783,6 @@ class Blockchain:
             return PreValidationResult(uint16(error_code.value), None, None, False, uint32(0))
 
         return PreValidationResult(None, required_iters, cost_result, False, uint32(0))
-
-    async def run_generator(self, unfinished_block: bytes, generator: BlockGenerator, height: uint32) -> NPCResult:
-        task = asyncio.get_running_loop().run_in_executor(
-            self.pool,
-            _run_generator,
-            self.constants,
-            unfinished_block,
-            bytes(generator),
-            height,
-        )
-        npc_result_bytes = await task
-        if npc_result_bytes is None:
-            raise ConsensusError(Err.UNKNOWN)
-        ret: NPCResult = NPCResult.from_bytes(npc_result_bytes)
-        if ret.error is not None:
-            raise ConsensusError(Err(ret.error))
-        return ret
 
     def contains_block(self, header_hash: bytes32) -> bool:
         """

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -537,18 +537,15 @@ class FullNodeAPI:
             return msg
         return None
 
-    @api_request(peer_required=True, bytes_required=True)
+    @api_request(peer_required=True)
     async def respond_unfinished_block(
         self,
         respond_unfinished_block: full_node_protocol.RespondUnfinishedBlock,
         peer: WSChiaConnection,
-        respond_unfinished_block_bytes: bytes = b"",
     ) -> Optional[Message]:
         if self.full_node.sync_store.get_sync_mode():
             return None
-        await self.full_node.add_unfinished_block(
-            respond_unfinished_block.unfinished_block, peer, block_bytes=respond_unfinished_block_bytes
-        )
+        await self.full_node.add_unfinished_block(respond_unfinished_block.unfinished_block, peer)
         return None
 
     @api_request(peer_required=True)


### PR DESCRIPTION
### Purpose:

The intention of this PR is to speed up and offload signature validation from the main thread onto the blockchain thread pool.

With the latest `chia_rs`, `run_block_generator()` (and `run_block_generator2()`) validates the block signature by default (unless the `DONT_VALIDATE_SIGNATURE` flag is passed in). By transitioning unfinished block validation to using this function directly, and have it validate the signature, there are a few single-purpose helper functions that can be removed.

`Blockchain.run_generator()` and `_run_generator()` are no longer needed and are removed by this change.

### Current Behavior:

When we receive unfinished blocks, we validate the block generator in the blockchain thread pool, but we validate the signature in the main thread, using the BLS cache.

### New Behavior:

We validate the block generator *and* the signature in the blockchain thread pool. This frees up time in the main thread as well as provides a small speed up because we can release the GIL once (instead of twice) and we don't need to pass back the PKM-pairs back into rust again.

### Testing Notes:

I ran a node on mainnet, ensuring it could keep up with new blocks.