### PR TITLE
CHIA-1709 Pass a ValidationState to validate_unfinished_block_header

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -36,6 +36,7 @@ from chia.types.generator_types import BlockGenerator
 from chia.types.header_block import HeaderBlock
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.types.unfinished_header_block import UnfinishedHeaderBlock
+from chia.types.validation_state import ValidationState
 from chia.types.weight_proof import SubEpochChallengeSegment
 from chia.util.cpu import available_logical_cores
 from chia.util.errors import Err
@@ -677,13 +678,13 @@ class Blockchain:
         sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
             self.constants, len(unfinished_header_block.finished_sub_slots) > 0, prev_b, self
         )
+        expected_vs = ValidationState(sub_slot_iters, difficulty, None)
         required_iters, error = validate_unfinished_header_block(
             self.constants,
             self,
             unfinished_header_block,
             False,
-            difficulty,
-            sub_slot_iters,
+            expected_vs,
             skip_overflow_ss_validation,
         )
         if error is not None:


### PR DESCRIPTION
### Purpose:

`validate_unfinished_block_header` takes `expected_difficulty`, `expected_sub_slot_iters` and `prev_ses_block` as separate parameters. Now that we have `ValidationState`, we can pass that directly.

### Current Behavior:

`validate_unfinished_block_header` takes `expected_difficulty`, `expected_sub_slot_iters` and `prev_ses_block` as separate parameters.

### New Behavior:

`validate_unfinished_block_header` takes a `ValidationState` instead.