### PR TITLE
[CHIA-1681] Replace black with Ruff

### DIFF
--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -118,8 +118,8 @@ jobs:
         python:
           - major_dot_minor: "3.10"
         check:
-          - name: black
-            command: black --check --diff .
+          - name: ruff
+            command: ruff format --check --diff .
           - name: generated protocol tests
             command: |
               python3 -m chia._tests.util.build_network_protocol_files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,9 @@ repos:
         pass_filenames: false
   - repo: local
     hooks:
-      - id: black
-        name: black
-        entry: ./activated.py black
+      - id: ruff_format
+        name: ruff format
+        entry: ./activated.py ruff format
         language: system
         require_serial: true
         types_or: [python, pyi]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,13 +57,12 @@ to configure how the tests are run. For example, for more logging: change the lo
 ```bash
 sh install.sh -d
 . ./activate
-black . && ruff check --fix && mypy && pylint benchmarks build_scripts chia tests tools *.py
+ruff format && ruff check --fix && mypy && pylint benchmarks build_scripts chia tests tools *.py
 py.test tests -v --durations 0
 ```
 
-The [black library](https://black.readthedocs.io/en/stable/) is used as an automatic style formatter to make things easier.
 The [Mypy library](https://mypy.readthedocs.io/en/stable/) is very useful for ensuring objects are of the correct type, so try to always add the type of the return value, and the type of local variables.
-The [Ruff library](https://docs.astral.sh) is used to sort, group, validate imports, ensure consistent style, and further lint all of the python files
+The [Ruff library](https://docs.astral.sh) is used to format, sort, group, validate imports, ensure consistent style, and further lint all of the python files
 
 If you want verbose logging for tests, edit the `tests/pytest.ini` file.
 
@@ -83,8 +82,7 @@ provided configuration with `pre-commit install`.
 2. Set the environment to `./venv/bin/python`
 3. Install mypy plugin
 4. Preferences > Settings > Python > Linting > mypy enabled
-5. Preferences > Settings > Formatting > Python > Provider > black
-6. Preferences > Settings > mypy > Targets: set to `./chia`
+5. Preferences > Settings > mypy > Targets: set to `./chia`
 
 ## Configure Pycharm
 

--- a/chia/_tests/blockchain/test_augmented_chain.py
+++ b/chia/_tests/blockchain/test_augmented_chain.py
@@ -15,7 +15,6 @@ from chia.util.ints import uint32
 
 @dataclass
 class NullBlockchain:
-
     if TYPE_CHECKING:
         from chia.consensus.blockchain_interface import BlocksProtocol
 
@@ -72,7 +71,6 @@ def BR(b: FullBlock) -> BlockRecord:
 @pytest.mark.anyio
 @pytest.mark.limit_consensus_modes(reason="save time")
 async def test_augmented_chain(default_10000_blocks: list[FullBlock]) -> None:
-
     blocks = default_10000_blocks
     # this test blockchain is expected to have block generators at these
     # heights:

--- a/chia/_tests/core/daemon/test_daemon.py
+++ b/chia/_tests/core/daemon/test_daemon.py
@@ -1404,7 +1404,7 @@ async def test_misc_daemon_ws(
 
 @pytest.mark.anyio
 async def test_unexpected_json(
-    daemon_connection_and_temp_keychain: tuple[aiohttp.ClientWebSocketResponse, Keychain]
+    daemon_connection_and_temp_keychain: tuple[aiohttp.ClientWebSocketResponse, Keychain],
 ) -> None:
     ws, _ = daemon_connection_and_temp_keychain
 

--- a/chia/_tests/core/full_node/stores/test_full_node_store.py
+++ b/chia/_tests/core/full_node/stores/test_full_node_store.py
@@ -481,7 +481,6 @@ async def test_basic_store(
 
     fork_info = ForkInfo(-1, -1, blockchain.constants.GENESIS_CHALLENGE)
     for block in blocks_reorg:
-
         peak = blockchain.get_peak()
         assert peak is not None
 

--- a/chia/_tests/core/full_node/test_conditions.py
+++ b/chia/_tests/core/full_node/test_conditions.py
@@ -503,7 +503,6 @@ class TestConditions:
         bt: BlockTools,
         consensus_mode: ConsensusMode,
     ) -> None:
-
         c = bt.constants
 
         additional_data = agg_sig_additional_data(c.AGG_SIG_ME_ADDITIONAL_DATA)

--- a/chia/_tests/core/mempool/test_mempool_fee_protocol.py
+++ b/chia/_tests/core/mempool/test_mempool_fee_protocol.py
@@ -22,7 +22,7 @@ from chia.wallet.wallet import Wallet
 async def test_protocol_messages(
     simulator_and_wallet: tuple[
         list[Union[FullNodeAPI, FullNodeSimulator]], list[tuple[Wallet, ChiaServer]], BlockTools
-    ]
+    ],
 ) -> None:
     full_nodes, _wallets, bt = simulator_and_wallet
     a_wallet = bt.get_pool_wallet_tool()

--- a/chia/_tests/core/server/test_server.py
+++ b/chia/_tests/core/server/test_server.py
@@ -193,7 +193,7 @@ async def test_call_api_of_specific(
 
 @pytest.mark.anyio
 async def test_call_api_of_specific_for_missing_peer(
-    two_nodes: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools]
+    two_nodes: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
 ) -> None:
     _, _, server_1, server_2, _ = two_nodes
 

--- a/chia/_tests/environments/wallet.py
+++ b/chia/_tests/environments/wallet.py
@@ -292,9 +292,9 @@ class WalletTestFramework:
             for env in self.environments:
                 ph_indexes: dict[uint32, Optional[DerivationRecord]] = {}
                 for wallet_id in env.wallet_state_manager.wallets:
-                    ph_indexes[wallet_id] = (
-                        await env.wallet_state_manager.puzzle_store.get_current_derivation_record_for_wallet(wallet_id)
-                    )
+                    ph_indexes[
+                        wallet_id
+                    ] = await env.wallet_state_manager.puzzle_store.get_current_derivation_record_for_wallet(wallet_id)
                 puzzle_hash_indexes.append(ph_indexes)
 
         pending_txs: list[list[TransactionRecord]] = []

--- a/chia/_tests/farmer_harvester/test_farmer_harvester.py
+++ b/chia/_tests/farmer_harvester/test_farmer_harvester.py
@@ -44,7 +44,7 @@ async def update_harvester_config(harvester_rpc_port: Optional[int], root_path: 
 
 @pytest.mark.anyio
 async def test_start_with_empty_keychain(
-    farmer_one_harvester_not_started: tuple[list[HarvesterService], FarmerService, BlockTools]
+    farmer_one_harvester_not_started: tuple[list[HarvesterService], FarmerService, BlockTools],
 ) -> None:
     _, farmer_service, bt = farmer_one_harvester_not_started
     farmer: Farmer = farmer_service._node
@@ -67,7 +67,7 @@ async def test_start_with_empty_keychain(
 
 @pytest.mark.anyio
 async def test_harvester_handshake(
-    farmer_one_harvester_not_started: tuple[list[HarvesterService], FarmerService, BlockTools]
+    farmer_one_harvester_not_started: tuple[list[HarvesterService], FarmerService, BlockTools],
 ) -> None:
     harvesters, farmer_service, bt = farmer_one_harvester_not_started
     harvester_service = harvesters[0]
@@ -212,7 +212,7 @@ async def test_harvester_config(farmer_one_harvester: tuple[list[HarvesterServic
 
 @pytest.mark.anyio
 async def test_missing_signage_point(
-    farmer_one_harvester: tuple[list[HarvesterService], FarmerService, BlockTools]
+    farmer_one_harvester: tuple[list[HarvesterService], FarmerService, BlockTools],
 ) -> None:
     _, farmer_service, _bt = farmer_one_harvester
     farmer_api = farmer_service._api

--- a/chia/_tests/fee_estimation/test_fee_estimation_integration.py
+++ b/chia/_tests/fee_estimation/test_fee_estimation_integration.py
@@ -253,7 +253,8 @@ def test_add_tx_called() -> None:
 
     # Replace with test method
     mempool.fee_estimator.tracker.add_tx = types.MethodType(  # type: ignore[attr-defined]
-        add_tx_called_fun, mempool.fee_estimator.tracker  # type: ignore[attr-defined]
+        add_tx_called_fun,
+        mempool.fee_estimator.tracker,  # type: ignore[attr-defined]
     )
 
     mempool.add_to_pool(item)

--- a/chia/_tests/fee_estimation/test_fee_estimation_rpc.py
+++ b/chia/_tests/fee_estimation/test_fee_estimation_rpc.py
@@ -47,7 +47,7 @@ async def setup_node_and_rpc(
 
 @pytest.fixture(scope="function")
 async def one_node_no_blocks(
-    one_node: tuple[list[SimulatorFullNodeService], list[WalletService], BlockTools]
+    one_node: tuple[list[SimulatorFullNodeService], list[WalletService], BlockTools],
 ) -> tuple[FullNodeRpcClient, FullNodeRpcApi]:
     full_nodes, _wallets, bt = one_node
     full_node_apis = [full_node_service._api for full_node_service in full_nodes]

--- a/chia/_tests/plot_sync/test_plot_sync.py
+++ b/chia/_tests/plot_sync/test_plot_sync.py
@@ -570,7 +570,7 @@ async def test_farmer_restart(environment: Environment) -> None:
 
 @pytest.mark.anyio
 async def test_sync_start_and_disconnect_while_sync_is_active(
-    farmer_one_harvester: tuple[list[HarvesterService], FarmerService, BlockTools]
+    farmer_one_harvester: tuple[list[HarvesterService], FarmerService, BlockTools],
 ) -> None:
     harvesters, farmer_service, _ = farmer_one_harvester
     harvester_service = harvesters[0]

--- a/chia/_tests/util/build_network_protocol_files.py
+++ b/chia/_tests/util/build_network_protocol_files.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-import sysconfig
+import sys
 from pathlib import Path
 from typing import Any, Callable
 
@@ -288,13 +288,11 @@ def main() -> None:
         "test_network_protocol_json.py": build_json_test,
     }
 
-    scripts_path = Path(sysconfig.get_path("scripts"))
-
     for name, function in name_to_function.items():
         path = tests_dir.joinpath(name)
         path.write_text(function())
         subprocess.run(
-            [scripts_path.joinpath("ruff"), "format", os.fspath(path.relative_to(tests_dir))],
+            [sys.executable, "-m", "ruff", "format", os.fspath(path.relative_to(tests_dir))],
             check=True,
             cwd=tests_dir,
         )

--- a/chia/_tests/util/build_network_protocol_files.py
+++ b/chia/_tests/util/build_network_protocol_files.py
@@ -293,9 +293,8 @@ def main() -> None:
     for name, function in name_to_function.items():
         path = tests_dir.joinpath(name)
         path.write_text(function())
-        # black seems to have trouble when run as a module so not using `python -m black`
         subprocess.run(
-            [scripts_path.joinpath("black"), os.fspath(path.relative_to(tests_dir))],
+            [scripts_path.joinpath("ruff"), "format", os.fspath(path.relative_to(tests_dir))],
             check=True,
             cwd=tests_dir,
         )

--- a/chia/_tests/util/test_network_protocol_files.py
+++ b/chia/_tests/util/test_network_protocol_files.py
@@ -20,7 +20,6 @@ def parse_blob(input_bytes: bytes) -> tuple[bytes, bytes]:
 
 
 def test_protocol_bytes() -> None:
-
     filename: Path = get_network_protocol_filename()
     assert filename.exists()
     with open(filename, "rb") as f:

--- a/chia/_tests/wallet/dao_wallet/test_dao_clvm.py
+++ b/chia/_tests/wallet/dao_wallet/test_dao_clvm.py
@@ -537,7 +537,11 @@ def test_validator() -> None:
 
     # Setup the spend_p2_singleton (proposal inner puz)
     spend_p2_singleton = SPEND_P2_SINGLETON_MOD.curry(
-        treasury_struct, CAT_MOD_HASH, conditions, [], p2_singleton_puzhash  # tailhash conds
+        treasury_struct,
+        CAT_MOD_HASH,
+        conditions,
+        [],
+        p2_singleton_puzhash,  # tailhash conds
     )
     spend_p2_singleton_puzhash = spend_p2_singleton.get_tree_hash()
 
@@ -820,7 +824,11 @@ def test_treasury() -> None:
 
     # Setup the spend_p2_singleton (proposal inner puz)
     spend_p2_singleton = SPEND_P2_SINGLETON_MOD.curry(
-        treasury_struct, CAT_MOD_HASH, conditions, [], p2_singleton_puzhash  # tailhash conds
+        treasury_struct,
+        CAT_MOD_HASH,
+        conditions,
+        [],
+        p2_singleton_puzhash,  # tailhash conds
     )
     spend_p2_singleton_puzhash = spend_p2_singleton.get_tree_hash()
 
@@ -1067,7 +1075,11 @@ def test_proposal_lifecycle() -> None:
 
     # Setup the spend_p2_singleton (proposal inner puz)
     spend_p2_singleton = SPEND_P2_SINGLETON_MOD.curry(
-        treasury_singleton_struct, CAT_MOD_HASH, conditions, [], p2_singleton_puzhash  # tailhash conds
+        treasury_singleton_struct,
+        CAT_MOD_HASH,
+        conditions,
+        [],
+        p2_singleton_puzhash,  # tailhash conds
     )
     spend_p2_singleton_puzhash = spend_p2_singleton.get_tree_hash()
 

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -1281,7 +1281,7 @@ async def test_retry_store(
     request_puzzle_solution_failure_tested = False
 
     def flaky_request_puzzle_solution(
-        func: Callable[[wallet_protocol.RequestPuzzleSolution], Awaitable[Optional[Message]]]
+        func: Callable[[wallet_protocol.RequestPuzzleSolution], Awaitable[Optional[Message]]],
     ) -> Callable[[wallet_protocol.RequestPuzzleSolution], Awaitable[Optional[Message]]]:
         @functools.wraps(func)
         async def new_func(request: wallet_protocol.RequestPuzzleSolution) -> Optional[Message]:

--- a/chia/_tests/wallet/test_conditions.py
+++ b/chia/_tests/wallet/test_conditions.py
@@ -206,7 +206,7 @@ def test_announcement_inversions(
         tuple[type[CreateCoinAnnouncement], type[AssertCoinAnnouncement]],
         tuple[type[CreatePuzzleAnnouncement], type[AssertPuzzleAnnouncement]],
         tuple[type[CreateAnnouncement], type[AssertAnnouncement]],
-    ]
+    ],
 ) -> None:
     create_driver, assert_driver = drivers
     # mypy is not smart enough to understand that this `if` narrows down the potential types it could be

--- a/chia/_tests/wallet/test_new_wallet_protocol.py
+++ b/chia/_tests/wallet/test_new_wallet_protocol.py
@@ -404,7 +404,7 @@ async def test_request_puzzle_state(one_node: OneNode, self_hostname: str) -> No
     simulator, _, peer = await connect_to_simulator(one_node, self_hostname)
 
     # Farm block to a puzzle hash we aren't looking at
-    await simulator.farm_blocks_to_puzzlehash(3, farm_to=bytes32(b"\x0A" * 32))
+    await simulator.farm_blocks_to_puzzlehash(3, farm_to=bytes32(b"\x0a" * 32))
 
     genesis = simulator.full_node.blockchain.constants.GENESIS_CHALLENGE
 

--- a/chia/_tests/wallet/test_signer_protocol.py
+++ b/chia/_tests/wallet/test_signer_protocol.py
@@ -147,9 +147,9 @@ async def test_p2dohp_wallet_signer_protocol(wallet_environments: WalletTestFram
         solution,
     )
 
-    derivation_record: Optional[DerivationRecord] = (
-        await wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(coin.puzzle_hash)
-    )
+    derivation_record: Optional[
+        DerivationRecord
+    ] = await wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(coin.puzzle_hash)
     assert derivation_record is not None
     pubkey: G1Element = derivation_record.pubkey
     atom = puzzle.uncurry()[1].at("f").atom

--- a/chia/_tests/wallet/test_util.py
+++ b/chia/_tests/wallet/test_util.py
@@ -77,9 +77,7 @@ def test_cs_config() -> None:
         {
             "excluded_coins": [coin_to_exclude.to_json_dict()],
         }
-    ).override(
-        max_coin_amount=100
-    ).autofill(constants=DEFAULT_CONSTANTS).to_json_dict() == {
+    ).override(max_coin_amount=100).autofill(constants=DEFAULT_CONSTANTS).to_json_dict() == {
         **default_cs_config,
         "excluded_coin_ids": ["0x" + coin_to_exclude.name().hex()],
         "max_coin_amount": 100,

--- a/chia/_tests/wallet/test_wallet.py
+++ b/chia/_tests/wallet/test_wallet.py
@@ -1113,10 +1113,10 @@ class TestWalletSimulator:
         await time_out_assert(20, wsm_2.coin_store.count_small_unspent, 0, 1000, CoinType.CLAWBACK)
 
         before_txs: dict[str, dict[TransactionType, int]] = {"sender": {}, "recipient": {}}
-        before_txs["sender"][TransactionType.INCOMING_CLAWBACK_SEND] = (
-            await wsm_1.tx_store.get_transaction_count_for_wallet(
-                1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_SEND])
-            )
+        before_txs["sender"][
+            TransactionType.INCOMING_CLAWBACK_SEND
+        ] = await wsm_1.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_SEND])
         )
         before_txs["sender"][TransactionType.OUTGOING_CLAWBACK] = await wsm_1.tx_store.get_transaction_count_for_wallet(
             1, type_filter=TransactionTypeFilter.include([TransactionType.OUTGOING_CLAWBACK])
@@ -1130,10 +1130,10 @@ class TestWalletSimulator:
         before_txs["sender"][TransactionType.COINBASE_REWARD] = await wsm_1.tx_store.get_transaction_count_for_wallet(
             1, type_filter=TransactionTypeFilter.include([TransactionType.COINBASE_REWARD])
         )
-        before_txs["recipient"][TransactionType.INCOMING_CLAWBACK_RECEIVE] = (
-            await wsm_2.tx_store.get_transaction_count_for_wallet(
-                1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_RECEIVE])
-            )
+        before_txs["recipient"][
+            TransactionType.INCOMING_CLAWBACK_RECEIVE
+        ] = await wsm_2.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_RECEIVE])
         )
         # Resync start
         env_1.node._close()
@@ -1160,10 +1160,10 @@ class TestWalletSimulator:
         wsm_2 = env_2.node.wallet_state_manager
 
         after_txs: dict[str, dict[TransactionType, int]] = {"sender": {}, "recipient": {}}
-        after_txs["sender"][TransactionType.INCOMING_CLAWBACK_SEND] = (
-            await wsm_1.tx_store.get_transaction_count_for_wallet(
-                1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_SEND])
-            )
+        after_txs["sender"][
+            TransactionType.INCOMING_CLAWBACK_SEND
+        ] = await wsm_1.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_SEND])
         )
         after_txs["sender"][TransactionType.OUTGOING_CLAWBACK] = await wsm_1.tx_store.get_transaction_count_for_wallet(
             1, type_filter=TransactionTypeFilter.include([TransactionType.OUTGOING_CLAWBACK])
@@ -1177,10 +1177,10 @@ class TestWalletSimulator:
         after_txs["sender"][TransactionType.COINBASE_REWARD] = await wsm_1.tx_store.get_transaction_count_for_wallet(
             1, type_filter=TransactionTypeFilter.include([TransactionType.COINBASE_REWARD])
         )
-        after_txs["recipient"][TransactionType.INCOMING_CLAWBACK_RECEIVE] = (
-            await wsm_2.tx_store.get_transaction_count_for_wallet(
-                1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_RECEIVE])
-            )
+        after_txs["recipient"][
+            TransactionType.INCOMING_CLAWBACK_RECEIVE
+        ] = await wsm_2.tx_store.get_transaction_count_for_wallet(
+            1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_RECEIVE])
         )
         # Check clawback
         clawback_tx_1 = await wsm_1.tx_store.get_transaction_record(clawback_coin_id_1)

--- a/chia/_tests/wallet/test_wallet_coin_store.py
+++ b/chia/_tests/wallet/test_wallet_coin_store.py
@@ -787,7 +787,7 @@ async def test_get_coin_records_total_count_cache() -> None:
         assert (await store.get_coin_records(include_total_count=True)).total_count == 3
         # Make sure the total count increases for the same query when rolling back
         assert (await store.get_coin_records(include_total_count=True)).total_count == 3
-        await store.rollback_to_block(0),
+        (await store.rollback_to_block(0),)
         assert (await store.get_coin_records(include_total_count=True)).total_count == 0
 
 

--- a/chia/_tests/wallet/test_wallet_coin_store.py
+++ b/chia/_tests/wallet/test_wallet_coin_store.py
@@ -787,7 +787,7 @@ async def test_get_coin_records_total_count_cache() -> None:
         assert (await store.get_coin_records(include_total_count=True)).total_count == 3
         # Make sure the total count increases for the same query when rolling back
         assert (await store.get_coin_records(include_total_count=True)).total_count == 3
-        (await store.rollback_to_block(0),)
+        await store.rollback_to_block(0)
         assert (await store.get_coin_records(include_total_count=True)).total_count == 0
 
 

--- a/chia/cmds/cmds_util.py
+++ b/chia/cmds/cmds_util.py
@@ -358,7 +358,6 @@ class TransactionBundle(Streamable):
 def tx_out_cmd(
     enable_timelock_args: Optional[bool] = None,
 ) -> Callable[[Callable[..., list[TransactionRecord]]], Callable[..., None]]:
-
     def _tx_out_cmd(func: Callable[..., list[TransactionRecord]]) -> Callable[..., None]:
         @timelock_args(enable=enable_timelock_args)
         def original_cmd(transaction_file: Optional[str] = None, **kwargs: Any) -> None:

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -851,7 +851,7 @@ def private_key_from_mnemonic_seed_file(filename: Path) -> PrivateKey:
 
 
 def resolve_derivation_master_key(
-    fingerprint_or_filename: Optional[Union[int, str, Path]]
+    fingerprint_or_filename: Optional[Union[int, str, Path]],
 ) -> tuple[Optional[int], Optional[PrivateKey]]:
     """
     Given a key fingerprint of file containing a mnemonic seed, return the private key.

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -1071,7 +1071,6 @@ async def transfer_did(
     push: bool,
     condition_valid_times: ConditionValidTimes,
 ) -> list[TransactionRecord]:
-
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, fingerprint, config):
         try:
             target_address = target_cli_address.original_address

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -962,7 +962,6 @@ class Blockchain:
         return False
 
     async def lookup_block_generators(self, header_hash: bytes32, generator_refs: set[uint32]) -> dict[uint32, bytes]:
-
         generators: dict[uint32, bytes] = {}
 
         # if this is empty, we shouldn't have called this function to begin with

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -57,7 +57,6 @@ def pre_validate_block(
     vs: ValidationState,
     validate_signatures: bool,
 ) -> PreValidationResult:
-
     try:
         validation_start = time.monotonic()
         tx_additions: list[Coin] = []

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -1096,8 +1096,7 @@ class DataLayer:
             }
 
             solver: dict[str, Any] = {
-                "0x"
-                + our_offer_store.store_id.hex(): {
+                "0x" + our_offer_store.store_id.hex(): {
                     "new_root": "0x" + our_store_proofs[our_offer_store.store_id].proofs[0].root().hex(),
                     "dependencies": [
                         {
@@ -1182,8 +1181,7 @@ class DataLayer:
             solver: dict[str, Any] = {
                 "proofs_of_inclusion": proofs_of_inclusion,
                 **{
-                    "0x"
-                    + our_offer_store.store_id.hex(): {
+                    "0x" + our_offer_store.store_id.hex(): {
                         "new_root": "0x" + root.hex(),
                         "dependencies": [
                             {

--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -277,9 +277,9 @@ class DataLayerWallet:
         await self.wallet_state_manager.add_interested_puzzle_hashes([launcher_id], [self.id()])
         await self.wallet_state_manager.add_interested_coin_ids([new_singleton.name()])
 
-        new_singleton_coin_record: Optional[WalletCoinRecord] = (
-            await self.wallet_state_manager.coin_store.get_coin_record(new_singleton.name())
-        )
+        new_singleton_coin_record: Optional[
+            WalletCoinRecord
+        ] = await self.wallet_state_manager.coin_store.get_coin_record(new_singleton.name())
         while new_singleton_coin_record is not None and new_singleton_coin_record.spent_block_height > 0:
             # We've already synced this before, so we need to sort of force a resync
             parent_spend = await fetch_coin_spend(new_singleton_coin_record.spent_block_height, new_singleton, peer)
@@ -400,10 +400,10 @@ class DataLayerWallet:
         if root_hash is None:
             root_hash = singleton_record.root
 
-        inner_puzzle_derivation: Optional[DerivationRecord] = (
-            await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(
-                singleton_record.inner_puzzle_hash
-            )
+        inner_puzzle_derivation: Optional[
+            DerivationRecord
+        ] = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(
+            singleton_record.inner_puzzle_hash
         )
         if inner_puzzle_derivation is None:
             raise ValueError(f"DL Wallet does not have permission to update Singleton with launcher ID {launcher_id}")
@@ -692,10 +692,10 @@ class DataLayerWallet:
                 # this is likely due to a race between getting the list and acquiring the extra data
                 continue
 
-            inner_puzzle_derivation: Optional[DerivationRecord] = (
-                await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(
-                    singleton_record.inner_puzzle_hash
-                )
+            inner_puzzle_derivation: Optional[
+                DerivationRecord
+            ] = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(
+                singleton_record.inner_puzzle_hash
             )
             if inner_puzzle_derivation is not None:
                 collected.append(singleton_record)
@@ -736,9 +736,9 @@ class DataLayerWallet:
         parent_coin: Coin = (
             await self.wallet_state_manager.wallet_node.get_coin_state([mirror_coin.parent_coin_info], peer=peer)
         )[0].coin
-        inner_puzzle_derivation: Optional[DerivationRecord] = (
-            await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(parent_coin.puzzle_hash)
-        )
+        inner_puzzle_derivation: Optional[
+            DerivationRecord
+        ] = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(parent_coin.puzzle_hash)
         if inner_puzzle_derivation is None:
             raise ValueError(f"DL Wallet does not have permission to delete mirror with ID {mirror_id}")
 

--- a/chia/data_layer/util/benchmark.py
+++ b/chia/data_layer/util/benchmark.py
@@ -23,7 +23,6 @@ async def generate_datastore(num_nodes: int, slow_mode: bool) -> None:
             os.remove(db_path)
 
         async with DataStore.managed(database=db_path) as data_store:
-
             store_id = bytes32(b"0" * 32)
             await data_store.create_tree(store_id)
 

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1482,7 +1482,6 @@ class FullNode:
         fork_info: ForkInfo,
         vs: ValidationState,  # in-out parameter
     ) -> list[FullBlock]:
-
         blocks_to_validate: list[FullBlock] = []
         for i, block in enumerate(all_blocks):
             header_hash = block.header_hash

--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -49,7 +49,7 @@ class UnfinishedBlockEntry:
 
 
 def find_best_block(
-    result: dict[Optional[bytes32], UnfinishedBlockEntry]
+    result: dict[Optional[bytes32], UnfinishedBlockEntry],
 ) -> tuple[Optional[bytes32], Optional[UnfinishedBlock]]:
     """
     Given a collection of UnfinishedBlocks (all with the same reward block

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -853,9 +853,9 @@ class PoolWallet:
 
             # Add some buffer (+2) to reduce chances of a reorg
             if peak_height > leave_height + 2:
-                unconfirmed: list[TransactionRecord] = (
-                    await self.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(self.wallet_id)
-                )
+                unconfirmed: list[
+                    TransactionRecord
+                ] = await self.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(self.wallet_id)
                 next_tip: Optional[Coin] = get_most_recent_singleton_coin_from_coin_spend(tip_spend)
                 assert next_tip is not None
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1177,7 +1177,6 @@ class WalletRpcApi:
     async def combine_coins(
         self, request: CombineCoins, action_scope: WalletActionScope, extra_conditions: tuple[Condition, ...] = tuple()
     ) -> CombineCoinsResponse:
-
         # Some "number of coins" validation
         if request.number_of_coins > request.coin_num_limit:
             raise ValueError(
@@ -1725,10 +1724,10 @@ class WalletRpcApi:
     @marshal
     async def get_notifications(self, request: GetNotifications) -> GetNotificationsResponse:
         if request.ids is None:
-            notifications: list[Notification] = (
-                await self.service.wallet_state_manager.notification_manager.notification_store.get_all_notifications(
-                    pagination=(request.start, request.end)
-                )
+            notifications: list[
+                Notification
+            ] = await self.service.wallet_state_manager.notification_manager.notification_store.get_all_notifications(
+                pagination=(request.start, request.end)
             )
         else:
             notifications = (

--- a/chia/util/action_scope.py
+++ b/chia/util/action_scope.py
@@ -29,7 +29,6 @@ class ResourceManager(Protocol):
 
 @dataclass
 class SQLiteResourceManager:
-
     _db: DBWrapper2
     _active_writer: Optional[aiosqlite.Connection] = field(init=False, default=None)
 

--- a/chia/util/augmented_chain.py
+++ b/chia/util/augmented_chain.py
@@ -52,7 +52,6 @@ class AugmentedBlockchain:
 
     # BlocksProtocol
     async def lookup_block_generators(self, header_hash: bytes32, generator_refs: set[uint32]) -> dict[uint32, bytes]:
-
         generators: dict[uint32, bytes] = {}
 
         # traverse the additional blocks (if any) and resolve heights into

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -436,9 +436,9 @@ class CATWallet:
         if new:
             return await self.get_new_puzzlehash()
         else:
-            record: Optional[DerivationRecord] = (
-                await self.wallet_state_manager.get_current_derivation_record_for_wallet(self.standard_wallet.id())
-            )
+            record: Optional[
+                DerivationRecord
+            ] = await self.wallet_state_manager.get_current_derivation_record_for_wallet(self.standard_wallet.id())
             if record is None:
                 return await self.get_new_puzzlehash()
             return record.puzzle_hash
@@ -538,18 +538,18 @@ class CATWallet:
         return coins
 
     async def inner_puzzle_for_cat_puzhash(self, cat_hash: bytes32) -> Program:
-        record: Optional[DerivationRecord] = (
-            await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(cat_hash)
-        )
+        record: Optional[
+            DerivationRecord
+        ] = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(cat_hash)
         if record is None:
             raise RuntimeError(f"Missing Derivation Record for CAT puzzle_hash {cat_hash}")
         inner_puzzle: Program = self.standard_wallet.puzzle_for_pk(record.pubkey)
         return inner_puzzle
 
     async def convert_puzzle_hash(self, puzzle_hash: bytes32) -> bytes32:
-        record: Optional[DerivationRecord] = (
-            await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(puzzle_hash)
-        )
+        record: Optional[
+            DerivationRecord
+        ] = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(puzzle_hash)
         if record is None:
             return puzzle_hash  # TODO: check if we have a test for this case!
         else:

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -191,9 +191,9 @@ class NFTWallet:
         metadata, p2_puzzle_hash = get_metadata_and_phs(uncurried_nft, data.parent_coin_spend.solution)
         self.log.debug("Got back puzhash from solution: %s", p2_puzzle_hash)
         self.log.debug("Got back updated metadata: %s", metadata)
-        derivation_record: Optional[DerivationRecord] = (
-            await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(p2_puzzle_hash)
-        )
+        derivation_record: Optional[
+            DerivationRecord
+        ] = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(p2_puzzle_hash)
         self.log.debug("Record for %s is: %s", p2_puzzle_hash, derivation_record)
         if derivation_record is None:
             self.log.debug("Not our NFT, pointing to %s, skipping", p2_puzzle_hash)
@@ -671,10 +671,10 @@ class NFTWallet:
         if unft.supports_did:
             if new_owner is None:
                 # If no new owner was specified and we're sending this to ourselves, let's not reset the DID
-                derivation_record: Optional[DerivationRecord] = (
-                    await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(
-                        payments[0].puzzle_hash
-                    )
+                derivation_record: Optional[
+                    DerivationRecord
+                ] = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(
+                    payments[0].puzzle_hash
                 )
                 if derivation_record is not None:
                     new_owner = unft.owner_did

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -181,9 +181,9 @@ class Wallet:
         if new:
             return await self.get_new_puzzle()
         else:
-            record: Optional[DerivationRecord] = (
-                await self.wallet_state_manager.get_current_derivation_record_for_wallet(self.id())
-            )
+            record: Optional[
+                DerivationRecord
+            ] = await self.wallet_state_manager.get_current_derivation_record_for_wallet(self.id())
             if record is None:
                 return await self.get_new_puzzle()  # pragma: no cover
             puzzle = puzzle_for_pk(record.pubkey)
@@ -193,9 +193,9 @@ class Wallet:
         if new:
             return await self.get_new_puzzlehash()
         else:
-            record: Optional[DerivationRecord] = (
-                await self.wallet_state_manager.get_current_derivation_record_for_wallet(self.id())
-            )
+            record: Optional[
+                DerivationRecord
+            ] = await self.wallet_state_manager.get_current_derivation_record_for_wallet(self.id())
             if record is None:
                 return await self.get_new_puzzlehash()
             return record.puzzle_hash
@@ -509,9 +509,9 @@ class Wallet:
 
     async def match_hinted_coin(self, coin: Coin, hint: bytes32) -> bool:
         if hint == coin.puzzle_hash:
-            wallet_identifier: Optional[WalletIdentifier] = (
-                await self.wallet_state_manager.puzzle_store.get_wallet_identifier_for_puzzle_hash(coin.puzzle_hash)
-            )
+            wallet_identifier: Optional[
+                WalletIdentifier
+            ] = await self.wallet_state_manager.puzzle_store.get_wallet_identifier_for_puzzle_hash(coin.puzzle_hash)
             if wallet_identifier is not None and wallet_identifier.id == self.id():
                 return True
         return False

--- a/chia/wallet/wallet_spend_bundle.py
+++ b/chia/wallet/wallet_spend_bundle.py
@@ -9,7 +9,6 @@ from chia.wallet.util.debug_spend_bundle import debug_spend_bundle
 
 
 class WalletSpendBundle(SpendBundle):
-
     @classmethod
     def aggregate(cls, spend_bundles: list[T_SpendBundle]) -> WalletSpendBundle:
         coin_spends: list[CoinSpend] = []

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1505,12 +1505,12 @@ class WalletStateManager:
             old_p2_puzhash,
             new_p2_puzhash,
         )
-        new_derivation_record: Optional[DerivationRecord] = (
-            await self.puzzle_store.get_derivation_record_for_puzzle_hash(new_p2_puzhash)
-        )
-        old_derivation_record: Optional[DerivationRecord] = (
-            await self.puzzle_store.get_derivation_record_for_puzzle_hash(old_p2_puzhash)
-        )
+        new_derivation_record: Optional[
+            DerivationRecord
+        ] = await self.puzzle_store.get_derivation_record_for_puzzle_hash(new_p2_puzhash)
+        old_derivation_record: Optional[
+            DerivationRecord
+        ] = await self.puzzle_store.get_derivation_record_for_puzzle_hash(old_p2_puzhash)
         if new_derivation_record is None and old_derivation_record is None:
             self.log.debug(
                 "Cannot find a P2 puzzle hash for NFT:%s, this NFT belongs to others.",
@@ -1583,9 +1583,9 @@ class WalletStateManager:
         assert coin_state.created_height is not None
         is_recipient: Optional[bool] = None
         # Check if the wallet is the sender
-        sender_derivation_record: Optional[DerivationRecord] = (
-            await self.puzzle_store.get_derivation_record_for_puzzle_hash(metadata.sender_puzzle_hash)
-        )
+        sender_derivation_record: Optional[
+            DerivationRecord
+        ] = await self.puzzle_store.get_derivation_record_for_puzzle_hash(metadata.sender_puzzle_hash)
         # Check if the wallet is the recipient
         recipient_derivation_record = await self.puzzle_store.get_derivation_record_for_puzzle_hash(
             metadata.recipient_puzzle_hash

--- a/poetry.lock
+++ b/poetry.lock
@@ -456,52 +456,6 @@ files = [
 bitarray = ">=2.8.0,<3.0.0"
 
 [[package]]
-name = "black"
-version = "24.8.0"
-description = "The uncompromising code formatter."
-optional = true
-python-versions = ">=3.8"
-files = [
-    {file = "black-24.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:09cdeb74d494ec023ded657f7092ba518e8cf78fa8386155e4a03fdcc44679e6"},
-    {file = "black-24.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:81c6742da39f33b08e791da38410f32e27d632260e599df7245cccee2064afeb"},
-    {file = "black-24.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:707a1ca89221bc8a1a64fb5e15ef39cd755633daa672a9db7498d1c19de66a42"},
-    {file = "black-24.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d6417535d99c37cee4091a2f24eb2b6d5ec42b144d50f1f2e436d9fe1916fe1a"},
-    {file = "black-24.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fb6e2c0b86bbd43dee042e48059c9ad7830abd5c94b0bc518c0eeec57c3eddc1"},
-    {file = "black-24.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:837fd281f1908d0076844bc2b801ad2d369c78c45cf800cad7b61686051041af"},
-    {file = "black-24.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62e8730977f0b77998029da7971fa896ceefa2c4c4933fcd593fa599ecbf97a4"},
-    {file = "black-24.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:72901b4913cbac8972ad911dc4098d5753704d1f3c56e44ae8dce99eecb0e3af"},
-    {file = "black-24.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:7c046c1d1eeb7aea9335da62472481d3bbf3fd986e093cffd35f4385c94ae368"},
-    {file = "black-24.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:649f6d84ccbae73ab767e206772cc2d7a393a001070a4c814a546afd0d423aed"},
-    {file = "black-24.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b59b250fdba5f9a9cd9d0ece6e6d993d91ce877d121d161e4698af3eb9c1018"},
-    {file = "black-24.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:6e55d30d44bed36593c3163b9bc63bf58b3b30e4611e4d88a0c3c239930ed5b2"},
-    {file = "black-24.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:505289f17ceda596658ae81b61ebbe2d9b25aa78067035184ed0a9d855d18afd"},
-    {file = "black-24.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b19c9ad992c7883ad84c9b22aaa73562a16b819c1d8db7a1a1a49fb7ec13c7d2"},
-    {file = "black-24.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f13f7f386f86f8121d76599114bb8c17b69d962137fc70efe56137727c7047e"},
-    {file = "black-24.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:f490dbd59680d809ca31efdae20e634f3fae27fba3ce0ba3208333b713bc3920"},
-    {file = "black-24.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eab4dd44ce80dea27dc69db40dab62d4ca96112f87996bca68cd75639aeb2e4c"},
-    {file = "black-24.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3c4285573d4897a7610054af5a890bde7c65cb466040c5f0c8b732812d7f0e5e"},
-    {file = "black-24.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e84e33b37be070ba135176c123ae52a51f82306def9f7d063ee302ecab2cf47"},
-    {file = "black-24.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:73bbf84ed136e45d451a260c6b73ed674652f90a2b3211d6a35e78054563a9bb"},
-    {file = "black-24.8.0-py3-none-any.whl", hash = "sha256:972085c618ee94f402da1af548a4f218c754ea7e5dc70acb168bfaca4c2542ed"},
-    {file = "black-24.8.0.tar.gz", hash = "sha256:2500945420b6784c38b9ee885af039f5e7471ef284ab03fa35ecdde4688cd83f"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "boto3"
 version = "1.35.43"
 description = "The AWS SDK for Python"
@@ -2124,17 +2078,6 @@ files = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.11.2"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = true
-python-versions = ">=3.7"
-files = [
-    {file = "pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
-    {file = "pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
-]
-
-[[package]]
 name = "pefile"
 version = "2023.2.7"
 description = "Python PE parsing module"
@@ -3276,11 +3219,11 @@ url = "https://pypi.chia.net/simple"
 reference = "chia"
 
 [extras]
-dev = ["aiohttp_cors", "black", "build", "coverage", "diff-cover", "lxml", "mypy", "pre-commit", "pre-commit", "py3createtorrent", "pyinstaller", "pytest", "pytest-cov", "pytest-mock", "pytest-monitor", "pytest-xdist", "ruff", "types-aiofiles", "types-cryptography", "types-pyyaml", "types-setuptools"]
+dev = ["aiohttp_cors", "build", "coverage", "diff-cover", "lxml", "mypy", "pre-commit", "pre-commit", "py3createtorrent", "pyinstaller", "pytest", "pytest-cov", "pytest-mock", "pytest-monitor", "pytest-xdist", "ruff", "types-aiofiles", "types-cryptography", "types-pyyaml", "types-setuptools"]
 legacy-keyring = ["keyrings.cryptfile"]
 upnp = ["miniupnpc"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9, <3.13"
-content-hash = "6b3b9e0892074f594508b0de1a6355cab962eed550da6e0648e21a3820493149"
+content-hash = "9f23f736c76b26eed517250deec643361090f891454a337eb807dd04e5d5f3fd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ zstd = [
 importlib-resources = "6.4.0"
 hsms = "0.3.1"
 aiohttp_cors = { version = "0.7.0", optional = true }
-black = { version = "24.8.0", optional = true }
 build = { version = "1.2.1", optional = true }
 coverage = { version = "7.6.4", optional = true }
 diff-cover = { version = "9.2.0", optional = true }
@@ -105,7 +104,7 @@ ruff = { version = "0.7.1", optional = true }
 
 
 [tool.poetry.extras]
-dev = ["aiohttp_cors", "black", "build", "coverage", "diff-cover", "mypy", "pre-commit", "py3createtorrent", "pyinstaller", "pytest", "pytest-cov", "pytest-mock", "pytest-monitor", "pytest-xdist", "ruff", "types-aiofiles", "types-cryptography", "types-pyyaml", "types-setuptools", "lxml"]
+dev = ["aiohttp_cors", "build", "coverage", "diff-cover", "mypy", "pre-commit", "py3createtorrent", "pyinstaller", "pytest", "pytest-cov", "pytest-mock", "pytest-monitor", "pytest-xdist", "ruff", "types-aiofiles", "types-cryptography", "types-pyyaml", "types-setuptools", "lxml"]
 upnp = ["miniupnpc"]
 legacy_keyring = ["keyrings.cryptfile"]
 
@@ -141,17 +140,6 @@ bump = true
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
 build-backend = "poetry_dynamic_versioning.backend"
-
-[tool.black]
-line-length = 120
-target-version =  ['py39', 'py310', 'py311', 'py312']
-include = '''
-^/(
-    [^/]*.py
-    | (benchmarks|build_scripts|chia|tests|tools)/.*\.pyi?
-)$
-'''
-exclude = ''
 
 [project]
 # This has to match the poetry python entry above

--- a/tools/run_block.py
+++ b/tools/run_block.py
@@ -35,6 +35,7 @@ associated with the coin being spent. Condition Opcodes are verified by every cl
 and in this way they control whether a spend is valid or not.
 
 """
+
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
See PR https://github.com/Chia-Network/chia-blockchain/pull/18759 for more information about Ruff. This PR continues the work of simplifying our pre-commit workflow by replacing another one of our tools with Ruff.

Ruff specifically targets black to replace with its formatter since black is so popular in the python ecosystem.  There are, however, some differences in opinion and they are all documented here: https://docs.astral.sh/ruff/formatter/black/ .  The main one that may be a little controversial is the fact that ruff would rather avoid parentheses than break up call expressions like so:
```
derivation_record: Optional[
    DerivationRecord
] = await wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(coin.puzzle_hash)
```