### PR TITLE
check network errors and their `.__cause__` for expected error types

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -378,8 +378,9 @@ class WSChiaConnection:
         except asyncio.CancelledError:
             pass
         except Exception as e:
+            expected_types = (BrokenPipeError, ConnectionResetError, TimeoutError)
             expected = False
-            if isinstance(e, (BrokenPipeError, ConnectionResetError, TimeoutError)):
+            if isinstance(e, expected_types) or isinstance(e.__cause__, expected_types):
                 expected = True
             elif isinstance(e, OSError):
                 if e.errno in {113}:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

We already have code to report 'expected' networking errors differently and more quietly than unexpected ones.  For example, we expect peers to disconnect sometimes and don't need a loud traceback in the logs for that.  But... it appears that there may have been a change where these exceptions are now being chained and thus not caught by the original check.  This expands that check to check both the exception directly and it's `.__cause__`.  That's where `e` goes when you, for example, `raise NewException() from e`.

```python-traceback
2024-11-11T13:53:38.205 2.4.4 full_node full_node_server        : ERROR    Exception Stack: Traceback (most recent call last):
  File "/home/altendky/.pyenv/versions/3.10.13/lib/python3.10/asyncio/selector_events.py", line 949, in _write_ready
    n = self._sock.send(self._buffer)
BrokenPipeError: [Errno 32] Broken pipe

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/farm/chia-blockchain/chia/server/ws_connection.py", line 374, in outbound_handler
    await self._send_message(msg)
  File "/farm/chia-blockchain/chia/server/ws_connection.py", line 647, in _send_message
    await self.ws.send_bytes(encoded)
  File "/farm/chia-blockchain/.venv/lib/python3.10/site-packages/aiohttp/web_ws.py", line 394, in send_bytes
    await self._writer.send(data, binary=True, compress=compress)
  File "/farm/chia-blockchain/.venv/lib/python3.10/site-packages/aiohttp/http_websocket.py", line 714, in send
    await self._send_frame(message, WSMsgType.BINARY, compress)
  File "/farm/chia-blockchain/.venv/lib/python3.10/site-packages/aiohttp/http_websocket.py", line 678, in _send_frame
    await self.protocol._drain_helper()
  File "/farm/chia-blockchain/.venv/lib/python3.10/site-packages/aiohttp/base_protocol.py", line 95, in _drain_helper
    await asyncio.shield(waiter)
ConnectionError: Connection lost
```

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
