### PR TITLE
CHIA-1697: Add new flag to support recursively scanning and following links

### DIFF
--- a/chia/_tests/plotting/test_plot_manager.py
+++ b/chia/_tests/plotting/test_plot_manager.py
@@ -757,6 +757,8 @@ async def test_recursive_plot_scan_symlinks(environment: Environment, follow_lin
     symlink_path = Path(root_plot_dir / "other")
 
     if use_hardlink:
+        if sys.version_info < (3, 10):
+            pytest.skip("hardlink_to is only available in Python 3.10+")
         try:
             symlink_path.hardlink_to(env.root_path / "other")
         except (NotImplementedError, PermissionError):

--- a/chia/_tests/plotting/test_plot_manager.py
+++ b/chia/_tests/plotting/test_plot_manager.py
@@ -14,6 +14,7 @@ import pytest
 from chia_rs import G1Element
 
 from chia._tests.plotting.util import get_test_plots
+from chia._tests.util.misc import boolean_datacases
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.plotting.cache import CURRENT_VERSION, CacheDataV1
 from chia.plotting.manager import Cache, PlotManager
@@ -742,7 +743,7 @@ async def test_recursive_plot_scan(environment: Environment) -> None:
     await env.refresh_tester.run(expected_result)
 
 
-@pytest.mark.parametrize("follow_links", [True, False], ids=["follow_links", "no_follow"])
+@boolean_datacases(name="follow_links", false="no_follow", true="follow")
 @pytest.mark.anyio
 async def test_recursive_plot_scan_symlinks(environment: Environment, follow_links: bool) -> None:
     env: Environment = environment

--- a/chia/_tests/plotting/test_plot_manager.py
+++ b/chia/_tests/plotting/test_plot_manager.py
@@ -33,6 +33,9 @@ from chia.util.streamable import VersionedBlob
 
 log = logging.getLogger(__name__)
 
+# These tests are not dependent on consensus rules
+pytestmark = [pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")]
+
 
 @dataclass
 class MockDiskProver:
@@ -739,8 +742,7 @@ async def test_recursive_plot_scan(environment: Environment) -> None:
     await env.refresh_tester.run(expected_result)
 
 
-@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
-@pytest.mark.parametrize("follow_links", [True, False])
+@pytest.mark.parametrize("follow_links", [True, False], ids=["follow_links", "no_follow"])
 @pytest.mark.anyio
 async def test_recursive_plot_scan_symlinks(environment: Environment, follow_links: bool) -> None:
     env: Environment = environment
@@ -754,11 +756,7 @@ async def test_recursive_plot_scan_symlinks(environment: Environment, follow_lin
 
     # Create a symlink to the other plot directory from inside the root plot directory
     symlink_path = Path(root_plot_dir / "other")
-
-    try:
-        symlink_path.symlink_to(env.root_path / "other")
-    except NotImplementedError:
-        pytest.skip("Symlinking is not supported on this platform")
+    symlink_path.symlink_to(env.root_path / "other")
 
     # Adding the root without `recursive_plot_scan` and running a test should not load any plots (match an empty result)
     expected_result = PlotRefreshResult()

--- a/chia/_tests/plotting/test_plot_manager.py
+++ b/chia/_tests/plotting/test_plot_manager.py
@@ -741,9 +741,8 @@ async def test_recursive_plot_scan(environment: Environment) -> None:
 
 @pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.parametrize("follow_links", [True, False])
-@pytest.mark.parametrize("use_hardlink", [True, False])
 @pytest.mark.anyio
-async def test_recursive_plot_scan_symlinks(environment: Environment, follow_links: bool, use_hardlink: bool) -> None:
+async def test_recursive_plot_scan_symlinks(environment: Environment, follow_links: bool) -> None:
     env: Environment = environment
     # Create a directory tree with some subdirectories containing plots, others not.
     root_plot_dir = env.root_path / "root"
@@ -756,18 +755,10 @@ async def test_recursive_plot_scan_symlinks(environment: Environment, follow_lin
     # Create a symlink to the other plot directory from inside the root plot directory
     symlink_path = Path(root_plot_dir / "other")
 
-    if use_hardlink:
-        if sys.version_info < (3, 10):
-            pytest.skip("hardlink_to is only available in Python 3.10+")
-        try:
-            symlink_path.hardlink_to(env.root_path / "other")
-        except (NotImplementedError, PermissionError):
-            pytest.skip("Hardlinking is not supported on this platform")
-    else:
-        try:
-            symlink_path.symlink_to(env.root_path / "other")
-        except NotImplementedError:
-            pytest.skip("Symlinking is not supported on this platform")
+    try:
+        symlink_path.symlink_to(env.root_path / "other")
+    except NotImplementedError:
+        pytest.skip("Symlinking is not supported on this platform")
 
     # Adding the root without `recursive_plot_scan` and running a test should not load any plots (match an empty result)
     expected_result = PlotRefreshResult()

--- a/chia/_tests/plotting/test_plot_manager.py
+++ b/chia/_tests/plotting/test_plot_manager.py
@@ -738,6 +738,7 @@ async def test_recursive_plot_scan(environment: Environment) -> None:
     expected_result.loaded = []
     await env.refresh_tester.run(expected_result)
 
+
 @pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.parametrize("follow_links", [True, False])
 @pytest.mark.parametrize("use_hardlink", [True, False])

--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -110,13 +110,14 @@ def get_plot_filenames(root_path: Path) -> dict[Path, list[Path]]:
     all_files: dict[Path, list[Path]] = {}
     config = load_config(root_path, "config.yaml")
     recursive_scan: bool = config["harvester"].get("recursive_plot_scan", DEFAULT_RECURSIVE_PLOT_SCAN)
+    recursive_follow_links: bool = config["harvester"].get("recursive_follow_links", False)
     for directory_name in get_plot_directories(root_path, config):
         try:
             directory = Path(directory_name).resolve()
         except (OSError, RuntimeError):
             log.exception(f"Failed to resolve {directory_name}")
             continue
-        all_files[directory] = get_filenames(directory, recursive_scan)
+        all_files[directory] = get_filenames(directory, recursive_scan, recursive_follow_links)
     return all_files
 
 
@@ -219,7 +220,7 @@ def update_harvester_config(
         save_config(root_path, "config.yaml", config)
 
 
-def get_filenames(directory: Path, recursive: bool) -> list[Path]:
+def get_filenames(directory: Path, recursive: bool, follow_links: bool) -> list[Path]:
     try:
         if not directory.exists():
             log.warning(f"Directory: {directory} does not exist.")
@@ -229,8 +230,19 @@ def get_filenames(directory: Path, recursive: bool) -> list[Path]:
         return []
     all_files: list[Path] = []
     try:
-        glob_function = directory.rglob if recursive else directory.glob
-        all_files = [child for child in glob_function("*.plot") if child.is_file() and not child.name.startswith("._")]
+        if follow_links and recursive:
+            import glob
+
+            files = glob.glob(str(directory / "**" / "*.plot"), recursive=True)
+            for file in files:
+                filepath = Path(file).resolve()
+                if filepath.is_file() and not filepath.name.startswith("._"):
+                    all_files.append(filepath)
+        else:
+            glob_function = directory.rglob if recursive else directory.glob
+            all_files = [
+                child for child in glob_function("*.plot") if child.is_file() and not child.name.startswith("._")
+            ]
         log.debug(f"get_filenames: {len(all_files)} files found in {directory}, recursive: {recursive}")
     except Exception as e:
         log.warning(f"Error reading directory {directory} {e}")

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -160,6 +160,7 @@ harvester:
   # Plots are searched for in the following directories
   plot_directories: []
   recursive_plot_scan: False # If True the harvester scans plots recursively in the provided directories.
+  recursive_follow_links: False # If True the harvester follows symlinks when scanning for plots recursively
 
   ssl:
     private_crt: "config/ssl/harvester/private_harvester.crt"


### PR DESCRIPTION
Fixes #16268

Adds new harvester option `follow_links` that only works when used with `recursive_scan` and uses `glob.glob` instead of `Path.rglob` in order to follow links when scanning recursively for plots.

