### PR TITLE
CHIA-1663 Simplify duplicate output validation in validate_block_body

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -359,8 +359,8 @@ async def validate_block_body(
 
     # 13. Check for duplicate outputs in additions
     addition_counter = collections.Counter(coin_name for _, coin_name in additions + coinbase_additions)
-    for k, v in addition_counter.items():
-        if v > 1:
+    for count in addition_counter.values():
+        if count > 1:
             return Err.DUPLICATE_OUTPUT, None
 
     # 14. Check for duplicate spends inside block


### PR DESCRIPTION
### Purpose:

When checking for duplicate outputs, we only need to check the values here, not the keys.

### Current Behavior:

We iterate through key value pairs in order to check for duplicate outputs inside a block. 

### New Behavior:

We iterate through values in order to do that check.