### PR TITLE
Reduce import cycle count

### DIFF
--- a/chia/cmds/beta_funcs.py
+++ b/chia/cmds/beta_funcs.py
@@ -5,7 +5,8 @@ import sys
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from chia.cmds.cmds_util import format_bytes, prompt_yes_no, validate_directory_writable
+from chia.cmds.cmds_util import format_bytes, validate_directory_writable
+from chia.cmds.passphrase_funcs import prompt_yes_no
 from chia.util.beta_metrics import metrics_log_interval_max, metrics_log_interval_min
 from chia.util.chia_logging import get_beta_logging_config
 from chia.util.errors import InvalidPathError

--- a/chia/cmds/cmds_util.py
+++ b/chia/cmds/cmds_util.py
@@ -478,16 +478,6 @@ def format_minutes(minutes: int) -> str:
     return "Unknown"
 
 
-def prompt_yes_no(prompt: str) -> bool:
-    while True:
-        response = str(input(prompt + " (y/n): ")).lower().strip()
-        ch = response[:1]
-        if ch == "y":
-            return True
-        elif ch == "n":
-            return False
-
-
 def validate_directory_writable(path: Path) -> None:
     write_test_path = path / ".write_test"
     try:

--- a/chia/cmds/passphrase_funcs.py
+++ b/chia/cmds/passphrase_funcs.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 import colorama
 
-from chia.cmds.cmds_util import prompt_yes_no
 from chia.daemon.client import acquire_connection_to_daemon
 from chia.util.errors import KeychainMaxUnlockAttempts
 from chia.util.keychain import Keychain, supports_os_passphrase_storage
@@ -69,6 +68,16 @@ def obtain_current_passphrase(prompt: str = DEFAULT_PASSPHRASE_PROMPT, use_passp
         time.sleep(FAILED_ATTEMPT_DELAY)
         print("Incorrect passphrase\n")
     raise KeychainMaxUnlockAttempts()
+
+
+def prompt_yes_no(prompt: str) -> bool:
+    while True:
+        response = str(input(prompt + " (y/n): ")).lower().strip()
+        ch = response[:1]
+        if ch == "y":
+            return True
+        elif ch == "n":
+            return False
 
 
 def verify_passphrase_meets_requirements(

--- a/chia/legacy/keyring.py
+++ b/chia/legacy/keyring.py
@@ -23,7 +23,7 @@ except ImportError:
     CryptFileKeyring = None
 
 
-from chia.cmds.cmds_util import prompt_yes_no
+from chia.cmds.passphrase_funcs import prompt_yes_no
 from chia.util.errors import KeychainUserNotFound
 from chia.util.keychain import MAX_KEYS, KeyData, KeyDataSecrets, get_private_key_user
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

See also https://gist.github.com/richardkiss/fbb6228eb55b3917d22dcdb85b8bff9f

This reduces the import cycle count reported by the tool above from 71 to 63.

### Current Behavior:

```
% git checkout 9f63f969164eab2950345d55d1c766ee96f66200
% vpa --directory rearrange  print_cycles  # uses the version of the tool in the gist above
cycle of length 2 found: ['chia/data_layer/data_layer_util.py', 'chia/data_layer/data_store.py']
cycle of length 2 found: ['chia/full_node/full_node.py', 'chia/full_node/full_node_api.py']
cycle of length 2 found: ['chia/rpc/util.py', 'chia/rpc/wallet_rpc_api.py']
cycle of length 2 found: ['chia/ssl/create_ssl.py', 'chia/util/ssl_check.py']
cycle of length 2 found: ['chia/util/file_keyring.py', 'chia/util/keyring_wrapper.py']
cycle of length 2 found: ['chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py']
cycle of length 2 found: ['chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 2 found: ['chia/wallet/wallet_node.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 3 found: ['chia/cmds/passphrase_funcs.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py']
cycle of length 3 found: ['chia/data_layer/data_layer_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 3 found: ['chia/data_layer/data_layer_wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/data_layer/dl_wallet_store.py']
cycle of length 3 found: ['chia/data_layer/data_layer_wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/trade_manager.py']
cycle of length 3 found: ['chia/full_node/full_node_api.py', 'chia/server/server.py', 'chia/util/network.py']
cycle of length 3 found: ['chia/pools/pool_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 3 found: ['chia/rpc/rpc_server.py', 'chia/rpc/util.py', 'chia/rpc/wallet_rpc_api.py']
cycle of length 3 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 3 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/cat_wallet/dao_cat_wallet.py']
cycle of length 3 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/vc_wallet/cr_cat_wallet.py']
cycle of length 3 found: ['chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_coin_record.py']
cycle of length 3 found: ['chia/wallet/vc_wallet/vc_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 3 found: ['chia/wallet/wallet.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 3 found: ['chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/wallet_protocol.py']
cycle of length 4 found: ['chia/cmds/cmds_util.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
cycle of length 4 found: ['chia/data_layer/data_layer_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/data_layer/dl_wallet_store.py']
cycle of length 4 found: ['chia/farmer/farmer.py', 'chia/rpc/rpc_server.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py']
cycle of length 4 found: ['chia/farmer/farmer_api.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py']
cycle of length 4 found: ['chia/full_node/full_node_api.py', 'chia/types/transaction_queue_entry.py', 'chia/server/ws_connection.py', 'chia/util/network.py']
cycle of length 4 found: ['chia/harvester/harvester.py', 'chia/rpc/rpc_server.py', 'chia/util/network.py', 'chia/harvester/harvester_api.py']
cycle of length 4 found: ['chia/introducer/introducer.py', 'chia/rpc/rpc_server.py', 'chia/util/network.py', 'chia/introducer/introducer_api.py']
cycle of length 4 found: ['chia/introducer/introducer_api.py', 'chia/rpc/rpc_server.py', 'chia/server/server.py', 'chia/util/network.py']
cycle of length 4 found: ['chia/rpc/rpc_server.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/timelord/timelord_api.py']
cycle of length 4 found: ['chia/rpc/rpc_server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/timelord/timelord_api.py']
cycle of length 4 found: ['chia/rpc/rpc_server.py', 'chia/util/network.py', 'chia/wallet/wallet_node_api.py', 'chia/wallet/wallet_node.py']
cycle of length 4 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/dao_wallet/dao_wallet.py']
cycle of length 4 found: ['chia/wallet/did_wallet/did_wallet.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 4 found: ['chia/wallet/nft_wallet/nft_wallet.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 4 found: ['chia/wallet/notification_manager.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 5 found: ['chia/cmds/cmds_util.py', 'chia/daemon/keychain_proxy.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
cycle of length 5 found: ['chia/daemon/keychain_proxy.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py']
cycle of length 5 found: ['chia/farmer/farmer.py', 'chia/plot_sync/receiver.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py']
cycle of length 5 found: ['chia/full_node/full_node.py', 'chia/server/node_discovery.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/full_node/full_node_api.py']
cycle of length 5 found: ['chia/full_node/full_node.py', 'chia/util/check_fork_next_block.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/full_node/full_node_api.py']
cycle of length 5 found: ['chia/full_node/full_node_api.py', 'chia/full_node/tx_processing_queue.py', 'chia/types/transaction_queue_entry.py', 'chia/server/ws_connection.py', 'chia/util/network.py']
cycle of length 5 found: ['chia/harvester/harvester.py', 'chia/plot_sync/sender.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/harvester/harvester_api.py']
cycle of length 5 found: ['chia/introducer/introducer.py', 'chia/rpc/rpc_server.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/introducer/introducer_api.py']
cycle of length 5 found: ['chia/rpc/rpc_server.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/timelord/timelord_api.py', 'chia/timelord/timelord.py']
cycle of length 5 found: ['chia/server/ws_connection.py', 'chia/util/network.py', 'chia/wallet/wallet_node_api.py', 'chia/wallet/wallet_node.py', 'chia/wallet/util/new_peak_queue.py']
cycle of length 5 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/puzzles/tails.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/cat_wallet/dao_cat_wallet.py']
cycle of length 5 found: ['chia/wallet/derivation_record.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 5 found: ['chia/wallet/derivation_record.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/wallet_puzzle_store.py']
cycle of length 5 found: ['chia/wallet/puzzles/clawback/drivers.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 5 found: ['chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/wallet_coin_store.py']
cycle of length 5 found: ['chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/wallet_user_store.py']
cycle of length 6 found: ['chia/cmds/cmds_util.py', 'chia/daemon/keychain_proxy.py', 'chia/cmds/init_funcs.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
cycle of length 6 found: ['chia/farmer/farmer_api.py', 'chia/harvester/harvester_api.py', 'chia/harvester/harvester.py', 'chia/plot_sync/sender.py', 'chia/server/ws_connection.py', 'chia/util/network.py']
cycle of length 6 found: ['chia/full_node/full_node.py', 'chia/rpc/rpc_server.py', 'chia/rpc/util.py', 'chia/rpc/wallet_rpc_api.py', 'chia/wallet/util/wallet_sync_utils.py', 'chia/full_node/full_node_api.py']
cycle of length 6 found: ['chia/rpc/rpc_server.py', 'chia/util/json_util.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 6 found: ['chia/wallet/derivation_record.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_coin_record.py', 'chia/wallet/puzzles/clawback/metadata.py', 'chia/wallet/wallet_puzzle_store.py']
cycle of length 6 found: ['chia/wallet/puzzles/clawback/drivers.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/util/puzzle_decorator.py', 'chia/wallet/puzzles/clawback/puzzle_decorator.py']
cycle of length 7 found: ['chia/cmds/cmds_util.py', 'chia/daemon/keychain_proxy.py', 'chia/cmds/init_funcs.py', 'chia/util/keychain.py', 'chia/util/keyring_wrapper.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
cycle of length 7 found: ['chia/cmds/cmds_util.py', 'chia/daemon/keychain_proxy.py', 'chia/daemon/keychain_server.py', 'chia/cmds/init_funcs.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
cycle of length 7 found: ['chia/daemon/client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/daemon/keychain_proxy.py']
cycle of length 7 found: ['chia/rpc/rpc_server.py', 'chia/util/ws_message.py', 'chia/util/json_util.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 7 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/coin_selection.py', 'chia/wallet/wallet_coin_record.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 8 found: ['chia/cmds/cmds_util.py', 'chia/rpc/data_layer_rpc_client.py', 'chia/data_layer/data_layer_util.py', 'chia/wallet/wallet_node.py', 'chia/daemon/keychain_proxy.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
cycle of length 8 found: ['chia/cmds/cmds_util.py', 'chia/rpc/farmer_rpc_client.py', 'chia/rpc/farmer_rpc_api.py', 'chia/farmer/farmer.py', 'chia/daemon/keychain_proxy.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
cycle of length 8 found: ['chia/cmds/cmds_util.py', 'chia/rpc/wallet_rpc_client.py', 'chia/data_layer/data_layer_util.py', 'chia/wallet/wallet_node.py', 'chia/daemon/keychain_proxy.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
cycle of length 10 found: ['chia/cmds/cmds_util.py', 'chia/rpc/rpc_client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
cycle of length 11 found: ['chia/cmds/cmds_util.py', 'chia/rpc/full_node_rpc_client.py', 'chia/rpc/rpc_client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
cycle of length 11 found: ['chia/cmds/cmds_util.py', 'chia/rpc/harvester_rpc_client.py', 'chia/rpc/rpc_client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
cycle of length 12 found: ['chia/cmds/cmds_util.py', 'chia/simulator/simulator_full_node_rpc_client.py', 'chia/rpc/full_node_rpc_client.py', 'chia/rpc/rpc_client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
cycle count: 71
worst edges:
 15 ('chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py')
 14 ('chia/server/ws_connection.py', 'chia/util/network.py')
 13 ('chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py')
 12 ('chia/util/keychain.py', 'chia/util/file_keyring.py')
 12 ('chia/cmds/passphrase_funcs.py', 'chia/cmds/cmds_util.py')
```
### New Behavior:

```
% git checkout rearrange # this change
% vpa --directory rearrange  print_cycles
cycle of length 2 found: ['chia/data_layer/data_layer_util.py', 'chia/data_layer/data_store.py']
cycle of length 2 found: ['chia/full_node/full_node.py', 'chia/full_node/full_node_api.py']
cycle of length 2 found: ['chia/rpc/util.py', 'chia/rpc/wallet_rpc_api.py']
cycle of length 2 found: ['chia/ssl/create_ssl.py', 'chia/util/ssl_check.py']
cycle of length 2 found: ['chia/util/file_keyring.py', 'chia/util/keyring_wrapper.py']
cycle of length 2 found: ['chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py']
cycle of length 2 found: ['chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 2 found: ['chia/wallet/wallet_node.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 3 found: ['chia/cmds/passphrase_funcs.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py']
cycle of length 3 found: ['chia/data_layer/data_layer_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 3 found: ['chia/data_layer/data_layer_wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/data_layer/dl_wallet_store.py']
cycle of length 3 found: ['chia/data_layer/data_layer_wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/trade_manager.py']
cycle of length 3 found: ['chia/full_node/full_node_api.py', 'chia/server/server.py', 'chia/util/network.py']
cycle of length 3 found: ['chia/pools/pool_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 3 found: ['chia/rpc/rpc_server.py', 'chia/rpc/util.py', 'chia/rpc/wallet_rpc_api.py']
cycle of length 3 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 3 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/cat_wallet/dao_cat_wallet.py']
cycle of length 3 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/vc_wallet/cr_cat_wallet.py']
cycle of length 3 found: ['chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_coin_record.py']
cycle of length 3 found: ['chia/wallet/vc_wallet/vc_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 3 found: ['chia/wallet/wallet.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 3 found: ['chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/wallet_protocol.py']
cycle of length 4 found: ['chia/cmds/passphrase_funcs.py', 'chia/util/keychain.py', 'chia/util/keyring_wrapper.py', 'chia/util/file_keyring.py']
cycle of length 4 found: ['chia/data_layer/data_layer_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/data_layer/dl_wallet_store.py']
cycle of length 4 found: ['chia/farmer/farmer.py', 'chia/rpc/rpc_server.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py']
cycle of length 4 found: ['chia/farmer/farmer_api.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py']
cycle of length 4 found: ['chia/full_node/full_node_api.py', 'chia/types/transaction_queue_entry.py', 'chia/server/ws_connection.py', 'chia/util/network.py']
cycle of length 4 found: ['chia/harvester/harvester.py', 'chia/rpc/rpc_server.py', 'chia/util/network.py', 'chia/harvester/harvester_api.py']
cycle of length 4 found: ['chia/introducer/introducer.py', 'chia/rpc/rpc_server.py', 'chia/util/network.py', 'chia/introducer/introducer_api.py']
cycle of length 4 found: ['chia/introducer/introducer_api.py', 'chia/rpc/rpc_server.py', 'chia/server/server.py', 'chia/util/network.py']
cycle of length 4 found: ['chia/rpc/rpc_server.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/timelord/timelord_api.py']
cycle of length 4 found: ['chia/rpc/rpc_server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/timelord/timelord_api.py']
cycle of length 4 found: ['chia/rpc/rpc_server.py', 'chia/util/network.py', 'chia/wallet/wallet_node_api.py', 'chia/wallet/wallet_node.py']
cycle of length 4 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/dao_wallet/dao_wallet.py']
cycle of length 4 found: ['chia/wallet/did_wallet/did_wallet.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 4 found: ['chia/wallet/nft_wallet/nft_wallet.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 4 found: ['chia/wallet/notification_manager.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 5 found: ['chia/daemon/keychain_proxy.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py']
cycle of length 5 found: ['chia/farmer/farmer.py', 'chia/plot_sync/receiver.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py']
cycle of length 5 found: ['chia/full_node/full_node.py', 'chia/server/node_discovery.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/full_node/full_node_api.py']
cycle of length 5 found: ['chia/full_node/full_node.py', 'chia/util/check_fork_next_block.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/full_node/full_node_api.py']
cycle of length 5 found: ['chia/full_node/full_node_api.py', 'chia/full_node/tx_processing_queue.py', 'chia/types/transaction_queue_entry.py', 'chia/server/ws_connection.py', 'chia/util/network.py']
cycle of length 5 found: ['chia/harvester/harvester.py', 'chia/plot_sync/sender.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/harvester/harvester_api.py']
cycle of length 5 found: ['chia/introducer/introducer.py', 'chia/rpc/rpc_server.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/introducer/introducer_api.py']
cycle of length 5 found: ['chia/rpc/rpc_server.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/timelord/timelord_api.py', 'chia/timelord/timelord.py']
cycle of length 5 found: ['chia/server/ws_connection.py', 'chia/util/network.py', 'chia/wallet/wallet_node_api.py', 'chia/wallet/wallet_node.py', 'chia/wallet/util/new_peak_queue.py']
cycle of length 5 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/puzzles/tails.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/cat_wallet/dao_cat_wallet.py']
cycle of length 5 found: ['chia/wallet/derivation_record.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 5 found: ['chia/wallet/derivation_record.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/wallet_puzzle_store.py']
cycle of length 5 found: ['chia/wallet/puzzles/clawback/drivers.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 5 found: ['chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/wallet_coin_store.py']
cycle of length 5 found: ['chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/wallet_user_store.py']
cycle of length 6 found: ['chia/daemon/client.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/daemon/keychain_proxy.py']
cycle of length 6 found: ['chia/farmer/farmer_api.py', 'chia/harvester/harvester_api.py', 'chia/harvester/harvester.py', 'chia/plot_sync/sender.py', 'chia/server/ws_connection.py', 'chia/util/network.py']
cycle of length 6 found: ['chia/full_node/full_node.py', 'chia/rpc/rpc_server.py', 'chia/rpc/util.py', 'chia/rpc/wallet_rpc_api.py', 'chia/wallet/util/wallet_sync_utils.py', 'chia/full_node/full_node_api.py']
cycle of length 6 found: ['chia/rpc/rpc_server.py', 'chia/util/json_util.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 6 found: ['chia/wallet/derivation_record.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_coin_record.py', 'chia/wallet/puzzles/clawback/metadata.py', 'chia/wallet/wallet_puzzle_store.py']
cycle of length 6 found: ['chia/wallet/puzzles/clawback/drivers.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/util/puzzle_decorator.py', 'chia/wallet/puzzles/clawback/puzzle_decorator.py']
cycle of length 7 found: ['chia/daemon/client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/daemon/keychain_proxy.py']
cycle of length 7 found: ['chia/rpc/rpc_server.py', 'chia/util/ws_message.py', 'chia/util/json_util.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 7 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/coin_selection.py', 'chia/wallet/wallet_coin_record.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
cycle of length 11 found: ['chia/cmds/init_funcs.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py', 'chia/daemon/client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/daemon/keychain_proxy.py']
cycle of length 11 found: ['chia/cmds/init_funcs.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py', 'chia/daemon/client.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/daemon/keychain_proxy.py', 'chia/daemon/keychain_server.py']
cycle count: 63
worst edges:
 15 ('chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py')
 11 ('chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py')
 11 ('chia/server/ws_connection.py', 'chia/util/network.py')
  9 ('chia/util/network.py', 'chia/farmer/farmer_api.py')
  9 ('chia/server/server.py', 'chia/util/network.py')
```

The diff:

```
@@ -20,7 +20,7 @@
 cycle of length 3 found: ['chia/wallet/vc_wallet/vc_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py']
 cycle of length 3 found: ['chia/wallet/wallet.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
 cycle of length 3 found: ['chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/wallet_protocol.py']
-cycle of length 4 found: ['chia/cmds/passphrase_funcs.py', 'chia/util/keychain.py', 'chia/util/keyring_wrapper.py', 'chia/util/file_keyring.py']
+cycle of length 4 found: ['chia/cmds/cmds_util.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
 cycle of length 4 found: ['chia/data_layer/data_layer_wallet.py', 'chia/wallet/wallet.py', 'chia/wallet/wallet_state_manager.py', 'chia/data_layer/dl_wallet_store.py']
 cycle of length 4 found: ['chia/farmer/farmer.py', 'chia/rpc/rpc_server.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py']
 cycle of length 4 found: ['chia/farmer/farmer_api.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py']
@@ -35,6 +35,7 @@
 cycle of length 4 found: ['chia/wallet/did_wallet/did_wallet.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py']
 cycle of length 4 found: ['chia/wallet/nft_wallet/nft_wallet.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py']
 cycle of length 4 found: ['chia/wallet/notification_manager.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py']
+cycle of length 5 found: ['chia/cmds/cmds_util.py', 'chia/daemon/keychain_proxy.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
 cycle of length 5 found: ['chia/daemon/keychain_proxy.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py']
 cycle of length 5 found: ['chia/farmer/farmer.py', 'chia/plot_sync/receiver.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py']
 cycle of length 5 found: ['chia/full_node/full_node.py', 'chia/server/node_discovery.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/full_node/full_node_api.py']
@@ -50,21 +51,28 @@
 cycle of length 5 found: ['chia/wallet/puzzles/clawback/drivers.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
 cycle of length 5 found: ['chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/wallet_coin_store.py']
 cycle of length 5 found: ['chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/wallet_user_store.py']
-cycle of length 6 found: ['chia/daemon/client.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/daemon/keychain_proxy.py']
+cycle of length 6 found: ['chia/cmds/cmds_util.py', 'chia/daemon/keychain_proxy.py', 'chia/cmds/init_funcs.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
 cycle of length 6 found: ['chia/farmer/farmer_api.py', 'chia/harvester/harvester_api.py', 'chia/harvester/harvester.py', 'chia/plot_sync/sender.py', 'chia/server/ws_connection.py', 'chia/util/network.py']
 cycle of length 6 found: ['chia/full_node/full_node.py', 'chia/rpc/rpc_server.py', 'chia/rpc/util.py', 'chia/rpc/wallet_rpc_api.py', 'chia/wallet/util/wallet_sync_utils.py', 'chia/full_node/full_node_api.py']
 cycle of length 6 found: ['chia/rpc/rpc_server.py', 'chia/util/json_util.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
 cycle of length 6 found: ['chia/wallet/derivation_record.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_coin_record.py', 'chia/wallet/puzzles/clawback/metadata.py', 'chia/wallet/wallet_puzzle_store.py']
 cycle of length 6 found: ['chia/wallet/puzzles/clawback/drivers.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_state_manager.py', 'chia/wallet/util/puzzle_decorator.py', 'chia/wallet/puzzles/clawback/puzzle_decorator.py']
+cycle of length 7 found: ['chia/cmds/cmds_util.py', 'chia/daemon/keychain_proxy.py', 'chia/cmds/init_funcs.py', 'chia/util/keychain.py', 'chia/util/keyring_wrapper.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
+cycle of length 7 found: ['chia/cmds/cmds_util.py', 'chia/daemon/keychain_proxy.py', 'chia/daemon/keychain_server.py', 'chia/cmds/init_funcs.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
 cycle of length 7 found: ['chia/daemon/client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/daemon/keychain_proxy.py']
 cycle of length 7 found: ['chia/rpc/rpc_server.py', 'chia/util/ws_message.py', 'chia/util/json_util.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
 cycle of length 7 found: ['chia/wallet/cat_wallet/cat_wallet.py', 'chia/wallet/coin_selection.py', 'chia/wallet/wallet_coin_record.py', 'chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py', 'chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py']
-cycle of length 11 found: ['chia/cmds/init_funcs.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py', 'chia/daemon/client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/daemon/keychain_proxy.py']
-cycle of length 11 found: ['chia/cmds/init_funcs.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py', 'chia/daemon/client.py', 'chia/server/server.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/daemon/keychain_proxy.py', 'chia/daemon/keychain_server.py']
-cycle count: 63
+cycle of length 8 found: ['chia/cmds/cmds_util.py', 'chia/rpc/data_layer_rpc_client.py', 'chia/data_layer/data_layer_util.py', 'chia/wallet/wallet_node.py', 'chia/daemon/keychain_proxy.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
+cycle of length 8 found: ['chia/cmds/cmds_util.py', 'chia/rpc/farmer_rpc_client.py', 'chia/rpc/farmer_rpc_api.py', 'chia/farmer/farmer.py', 'chia/daemon/keychain_proxy.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
+cycle of length 8 found: ['chia/cmds/cmds_util.py', 'chia/rpc/wallet_rpc_client.py', 'chia/data_layer/data_layer_util.py', 'chia/wallet/wallet_node.py', 'chia/daemon/keychain_proxy.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
+cycle of length 10 found: ['chia/cmds/cmds_util.py', 'chia/rpc/rpc_client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
+cycle of length 11 found: ['chia/cmds/cmds_util.py', 'chia/rpc/full_node_rpc_client.py', 'chia/rpc/rpc_client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
+cycle of length 11 found: ['chia/cmds/cmds_util.py', 'chia/rpc/harvester_rpc_client.py', 'chia/rpc/rpc_client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
+cycle of length 12 found: ['chia/cmds/cmds_util.py', 'chia/simulator/simulator_full_node_rpc_client.py', 'chia/rpc/full_node_rpc_client.py', 'chia/rpc/rpc_client.py', 'chia/server/server.py', 'chia/server/ws_connection.py', 'chia/util/network.py', 'chia/farmer/farmer_api.py', 'chia/farmer/farmer.py', 'chia/util/keychain.py', 'chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py']
+cycle count: 71
 worst edges:
  15 ('chia/wallet/util/wallet_types.py', 'chia/wallet/wallet_protocol.py')
- 11 ('chia/wallet/wallet_action_scope.py', 'chia/wallet/wallet_state_manager.py')
- 11 ('chia/server/ws_connection.py', 'chia/util/network.py')
-  9 ('chia/util/network.py', 'chia/farmer/farmer_api.py')
-  9 ('chia/server/server.py', 'chia/util/network.py')
+ 14 ('chia/server/ws_connection.py', 'chia/util/network.py')
+ 13 ('chia/util/file_keyring.py', 'chia/cmds/passphrase_funcs.py')
+ 12 ('chia/util/keychain.py', 'chia/util/file_keyring.py')
+ 12 ('chia/cmds/passphrase_funcs.py', 'chia/cmds/cmds_util.py')
```

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
