### PR TITLE
allow backcompat mode for logging

### DIFF
--- a/chia/util/chia_logging.py
+++ b/chia/util/chia_logging.py
@@ -69,6 +69,7 @@ def initialize_logging(
             colorlog.ColoredFormatter(
                 (
                     f"%(asctime)s.%(msecs)03d {service_name} %(name)-{file_name_length}s: "
+                    f"%(log_color)s%(levelname)-8s%(reset)s %(message)s"
                     if log_backcompat
                     else f"%(asctime)s.%(msecs)03d {__version__} {service_name} %(name)-{file_name_length}s: "
                     f"%(log_color)s%(levelname)-8s%(reset)s %(message)s"

--- a/chia/util/chia_logging.py
+++ b/chia/util/chia_logging.py
@@ -49,12 +49,17 @@ def initialize_logging(
     root_path: Path,
     beta_root_path: Optional[Path] = None,
 ) -> None:
+    log_backcompat = logging_config.get("log_backcompat", False)
     log_level = logging_config.get("log_level", default_log_level)
     file_name_length = 33 - len(service_name)
     log_date_format = "%Y-%m-%dT%H:%M:%S"
     file_log_formatter = logging.Formatter(
-        fmt=f"%(asctime)s.%(msecs)03d {__version__} {service_name} %(name)-{file_name_length}s: "
-        f"%(levelname)-8s %(message)s",
+        fmt=(
+            f"%(asctime)s.%(msecs)03d {service_name} %(name)-{file_name_length}s: %(levelname)-8s %(message)s"
+            if log_backcompat
+            else f"%(asctime)s.%(msecs)03d {__version__} {service_name} %(name)-{file_name_length}s: "
+            f"%(levelname)-8s %(message)s"
+        ),
         datefmt=log_date_format,
     )
     handlers: list[logging.Handler] = []
@@ -62,8 +67,12 @@ def initialize_logging(
         stdout_handler = colorlog.StreamHandler()
         stdout_handler.setFormatter(
             colorlog.ColoredFormatter(
-                f"%(asctime)s.%(msecs)03d {__version__} {service_name} %(name)-{file_name_length}s: "
-                f"%(log_color)s%(levelname)-8s%(reset)s %(message)s",
+                (
+                    f"%(asctime)s.%(msecs)03d {service_name} %(name)-{file_name_length}s: "
+                    if log_backcompat
+                    else f"%(asctime)s.%(msecs)03d {__version__} {service_name} %(name)-{file_name_length}s: "
+                    f"%(log_color)s%(levelname)-8s%(reset)s %(message)s"
+                ),
                 datefmt=log_date_format,
                 reset=True,
             )

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -86,6 +86,7 @@ daemon_ssl:
 # Controls logging of all servers (harvester, farmer, etc..). Each one can be overridden.
 logging: &logging
   log_stdout: False # If True, outputs to stdout instead of a file
+  log_backcompat: False
   log_filename: "log/debug.log"
   log_level: "WARNING" # Can be CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET
   log_maxfilesrotation: 7 #  Max files in rotation. Default value 7 if the key is not set


### PR DESCRIPTION
### Purpose:

Third party scripts break with logging changes from
https://github.com/Chia-Network/chia-blockchain/pull/18608

### Current Behavior:

Display version in logging line

### New Behavior:

Conditional old and new behavior with log_backcompat config setting
