### PR TITLE
[CHIA-1673] Comment out a manual `._finish_sync()` call

### DIFF
--- a/chia/simulator/add_blocks_in_batches.py
+++ b/chia/simulator/add_blocks_in_batches.py
@@ -55,3 +55,8 @@ async def add_blocks_in_batches(
                 peak_fb, state_change_summary, None
             )
             await full_node.peak_post_processing_2(peak_fb, None, state_change_summary, ppp_result)
+    # this is commented out because we already call post_processing_peak2 which already sends
+    # the peak to the wallet this causes finish_sync to resend a peak the wallet already received
+    # that will cause the wallet to reorg the peak (even though its redundant) which causes it to
+    # go out of sync momentarily. When this redundant behavior is fixed, this line can be uncommented.
+    # await full_node._finish_sync()

--- a/chia/simulator/add_blocks_in_batches.py
+++ b/chia/simulator/add_blocks_in_batches.py
@@ -55,4 +55,3 @@ async def add_blocks_in_batches(
                 peak_fb, state_change_summary, None
             )
             await full_node.peak_post_processing_2(peak_fb, None, state_change_summary, ppp_result)
-    await full_node._finish_sync()


### PR DESCRIPTION
Some wallet tests were turning flaky around this call being in.  @almogdepaz says it's due to a revealed bug in the wallet sync process that he intends to fix.  For now, we'll comment this out to help test flakiness.