### PR TITLE
Add a BLSMember puzzle, a corresponding class, and a test

### DIFF
--- a/chia/_tests/clvm/test_custody_architecture.py
+++ b/chia/_tests/clvm/test_custody_architecture.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field, replace
 from typing import List, Literal
 
 import pytest
-from chia_rs import AugSchemeMPL, G2Element
+from chia_rs import G2Element
 
 from chia.clvm.spend_sim import CostLogger, sim_and_client
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
@@ -15,7 +15,6 @@ from chia.types.coin_spend import make_spend
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.wallet.conditions import CreateCoinAnnouncement
 from chia.wallet.puzzles.custody.custody_architecture import (
-    BLSMember,
     MemberOrDPuz,
     MofN,
     ProvenSpend,
@@ -298,106 +297,6 @@ async def test_m_of_n(cost_logger: CostLogger, with_restrictions: bool) -> None:
                     assert result == (MempoolInclusionStatus.SUCCESS, None)
                     await sim.farm_block()
                     await sim.rewind(block_height)
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize(
-    "with_restrictions",
-    [True, False],
-)
-async def test_2_of_4_bls_members(cost_logger: CostLogger, with_restrictions: bool) -> None:
-    """
-    This tests the various functionality of the MofN drivers including that m of n puzzles can be constructed and solved
-    for every combination of its nodes from size 1 - 5.
-    """
-    restrictions: List[Restriction[MemberOrDPuz]] = [ACSDPuzValidator()] if with_restrictions else []
-    async with sim_and_client() as (sim, client):
-        m = 2
-        n = 4
-        keys = []
-        delegated_puzzle = Program.to(1)
-        delegated_puzzle_hash = delegated_puzzle.get_tree_hash()
-        for _ in range(0, n):
-            sk = AugSchemeMPL.key_gen(bytes.fromhex(str(n) * 64))
-            keys.append(sk)
-        m_of_n = PuzzleWithRestrictions(
-            0,
-            [],
-            MofN(
-                m, [PuzzleWithRestrictions(n_i, restrictions, BLSMember(keys[n_i].public_key())) for n_i in range(0, n)]
-            ),
-        )
-
-        # Farm and find coin
-        await sim.farm_block(m_of_n.puzzle_hash())
-        m_of_n_coin = (
-            await client.get_coin_records_by_puzzle_hashes([m_of_n.puzzle_hash()], include_spent_coins=False)
-        )[0].coin
-        block_height = sim.block_height
-
-        # Create two announcements to be asserted from a) the delegated puzzle b) the puzzle in the MofN
-        announcement = CreateCoinAnnouncement(msg=b"foo", coin_id=m_of_n_coin.name())
-
-        # Test a spend of every combination of m of n
-        for indexes in itertools.combinations(range(0, n), m):
-            proven_spends = {
-                PuzzleWithRestrictions(index, restrictions, BLSMember(keys[index].public_key())).puzzle_hash(
-                    _top_level=False
-                ): ProvenSpend(
-                    PuzzleWithRestrictions(index, restrictions, BLSMember(keys[index].public_key())).puzzle_reveal(
-                        _top_level=False
-                    ),
-                    PuzzleWithRestrictions(index, restrictions, BLSMember(keys[index].public_key())).solve(
-                        [],
-                        [Program.to(None)] if with_restrictions else [],
-                        [],  # no solution required for this member puzzle, only sig
-                    ),
-                )
-                for index in indexes
-            }
-            sig = G2Element()
-            for index in indexes:
-                sig = AugSchemeMPL.aggregate(
-                    [
-                        sig,
-                        keys[index].sign(
-                            delegated_puzzle_hash + m_of_n_coin.name() + DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA
-                        ),  # noqa)
-                    ]
-                )
-            assert isinstance(m_of_n.puzzle, MofN)
-            sb = WalletSpendBundle(
-                [
-                    make_spend(
-                        m_of_n_coin,
-                        m_of_n.puzzle_reveal(),
-                        m_of_n.solve(
-                            [],
-                            [],
-                            m_of_n.puzzle.solve(proven_spends),
-                            (
-                                delegated_puzzle,
-                                Program.to(
-                                    [
-                                        announcement.to_program(),
-                                        announcement.corresponding_assertion().to_program(),
-                                    ]
-                                ),
-                            ),
-                        ),
-                    )
-                ],
-                sig,
-            )
-            result = await client.push_tx(
-                cost_logger.add_cost(
-                    f"M={m}, N={n}, indexes={indexes}{'w/ res.' if with_restrictions else ''}",
-                    sb,
-                )
-            )
-            assert result == (MempoolInclusionStatus.SUCCESS, None)
-            await sim.farm_block()
-            await sim.rewind(block_height)
 
 
 @dataclass(frozen=True)

--- a/chia/_tests/clvm/test_custody_architecture.py
+++ b/chia/_tests/clvm/test_custody_architecture.py
@@ -8,7 +8,6 @@ import pytest
 from chia_rs import G2Element
 
 from chia.clvm.spend_sim import CostLogger, sim_and_client
-from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import make_spend

--- a/chia/_tests/clvm/test_custody_architecture.py
+++ b/chia/_tests/clvm/test_custody_architecture.py
@@ -8,6 +8,7 @@ import pytest
 from chia_rs import G1Element, G2Element, AugSchemeMPL
 
 from chia.clvm.spend_sim import CostLogger, sim_and_client
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import make_spend
@@ -351,7 +352,10 @@ async def test_2_of_4_bls_members(cost_logger: CostLogger, with_restrictions: bo
             }
             sig = G2Element()
             for index in indexes:
-                sig = AugSchemeMPL.aggregate([sig, keys[index].sign(delegated_puzzle_hash)])
+                sig = AugSchemeMPL.aggregate([
+                    sig, 
+                    keys[index].sign(delegated_puzzle_hash + m_of_n_coin.name() + DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA),  # noqa)
+                ])
             assert isinstance(m_of_n.puzzle, MofN)
             sb = WalletSpendBundle(
                 [
@@ -376,7 +380,6 @@ async def test_2_of_4_bls_members(cost_logger: CostLogger, with_restrictions: bo
                 ],
                 sig,
             )
-            breakpoint()
             result = await client.push_tx(
                 cost_logger.add_cost(
                     f"M={m}, N={n}, indexes={indexes}{'w/ res.' if with_restrictions else ''}",

--- a/chia/_tests/clvm/test_member_puzzles.py
+++ b/chia/_tests/clvm/test_member_puzzles.py
@@ -90,7 +90,7 @@ async def test_2_of_4_bls_members(cost_logger: CostLogger, with_restrictions: bo
                     PuzzleWithRestrictions(index, restrictions, BLSMember(keys[index].public_key())).solve(
                         [],
                         [Program.to(None)] if with_restrictions else [],
-                        [],  # no solution required for this member puzzle, only sig
+                        Program.to(0),  # no solution required for this member puzzle, only sig
                     ),
                 )
                 for index in indexes

--- a/chia/_tests/clvm/test_member_puzzles.py
+++ b/chia/_tests/clvm/test_member_puzzles.py
@@ -7,6 +7,7 @@ from typing import List, Literal
 import pytest
 from chia_rs import AugSchemeMPL, G2Element
 
+from chia._tests.clvm.test_custody_architecture import ACSDPuzValidator
 from chia.clvm.spend_sim import CostLogger, sim_and_client
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.program import Program
@@ -23,21 +24,6 @@ from chia.wallet.puzzles.custody.custody_architecture import (
 )
 from chia.wallet.puzzles.custody.member_puzzles.member_puzzles import BLSMember
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
-
-
-@dataclass(frozen=True)
-class ACSDPuzValidator:
-    member_not_dpuz: Literal[False] = field(init=False, default=False)
-
-    def memo(self, nonce: int) -> Program:
-        raise NotImplementedError()  # pragma: no cover
-
-    def puzzle(self, nonce: int) -> Program:
-        # (mod (dpuz . program) (a program conditions))
-        return Program.to([2, 3, 2])
-
-    def puzzle_hash(self, nonce: int) -> bytes32:
-        return self.puzzle(nonce).get_tree_hash()
 
 
 @pytest.mark.anyio

--- a/chia/_tests/clvm/test_member_puzzles.py
+++ b/chia/_tests/clvm/test_member_puzzles.py
@@ -117,7 +117,7 @@ async def test_2_of_4_bls_members(cost_logger: CostLogger, with_restrictions: bo
                         m_of_n.solve(
                             [],
                             [],
-                            m_of_n.puzzle.solve(proven_spends),
+                            m_of_n.puzzle.solve(proven_spends),  # pylint: disable=no-member
                             (
                                 delegated_puzzle,
                                 Program.to(

--- a/chia/_tests/clvm/test_member_puzzles.py
+++ b/chia/_tests/clvm/test_member_puzzles.py
@@ -17,6 +17,7 @@ from chia.wallet.puzzles.custody.custody_architecture import (
     MemberOrDPuz,
     MofN,
     ProvenSpend,
+    PuzzleHint,
     PuzzleWithRestrictions,
     Restriction,
 )
@@ -32,6 +33,22 @@ async def test_bls_member(cost_logger: CostLogger) -> None:
         sk = AugSchemeMPL.key_gen(bytes.fromhex(str(0) * 64))
 
         bls_puzzle = PuzzleWithRestrictions(0, [], BLSMember(sk.public_key()))
+        memo = PuzzleHint(
+            bls_puzzle.puzzle.puzzle_hash(0),
+            bls_puzzle.puzzle.memo(0),
+        )
+        memo = Program.to(
+            (
+                bls_puzzle.spec_namespace,
+                [
+                    bls_puzzle.nonce,
+                    [],
+                    0,
+                    memo.to_program(),
+                ],
+            )
+        )
+        assert bls_puzzle.memo() == memo
 
         # Farm and find coin
         await sim.farm_block(bls_puzzle.puzzle_hash())

--- a/chia/_tests/clvm/test_member_puzzles.py
+++ b/chia/_tests/clvm/test_member_puzzles.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass, field
+from typing import List, Literal
+
+import pytest
+from chia_rs import AugSchemeMPL, G2Element
+
+from chia.clvm.spend_sim import CostLogger, sim_and_client
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.coin_spend import make_spend
+from chia.types.mempool_inclusion_status import MempoolInclusionStatus
+from chia.wallet.conditions import CreateCoinAnnouncement
+from chia.wallet.puzzles.custody.custody_architecture import (
+    MemberOrDPuz,
+    MofN,
+    ProvenSpend,
+    PuzzleWithRestrictions,
+    Restriction,
+)
+from chia.wallet.puzzles.custody.member_puzzles.member_puzzles import BLSMember
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
+
+
+@dataclass(frozen=True)
+class ACSDPuzValidator:
+    member_not_dpuz: Literal[False] = field(init=False, default=False)
+
+    def memo(self, nonce: int) -> Program:
+        raise NotImplementedError()  # pragma: no cover
+
+    def puzzle(self, nonce: int) -> Program:
+        # (mod (dpuz . program) (a program conditions))
+        return Program.to([2, 3, 2])
+
+    def puzzle_hash(self, nonce: int) -> bytes32:
+        return self.puzzle(nonce).get_tree_hash()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "with_restrictions",
+    [True, False],
+)
+async def test_2_of_4_bls_members(cost_logger: CostLogger, with_restrictions: bool) -> None:
+    """
+    This tests the various functionality of the MofN drivers including that m of n puzzles can be constructed and solved
+    for every combination of its nodes from size 1 - 5.
+    """
+    restrictions: List[Restriction[MemberOrDPuz]] = [ACSDPuzValidator()] if with_restrictions else []
+    async with sim_and_client() as (sim, client):
+        m = 2
+        n = 4
+        keys = []
+        delegated_puzzle = Program.to(1)
+        delegated_puzzle_hash = delegated_puzzle.get_tree_hash()
+        for _ in range(0, n):
+            sk = AugSchemeMPL.key_gen(bytes.fromhex(str(n) * 64))
+            keys.append(sk)
+        m_of_n = PuzzleWithRestrictions(
+            0,
+            [],
+            MofN(
+                m, [PuzzleWithRestrictions(n_i, restrictions, BLSMember(keys[n_i].public_key())) for n_i in range(0, n)]
+            ),
+        )
+
+        # Farm and find coin
+        await sim.farm_block(m_of_n.puzzle_hash())
+        m_of_n_coin = (
+            await client.get_coin_records_by_puzzle_hashes([m_of_n.puzzle_hash()], include_spent_coins=False)
+        )[0].coin
+        block_height = sim.block_height
+
+        # Create two announcements to be asserted from a) the delegated puzzle b) the puzzle in the MofN
+        announcement = CreateCoinAnnouncement(msg=b"foo", coin_id=m_of_n_coin.name())
+
+        # Test a spend of every combination of m of n
+        for indexes in itertools.combinations(range(0, n), m):
+            proven_spends = {
+                PuzzleWithRestrictions(index, restrictions, BLSMember(keys[index].public_key())).puzzle_hash(
+                    _top_level=False
+                ): ProvenSpend(
+                    PuzzleWithRestrictions(index, restrictions, BLSMember(keys[index].public_key())).puzzle_reveal(
+                        _top_level=False
+                    ),
+                    PuzzleWithRestrictions(index, restrictions, BLSMember(keys[index].public_key())).solve(
+                        [],
+                        [Program.to(None)] if with_restrictions else [],
+                        [],  # no solution required for this member puzzle, only sig
+                    ),
+                )
+                for index in indexes
+            }
+            sig = G2Element()
+            for index in indexes:
+                sig = AugSchemeMPL.aggregate(
+                    [
+                        sig,
+                        keys[index].sign(
+                            delegated_puzzle_hash + m_of_n_coin.name() + DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA
+                        ),  # noqa)
+                    ]
+                )
+            assert isinstance(m_of_n.puzzle, MofN)
+            sb = WalletSpendBundle(
+                [
+                    make_spend(
+                        m_of_n_coin,
+                        m_of_n.puzzle_reveal(),
+                        m_of_n.solve(
+                            [],
+                            [],
+                            m_of_n.puzzle.solve(proven_spends),
+                            (
+                                delegated_puzzle,
+                                Program.to(
+                                    [
+                                        announcement.to_program(),
+                                        announcement.corresponding_assertion().to_program(),
+                                    ]
+                                ),
+                            ),
+                        ),
+                    )
+                ],
+                sig,
+            )
+            result = await client.push_tx(
+                cost_logger.add_cost(
+                    f"M={m}, N={n}, indexes={indexes}{'w/ res.' if with_restrictions else ''}",
+                    sb,
+                )
+            )
+            assert result == (MempoolInclusionStatus.SUCCESS, None)
+            await sim.farm_block()
+            await sim.rewind(block_height)

--- a/chia/_tests/clvm/test_member_puzzles.py
+++ b/chia/_tests/clvm/test_member_puzzles.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import itertools
-from dataclasses import dataclass, field
-from typing import List, Literal
+from typing import List
 
 import pytest
 from chia_rs import AugSchemeMPL, G2Element
@@ -11,7 +10,6 @@ from chia._tests.clvm.test_custody_architecture import ACSDPuzValidator
 from chia.clvm.spend_sim import CostLogger, sim_and_client
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.program import Program
-from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import make_spend
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.wallet.conditions import CreateCoinAnnouncement

--- a/chia/_tests/clvm/test_member_puzzles.py
+++ b/chia/_tests/clvm/test_member_puzzles.py
@@ -47,8 +47,11 @@ class ACSDPuzValidator:
 )
 async def test_2_of_4_bls_members(cost_logger: CostLogger, with_restrictions: bool) -> None:
     """
-    This tests the various functionality of the MofN drivers including that m of n puzzles can be constructed and solved
-    for every combination of its nodes from size 1 - 5.
+    This tests the BLS Member puzzle with 4 different keys. 
+    It loops through every combination inside an M of N Puzzle where
+    m = 2
+    n = 4
+    and every member puzzle is a unique BLSMember puzzle.
     """
     restrictions: List[Restriction[MemberOrDPuz]] = [ACSDPuzValidator()] if with_restrictions else []
     async with sim_and_client() as (sim, client):
@@ -75,7 +78,7 @@ async def test_2_of_4_bls_members(cost_logger: CostLogger, with_restrictions: bo
         )[0].coin
         block_height = sim.block_height
 
-        # Create two announcements to be asserted from a) the delegated puzzle b) the puzzle in the MofN
+        # Create an announcements to be asserted in the delegated puzzle
         announcement = CreateCoinAnnouncement(msg=b"foo", coin_id=m_of_n_coin.name())
 
         # Test a spend of every combination of m of n

--- a/chia/_tests/clvm/test_member_puzzles.py
+++ b/chia/_tests/clvm/test_member_puzzles.py
@@ -47,7 +47,7 @@ class ACSDPuzValidator:
 )
 async def test_2_of_4_bls_members(cost_logger: CostLogger, with_restrictions: bool) -> None:
     """
-    This tests the BLS Member puzzle with 4 different keys. 
+    This tests the BLS Member puzzle with 4 different keys.
     It loops through every combination inside an M of N Puzzle where
     m = 2
     n = 4

--- a/chia/_tests/clvm/test_member_puzzles.py
+++ b/chia/_tests/clvm/test_member_puzzles.py
@@ -37,7 +37,8 @@ async def test_bls_member(cost_logger: CostLogger) -> None:
             bls_puzzle.puzzle.puzzle_hash(0),
             bls_puzzle.puzzle.memo(0),
         )
-        memo = Program.to(
+
+        assert bls_puzzle.memo() == Program.to(
             (
                 bls_puzzle.spec_namespace,
                 [
@@ -48,7 +49,6 @@ async def test_bls_member(cost_logger: CostLogger) -> None:
                 ],
             )
         )
-        assert bls_puzzle.memo() == memo
 
         # Farm and find coin
         await sim.farm_block(bls_puzzle.puzzle_hash())

--- a/chia/wallet/puzzles/custody/custody_architecture.py
+++ b/chia/wallet/puzzles/custody/custody_architecture.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from typing import ClassVar, Dict, List, Literal, Mapping, Optional, Protocol, Tuple, TypeVar, Union
 
-from typing_extensions import runtime_checkable
 from chia_rs import G1Element
+from typing_extensions import runtime_checkable
+
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
@@ -235,6 +236,7 @@ class BLSMember:
     def puzzle_hash(self, nonce) -> bytes32:
         return self.puzzle(nonce).get_tree_hash()
 
+
 # The top-level object inside every "outer" puzzle
 @dataclass(frozen=True)
 class PuzzleWithRestrictions:
@@ -414,7 +416,7 @@ class PuzzleWithRestrictions:
     def solve(
         self,
         member_validator_solutions: List[Program],  # solution for the restriction puzzle
-        dpuz_validator_solutions: List[Program],  # 
+        dpuz_validator_solutions: List[Program],  #
         member_solution: Program,
         delegated_puzzle_and_solution: Optional[Tuple[Program, Program]] = None,
     ) -> Program:

--- a/chia/wallet/puzzles/custody/custody_architecture.py
+++ b/chia/wallet/puzzles/custody/custody_architecture.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, replace
 from typing import ClassVar, Dict, List, Literal, Mapping, Optional, Protocol, Tuple, TypeVar, Union
 
 from typing_extensions import runtime_checkable
-
+from chia_rs import G1Element
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
@@ -18,6 +18,9 @@ OneOfN_MOD = load_clvm_maybe_recompile(
 )
 NofN_MOD = load_clvm_maybe_recompile(
     "n_of_n.clsp", package_or_requirement="chia.wallet.puzzles.custody.optimization_puzzles"
+)
+BLS_MEMBER_MOD = load_clvm_maybe_recompile(
+    "bls_member.clsp", package_or_requirement="chia.wallet.puzzles.custody.member_puzzles"
 )
 RESTRICTION_MOD = load_clvm_maybe_recompile(
     "restrictions.clsp", package_or_requirement="chia.wallet.puzzles.custody.architecture_puzzles"
@@ -221,6 +224,16 @@ class MofN:  # Technically matches Puzzle protocol but is a bespoke part of the 
         else:
             return self.puzzle(nonce).get_tree_hash()
 
+
+@dataclass(frozen=True)
+class BLSMember:
+    public_key: G1Element
+
+    def puzzle(self) -> Program:
+        return BLS_MEMBER_MOD.curry(self.public_key)
+
+    def puzzle_hash(self) -> bytes32:
+        return self.puzzle().get_tree_hash()
 
 # The top-level object inside every "outer" puzzle
 @dataclass(frozen=True)

--- a/chia/wallet/puzzles/custody/custody_architecture.py
+++ b/chia/wallet/puzzles/custody/custody_architecture.py
@@ -401,7 +401,7 @@ class PuzzleWithRestrictions:
     def solve(
         self,
         member_validator_solutions: List[Program],  # solution for the restriction puzzle
-        dpuz_validator_solutions: List[Program],  #
+        dpuz_validator_solutions: List[Program],
         member_solution: Program,
         delegated_puzzle_and_solution: Optional[Tuple[Program, Program]] = None,
     ) -> Program:

--- a/chia/wallet/puzzles/custody/custody_architecture.py
+++ b/chia/wallet/puzzles/custody/custody_architecture.py
@@ -20,9 +20,6 @@ OneOfN_MOD = load_clvm_maybe_recompile(
 NofN_MOD = load_clvm_maybe_recompile(
     "n_of_n.clsp", package_or_requirement="chia.wallet.puzzles.custody.optimization_puzzles"
 )
-BLS_MEMBER_MOD = load_clvm_maybe_recompile(
-    "bls_member.clsp", package_or_requirement="chia.wallet.puzzles.custody.member_puzzles"
-)
 RESTRICTION_MOD = load_clvm_maybe_recompile(
     "restrictions.clsp", package_or_requirement="chia.wallet.puzzles.custody.architecture_puzzles"
 )
@@ -210,7 +207,7 @@ class MofN:  # Technically matches Puzzle protocol but is a bespoke part of the 
     def memo(self, nonce: int) -> Program:  # pragma: no cover
         raise NotImplementedError("PuzzleWithRestrictions handles MofN memos, this method should not be called")
 
-    def puzzle(self, _nonce: int) -> Program:
+    def puzzle(self, nonce: int) -> Program:
         if self.m == self.n:
             return NofN_MOD.curry([member.puzzle_reveal(_top_level=False) for member in self.members])
         elif self.m > 1:
@@ -224,17 +221,6 @@ class MofN:  # Technically matches Puzzle protocol but is a bespoke part of the 
             return NofN_MOD.curry(member_hashes).get_tree_hash_precalc(*member_hashes)
         else:
             return self.puzzle(nonce).get_tree_hash()
-
-
-@dataclass(frozen=True)
-class BLSMember:
-    public_key: G1Element
-
-    def puzzle(self, _nonce) -> Program:
-        return BLS_MEMBER_MOD.curry(bytes(self.public_key))
-
-    def puzzle_hash(self, nonce) -> bytes32:
-        return self.puzzle(nonce).get_tree_hash()
 
 
 # The top-level object inside every "outer" puzzle

--- a/chia/wallet/puzzles/custody/custody_architecture.py
+++ b/chia/wallet/puzzles/custody/custody_architecture.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from typing import ClassVar, Dict, List, Literal, Mapping, Optional, Protocol, Tuple, TypeVar, Union
 
-from chia_rs import G1Element
 from typing_extensions import runtime_checkable
 
 from chia.types.blockchain_format.program import Program

--- a/chia/wallet/puzzles/custody/custody_architecture.py
+++ b/chia/wallet/puzzles/custody/custody_architecture.py
@@ -209,7 +209,7 @@ class MofN:  # Technically matches Puzzle protocol but is a bespoke part of the 
     def memo(self, nonce: int) -> Program:  # pragma: no cover
         raise NotImplementedError("PuzzleWithRestrictions handles MofN memos, this method should not be called")
 
-    def puzzle(self, nonce: int) -> Program:
+    def puzzle(self, _nonce: int) -> Program:
         if self.m == self.n:
             return NofN_MOD.curry([member.puzzle_reveal(_top_level=False) for member in self.members])
         elif self.m > 1:
@@ -229,11 +229,11 @@ class MofN:  # Technically matches Puzzle protocol but is a bespoke part of the 
 class BLSMember:
     public_key: G1Element
 
-    def puzzle(self) -> Program:
-        return BLS_MEMBER_MOD.curry(self.public_key)
+    def puzzle(self, _nonce) -> Program:
+        return BLS_MEMBER_MOD.curry(bytes(self.public_key))
 
-    def puzzle_hash(self) -> bytes32:
-        return self.puzzle().get_tree_hash()
+    def puzzle_hash(self, nonce) -> bytes32:
+        return self.puzzle(nonce).get_tree_hash()
 
 # The top-level object inside every "outer" puzzle
 @dataclass(frozen=True)
@@ -413,8 +413,8 @@ class PuzzleWithRestrictions:
 
     def solve(
         self,
-        member_validator_solutions: List[Program],
-        dpuz_validator_solutions: List[Program],
+        member_validator_solutions: List[Program],  # solution for the restriction puzzle
+        dpuz_validator_solutions: List[Program],  # 
         member_solution: Program,
         delegated_puzzle_and_solution: Optional[Tuple[Program, Program]] = None,
     ) -> Program:

--- a/chia/wallet/puzzles/custody/member_puzzles/bls_member.clsp
+++ b/chia/wallet/puzzles/custody/member_puzzles/bls_member.clsp
@@ -1,4 +1,4 @@
-; this puzzle belongs inside an M of N puzzle following the Standardised Inner Puzzle Spec SIPS01
+; this puzzle follows the Managed Inner Puzzle Spec MIPS01 as a Member Puzzle
 ; this code offers a secure approval of a delegated puzzle passed in as a Truth to be run elsewhere
 
 (mod (PUBLIC_KEY Delegated_Puzzle)  ; delegated puzzle is passed in from the above M of N layer

--- a/chia/wallet/puzzles/custody/member_puzzles/bls_member.clsp
+++ b/chia/wallet/puzzles/custody/member_puzzles/bls_member.clsp
@@ -1,5 +1,5 @@
 ; this puzzle belongs inside an M of N puzzle following the Standardised Inner Puzzle Spec SIPS01
-; this code just offers a secure approval of a delegated puzzle to be run elsewhere which will generate the majority of condition_codes
+; this code offers a secure approval of a delegated puzzle passed in as a Truth to be run elsewhere
 
 (mod (PUBLIC_KEY Delegated_Puzzle)  ; delegated puzzle is passed in from the above M of N layer
     (include condition_codes.clib)

--- a/chia/wallet/puzzles/custody/member_puzzles/bls_member.clsp
+++ b/chia/wallet/puzzles/custody/member_puzzles/bls_member.clsp
@@ -2,7 +2,7 @@
 ; this code offers a secure approval of a delegated puzzle passed in as a Truth to be run elsewhere
 
 (mod (PUBLIC_KEY Delegated_Puzzle)  ; delegated puzzle is passed in from the above M of N layer
-    (include condition_codes.clib)
+  (include condition_codes.clib)
 
-    (list (list AGG_SIG_ME PUBLIC_KEY Delegated_Puzzle))
+  (list (list AGG_SIG_ME PUBLIC_KEY Delegated_Puzzle))
 )

--- a/chia/wallet/puzzles/custody/member_puzzles/bls_member.clsp
+++ b/chia/wallet/puzzles/custody/member_puzzles/bls_member.clsp
@@ -1,0 +1,8 @@
+; this puzzle belongs inside an M of N puzzle following the Standardised Inner Puzzle Spec SIPS01
+; this code just offers a secure approval of a delegated puzzle to be run elsewhere which will generate the majority of condition_codes
+
+(mod (PUBLIC_KEY Delegated_Puzzle)  ; delegated puzzle is passed in from the above M of N layer
+    (include condition_codes.clib)
+
+    (list (list AGG_SIG_ME PUBLIC_KEY Delegated_Puzzle))
+)

--- a/chia/wallet/puzzles/custody/member_puzzles/bls_member.clsp.hex
+++ b/chia/wallet/puzzles/custody/member_puzzles/bls_member.clsp.hex
@@ -1,0 +1,1 @@
+ff02ffff01ff04ffff04ff02ffff04ff05ffff04ff0bff80808080ff8080ffff04ffff0132ff018080

--- a/chia/wallet/puzzles/custody/member_puzzles/member_puzzles.py
+++ b/chia/wallet/puzzles/custody/member_puzzles/member_puzzles.py
@@ -19,7 +19,7 @@ class BLSMember(Puzzle):
     public_key: G1Element
 
     def memo(self, nonce: int) -> Program:
-        return Program.to(bytes(self.public_key))
+        return Program.to(0)
 
     def puzzle(self, nonce: int) -> Program:
         return BLS_MEMBER_MOD.curry(bytes(self.public_key))

--- a/chia/wallet/puzzles/custody/member_puzzles/member_puzzles.py
+++ b/chia/wallet/puzzles/custody/member_puzzles/member_puzzles.py
@@ -6,6 +6,7 @@ from chia_rs import G1Element
 
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.wallet.puzzles.custody.custody_architecture import Puzzle
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
 
 BLS_MEMBER_MOD = load_clvm_maybe_recompile(
@@ -14,11 +15,14 @@ BLS_MEMBER_MOD = load_clvm_maybe_recompile(
 
 
 @dataclass(frozen=True)
-class BLSMember:
+class BLSMember(Puzzle):
     public_key: G1Element
 
-    def puzzle(self, nonce) -> Program:
+    def memo(self, nonce: int) -> Program:
+        return Program.to(bytes(self.public_key))
+
+    def puzzle(self, nonce: int) -> Program:
         return BLS_MEMBER_MOD.curry(bytes(self.public_key))
 
-    def puzzle_hash(self, nonce) -> bytes32:
+    def puzzle_hash(self, nonce: int) -> bytes32:
         return self.puzzle(nonce).get_tree_hash()

--- a/chia/wallet/puzzles/custody/member_puzzles/member_puzzles.py
+++ b/chia/wallet/puzzles/custody/member_puzzles/member_puzzles.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from chia_rs import G1Element
+
+from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
+
+BLS_MEMBER_MOD = load_clvm_maybe_recompile(
+    "bls_member.clsp", package_or_requirement="chia.wallet.puzzles.custody.member_puzzles"
+)
+
+
+@dataclass(frozen=True)
+class BLSMember:
+    public_key: G1Element
+
+    def puzzle(self, nonce) -> Program:
+        return BLS_MEMBER_MOD.curry(bytes(self.public_key))
+
+    def puzzle_hash(self, nonce) -> bytes32:
+        return self.puzzle(nonce).get_tree_hash()

--- a/chia/wallet/puzzles/deployed_puzzle_hashes.json
+++ b/chia/wallet/puzzles/deployed_puzzle_hashes.json
@@ -2,7 +2,7 @@
   "1_of_n": "bcb9aa74893bebcfa2da87271b0330bf2773b6391144ae72262b6824d9c55939",
   "augmented_condition": "d303eafa617bedf0bc05850dd014e10fbddf622187dc07891a2aacba9d8a93f6",
   "block_program_zero": "f0a38c8efe58895ae527c65c37f700a4238504691b83990e5dd91bd8b3c30eae",
-  "bls_member": "9fe5ef266f747bc82ca42e53b6e241d628da90690b6639be4cb922ce468a99e4",
+  "bls_member": "21a3ae8b3ce64d41ca98d6d8df8f465c9e1bfb19ab40284a5da8479ba7fade78",
   "cat_v2": "37bef360ee858133b69d595a906dc45d01af50379dad515eb9518abb7c1d2a7a",
   "chialisp_deserialisation": "94ec19077f9a34e0b11ad2456af0170f4cc03f11230ca42e3f82e6e644ac4f5d",
   "conditions_w_fee_announce": "1a169582dc619f2542f8eb79f02823e1595ba0aca53820f503eda5ff20b47856",

--- a/chia/wallet/puzzles/deployed_puzzle_hashes.json
+++ b/chia/wallet/puzzles/deployed_puzzle_hashes.json
@@ -2,7 +2,7 @@
   "1_of_n": "bcb9aa74893bebcfa2da87271b0330bf2773b6391144ae72262b6824d9c55939",
   "augmented_condition": "d303eafa617bedf0bc05850dd014e10fbddf622187dc07891a2aacba9d8a93f6",
   "block_program_zero": "f0a38c8efe58895ae527c65c37f700a4238504691b83990e5dd91bd8b3c30eae",
-  "bls_member": "8f3b8d280c083b126a654c8c264e048b1f2528cceae5b0088951eaef852a7c80",
+  "bls_member": "9fe5ef266f747bc82ca42e53b6e241d628da90690b6639be4cb922ce468a99e4",
   "cat_v2": "37bef360ee858133b69d595a906dc45d01af50379dad515eb9518abb7c1d2a7a",
   "chialisp_deserialisation": "94ec19077f9a34e0b11ad2456af0170f4cc03f11230ca42e3f82e6e644ac4f5d",
   "conditions_w_fee_announce": "1a169582dc619f2542f8eb79f02823e1595ba0aca53820f503eda5ff20b47856",

--- a/chia/wallet/puzzles/deployed_puzzle_hashes.json
+++ b/chia/wallet/puzzles/deployed_puzzle_hashes.json
@@ -2,6 +2,7 @@
   "1_of_n": "bcb9aa74893bebcfa2da87271b0330bf2773b6391144ae72262b6824d9c55939",
   "augmented_condition": "d303eafa617bedf0bc05850dd014e10fbddf622187dc07891a2aacba9d8a93f6",
   "block_program_zero": "f0a38c8efe58895ae527c65c37f700a4238504691b83990e5dd91bd8b3c30eae",
+  "bls_member": "8f3b8d280c083b126a654c8c264e048b1f2528cceae5b0088951eaef852a7c80",
   "cat_v2": "37bef360ee858133b69d595a906dc45d01af50379dad515eb9518abb7c1d2a7a",
   "chialisp_deserialisation": "94ec19077f9a34e0b11ad2456af0170f4cc03f11230ca42e3f82e6e644ac4f5d",
   "conditions_w_fee_announce": "1a169582dc619f2542f8eb79f02823e1595ba0aca53820f503eda5ff20b47856",


### PR DESCRIPTION

### Purpose:

Adds the BLSMember puzzle which simply has a curried key and then returns an `AGG_SIG_ME` of the delegated puzzle hash which is passed in as a Truth.

### Testing Notes:

added a new test called `test_2_of_4_bls_members` in `test_custody_architecture.py`
