### PR TITLE
[CHIA-1562] move signature validation into `run_block_generator()`

### DIFF
--- a/chia/_tests/blockchain/blockchain_test_utils.py
+++ b/chia/_tests/blockchain/blockchain_test_utils.py
@@ -79,7 +79,7 @@ async def _validate_and_add_block(
         else:
             # fake the signature validation. Just say True here.
             conds = SpendBundleConditions([], 0, 0, 0, None, None, [], 0, 0, 0, True)
-        results = PreValidationResult(None, uint64(1), conds, True, uint32(0))
+        results = PreValidationResult(None, uint64(1), conds, uint32(0))
     else:
         futures = await pre_validate_blocks_multiprocessing(
             blockchain.constants,

--- a/chia/_tests/blockchain/blockchain_test_utils.py
+++ b/chia/_tests/blockchain/blockchain_test_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from typing import Optional
 
-from chia_rs import BLSCache
+from chia_rs import SpendBundleConditions
 
 from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.blockchain import AddBlockResult, Blockchain
@@ -52,7 +52,6 @@ async def _validate_and_add_block(
     expected_error: Optional[Err] = None,
     skip_prevalidation: bool = False,
     fork_info: Optional[ForkInfo] = None,
-    use_bls_cache: bool = False,
 ) -> None:
     # Tries to validate and add the block, and checks that there are no errors in the process and that the
     # block is added to the peak.
@@ -73,11 +72,15 @@ async def _validate_and_add_block(
     new_slot = len(block.finished_sub_slots) > 0
     ssi, diff = get_next_sub_slot_iters_and_difficulty(blockchain.constants, new_slot, prev_b, blockchain)
     await check_block_store_invariant(blockchain)
+
     if skip_prevalidation:
-        results = PreValidationResult(None, uint64(1), None, False, uint32(0))
+        if block.transactions_generator is None:
+            conds = None
+        else:
+            # fake the signature validation. Just say True here.
+            conds = SpendBundleConditions([], 0, 0, 0, None, None, [], 0, 0, 0, True)
+        results = PreValidationResult(None, uint64(1), conds, True, uint32(0))
     else:
-        # validate_signatures must be False in order to trigger add_block() to
-        # validate the signature.
         futures = await pre_validate_blocks_multiprocessing(
             blockchain.constants,
             AugmentedBlockchain(blockchain),
@@ -85,7 +88,6 @@ async def _validate_and_add_block(
             blockchain.pool,
             {},
             ValidationState(ssi, diff, prev_ses_block),
-            validate_signatures=False,
         )
         pre_validation_results: list[PreValidationResult] = list(await asyncio.gather(*futures))
         assert pre_validation_results is not None
@@ -105,16 +107,12 @@ async def _validate_and_add_block(
         return None
     if fork_info is None:
         fork_info = ForkInfo(block.height - 1, block.height - 1, block.prev_header_hash)
-    if use_bls_cache:
-        bls_cache = BLSCache(100)
-    else:
-        bls_cache = None
 
     (
         result,
         err,
         _,
-    ) = await blockchain.add_block(block, results, bls_cache, ssi, fork_info=fork_info)
+    ) = await blockchain.add_block(block, results, ssi, fork_info=fork_info)
     await check_block_store_invariant(blockchain)
 
     if expected_error is None and expected_result != AddBlockResult.INVALID_BLOCK:

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -2622,9 +2622,7 @@ class TestBodyValidation:
         err = (
             await b.add_block(
                 blocks[-1],
-                PreValidationResult(
-                    None, uint64(1), npc_result.conds.replace(validated_signature=True), True, uint32(0)
-                ),
+                PreValidationResult(None, uint64(1), npc_result.conds.replace(validated_signature=True), uint32(0)),
                 sub_slot_iters=ssi,
                 fork_info=fork_info,
             )
@@ -2703,7 +2701,7 @@ class TestBodyValidation:
         fork_info = ForkInfo(block_2.height - 1, block_2.height - 1, block_2.prev_header_hash)
         _, err, _ = await b.add_block(
             block_2,
-            PreValidationResult(None, uint64(1), npc_result.conds.replace(validated_signature=True), True, uint32(0)),
+            PreValidationResult(None, uint64(1), npc_result.conds.replace(validated_signature=True), uint32(0)),
             sub_slot_iters=ssi,
             fork_info=fork_info,
         )
@@ -2737,7 +2735,7 @@ class TestBodyValidation:
         fork_info = ForkInfo(block_2.height - 1, block_2.height - 1, block_2.prev_header_hash)
         _, err, _ = await b.add_block(
             block_2,
-            PreValidationResult(None, uint64(1), npc_result.conds.replace(validated_signature=True), True, uint32(0)),
+            PreValidationResult(None, uint64(1), npc_result.conds.replace(validated_signature=True), uint32(0)),
             sub_slot_iters=ssi,
             fork_info=fork_info,
         )
@@ -2776,7 +2774,7 @@ class TestBodyValidation:
         fork_info = ForkInfo(block_2.height - 1, block_2.height - 1, block_2.prev_header_hash)
         _result, err, _ = await b.add_block(
             block_2,
-            PreValidationResult(None, uint64(1), npc_result.conds.replace(validated_signature=True), True, uint32(0)),
+            PreValidationResult(None, uint64(1), npc_result.conds.replace(validated_signature=True), uint32(0)),
             sub_slot_iters=ssi,
             fork_info=fork_info,
         )

--- a/chia/_tests/core/full_node/stores/test_coin_store.py
+++ b/chia/_tests/core/full_node/stores/test_coin_store.py
@@ -99,6 +99,7 @@ async def test_basic_coin_store(db_version: int, softfork_height: uint32, bt: Bl
             should_be_included.add(pool_coin)
             if block.is_transaction_block():
                 if block.transactions_generator is not None:
+                    assert block.transactions_info is not None
                     block_gen: BlockGenerator = BlockGenerator(block.transactions_generator, [])
                     npc_result = get_name_puzzle_conditions(
                         block_gen,

--- a/chia/_tests/core/full_node/stores/test_full_node_store.py
+++ b/chia/_tests/core/full_node/stores/test_full_node_store.py
@@ -95,9 +95,7 @@ async def test_unfinished_block_rank(
     # shuffle them to ensure the order we add them to the store isn't relevant
     seeded_random.shuffle(unfinished)
     for new_unf in unfinished:
-        store.add_unfinished_block(
-            uint32(2), new_unf, PreValidationResult(None, uint64(123532), None, False, uint32(0))
-        )
+        store.add_unfinished_block(uint32(2), new_unf, PreValidationResult(None, uint64(123532), None, uint32(0)))
 
     # now ask for "the" unfinished block given the proof-of-space.
     # the FullNodeStore should return the one with the lowest foliage tx block
@@ -221,7 +219,7 @@ async def test_basic_store(
         assert store.get_unfinished_block(unf_block.partial_hash) is None
         assert store.get_unfinished_block2(unf_block.partial_hash, None) == (None, 0, False)
         store.add_unfinished_block(
-            uint32(height), unf_block, PreValidationResult(None, uint64(123532), None, False, uint32(0))
+            uint32(height), unf_block, PreValidationResult(None, uint64(123532), None, uint32(0))
         )
         assert store.get_unfinished_block(unf_block.partial_hash) == unf_block
         assert store.get_unfinished_block2(
@@ -277,9 +275,7 @@ async def test_basic_store(
     assert unf3.foliage.foliage_transaction_block_hash is None
     assert unf4.foliage.foliage_transaction_block_hash is None
     for val, unf_block in enumerate([unf1, unf2, unf3, unf4]):
-        store.add_unfinished_block(
-            uint32(height), unf_block, PreValidationResult(None, uint64(val), None, False, uint32(0))
-        )
+        store.add_unfinished_block(uint32(height), unf_block, PreValidationResult(None, uint64(val), None, uint32(0)))
 
     # when not specifying a foliage hash, you get the "best" one
     # best is defined as the lowest foliage hash

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -437,7 +437,6 @@ class TestFullNodeBlockCompression:
                         blockchain.pool,
                         {},
                         ValidationState(ssi, diff, None),
-                        validate_signatures=False,
                     )
                     results: list[PreValidationResult] = list(await asyncio.gather(*futures))
                     assert results is not None
@@ -456,7 +455,6 @@ class TestFullNodeBlockCompression:
                         blockchain.pool,
                         {},
                         ValidationState(ssi, diff, None),
-                        validate_signatures=False,
                     )
                     results: list[PreValidationResult] = list(await asyncio.gather(*futures))
                     assert results is not None

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -10,7 +10,7 @@ from collections.abc import Coroutine
 from typing import Optional
 
 import pytest
-from chia_rs import AugSchemeMPL, G2Element, PrivateKey
+from chia_rs import AugSchemeMPL, G2Element, PrivateKey, SpendBundleConditions
 from clvm.casts import int_to_bytes
 from packaging.version import Version
 
@@ -71,6 +71,16 @@ from chia.util.recursive_replace import recursive_replace
 from chia.util.vdf_prover import get_vdf_info_and_proof
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
+
+
+def test_pre_validation_result() -> None:
+    conds = SpendBundleConditions([], 0, 0, 0, None, None, [], 0, 0, 0, True)
+    results = PreValidationResult(None, uint64(1), conds, uint32(0))
+    assert results.validated_signature is True
+
+    conds = SpendBundleConditions([], 0, 0, 0, None, None, [], 0, 0, 0, False)
+    results = PreValidationResult(None, uint64(1), conds, uint32(0))
+    assert results.validated_signature is False
 
 
 async def new_transaction_not_requested(incoming, new_spend):

--- a/chia/_tests/core/full_node/test_subscriptions.py
+++ b/chia/_tests/core/full_node/test_subscriptions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from chia_rs import AugSchemeMPL, Coin, CoinSpend, Program
+from chia_rs import AugSchemeMPL, Coin, CoinSpend, G2Element, Program
 from chia_rs.sized_ints import uint32, uint64
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
@@ -456,7 +456,7 @@ def test_peers_for_spent_coin() -> None:
 
     coin_spends = [CoinSpend(IDENTITY_COIN, IDENTITY_PUZZLE, Program.to([]))]
 
-    spend_bundle = SpendBundle(coin_spends, AugSchemeMPL.aggregate([]))
+    spend_bundle = SpendBundle(coin_spends, G2Element())
     generator = simple_solution_generator(spend_bundle)
     npc_result = get_name_puzzle_conditions(
         generator=generator, max_cost=INFINITE_COST, mempool_mode=True, height=uint32(0), constants=DEFAULT_CONSTANTS
@@ -481,7 +481,7 @@ def test_peers_for_created_coin() -> None:
         CoinSpend(IDENTITY_COIN, IDENTITY_PUZZLE, Program.to([[51, OTHER_PUZZLE_HASH, 1000, [HINT_PUZZLE_HASH]]]))
     ]
 
-    spend_bundle = SpendBundle(coin_spends, AugSchemeMPL.aggregate([]))
+    spend_bundle = SpendBundle(coin_spends, G2Element())
     generator = simple_solution_generator(spend_bundle)
     npc_result = get_name_puzzle_conditions(
         generator=generator, max_cost=INFINITE_COST, mempool_mode=True, height=uint32(0), constants=DEFAULT_CONSTANTS

--- a/chia/_tests/core/test_db_conversion.py
+++ b/chia/_tests/core/test_db_conversion.py
@@ -74,7 +74,7 @@ async def test_blocks(default_1000_blocks, with_hints: bool):
                     if block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters is not None:
                         sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters
                 # await _validate_and_add_block(bc, block)
-                results = PreValidationResult(None, uint64(1), None, False, uint32(0))
+                results = PreValidationResult(None, uint64(1), None, uint32(0))
                 fork_info = ForkInfo(block.height - 1, block.height - 1, block.prev_header_hash)
                 _, err, _ = await bc.add_block(block, results, sub_slot_iters=sub_slot_iters, fork_info=fork_info)
                 assert err is None

--- a/chia/_tests/core/test_db_conversion.py
+++ b/chia/_tests/core/test_db_conversion.py
@@ -76,9 +76,7 @@ async def test_blocks(default_1000_blocks, with_hints: bool):
                 # await _validate_and_add_block(bc, block)
                 results = PreValidationResult(None, uint64(1), None, False, uint32(0))
                 fork_info = ForkInfo(block.height - 1, block.height - 1, block.prev_header_hash)
-                _result, err, _ = await bc.add_block(
-                    block, results, None, sub_slot_iters=sub_slot_iters, fork_info=fork_info
-                )
+                _, err, _ = await bc.add_block(block, results, sub_slot_iters=sub_slot_iters, fork_info=fork_info)
                 assert err is None
 
         # now, convert v1 in_file to v2 out_file

--- a/chia/_tests/core/test_db_validation.py
+++ b/chia/_tests/core/test_db_validation.py
@@ -146,9 +146,7 @@ async def make_db(db_file: Path, blocks: list[FullBlock]) -> None:
                     sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters
             results = PreValidationResult(None, uint64(1), None, False, uint32(0))
             fork_info = ForkInfo(block.height - 1, block.height - 1, block.prev_header_hash)
-            _result, err, _ = await bc.add_block(
-                block, results, None, sub_slot_iters=sub_slot_iters, fork_info=fork_info
-            )
+            _, err, _ = await bc.add_block(block, results, sub_slot_iters=sub_slot_iters, fork_info=fork_info)
             assert err is None
 
 

--- a/chia/_tests/core/test_db_validation.py
+++ b/chia/_tests/core/test_db_validation.py
@@ -144,7 +144,7 @@ async def make_db(db_file: Path, blocks: list[FullBlock]) -> None:
             if block.height != 0 and len(block.finished_sub_slots) > 0:
                 if block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters is not None:
                     sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters
-            results = PreValidationResult(None, uint64(1), None, False, uint32(0))
+            results = PreValidationResult(None, uint64(1), None, uint32(0))
             fork_info = ForkInfo(block.height - 1, block.height - 1, block.prev_header_hash)
             _, err, _ = await bc.add_block(block, results, sub_slot_iters=sub_slot_iters, fork_info=fork_info)
             assert err is None

--- a/chia/_tests/farmer_harvester/test_third_party_harvesters.py
+++ b/chia/_tests/farmer_harvester/test_third_party_harvesters.py
@@ -445,7 +445,6 @@ async def add_test_blocks_into_full_node(blocks: list[FullBlock], full_node: Ful
         full_node.blockchain.pool,
         {},
         ValidationState(ssi, diff, prev_ses_block),
-        validate_signatures=True,
     )
     pre_validation_results: list[PreValidationResult] = list(await asyncio.gather(*futures))
     assert pre_validation_results is not None and len(pre_validation_results) == len(blocks)
@@ -456,7 +455,7 @@ async def add_test_blocks_into_full_node(blocks: list[FullBlock], full_node: Ful
                 ssi = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters
         fork_info = ForkInfo(block.height - 1, block.height - 1, block.prev_header_hash)
         r, _, _ = await full_node.blockchain.add_block(
-            blocks[i], pre_validation_results[i], None, sub_slot_iters=ssi, fork_info=fork_info
+            blocks[i], pre_validation_results[i], sub_slot_iters=ssi, fork_info=fork_info
         )
         assert r == AddBlockResult.NEW_PEAK
 

--- a/chia/_tests/wallet/conftest.py
+++ b/chia/_tests/wallet/conftest.py
@@ -6,16 +6,23 @@ from dataclasses import replace
 from typing import Any, Callable, Literal, Optional
 
 import pytest
+from chia_rs import (
+    DONT_VALIDATE_SIGNATURE,
+    SpendBundleConditions,
+    get_flags_for_height_and_constants,
+    run_block_generator,
+    run_block_generator2,
+)
 
 from chia._tests.environments.wallet import WalletEnvironment, WalletState, WalletTestFramework
 from chia._tests.util.setup_nodes import setup_simulators_and_wallets_service
 from chia._tests.wallet.wallet_block_tools import WalletBlockTools
 from chia.consensus.constants import ConsensusConstants
-from chia.consensus.cost_calculator import NPCResult
 from chia.full_node.full_node import FullNode
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
 from chia.util.ints import uint32, uint64, uint128
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, TXConfig
@@ -56,8 +63,8 @@ async def ignore_block_validation(
     if "standard_block_tools" in request.keywords:
         return None
 
-    async def validate_block_body(*args: Any, **kwargs: Any) -> tuple[Literal[None], NPCResult]:
-        return None, args[7]
+    async def validate_block_body(*args: Any) -> tuple[Literal[None], Optional[SpendBundleConditions]]:
+        return None, None if args[5] is None else args[5].replace(validated_signature=True)
 
     def create_wrapper(original_create: Any) -> Any:
         async def new_create(*args: Any, **kwargs: Any) -> Any:
@@ -74,9 +81,34 @@ async def ignore_block_validation(
 
         return new_create
 
+    def run_block(
+        block: FullBlock, prev_generators: list[bytes], constants: ConsensusConstants
+    ) -> tuple[Optional[int], Optional[SpendBundleConditions]]:
+        assert block.transactions_generator is not None
+        assert block.transactions_info is not None
+        flags = get_flags_for_height_and_constants(block.height, constants) | DONT_VALIDATE_SIGNATURE
+        if block.height >= constants.HARD_FORK_HEIGHT:
+            run_block = run_block_generator2
+        else:
+            run_block = run_block_generator
+        err, conds = run_block(
+            bytes(block.transactions_generator),
+            prev_generators,
+            block.transactions_info.cost,
+            flags,
+            block.transactions_info.aggregated_signature,
+            None,
+            constants,
+        )
+        # pretend that the signatures are OK
+        if conds is not None:
+            conds = conds.replace(validated_signature=True)
+        return err, conds
+
     monkeypatch.setattr("chia.simulator.block_tools.BlockTools", WalletBlockTools)
     monkeypatch.setattr(FullNode, "create", create_wrapper(FullNode.create))
     monkeypatch.setattr("chia.consensus.blockchain.validate_block_body", validate_block_body)
+    monkeypatch.setattr("chia.consensus.multiprocess_validation._run_block", run_block)
     monkeypatch.setattr(
         "chia.consensus.block_header_validation.validate_unfinished_header_block", lambda *_, **__: (uint64(1), None)
     )

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -696,7 +696,7 @@ class Blockchain:
         required_iters, error = await self.validate_unfinished_block_header(block, skip_overflow_ss_validation)
 
         if error is not None:
-            return PreValidationResult(uint16(error.value), None, None, False, uint32(0))
+            return PreValidationResult(uint16(error.value), None, None, uint32(0))
 
         prev_height = (
             -1
@@ -717,9 +717,9 @@ class Blockchain:
         )
 
         if error_code is not None:
-            return PreValidationResult(uint16(error_code.value), None, None, False, uint32(0))
+            return PreValidationResult(uint16(error_code.value), None, None, uint32(0))
 
-        return PreValidationResult(None, required_iters, cost_result, False, uint32(0))
+        return PreValidationResult(None, required_iters, cost_result, uint32(0))
 
     def contains_block(self, header_hash: bytes32) -> bool:
         """

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -10,7 +10,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Optional, cast
 
-from chia_rs import BLSCache, additions_and_removals, get_flags_for_height_and_constants
+from chia_rs import additions_and_removals, get_flags_for_height_and_constants
 
 from chia.consensus.block_body_validation import ForkInfo, validate_block_body
 from chia.consensus.block_header_validation import validate_unfinished_header_block
@@ -279,7 +279,6 @@ class Blockchain:
         self,
         block: FullBlock,
         pre_validation_result: PreValidationResult,
-        bls_cache: Optional[BLSCache],
         sub_slot_iters: uint64,
         fork_info: ForkInfo,
         prev_ses_block: Optional[BlockRecord] = None,
@@ -294,9 +293,6 @@ class Blockchain:
         Args:
             block: The FullBlock to be validated.
             pre_validation_result: A result of successful pre validation
-            bls_cache: An optional cache of pairings that are likely to be part
-               of the aggregate signature. If this is set, the cache will always
-               be used (which may be slower if there are no cache hits).
             fork_info: Information about the fork chain this block is part of,
                to make validation more efficient. This is an in-out parameter.
 
@@ -358,6 +354,7 @@ class Blockchain:
         assert fork_info.peak_height == block.height - 1
         assert block.height == 0 or fork_info.peak_hash == block.prev_header_hash
 
+        assert block.transactions_generator is None or pre_validation_result.validated_signature
         error_code, _ = await validate_block_body(
             self.constants,
             self,
@@ -366,9 +363,6 @@ class Blockchain:
             block.height,
             pre_validation_result.conds,
             fork_info,
-            bls_cache,
-            # If we did not already validate the signature, validate it now
-            validate_signature=not pre_validation_result.validated_signature,
         )
         if error_code is not None:
             return AddBlockResult.INVALID_BLOCK, error_code, None
@@ -720,8 +714,6 @@ class Blockchain:
             uint32(prev_height + 1),
             None if npc_result is None else npc_result.conds,
             fork_info,
-            None,
-            validate_signature=False,  # Signature was already validated before calling this method, no need to validate
         )
 
         if error_code is not None:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2332,9 +2332,6 @@ class FullNode:
                 raise ConsensusError(Err(validate_result.error))
             validation_time = time.monotonic() - validation_start
 
-        # respond_block will later use the cache (validated_signature=True)
-        validate_result = dataclasses.replace(validate_result, validated_signature=True)
-
         assert validate_result.required_iters is not None
 
         # Perform another check, in case we have already concurrently added the same unfinished block

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1550,7 +1550,6 @@ class FullNode:
             {},
             vs,
             wp_summaries=wp_summaries,
-            validate_signatures=True,
         )
 
     async def add_prevalidated_blocks(
@@ -1586,7 +1585,7 @@ class FullNode:
                     assert expected_sub_slot_iters == vs.current_ssi
                     assert expected_difficulty == vs.current_difficulty
             result, error, state_change_summary = await self.blockchain.add_block(
-                block, pre_validation_results[i], None, vs.current_ssi, fork_info, prev_ses_block=vs.prev_ses_block
+                block, pre_validation_results[i], vs.current_ssi, fork_info, prev_ses_block=vs.prev_ses_block
             )
             if error is None:
                 blockchain.remove_extra_block(header_hash)
@@ -1981,6 +1980,7 @@ class FullNode:
             unf_entry: Optional[UnfinishedBlockEntry] = self.full_node_store.get_unfinished_block_result(
                 unfinished_rh, foliage_hash
             )
+            assert unf_entry is None or unf_entry.result is None or unf_entry.result.validated_signature is True
             if (
                 unf_entry is not None
                 and unf_entry.unfinished_block is not None
@@ -2062,7 +2062,6 @@ class FullNode:
                 self.blockchain.pool,
                 block_height_conds_map,
                 ValidationState(ssi, diff, prev_ses_block),
-                validate_signatures=False,
             )
             pre_validation_results = list(await asyncio.gather(*futures))
             added: Optional[AddBlockResult] = None
@@ -2088,7 +2087,7 @@ class FullNode:
                     assert result_to_validate.required_iters == pre_validation_results[0].required_iters
                     fork_info = ForkInfo(block.height - 1, block.height - 1, block.prev_header_hash)
                     (added, error_code, state_change_summary) = await self.blockchain.add_block(
-                        block, result_to_validate, bls_cache, ssi, fork_info
+                        block, result_to_validate, ssi, fork_info
                     )
                 if added == AddBlockResult.ALREADY_HAVE_BLOCK:
                     return None

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -182,7 +182,6 @@ class FullNodeSimulator(FullNodeAPI):
                     self.full_node.blockchain.pool,
                     {},
                     ValidationState(ssi, diff, None),
-                    validate_signatures=True,
                 )
                 pre_validation_results: list[PreValidationResult] = list(await asyncio.gather(*futures))
                 assert pre_validation_results is not None
@@ -190,7 +189,6 @@ class FullNodeSimulator(FullNodeAPI):
                 await self.full_node.blockchain.add_block(
                     genesis,
                     pre_validation_results[0],
-                    self.full_node._bls_cache,
                     self.full_node.constants.SUB_SLOT_ITERS_STARTING,
                     fork_info,
                 )
@@ -246,14 +244,11 @@ class FullNodeSimulator(FullNodeAPI):
                     self.full_node.blockchain.pool,
                     {},
                     ValidationState(ssi, diff, None),
-                    validate_signatures=True,
                 )
                 pre_validation_results: list[PreValidationResult] = list(await asyncio.gather(*futures))
                 assert pre_validation_results is not None
                 fork_info = ForkInfo(-1, -1, self.full_node.constants.GENESIS_CHALLENGE)
-                await self.full_node.blockchain.add_block(
-                    genesis, pre_validation_results[0], self.full_node._bls_cache, ssi, fork_info
-                )
+                await self.full_node.blockchain.add_block(genesis, pre_validation_results[0], ssi, fork_info)
             peak = self.full_node.blockchain.get_peak()
             assert peak is not None
             curr: BlockRecord = peak


### PR DESCRIPTION
This PR is best reviewed one commit at a time. However, the second commit contains the bulk of the changes.

### Purpose:

By combining executing CLVM, parsing (and some validation of) conditions with signature validation, we do more work under a single GIL release, improving the concurrency of block validation.

This is arguably also a simplification of the code, making it a bit more robust. Instead of optionally validating signatures in two places, we now do it *unconditionally* in one place. (although, there is technically still the option to not validate the signatures, but we currently only use that in tests and in block creation when all we want to do is to compute the final cost of the block).

This is also a step twoards demoting `get_name_puzzle_conditions()` into a test-only function. It's used in many places where the signature is either not available or not set correctly. This PR replaces all production uses of this function.

### Validating signatures in pre-validate

`pre_validate_blocks_multiprocessing()` no longer accepts the `validate_signatures=False` parameter. It's always validates signatures.

Since signature validation now happens in the pre-validation step, `validate_block_body()` no longer validates it. Which also means it doesn't need the `BLSCache` passed in to it.

This also means `Blockchain.add_block()` no longer needs to take the BLS cache. It validates the block body, but the signature validation has already happened in pre-validate.

### Current Behavior:

The block signature validation is done in `validate_block_body()` or `pre_validate_block()`. In `validate_block_body()` we can optionally pass in the BLS cache, to save time on BLS pairings. We do this for new unfinished blocks, since they are likely to contain signatures that we've already validated in the mempool. The mempool adds pairings to the BLS cache.

Both of these functions can optionally *not* validate signatures. Sometimes we rely on this in tests, where we don't bother producing correct signatures, or want to save time. The `validate_signature=False` option is used when we receive a new `FullBlock` whose corresponding `UnfinishedBlock` we've already validated. We save time by not validating the signatures again.

### New Behavior:

The block signature validation is done in `run_block_generator()` (and `run_block_generator2()`, post hard-fork). This happens along side of running the block generator and parsing the resulting conditions. An invalid signature generates a failure directly in this step.

This is always run as part of pre-validation, in thread pools.

`run_block_generator()` takes an optional BLS cache and signature to validate. We pass in the BLS cache only when validating `UnfinishedBlocks`. This is already done in `main`, in `FullNode.add_unfinished_block()`. What's new is that the resulting `SpendBundleConditions` now records that we've validated the conditions, and when adding the corresponding FullBlock, we just pick up the `SpendBundleConditions` from the unfinished block cache.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
