### PR TITLE
move add_blocks_in_batches() out of tests

### DIFF
--- a/chia/_tests/blockchain/test_blockchain_transactions.py
+++ b/chia/_tests/blockchain/test_blockchain_transactions.py
@@ -7,10 +7,10 @@ from clvm.casts import int_to_bytes
 
 from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from chia._tests.util.generator_tools_testing import run_and_get_removals_and_additions
-from chia._tests.util.misc import add_blocks_in_batches
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols import wallet_protocol
 from chia.server.server import ChiaServer
+from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.simulator.block_tools import BlockTools, test_constants
 from chia.simulator.wallet_tools import WalletTool
 from chia.types.blockchain_format.sized_bytes import bytes32

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -20,7 +20,7 @@ from chia._tests.connection_utils import add_dummy_connection, connect_and_get_p
 from chia._tests.core.full_node.stores.test_coin_store import get_future_reward_coins
 from chia._tests.core.make_block_generator import make_spend_bundle
 from chia._tests.core.node_height import node_height_at_least
-from chia._tests.util.misc import add_blocks_in_batches, wallet_height_at_least
+from chia._tests.util.misc import wallet_height_at_least
 from chia._tests.util.setup_nodes import SimulatorsAndWalletsServices
 from chia._tests.util.time_out_assert import time_out_assert, time_out_assert_custom_interval, time_out_messages
 from chia.consensus.block_body_validation import ForkInfo
@@ -40,6 +40,7 @@ from chia.protocols.wallet_protocol import SendTransaction, TransactionAck
 from chia.server.address_manager import AddressManager
 from chia.server.outbound_message import Message, NodeType
 from chia.server.server import ChiaServer
+from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.simulator.block_tools import BlockTools, create_block_tools_async, get_signage_point, make_unfinished_block
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.keyring import TempKeyring

--- a/chia/_tests/core/mempool/test_mempool_performance.py
+++ b/chia/_tests/core/mempool/test_mempool_performance.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import pytest
 
-from chia._tests.util.misc import BenchmarkRunner, add_blocks_in_batches, wallet_height_at_least
+from chia._tests.util.misc import BenchmarkRunner, wallet_height_at_least
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
 from chia._tests.util.time_out_assert import time_out_assert
+from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.types.full_block import FullBlock
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.peer_info import PeerInfo

--- a/chia/_tests/core/test_full_node_rpc.py
+++ b/chia/_tests/core/test_full_node_rpc.py
@@ -9,7 +9,6 @@ from chia import __version__
 from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from chia._tests.conftest import ConsensusMode
 from chia._tests.connection_utils import connect_and_get_peer
-from chia._tests.util.misc import add_blocks_in_batches
 from chia._tests.util.rpc import validate_get_routes
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.block_record import BlockRecord
@@ -19,6 +18,7 @@ from chia.protocols import full_node_protocol
 from chia.rpc.full_node_rpc_api import get_average_block_time, get_nearest_transaction_block
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
 from chia.server.outbound_message import NodeType
+from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.simulator.block_tools import get_signage_point
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, ReorgProtocol
 from chia.simulator.wallet_tools import WalletTool

--- a/chia/_tests/util/misc.py
+++ b/chia/_tests/util/misc.py
@@ -33,19 +33,11 @@ from chia_rs import Coin
 import chia
 import chia._tests
 from chia._tests import ether
-from chia._tests.connection_utils import add_dummy_connection
 from chia._tests.core.data_layer.util import ChiaRoot
 from chia._tests.util.time_out_assert import DataTypeProtocol, caller_file_and_line
-from chia.consensus.block_body_validation import ForkInfo
-from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
-from chia.full_node.full_node import FullNode, PeakPostProcessingResult
 from chia.full_node.mempool import Mempool
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
-from chia.types.full_block import FullBlock
-from chia.types.peer_info import PeerInfo
-from chia.types.validation_state import ValidationState
-from chia.util.batches import to_batches
 from chia.util.hash import std_hash
 from chia.util.ints import uint16, uint32, uint64
 from chia.util.network import WebServer
@@ -638,49 +630,3 @@ class ComparableEnum(Enum):
             return NotImplemented
 
         return self.value.__ge__(other.value)
-
-
-async def add_blocks_in_batches(
-    blocks: list[FullBlock],
-    full_node: FullNode,
-    header_hash: Optional[bytes32] = None,
-) -> None:
-    if header_hash is None:
-        diff = full_node.constants.DIFFICULTY_STARTING
-        ssi = full_node.constants.SUB_SLOT_ITERS_STARTING
-        fork_height = -1
-        fork_info = ForkInfo(-1, fork_height, full_node.constants.GENESIS_CHALLENGE)
-    else:
-        block_record = await full_node.blockchain.get_block_record_from_db(header_hash)
-        assert block_record is not None
-        ssi, diff = get_next_sub_slot_iters_and_difficulty(
-            full_node.constants, True, block_record, full_node.blockchain
-        )
-        fork_height = block_record.height
-        fork_info = ForkInfo(block_record.height, fork_height, block_record.header_hash)
-
-    _, dummy_node_id = await add_dummy_connection(full_node.server, "127.0.0.1", 12315)
-    dummy_peer = full_node.server.all_connections[dummy_node_id]
-    vs = ValidationState(ssi, diff, None)
-
-    for block_batch in to_batches(blocks, 64):
-        b = block_batch.entries[0]
-        if (b.height % 128) == 0:
-            print(f"main chain: {b.height:4} weight: {b.weight}")
-        # vs is updated by the call to add_block_batch()
-        success, state_change_summary, err = await full_node.add_block_batch(
-            block_batch.entries,
-            PeerInfo("0.0.0.0", 0),
-            fork_info,
-            vs,
-        )
-        assert err is None
-        assert success is True
-        if state_change_summary is not None:
-            peak_fb: Optional[FullBlock] = await full_node.blockchain.get_full_peak()
-            assert peak_fb is not None
-            ppp_result: PeakPostProcessingResult = await full_node.peak_post_processing(
-                peak_fb, state_change_summary, dummy_peer
-            )
-            await full_node.peak_post_processing_2(peak_fb, dummy_peer, state_change_summary, ppp_result)
-    await full_node._finish_sync()

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -15,7 +15,7 @@ from colorlog import getLogger
 
 from chia._tests.connection_utils import disconnect_all, disconnect_all_and_reconnect
 from chia._tests.util.blockchain_mock import BlockchainMock
-from chia._tests.util.misc import add_blocks_in_batches, wallet_height_at_least
+from chia._tests.util.misc import wallet_height_at_least
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
 from chia._tests.util.time_out_assert import time_out_assert, time_out_assert_not_none
 from chia._tests.weight_proof.test_weight_proof import load_blocks_dont_validate
@@ -37,6 +37,7 @@ from chia.protocols.wallet_protocol import (
 )
 from chia.server.outbound_message import Message, make_msg
 from chia.server.ws_connection import WSChiaConnection
+from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32

--- a/chia/_tests/wallet/test_wallet_blockchain.py
+++ b/chia/_tests/wallet/test_wallet_blockchain.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import pytest
 
 from chia._tests.util.db_connection import DBConnection
-from chia._tests.util.misc import add_blocks_in_batches
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
 from chia.consensus.blockchain import AddBlockResult
 from chia.protocols import full_node_protocol
+from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.types.blockchain_format.vdf import VDFProof
 from chia.types.full_block import FullBlock
 from chia.types.header_block import HeaderBlock

--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -10,13 +10,14 @@ from typing import Any, Optional
 import pytest
 from chia_rs import G1Element, PrivateKey
 
-from chia._tests.util.misc import CoinGenerator, add_blocks_in_batches
+from chia._tests.util.misc import CoinGenerator
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.protocols import wallet_protocol
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.wallet_protocol import CoinState
 from chia.server.outbound_message import Message, make_msg
+from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.simulator.block_tools import test_constants
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32

--- a/chia/simulator/add_blocks_in_batches.py
+++ b/chia/simulator/add_blocks_in_batches.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from chia.consensus.block_body_validation import ForkInfo
+from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
+from chia.full_node.full_node import FullNode, PeakPostProcessingResult
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.full_block import FullBlock
+from chia.types.peer_info import PeerInfo
+from chia.types.validation_state import ValidationState
+from chia.util.batches import to_batches
+
+
+async def add_blocks_in_batches(
+    blocks: list[FullBlock],
+    full_node: FullNode,
+    header_hash: Optional[bytes32] = None,
+) -> None:
+    if header_hash is None:
+        diff = full_node.constants.DIFFICULTY_STARTING
+        ssi = full_node.constants.SUB_SLOT_ITERS_STARTING
+        fork_height = -1
+        fork_info = ForkInfo(-1, fork_height, full_node.constants.GENESIS_CHALLENGE)
+    else:
+        block_record = await full_node.blockchain.get_block_record_from_db(header_hash)
+        assert block_record is not None
+        ssi, diff = get_next_sub_slot_iters_and_difficulty(
+            full_node.constants, True, block_record, full_node.blockchain
+        )
+        fork_height = block_record.height
+        fork_info = ForkInfo(block_record.height, fork_height, block_record.header_hash)
+
+    vs = ValidationState(ssi, diff, None)
+
+    for block_batch in to_batches(blocks, 64):
+        b = block_batch.entries[0]
+        if (b.height % 128) == 0:
+            print(f"main chain: {b.height:4} weight: {b.weight}")
+        # vs is updated by the call to add_block_batch()
+        success, state_change_summary, err = await full_node.add_block_batch(
+            block_batch.entries,
+            PeerInfo("0.0.0.0", 0),
+            fork_info,
+            vs,
+        )
+        assert err is None
+        assert success is True
+        if state_change_summary is not None:
+            peak_fb: Optional[FullBlock] = await full_node.blockchain.get_full_peak()
+            assert peak_fb is not None
+            ppp_result: PeakPostProcessingResult = await full_node.peak_post_processing(
+                peak_fb, state_change_summary, None
+            )
+            await full_node.peak_post_processing_2(peak_fb, None, state_change_summary, ppp_result)
+    await full_node._finish_sync()

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -8,7 +8,6 @@ from typing import Any, Optional, Union
 
 import anyio
 
-from chia._tests.util.misc import add_blocks_in_batches
 from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
@@ -18,6 +17,7 @@ from chia.full_node.full_node import FullNode
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.rpc.rpc_server import default_get_connections
 from chia.server.outbound_message import NodeType
+from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, GetAllCoinsProtocol, ReorgProtocol
 from chia.types.blockchain_format.coin import Coin


### PR DESCRIPTION
since the node simulator depends on it.

This is what's causing CI to be red currently, the dependency from production code on tests.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

Fix CI, and the dependency cycle.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
