### PR TITLE
use signed integers for keys and values

### DIFF
--- a/chia/_tests/core/data_layer/test_merkle_blob.py
+++ b/chia/_tests/core/data_layer/test_merkle_blob.py
@@ -210,16 +210,16 @@ def generate_kvid(seed: int) -> Tuple[KVId, KVId]:
     kv_ids: List[KVId] = []
 
     for offset in range(2):
-        seed_bytes = (2 * seed + offset).to_bytes(8, byteorder="big")
+        seed_bytes = (2 * seed + offset).to_bytes(8, byteorder="big", signed=True)
         hash_obj = hashlib.sha256(seed_bytes)
-        hash_int = int.from_bytes(hash_obj.digest()[:8], byteorder="big")
+        hash_int = int.from_bytes(hash_obj.digest()[:8], byteorder="big", signed=True)
         kv_ids.append(KVId(hash_int))
 
     return kv_ids[0], kv_ids[1]
 
 
 def generate_hash(seed: int) -> bytes:
-    seed_bytes = seed.to_bytes(8, byteorder="big")
+    seed_bytes = seed.to_bytes(8, byteorder="big", signed=True)
     hash_obj = hashlib.sha256(seed_bytes)
     return hash_obj.digest()
 

--- a/chia/data_layer/util/merkle_blob.py
+++ b/chia/data_layer/util/merkle_blob.py
@@ -360,7 +360,7 @@ class MerkleBlob:
             self.last_allocated_index = TreeIndex(1)
             return
 
-        seed = std_hash(key.to_bytes(8, byteorder="big"))
+        seed = std_hash(key.to_bytes(8, byteorder="big", signed=True))
         if reference_kid is None:
             old_leaf: RawMerkleNodeProtocol = self.get_random_leaf_node(bytes(seed))
         else:
@@ -643,7 +643,7 @@ class RawLeafMerkleNode:
     type: ClassVar[NodeType] = NodeType.leaf
     # TODO: make a check for this?
     # must match attribute type and order such that cls(*struct.unpack(cls.format, blob) works
-    struct: ClassVar[struct.Struct] = struct.Struct(">32sIQQ")
+    struct: ClassVar[struct.Struct] = struct.Struct(">32sIqq")
 
     hash: bytes
     parent: TreeIndex


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

key and value ids are intended to be their corresponding sqlite row id.  sqlite uses signed 64 for this as i understand it.  let's do the same.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
