### PR TITLE
CHIA-1716 Speedup get_header_blocks_in_range w.r.t. blocks with no transactions

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -843,6 +843,10 @@ class Blockchain:
                 raise ValueError(f"Block at {block.header_hash} is no longer in the blockchain (it's in a fork)")
             if tx_filter is False:
                 header = get_block_header(block, [], [])
+            elif block.transactions_generator is None:
+                # There is no point in getting additions and removals for
+                # blocks that do not have transactions.
+                header = get_block_header(block, [], [])
             else:
                 tx_additions: list[CoinRecord] = [
                     c for c in (await self.coin_store.get_coins_added_at_height(block.height)) if not c.coinbase


### PR DESCRIPTION
### Purpose:

There is no point in getting additions and removals for blocks that do not have transactions.

### Current Behavior:

`get_header_blocks_in_range` prepares additions and removals even blocks without transactions.

### New Behavior:

`get_header_blocks_in_range` only prepares additions and removals for blocks with transactions.