### PR TITLE
CHIA-1669 Simplify tx_additions and tx_removals in validate_block_merkle_roots

### DIFF
--- a/chia/consensus/block_root_validation.py
+++ b/chia/consensus/block_root_validation.py
@@ -12,14 +12,9 @@ from chia.util.errors import Err
 def validate_block_merkle_roots(
     block_additions_root: bytes32,
     block_removals_root: bytes32,
-    tx_additions: Optional[list[tuple[Coin, bytes32]]] = None,
-    tx_removals: Optional[list[bytes32]] = None,
+    tx_additions: list[tuple[Coin, bytes32]],
+    tx_removals: list[bytes32],
 ) -> Optional[Err]:
-    if tx_removals is None:
-        tx_removals = []
-    if tx_additions is None:
-        tx_additions = []
-
     # Create addition Merkle set
     puzzlehash_coins_map: dict[bytes32, list[bytes32]] = {}
 


### PR DESCRIPTION
### Purpose:

Considering we always pass `tx_additions` and `tx_removals` to `validate_block_merkle_roots` as lists, there is no need to account for (and handle) optionality here.

### Current Behavior:

`validate_block_merkle_roots` expects `tx_additions` and `tx_removals` to be optional lists.

### New Behavior:

`validate_block_merkle_roots` expects `tx_additions` and `tx_removals` to be lists.