### PR TITLE
CHIA-1734 Annotate spend_bundles as a sequence in WalletSpendBundle's aggregate

### DIFF
--- a/chia/wallet/wallet_spend_bundle.py
+++ b/chia/wallet/wallet_spend_bundle.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Sequence
+
 from chia_rs import AugSchemeMPL, G2Element
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
@@ -10,7 +12,7 @@ from chia.wallet.util.debug_spend_bundle import debug_spend_bundle
 
 class WalletSpendBundle(SpendBundle):
     @classmethod
-    def aggregate(cls, spend_bundles: list[T_SpendBundle]) -> WalletSpendBundle:
+    def aggregate(cls, spend_bundles: Sequence[T_SpendBundle]) -> WalletSpendBundle:
         coin_spends: list[CoinSpend] = []
         sigs: list[G2Element] = []
         for bundle in spend_bundles:


### PR DESCRIPTION
### Purpose:

This allows us to leverage SpendBundle's aggregate with one extra fix.

### Current Behavior:

### New Behavior:
