### PR TITLE
Use #!/usr/bin/env bash

### DIFF
--- a/activated.sh
+++ b/activated.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -o errexit
 

--- a/build_scripts/build_license_directory.sh
+++ b/build_scripts/build_license_directory.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+ #!/usr/bin/env bash
 
 # PULL IN LICENSES USING NPM - LICENSE CHECKER
 npm install -g license-checker

--- a/build_scripts/build_license_directory.sh
+++ b/build_scripts/build_license_directory.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # PULL IN LICENSES USING NPM - LICENSE CHECKER
 npm install -g license-checker

--- a/build_scripts/build_linux_deb-1-gui.sh
+++ b/build_scripts/build_linux_deb-1-gui.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -o errexit
 

--- a/build_scripts/build_linux_deb-1-gui.sh
+++ b/build_scripts/build_linux_deb-1-gui.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+ #!/usr/bin/env bash
 
 set -o errexit
 

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -o errexit
 

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+ #!/usr/bin/env bash
 
 set -o errexit
 

--- a/build_scripts/build_linux_rpm-1-gui.sh
+++ b/build_scripts/build_linux_rpm-1-gui.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -o errexit
 

--- a/build_scripts/build_linux_rpm-1-gui.sh
+++ b/build_scripts/build_linux_rpm-1-gui.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+ #!/usr/bin/env bash
 
 set -o errexit
 

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -o errexit
 

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+ #!/usr/bin/env bash
 
 set -o errexit
 

--- a/build_scripts/build_macos-1-gui.sh
+++ b/build_scripts/build_macos-1-gui.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -o errexit -o nounset
 

--- a/build_scripts/build_macos-1-gui.sh
+++ b/build_scripts/build_macos-1-gui.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+ #!/usr/bin/env bash
 
 set -o errexit -o nounset
 

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -o errexit -o nounset
 

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+ #!/usr/bin/env bash
 
 set -o errexit -o nounset
 

--- a/build_scripts/build_win_license_dir.sh
+++ b/build_scripts/build_win_license_dir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+ #!/usr/bin/env bash
 
 # PULL IN LICENSES USING NPM - LICENSE CHECKER
 npm install -g license-checker

--- a/build_scripts/build_win_license_dir.sh
+++ b/build_scripts/build_win_license_dir.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # PULL IN LICENSES USING NPM - LICENSE CHECKER
 npm install -g license-checker

--- a/build_scripts/clean-runner.sh
+++ b/build_scripts/clean-runner.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 # Cleans up files/directories that may be left over from previous runs for a clean slate before starting a new build
 
 set -o errexit

--- a/build_scripts/clean-runner.sh
+++ b/build_scripts/clean-runner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+ #!/usr/bin/env bash
 # Cleans up files/directories that may be left over from previous runs for a clean slate before starting a new build
 
 set -o errexit

--- a/install-gui.sh
+++ b/install-gui.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -o errexit
 

--- a/install-gui.sh
+++ b/install-gui.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+ #!/usr/bin/env bash
 
 set -o errexit
 

--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -o errexit
 

--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+ #!/usr/bin/env bash
 
 set -o errexit
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 

--- a/setup-poetry.sh
+++ b/setup-poetry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 

--- a/start-gui.sh
+++ b/start-gui.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -o errexit
 

--- a/start-gui.sh
+++ b/start-gui.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+ #!/usr/bin/env bash
 
 set -o errexit
 

--- a/tools/run_benchmark.sh
+++ b/tools/run_benchmark.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # pass in the name of the test run as the first argument
 


### PR DESCRIPTION
After some testing on FreeBSD, which doesn't have `/bin/bash` - the wisdom of the internet suggests that using a shebang of `#!/usr/bin/env bash` is more cross-platform - and indeed this does work on FreeBSD and the other supported platforms (of course bash does have to exist somewhere in the path)

Apparently this is not guaranteed as some very esoteric systems have `/bin/env` but this is more cross platform than expecting`/bin/bash`