### PR TITLE
Replace Isort with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,13 +94,6 @@ repos:
         pass_filenames: false
   - repo: local
     hooks:
-      - id: isort
-        name: isort
-        entry: ./activated.py isort
-        language: system
-        types: [python]
-  - repo: local
-    hooks:
       - id: flake8
         name: Flake8
         entry: ./activated.py flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,15 +57,14 @@ to configure how the tests are run. For example, for more logging: change the lo
 ```bash
 sh install.sh -d
 . ./activate
-black . && isort benchmarks build_scripts chia tests tools *.py && mypy && flake8 benchmarks build_scripts chia tests tools *.py && pylint benchmarks build_scripts chia tests tools *.py
+black . && ruff check --fix && mypy && flake8 benchmarks build_scripts chia tests tools *.py && pylint benchmarks build_scripts chia tests tools *.py
 py.test tests -v --durations 0
 ```
 
 The [black library](https://black.readthedocs.io/en/stable/) is used as an automatic style formatter to make things easier.
 The [flake8 library](https://readthedocs.org/projects/flake8/) helps ensure consistent style.
 The [Mypy library](https://mypy.readthedocs.io/en/stable/) is very useful for ensuring objects are of the correct type, so try to always add the type of the return value, and the type of local variables.
-The [isort library](https://isort.readthedocs.io) is used to sort, group and validate imports in all python files.
-The [Ruff library](https://docs.astral.sh) is used to further lint all of the python files
+The [Ruff library](https://docs.astral.sh) is used to sort, group, validate imports, and further lint all of the python files
 
 If you want verbose logging for tests, edit the `tests/pytest.ini` file.
 

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -30,9 +30,8 @@ from chia.full_node.full_node import WalletUpdate
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.full_node.signage_point import SignagePoint
 from chia.full_node.sync_store import Peak
-from chia.protocols import full_node_protocol
+from chia.protocols import full_node_protocol, timelord_protocol, wallet_protocol
 from chia.protocols import full_node_protocol as fnp
-from chia.protocols import timelord_protocol, wallet_protocol
 from chia.protocols.full_node_protocol import RespondTransaction
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.shared_protocol import Capability, default_capabilities

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from chia_rs import DONT_VALIDATE_SIGNATURE, MEMPOOL_MODE, G2Element, get_flags_for_height_and_constants
+from chia_rs import (
+    DONT_VALIDATE_SIGNATURE,
+    MEMPOOL_MODE,
+    G2Element,
+    get_flags_for_height_and_constants,
+    run_block_generator,
+    run_block_generator2,
+    run_chia_program,
+)
 from chia_rs import get_puzzle_and_solution_for_coin2 as get_puzzle_and_solution_for_coin_rust
-from chia_rs import run_block_generator, run_block_generator2, run_chia_program
 
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.cost_calculator import NPCResult

--- a/chia/wallet/dao_wallet/dao_wallet.py
+++ b/chia/wallet/dao_wallet/dao_wallet.py
@@ -21,9 +21,13 @@ from chia.types.coin_spend import CoinSpend, make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.ints import uint32, uint64, uint128
 from chia.wallet import singleton
-from chia.wallet.cat_wallet.cat_utils import CAT_MOD, SpendableCAT, construct_cat_puzzle
+from chia.wallet.cat_wallet.cat_utils import (
+    CAT_MOD,
+    SpendableCAT,
+    construct_cat_puzzle,
+    unsigned_spend_bundle_for_spendable_cats,
+)
 from chia.wallet.cat_wallet.cat_utils import get_innerpuzzle_from_puzzle as get_innerpuzzle_from_cat_puzzle
-from chia.wallet.cat_wallet.cat_utils import unsigned_spend_bundle_for_spendable_cats
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
 from chia.wallet.cat_wallet.dao_cat_wallet import DAOCATWallet
 from chia.wallet.coin_selection import select_coins

--- a/poetry.lock
+++ b/poetry.lock
@@ -1500,20 +1500,6 @@ files = [
 ]
 
 [[package]]
-name = "isort"
-version = "5.13.2"
-description = "A Python utility / library to sort Python imports."
-optional = true
-python-versions = ">=3.8.0"
-files = [
-    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
-    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.6)"]
-
-[[package]]
 name = "jaraco-classes"
 version = "3.3.0"
 description = "Utility functions for Python class constructs"
@@ -3364,11 +3350,11 @@ url = "https://pypi.chia.net/simple"
 reference = "chia"
 
 [extras]
-dev = ["aiohttp_cors", "black", "build", "coverage", "diff-cover", "flake8", "isort", "lxml", "mypy", "pre-commit", "pre-commit", "py3createtorrent", "pyinstaller", "pytest", "pytest-cov", "pytest-mock", "pytest-monitor", "pytest-xdist", "pyupgrade", "ruff", "types-aiofiles", "types-cryptography", "types-pyyaml", "types-setuptools"]
+dev = ["aiohttp_cors", "black", "build", "coverage", "diff-cover", "flake8", "lxml", "mypy", "pre-commit", "pre-commit", "py3createtorrent", "pyinstaller", "pytest", "pytest-cov", "pytest-mock", "pytest-monitor", "pytest-xdist", "pyupgrade", "ruff", "types-aiofiles", "types-cryptography", "types-pyyaml", "types-setuptools"]
 legacy-keyring = ["keyrings.cryptfile"]
 upnp = ["miniupnpc"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9, <3.13"
-content-hash = "5cd871c7144e26b4ffeaf47fecd23aebdcdd1384048fdbede76f2c58b923d643"
+content-hash = "d403dbbafd58dde2819efa7890b10324cafdab0f72891b1d0634acdaea7bd19a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ build = { version = "1.2.1", optional = true }
 coverage = { version = "7.6.4", optional = true }
 diff-cover = { version = "9.2.0", optional = true }
 flake8 = { version = "7.1.1", optional = true }
-isort = { version = "5.13.2", optional = true }
 # TODO: but...  keyrings_cryptfile goes 15 minutes without locking while this does in 75 seconds
 "keyrings.cryptfile" = { version = "1.3.9", optional = true }
 mypy = { version = "1.11.1", optional = true }
@@ -108,7 +107,7 @@ ruff = { version = "0.7.1", optional = true }
 
 
 [tool.poetry.extras]
-dev = ["aiohttp_cors", "black", "build", "coverage", "diff-cover", "flake8", "isort", "mypy", "pre-commit", "py3createtorrent", "pyinstaller", "pytest", "pytest-cov", "pytest-mock", "pytest-monitor", "pytest-xdist", "ruff", "types-aiofiles", "types-cryptography", "types-pyyaml", "types-setuptools", "pyupgrade", "lxml"]
+dev = ["aiohttp_cors", "black", "build", "coverage", "diff-cover", "flake8", "mypy", "pre-commit", "py3createtorrent", "pyinstaller", "pytest", "pytest-cov", "pytest-mock", "pytest-monitor", "pytest-xdist", "ruff", "types-aiofiles", "types-cryptography", "types-pyyaml", "types-setuptools", "pyupgrade", "lxml"]
 upnp = ["miniupnpc"]
 legacy_keyring = ["keyrings.cryptfile"]
 
@@ -161,7 +160,7 @@ line-length = 120
 
 [tool.ruff.lint]
 preview = true
-select = ["PL"]
+select = ["PL", "I", "FA"]
 explicit-preview-rules = false
 ignore = [
     # Pylint convention
@@ -205,6 +204,9 @@ ignore = [
     "PLW1510", # subprocess-run-without-check
     "PLW0120", # useless-else-on-loop
 ]
+
+[tool.ruff.lint.isort]
+required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.pylint]
 max-args = 5


### PR DESCRIPTION
See PR https://github.com/Chia-Network/chia-blockchain/pull/18759 for more information about Ruff.  This PR continues the work of simplifying our pre-commit workflow by replacing another one of our tools with Ruff.