### PR TITLE
[CHIA-1236] Sort offers in CLI by `RELEVANCE`

### DIFF
--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -923,6 +923,7 @@ def test_get_offers(capsys: object, get_test_cli_clients: tuple[TestRpcClients, 
         "--exclude-taken-offers",
         "--include-completed",
         "--reverse",
+        "--sort-by-relevance",
     ]
     # these are various things that should be in the output
     assert_list = [
@@ -940,7 +941,7 @@ def test_get_offers(capsys: object, get_test_cli_clients: tuple[TestRpcClients, 
         "Record with id: 0101010101010101010101010101010101010101010101010101010101010101",
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
-    expected_calls: logType = {"get_all_offers": [(0, 10, None, True, False, True, True, True)]}
+    expected_calls: logType = {"get_all_offers": [(0, 10, "RELEVANCE", True, False, True, True, True)]}
     command_args = [
         "wallet",
         "get_offers",
@@ -960,7 +961,7 @@ def test_get_offers(capsys: object, get_test_cli_clients: tuple[TestRpcClients, 
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     assert expected_calls["get_all_offers"] is not None
-    expected_calls["get_all_offers"].append((0, 10, None, False, True, False, False, False))
+    expected_calls["get_all_offers"].append((0, 10, "CONFIRMED_AT_HEIGHT", False, True, False, False, False))
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
 
 

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -541,6 +541,7 @@ def make_offer_cmd(
     "-ic", "--include-completed", help="Include offers that have been confirmed/cancelled or failed", is_flag=True
 )
 @click.option("-s", "--summaries", help="Show the assets being offered and requested for each offer", is_flag=True)
+@click.option("--sort-by-relevance/--sort-by-confirmed-height", help="Sort the offers one of two ways", is_flag=True)
 @click.option("-r", "--reverse", help="Reverse the order of the output", is_flag=True)
 def get_offers_cmd(
     wallet_rpc_port: Optional[int],
@@ -552,6 +553,7 @@ def get_offers_cmd(
     include_completed: bool,
     summaries: bool,
     reverse: bool,
+    sort_by_relevance: bool,
 ) -> None:
     from .wallet_funcs import get_offers
 
@@ -566,6 +568,7 @@ def get_offers_cmd(
             include_completed=include_completed,
             summaries=summaries,
             reverse=reverse,
+            sort_by_relevance=sort_by_relevance,
         )
     )
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -659,6 +659,7 @@ async def get_offers(
     include_completed: bool = False,
     summaries: bool = False,
     reverse: bool = False,
+    sort_by_relevance: bool = True,
 ) -> None:
     async with get_wallet_client(wallet_rpc_port, fp) as (wallet_client, _, _):
         file_contents: bool = (filepath is not None) or summaries
@@ -673,6 +674,7 @@ async def get_offers(
                 new_records: list[TradeRecord] = await wallet_client.get_all_offers(
                     start,
                     end,
+                    sort_key="RELEVANCE" if sort_by_relevance else "CONFIRMED_AT_HEIGHT",
                     reverse=reverse,
                     file_contents=file_contents,
                     exclude_my_offers=exclude_my_offers,


### PR DESCRIPTION
Previously these were sorted in reverse order of confirmed time.  This should be a better sort that is closer to how the GUI displays offers.  It should also make expired offers easier to find and cancel.