### PR TITLE
Specifically use bash to run setup-poetry.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -168,7 +168,7 @@ if [ "$OPENSSL_VERSION_INT" -lt "269488367" ]; then
   echo "Your OS may have patched OpenSSL and not updated the version to 1.1.1n"
 fi
 
-./setup-poetry.sh -c "${INSTALL_PYTHON_PATH}"
+bash ./setup-poetry.sh -c "${INSTALL_PYTHON_PATH}"
 .penv/bin/poetry env use "${INSTALL_PYTHON_PATH}"
 # shellcheck disable=SC2086
 .penv/bin/poetry install ${EXTRAS}


### PR DESCRIPTION
I noticed this specifically on FreeBSD - even though setup-poetry.sh is marked executable, the install script was complaining about being unable to find it with error `install.sh: ./setup-poetry.sh: not found`

This solved it and should not have any negative impact on other platforms I don't think

Optionally PR #18762 is another way to solve this - the internet suggest `#!/usr/bin/env bash` is more cross-platform