### PR TITLE
move `get_name_puzzle_conditions()` into test utils

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -22,6 +22,7 @@ from chia._tests.blockchain.blockchain_test_utils import (
 )
 from chia._tests.conftest import ConsensusMode
 from chia._tests.util.blockchain import create_blockchain
+from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.block_header_validation import validate_finished_header_block
 from chia.consensus.block_record import BlockRecord
@@ -34,7 +35,6 @@ from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.get_block_generator import get_block_generator
 from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_block
 from chia.consensus.pot_iterations import is_overflow_block
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.simulator.block_tools import BlockTools, create_block_tools_async
 from chia.simulator.keyring import TempKeyring
 from chia.simulator.wallet_tools import WalletTool

--- a/chia/_tests/clvm/benchmark_costs.py
+++ b/chia/_tests/clvm/benchmark_costs.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bundle_tools import simple_solution_generator
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.blockchain_format.program import INFINITE_COST
 from chia.types.generator_types import BlockGenerator
 from chia.types.spend_bundle import SpendBundle

--- a/chia/_tests/clvm/coin_store.py
+++ b/chia/_tests/clvm/coin_store.py
@@ -5,10 +5,11 @@ from collections.abc import Iterator
 from dataclasses import dataclass, replace
 from typing import Optional
 
+from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.cost_calculator import NPCResult
 from chia.full_node.bundle_tools import simple_solution_generator
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, mempool_check_time_locks
+from chia.full_node.mempool_check_conditions import mempool_check_time_locks
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord

--- a/chia/_tests/core/full_node/stores/test_coin_store.py
+++ b/chia/_tests/core/full_node/stores/test_coin_store.py
@@ -10,6 +10,7 @@ from clvm.casts import int_to_bytes
 
 from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from chia._tests.util.db_connection import DBConnection
+from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia._tests.util.misc import Marks, datacases
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.blockchain import AddBlockResult, Blockchain
@@ -17,7 +18,6 @@ from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.hint_store import HintStore
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.protocols.wallet_protocol import CoinState
 from chia.simulator.block_tools import BlockTools, test_constants
 from chia.simulator.wallet_tools import WalletTool

--- a/chia/_tests/core/full_node/test_subscriptions.py
+++ b/chia/_tests/core/full_node/test_subscriptions.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from chia_rs import AugSchemeMPL, Coin, CoinSpend, G2Element, Program
 from chia_rs.sized_ints import uint32, uint64
 
+from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bundle_tools import simple_solution_generator
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.full_node.subscriptions import PeerSubscriptions, peers_for_spend_bundle
 from chia.types.blockchain_format.program import INFINITE_COST
 from chia.types.blockchain_format.sized_bytes import bytes32

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -23,6 +23,7 @@ from chia._tests.core.mempool.test_mempool_manager import (
     spend_bundle_from_conditions,
 )
 from chia._tests.core.node_height import node_height_at_least
+from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia._tests.util.misc import BenchmarkRunner, invariant_check_mempool
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.condition_costs import ConditionCost
@@ -31,7 +32,7 @@ from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
 from chia.full_node.fee_estimation import EmptyMempoolInfo, MempoolInfo
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.full_node.mempool import Mempool
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, get_puzzle_and_solution_for_coin
+from chia.full_node.mempool_check_conditions import get_puzzle_and_solution_for_coin
 from chia.full_node.mempool_manager import MEMPOOL_MIN_FEE_INCREASE
 from chia.full_node.pending_tx_cache import ConflictTxCache, PendingTxCache
 from chia.protocols import full_node_protocol, wallet_protocol

--- a/chia/_tests/core/mempool/test_mempool_item_queries.py
+++ b/chia/_tests/core/mempool/test_mempool_item_queries.py
@@ -5,12 +5,12 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
 from chia._tests.core.mempool.test_mempool_manager import TEST_HEIGHT, make_bundle_spends_map_and_fee
+from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
 from chia.full_node.bundle_tools import simple_solution_generator
 from chia.full_node.fee_estimation import MempoolInfo
 from chia.full_node.mempool import Mempool
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.blockchain_format.program import INFINITE_COST
 from chia.types.clvm_cost import CLVMCost
 from chia.types.coin_spend import CoinSpend

--- a/chia/_tests/core/test_cost_calculation.py
+++ b/chia/_tests/core/test_cost_calculation.py
@@ -7,12 +7,13 @@ import pytest
 from chia_rs import G1Element
 from clvm_tools import binutils
 
+from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia._tests.util.misc import BenchmarkRunner
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bundle_tools import simple_solution_generator
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions, get_puzzle_and_solution_for_coin
+from chia.full_node.mempool_check_conditions import get_puzzle_and_solution_for_coin
 from chia.simulator.block_tools import BlockTools, test_constants
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program

--- a/chia/_tests/generator/test_rom.py
+++ b/chia/_tests/generator/test_rom.py
@@ -4,9 +4,9 @@ from clvm.CLVMObject import CLVMStorage
 from clvm_tools import binutils
 from clvm_tools.clvmc import compile_clvm_text
 
+from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32

--- a/chia/_tests/util/generator_tools_testing.py
+++ b/chia/_tests/util/generator_tools_testing.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock

--- a/chia/_tests/util/get_name_puzzle_conditions.py
+++ b/chia/_tests/util/get_name_puzzle_conditions.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import logging
+
+from chia_rs import (
+    DONT_VALIDATE_SIGNATURE,
+    MEMPOOL_MODE,
+    G2Element,
+    get_flags_for_height_and_constants,
+    run_block_generator,
+    run_block_generator2,
+)
+
+from chia.consensus.constants import ConsensusConstants
+from chia.consensus.cost_calculator import NPCResult
+from chia.types.generator_types import BlockGenerator
+from chia.util.errors import Err
+from chia.util.ints import uint16, uint32
+
+log = logging.getLogger(__name__)
+
+
+def get_name_puzzle_conditions(
+    generator: BlockGenerator,
+    max_cost: int,
+    *,
+    mempool_mode: bool,
+    height: uint32,
+    constants: ConsensusConstants,
+) -> NPCResult:
+    flags = get_flags_for_height_and_constants(height, constants) | DONT_VALIDATE_SIGNATURE
+
+    if mempool_mode:
+        flags |= MEMPOOL_MODE
+
+    if height >= constants.HARD_FORK_HEIGHT:
+        run_block = run_block_generator2
+    else:
+        run_block = run_block_generator
+
+    try:
+        block_args = generator.generator_refs
+        err, result = run_block(bytes(generator.program), block_args, max_cost, flags, G2Element(), None, constants)
+        assert (err is None) != (result is None)
+        if err is not None:
+            return NPCResult(uint16(err), None)
+        else:
+            assert result is not None
+            return NPCResult(None, result)
+    except BaseException:
+        log.exception("get_name_puzzle_condition failed")
+        return NPCResult(uint16(Err.GENERATOR_RUNTIME_ERROR.value), None)

--- a/chia/_tests/wallet/cat_wallet/test_trades.py
+++ b/chia/_tests/wallet/cat_wallet/test_trades.py
@@ -8,12 +8,12 @@ from chia_rs import G2Element
 
 from chia._tests.conftest import SOFTFORK_HEIGHTS
 from chia._tests.environments.wallet import WalletStateTransition, WalletTestFramework
+from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia._tests.util.time_out_assert import time_out_assert
 from chia._tests.wallet.vc_wallet.test_vc_wallet import mint_cr_cat
 from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bundle_tools import simple_solution_generator
-from chia.full_node.mempool_check_conditions import get_name_puzzle_conditions
 from chia.types.blockchain_format.program import INFINITE_COST, Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.spend_bundle import SpendBundle

--- a/chia/full_node/mempool_check_conditions.py
+++ b/chia/full_node/mempool_check_conditions.py
@@ -4,18 +4,12 @@ import logging
 from typing import Optional
 
 from chia_rs import (
-    DONT_VALIDATE_SIGNATURE,
-    MEMPOOL_MODE,
-    G2Element,
     get_flags_for_height_and_constants,
-    run_block_generator,
-    run_block_generator2,
     run_chia_program,
 )
 from chia_rs import get_puzzle_and_solution_for_coin2 as get_puzzle_and_solution_for_coin_rust
 
 from chia.consensus.constants import ConsensusConstants
-from chia.consensus.cost_calculator import NPCResult
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
@@ -25,7 +19,7 @@ from chia.types.generator_types import BlockGenerator
 from chia.types.spend_bundle_conditions import SpendBundleConditions
 from chia.util.condition_tools import conditions_for_solution
 from chia.util.errors import Err
-from chia.util.ints import uint16, uint32, uint64
+from chia.util.ints import uint32, uint64
 from chia.wallet.puzzles.load_clvm import load_serialized_clvm_maybe_recompile
 
 DESERIALIZE_MOD = load_serialized_clvm_maybe_recompile(
@@ -33,38 +27,6 @@ DESERIALIZE_MOD = load_serialized_clvm_maybe_recompile(
 )
 
 log = logging.getLogger(__name__)
-
-
-def get_name_puzzle_conditions(
-    generator: BlockGenerator,
-    max_cost: int,
-    *,
-    mempool_mode: bool,
-    height: uint32,
-    constants: ConsensusConstants,
-) -> NPCResult:
-    flags = get_flags_for_height_and_constants(height, constants) | DONT_VALIDATE_SIGNATURE
-
-    if mempool_mode:
-        flags |= MEMPOOL_MODE
-
-    if height >= constants.HARD_FORK_HEIGHT:
-        run_block = run_block_generator2
-    else:
-        run_block = run_block_generator
-
-    try:
-        block_args = generator.generator_refs
-        err, result = run_block(bytes(generator.program), block_args, max_cost, flags, G2Element(), None, constants)
-        assert (err is None) != (result is None)
-        if err is not None:
-            return NPCResult(uint16(err), None)
-        else:
-            assert result is not None
-            return NPCResult(None, result)
-    except BaseException:
-        log.exception("get_name_puzzle_condition failed")
-        return NPCResult(uint16(Err.GENERATOR_RUNTIME_ERROR.value), None)
 
 
 def get_puzzle_and_solution_for_coin(


### PR DESCRIPTION
It's only used by tests now.

### Purpose:

reduce the amount of production code.

### Current Behavior:

`get_name_puzzle_conditions()` is only used by tests but live in `chia.full_node.mempool_check_conditions`

### New Behavior:

`get_name_puzzle_conditions()` is only used by tests and live in `chia._tests.util.get_name_puzzle_conditions`

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
