### PR TITLE
Add support for a static list of peers to always have available in the dns_server

### DIFF
--- a/chia/_tests/core/test_seeder.py
+++ b/chia/_tests/core/test_seeder.py
@@ -5,16 +5,17 @@ from dataclasses import dataclass
 from ipaddress import IPv4Address, IPv6Address
 from socket import AF_INET, AF_INET6, SOCK_STREAM
 from typing import cast
+from unittest.mock import AsyncMock
 
 import dns
-from unittest.mock import AsyncMock
+import pytest
+from dns.name import from_text
+from dns.rdataclass import IN
+from dns.rdatatype import AAAA as AAAA_TYPE
+from dns.rdatatype import A as A_TYPE
 from dns.rdtypes.IN.A import A
 from dns.rdtypes.IN.AAAA import AAAA
 from dns.rrset import RRset
-from dns.name import from_text
-from dns.rdataclass import IN
-from dns.rdatatype import A as A_TYPE, AAAA as AAAA_TYPE
-import pytest
 
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.seeder.dns_server import DNSServer

--- a/chia/_tests/core/test_seeder.py
+++ b/chia/_tests/core/test_seeder.py
@@ -4,7 +4,7 @@ import time
 from dataclasses import dataclass
 from ipaddress import IPv4Address, IPv6Address
 from socket import AF_INET, AF_INET6, SOCK_STREAM
-from typing import cast
+from typing import Optional, Union, cast
 from unittest.mock import AsyncMock
 
 import dns
@@ -354,20 +354,24 @@ async def test_static_peers(
     assert answer[0].to_text() == expected
 
 
-def get_mock_resolver():
+def get_mock_resolver() -> AsyncMock:
     # Mock IPv4 response
     mock_rrset_a = RRset(from_text("node.example.com."), IN, A_TYPE)
-    mock_rrset_a.add(A(IN, A_TYPE, "1.2.3.4"))
+    mock_rrset_a.add(A(IN, A_TYPE, "1.2.3.4"))  # type: ignore
 
     # Mock IPv6 response
     mock_rrset_aaaa = RRset(from_text("node.example.com."), IN, AAAA_TYPE)
-    mock_rrset_aaaa.add(AAAA(IN, AAAA_TYPE, "2001:db8::5"))
+    mock_rrset_aaaa.add(AAAA(IN, AAAA_TYPE, "2001:db8::5"))  # type: ignore
 
     # Create a mock Resolver
     mock_resolver = AsyncMock()
 
     # Adjust mock_resolve to accept all arguments
-    async def mock_resolve(qname, rdtype="A", *args, **kwargs):
+    async def mock_resolve(
+        qname: Union[dns.name.Name, str],
+        rdtype: Union[dns.rdatatype.RdataType, str] = dns.rdatatype.A,
+        lifetime: Optional[float] = None,
+    ) -> RRset:
         if rdtype == "A":
             return mock_rrset_a
         elif rdtype == "AAAA":

--- a/chia/seeder/dns_server.py
+++ b/chia/seeder/dns_server.py
@@ -439,7 +439,6 @@ class DNSServer:
                                     new_reliable_peers.append(ip)
                                 except ValueError:
                                     pass
-                    continue
 
         if len(new_reliable_peers) == 0:
             log.warning("No reliable peers found in database, waiting for db to be populated.")

--- a/chia/seeder/dns_server.py
+++ b/chia/seeder/dns_server.py
@@ -412,7 +412,7 @@ class DNSServer:
         if self.crawl_store is None:
             return
         new_reliable_peers: list[str] = []
-        while True:
+        while not self.shutdown_event.is_set() and self.crawl_store is not None:
             try:
                 new_reliable_peers = await self.crawl_store.get_good_peers()
             except Exception as e:

--- a/chia/seeder/dns_server.py
+++ b/chia/seeder/dns_server.py
@@ -412,7 +412,7 @@ class DNSServer:
         if self.crawl_store is None:
             return
         new_reliable_peers: list[str] = []
-        while not self.shutdown_event.is_set() and self.crawl_store is not None:
+        while not self.shutdown_event.is_set():
             try:
                 new_reliable_peers = await self.crawl_store.get_good_peers()
             except Exception as e:

--- a/chia/seeder/dns_server.py
+++ b/chia/seeder/dns_server.py
@@ -408,7 +408,9 @@ class DNSServer:
             sleep_interval = min(15, sleep_interval + 1)
             await asyncio.sleep(sleep_interval * 60)
 
-    async def refresh_reliable_peers(self):
+    async def refresh_reliable_peers(self) -> None:
+        if self.crawl_store is None:
+            return
         try:
             new_reliable_peers = await self.crawl_store.get_good_peers()
         except Exception as e:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -110,6 +110,9 @@ seeder:
   # Peers used for the initial run.
   bootstrap_peers:
     - "node.chia.net"
+  # Peers to respond with regardless of what the crawler finds
+  # Can be IPs or Hostnames. Hostnames will be resolved to IPs
+  static_peers: []
   # Only consider nodes synced at least to this height.
   minimum_height: 240000
   # How many of a particular version we need to see before reporting it in the logs


### PR DESCRIPTION
This is particularly useful for small testnets where we know the dns names or IPs of the full nodes, and want to get things bootstrapped even before the network has any blocks