### PR TITLE
Also set stdin and stderr when setting stdout for daemon start

### DIFF
--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -35,6 +35,8 @@ def launch_start_daemon(root_path: Path) -> subprocess.Popen:
         [cmd_to_execute, "run_daemon", "--wait-for-unlock"],
         encoding="utf-8",
         stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
         creationflags=creationflags,
     )
 


### PR DESCRIPTION
Fixes #16396

Although I'm not entirely sure on the behavior, empirical testing suggests that setting stderr and stdin to either devnull or PIPE is required for the daemon to detach from the tty. I suspect because stdout is redirected, the others need to be as well. This PR chooses to use DEVNULL.

Further testing will be required to ensure this doesn't have any side-effects