### PR TITLE
[CHIA-1696] Show an `INCOMING_TX` for pool reward claims

### DIFF
--- a/chia/_tests/pools/test_pool_rpc.py
+++ b/chia/_tests/pools/test_pool_rpc.py
@@ -450,7 +450,7 @@ class TestPoolWalletRpc:
                     [
                         tx
                         for tx in await wallet_node.wallet_state_manager.tx_store.get_all_transactions()
-                        if TransactionType(tx.type) is TransactionType.INCOMING_TX
+                        if TransactionType(tx.type) is TransactionType.INCOMING_TX and tx.amount == 1_750_000_000_000
                     ]
                 )
                 == 2

--- a/chia/_tests/pools/test_pool_rpc.py
+++ b/chia/_tests/pools/test_pool_rpc.py
@@ -35,6 +35,7 @@ from chia.util.config import load_config
 from chia.util.ints import uint32, uint64
 from chia.wallet.derive_keys import find_authentication_sk, find_owner_sk
 from chia.wallet.transaction_record import TransactionRecord
+from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_node import WalletNode
@@ -444,6 +445,16 @@ class TestPoolWalletRpc:
             await full_node_api.farm_blocks_to_puzzlehash(count=2, farm_to=our_ph, guarantee_transaction_blocks=True)
             await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
             await full_node_api.check_transactions_confirmed(wallet_node.wallet_state_manager, absorb_txs)
+            assert (
+                len(
+                    [
+                        tx
+                        for tx in await wallet_node.wallet_state_manager.tx_store.get_all_transactions()
+                        if TransactionType(tx.type) is TransactionType.INCOMING_TX
+                    ]
+                )
+                == 2
+            )
             new_status: PoolWalletInfo = (await client.pw_status(2))[0]
             assert status.current == new_status.current
             assert status.tip_singleton_coin_id != new_status.tip_singleton_coin_id

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -808,7 +808,6 @@ class PoolWallet:
         current_time = uint64(int(time.time()))
         # The claim spend, minus the fee amount from the main wallet
         async with action_scope.use() as interface:
-            pool_reward_coin_ids = {cr.coin.name() for cr in unspent_coin_records}
             interface.side_effects.transactions.append(
                 TransactionRecord(
                     confirmed_at_height=uint32(0),
@@ -819,7 +818,7 @@ class PoolWallet:
                     confirmed=False,
                     sent=uint32(0),
                     spend_bundle=claim_spend,
-                    additions=[add for add in claim_spend.additions() if add.parent_coin_info in pool_reward_coin_ids],
+                    additions=[add for add in claim_spend.additions() if add.amount == last_solution.coin.amount],
                     removals=claim_spend.removals(),
                     wallet_id=uint32(self.wallet_id),
                     sent_to=[],

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -808,6 +808,7 @@ class PoolWallet:
         current_time = uint64(int(time.time()))
         # The claim spend, minus the fee amount from the main wallet
         async with action_scope.use() as interface:
+            pool_reward_coin_ids = {cr.coin.name() for cr in unspent_coin_records}
             interface.side_effects.transactions.append(
                 TransactionRecord(
                     confirmed_at_height=uint32(0),
@@ -818,7 +819,7 @@ class PoolWallet:
                     confirmed=False,
                     sent=uint32(0),
                     spend_bundle=claim_spend,
-                    additions=claim_spend.additions(),
+                    additions=[add for add in claim_spend.additions() if add.parent_coin_info in pool_reward_coin_ids],
                     removals=claim_spend.removals(),
                     wallet_id=uint32(self.wallet_id),
                     sent_to=[],


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/issues/13251

Fixes an issue where claims for self pooling would not show up as an INCOMING_TX in the wallet.  This is because of improperly set up additions on the transaction record that triggered some logic to skip creating that transaction.