### PR TITLE
[CHIA-1640] simplify pre_validate_blocks_multiprocessing()

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -33,7 +33,7 @@ from chia.consensus.constants import ConsensusConstants
 from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
 from chia.consensus.make_sub_epoch_summary import next_sub_epoch_summary
-from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_blocks_multiprocessing
+from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_block
 from chia.consensus.pot_iterations import calculate_sp_iters
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
@@ -1526,7 +1526,7 @@ class FullNode:
         wp_summaries: Optional[list[SubEpochSummary]] = None,
     ) -> Sequence[Awaitable[PreValidationResult]]:
         """
-        This is a thin wrapper over pre_validate_blocks_multiprocessing().
+        This is a thin wrapper over pre_validate_block().
 
         Args:
             blockchain:
@@ -1540,17 +1540,22 @@ class FullNode:
         # Validates signatures in multiprocessing since they take a while, and we don't have cached transactions
         # for these blocks (unlike during normal operation where we validate one at a time)
         # We have to copy the ValidationState object to preserve it for the add_block()
-        # call below. pre_validate_blocks_multiprocessing() will update the
+        # call below. pre_validate_block() will update the
         # object we pass in.
-        return await pre_validate_blocks_multiprocessing(
-            self.constants,
-            blockchain,
-            blocks_to_validate,
-            self.blockchain.pool,
-            {},
-            vs,
-            wp_summaries=wp_summaries,
-        )
+        ret: list[Awaitable[PreValidationResult]] = []
+        for block in blocks_to_validate:
+            ret.append(
+                await pre_validate_block(
+                    self.constants,
+                    blockchain,
+                    block,
+                    self.blockchain.pool,
+                    None,
+                    vs,
+                    wp_summaries=wp_summaries,
+                )
+            )
+        return ret
 
     async def add_prevalidated_blocks(
         self,
@@ -2038,9 +2043,9 @@ class FullNode:
                 return None
             validation_start = time.monotonic()
             # Tries to add the block to the blockchain, if we already validated transactions, don't do it again
-            block_height_conds_map = {}
+            conds = None
             if pre_validation_result is not None and pre_validation_result.conds is not None:
-                block_height_conds_map[block.height] = pre_validation_result.conds
+                conds = pre_validation_result.conds
 
             # Don't validate signatures because we want to validate them in the main thread later, since we have a
             # cache available
@@ -2055,36 +2060,34 @@ class FullNode:
                 prev_ses_block = curr
             new_slot = len(block.finished_sub_slots) > 0
             ssi, diff = get_next_sub_slot_iters_and_difficulty(self.constants, new_slot, prev_b, self.blockchain)
-            futures = await pre_validate_blocks_multiprocessing(
+            future = await pre_validate_block(
                 self.blockchain.constants,
                 AugmentedBlockchain(self.blockchain),
-                [block],
+                block,
                 self.blockchain.pool,
-                block_height_conds_map,
+                conds,
                 ValidationState(ssi, diff, prev_ses_block),
             )
-            pre_validation_results = list(await asyncio.gather(*futures))
+            pre_validation_result = await future
             added: Optional[AddBlockResult] = None
             pre_validation_time = time.monotonic() - validation_start
             try:
-                if len(pre_validation_results) < 1:
-                    raise ValueError(f"Failed to validate block {header_hash} height {block.height}")
-                if pre_validation_results[0].error is not None:
-                    if Err(pre_validation_results[0].error) == Err.INVALID_PREV_BLOCK_HASH:
+                if pre_validation_result.error is not None:
+                    if Err(pre_validation_result.error) == Err.INVALID_PREV_BLOCK_HASH:
                         added = AddBlockResult.DISCONNECTED_BLOCK
                         error_code: Optional[Err] = Err.INVALID_PREV_BLOCK_HASH
-                    elif Err(pre_validation_results[0].error) == Err.TIMESTAMP_TOO_FAR_IN_FUTURE:
+                    elif Err(pre_validation_result.error) == Err.TIMESTAMP_TOO_FAR_IN_FUTURE:
                         raise TimestampError()
                     else:
                         raise ValueError(
                             f"Failed to validate block {header_hash} height "
-                            f"{block.height}: {Err(pre_validation_results[0].error).name}"
+                            f"{block.height}: {Err(pre_validation_result.error).name}"
                         )
                 else:
                     result_to_validate = (
-                        pre_validation_results[0] if pre_validation_result is None else pre_validation_result
+                        pre_validation_result if pre_validation_result is None else pre_validation_result
                     )
-                    assert result_to_validate.required_iters == pre_validation_results[0].required_iters
+                    assert result_to_validate.required_iters == pre_validation_result.required_iters
                     fork_info = ForkInfo(block.height - 1, block.height - 1, block.prev_header_hash)
                     (added, error_code, state_change_summary) = await self.blockchain.add_block(
                         block, result_to_validate, ssi, fork_info
@@ -2142,7 +2145,7 @@ class FullNode:
             logging.WARNING if validation_time > 2 else logging.DEBUG,
             f"Block validation: {validation_time:0.2f}s, "
             f"pre_validation: {pre_validation_time:0.2f}s, "
-            f"CLVM: {pre_validation_results[0].timing / 1000.0:0.2f}s, "
+            f"CLVM: {pre_validation_result.timing / 1000.0:0.2f}s, "
             f"post-process: {post_process_time:0.2f}s, "
             f"cost: {block.transactions_info.cost if block.transactions_info is not None else 'None'}"
             f"{percent_full_str} header_hash: {header_hash.hex()} height: {block.height}",

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -12,7 +12,7 @@ from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.blockchain import BlockchainMutexPriority
-from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_blocks_multiprocessing
+from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_block
 from chia.full_node.full_node import FullNode
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.rpc.rpc_server import default_get_connections
@@ -175,20 +175,19 @@ class FullNodeSimulator(FullNodeAPI):
             current_blocks = await self.get_all_full_blocks()
             if len(current_blocks) == 0:
                 genesis = self.bt.get_consecutive_blocks(uint8(1))[0]
-                futures = await pre_validate_blocks_multiprocessing(
+                future = await pre_validate_block(
                     self.full_node.blockchain.constants,
                     AugmentedBlockchain(self.full_node.blockchain),
-                    [genesis],
+                    genesis,
                     self.full_node.blockchain.pool,
-                    {},
+                    None,
                     ValidationState(ssi, diff, None),
                 )
-                pre_validation_results: list[PreValidationResult] = list(await asyncio.gather(*futures))
-                assert pre_validation_results is not None
+                pre_validation_result: PreValidationResult = await future
                 fork_info = ForkInfo(-1, -1, self.full_node.constants.GENESIS_CHALLENGE)
                 await self.full_node.blockchain.add_block(
                     genesis,
-                    pre_validation_results[0],
+                    pre_validation_result,
                     self.full_node.constants.SUB_SLOT_ITERS_STARTING,
                     fork_info,
                 )
@@ -237,18 +236,17 @@ class FullNodeSimulator(FullNodeAPI):
             current_blocks = await self.get_all_full_blocks()
             if len(current_blocks) == 0:
                 genesis = self.bt.get_consecutive_blocks(uint8(1))[0]
-                futures = await pre_validate_blocks_multiprocessing(
+                future = await pre_validate_block(
                     self.full_node.blockchain.constants,
                     AugmentedBlockchain(self.full_node.blockchain),
-                    [genesis],
+                    genesis,
                     self.full_node.blockchain.pool,
-                    {},
+                    None,
                     ValidationState(ssi, diff, None),
                 )
-                pre_validation_results: list[PreValidationResult] = list(await asyncio.gather(*futures))
-                assert pre_validation_results is not None
+                pre_validation_result: PreValidationResult = await future
                 fork_info = ForkInfo(-1, -1, self.full_node.constants.GENESIS_CHALLENGE)
-                await self.full_node.blockchain.add_block(genesis, pre_validation_results[0], ssi, fork_info)
+                await self.full_node.blockchain.add_block(genesis, pre_validation_result, ssi, fork_info)
             peak = self.full_node.blockchain.get_peak()
             assert peak is not None
             curr: BlockRecord = peak


### PR DESCRIPTION
The main part of this PR (in `multiprocess_validation.py`) is best reviewed with whitespace changes ignored. Most of the change is removing a loop, thus de-indenting a lot of code.

### Purpose:

The function `pre_validate_blocks_multiprocessing()` is only ever called with a single block at a time, in production code. (There are some tests that ensures it supports more than one block).

Specifically in `chia/full_node/full_node.py` and `chia/simulator/full_node_simulator.py`.

This patch simplifies this function by making it just take a single block, instead of a list. All other changes in this PR are call sites that need to be updated accordingly. Some tests are simplified, since we not longer need to test various lengths of block arrays being passed in.

The function is also renamed to reflect this, `pre_validate_blocks_multiprocessing()` -> `pre_validate_block()`.

### Current Behavior:

`pre_validate_blocks_multiprocessing()` accepts a list of blocks to validate.

### New Behavior:

`pre_validate_blocks_multiprocessing()` is renamed to `pre_validate_block()` and only  accepts a single block.