### PR TITLE
Logging changes for feeler connections

### DIFF
--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -510,7 +510,8 @@ class ChiaServer:
             if e.code == Err.INVALID_HANDSHAKE:
                 if is_feeler:
                     self.log.warning(
-                        f"Invalid handshake with peer {target_node} during feeler connection. Maybe the peer is running old software."
+                        f"Invalid handshake with peer {target_node} during feeler connection. "
+                        f"Maybe the peer is running old software."
                     )
                 else:
                     self.log.warning(

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -509,12 +509,18 @@ class ChiaServer:
                 await connection.close(self.invalid_protocol_ban_seconds, WSCloseCode.PROTOCOL_ERROR, e.code)
             if e.code == Err.INVALID_HANDSHAKE:
                 if is_feeler:
-                    self.log.warning(f"Invalid handshake with peer {target_node} during feeler connection. Maybe the peer is running old software.")
+                    self.log.warning(
+                        f"Invalid handshake with peer {target_node} during feeler connection. Maybe the peer is running old software."
+                    )
                 else:
-                    self.log.warning(f"Invalid handshake with peer {target_node}. Maybe the peer is running old software.")
+                    self.log.warning(
+                        f"Invalid handshake with peer {target_node}. Maybe the peer is running old software."
+                    )
             elif e.code == Err.INCOMPATIBLE_NETWORK_ID:
                 if is_feeler:
-                    self.log.warning("Incompatible network ID during feeler connection. Maybe the peer is on another network")
+                    self.log.warning(
+                        "Incompatible network ID during feeler connection. Maybe the peer is on another network"
+                    )
                 else:
                     self.log.warning("Incompatible network ID. Maybe the peer is on another network")
             elif e.code == Err.SELF_CONNECTION:

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -493,29 +493,47 @@ class ChiaServer:
             connection_type_str = ""
             if connection.connection_type is not None:
                 connection_type_str = connection.connection_type.name.lower()
-            self.log.info(f"Connected with {connection_type_str} {target_node}")
-            if is_feeler:
+            if not is_feeler:
+                self.log.info(f"Connected with {connection_type_str} {target_node}")
+            else:
+                self.log.debug(f"Successful feeler connection with {connection_type_str} {target_node}")
                 asyncio.create_task(connection.close())
             return True
         except client_exceptions.ClientConnectorError as e:
-            self.log.info(f"{e}")
+            if not is_feeler:
+                self.log.info(f"{e}")
+            else:
+                self.log.debug(f"Feeler connection error. {e}")
         except ProtocolError as e:
             if connection is not None:
                 await connection.close(self.invalid_protocol_ban_seconds, WSCloseCode.PROTOCOL_ERROR, e.code)
             if e.code == Err.INVALID_HANDSHAKE:
-                self.log.warning(f"Invalid handshake with peer {target_node}. Maybe the peer is running old software.")
+                if is_feeler:
+                    self.log.warning(f"Invalid handshake with peer {target_node} during feeler connection. Maybe the peer is running old software.")
+                else:
+                    self.log.warning(f"Invalid handshake with peer {target_node}. Maybe the peer is running old software.")
             elif e.code == Err.INCOMPATIBLE_NETWORK_ID:
-                self.log.warning("Incompatible network ID. Maybe the peer is on another network")
+                if is_feeler:
+                    self.log.warning("Incompatible network ID during feeler connection. Maybe the peer is on another network")
+                else:
+                    self.log.warning("Incompatible network ID. Maybe the peer is on another network")
             elif e.code == Err.SELF_CONNECTION:
                 pass
             else:
-                error_stack = traceback.format_exc()
-                self.log.error(f"Exception {e}, exception Stack: {error_stack}")
+                if is_feeler:
+                    error_stack = traceback.format_exc()
+                    self.log.error(f"Feeler connection exception {e}, exception Stack: {error_stack}")
+                else:
+                    error_stack = traceback.format_exc()
+                    self.log.error(f"Exception {e}, exception Stack: {error_stack}")
         except Exception as e:
             if connection is not None:
                 await connection.close(self.invalid_protocol_ban_seconds, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
             error_stack = traceback.format_exc()
-            self.log.error(f"Exception {e}, exception Stack: {error_stack}")
+            if is_feeler:
+                self.log.error(f"Feeler connection exception {e}, exception Stack: {error_stack}")
+            else:
+                self.log.error(f"Exception {e}, exception Stack: {error_stack}")
         finally:
             if session is not None:
                 await session.close()


### PR DESCRIPTION
Check if connections are classified as feelers and log connection successes/failures to debug level only and also designate them as feelers. Continue logging warnings/errors as before, just specify if they are associated with feeler connections.

### Purpose:

This should help reduce unnecessary noise in the INFO level logs. There have been folks questioning why client connections are still occurring in the logs even when target connection thresholds have been met.  Obfuscating the feeler connections should help reduce confusion.

### Current Behavior:

Log all successful and failed peer connections to INFO level logging.

### New Behavior:

Log all successful and failed peer connections to INFO level logging unless they are feelers.  Feeler successes/failures will be logged at the DEBUG level.  Protocol-level errors will still be logged regardless of the connection type, but if it is a feeler connection it will be designated as such in the logging info.

### Testing Notes:
