### PR TITLE
remove unnecessary use of `.__members__` on `ConditionOpcode` iteration

### DIFF
--- a/chia/_tests/clvm/test_condition_codes.py
+++ b/chia/_tests/clvm/test_condition_codes.py
@@ -9,5 +9,5 @@ from chia.types.condition_opcodes import ConditionOpcode
 def test_condition_codes_is_complete() -> None:
     condition_codes_path = importlib_resources.files("chia.wallet.puzzles").joinpath("condition_codes.clib")
     contents = condition_codes_path.read_text(encoding="utf-8")
-    for name, value in ConditionOpcode.__members__.items():
-        assert f"(defconstant {name} {int_from_bytes(value)})" in contents
+    for opcode in ConditionOpcode:
+        assert f"(defconstant {opcode.name} {int_from_bytes(opcode.value)})" in contents

--- a/chia/wallet/util/debug_spend_bundle.py
+++ b/chia/wallet/util/debug_spend_bundle.py
@@ -12,7 +12,7 @@ from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_fo
 from chia.util.hash import std_hash
 from chia.wallet.uncurried_puzzle import UncurriedPuzzle
 
-CONDITIONS = {k: bytes(v)[0] for k, v in ConditionOpcode.__members__.items()}  # pylint: disable=E1101
+CONDITIONS = {opcode.name: opcode.value[0] for opcode in ConditionOpcode}
 KFA = {v: k for k, v in CONDITIONS.items()}
 
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

```python-console
>>> from chia.types.condition_opcodes import ConditionOpcode
>>> list(ConditionOpcode)[0]
<ConditionOpcode.AGG_SIG_PARENT: b'+'>
>>> list(ConditionOpcode.__members__.items())[0]
('AGG_SIG_PARENT', <ConditionOpcode.AGG_SIG_PARENT: b'+'>)
>>> opcode = list(ConditionOpcode)[0]
>>> opcode.name
'AGG_SIG_PARENT'
>>> opcode.value
b'+'
```

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
