### PR TITLE
fix the rollback of fork_info when validating a block fails

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -389,6 +389,7 @@ class Blockchain:
         # in case we fail and need to restore the blockchain state, remember the
         # peak height
         previous_peak_height = self._peak_height
+        prev_fork_peak = (fork_info.peak_height, fork_info.peak_hash)
 
         try:
             # Always add the block to the database
@@ -425,7 +426,8 @@ class Blockchain:
                 self.remove_block_record(header_hash)
             except KeyError:
                 pass
-            fork_info.rollback(header_hash, -1 if previous_peak_height is None else previous_peak_height)
+            # restore fork_info to the state before adding the block
+            fork_info.rollback(prev_fork_peak[1], prev_fork_peak[0])
             self.block_store.rollback_cache_block(header_hash)
             self._peak_height = previous_peak_height
             log.error(

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -650,10 +650,8 @@ class FullNode:
                             raise
                         finally:
                             self.log.info(f"Added blocks {height}-{end_height}")
-        except (asyncio.CancelledError, Exception):
+        finally:
             self.sync_store.batch_syncing.remove(peer.peer_node_id)
-            raise
-        self.sync_store.batch_syncing.remove(peer.peer_node_id)
         return True
 
     async def short_sync_backtrack(


### PR DESCRIPTION
### Purpose:

When we try to add a block to the blockchain, and it fails, we restore all state to what it was before trying to add the block. One of these is the `ForkInfo`, which contains state related to forks. i.e. blocks that are not part of the main chain, but that we may be attempting to reorg onto.

Currently we restore this state like this:

```
fork_info.rollback(header_hash, -1 if previous_peak_height is None else previous_peak_height)
```

`header_hash` is supposed to be the header hash of the fork point, but we pass in the failed block's hash. Also, in a reorg scenario, the fork point may be below the current peak.

The updated code records the fork info peak before the attempt to add the block, and restores them. Both height and header hash.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
