### PR TITLE
add new configuration option to log the first 6 hex digits of coins

### DIFF
--- a/chia/_tests/util/blockchain.py
+++ b/chia/_tests/util/blockchain.py
@@ -25,7 +25,7 @@ async def create_blockchain(
     async with DBWrapper2.managed(database=db_uri, uri=True, reader_count=1, db_version=db_version) as wrapper:
         coin_store = await CoinStore.create(wrapper)
         store = await BlockStore.create(wrapper)
-        bc1 = await Blockchain.create(coin_store, store, constants, Path("."), 2, single_threaded=True)
+        bc1 = await Blockchain.create(coin_store, store, constants, Path("."), 2, single_threaded=True, log_coins=True)
         try:
             assert bc1.get_peak() is None
             yield bc1, wrapper

--- a/chia/_tests/util/setup_nodes.py
+++ b/chia/_tests/util/setup_nodes.py
@@ -85,7 +85,7 @@ async def setup_two_nodes(
     Setup and teardown of two full nodes, with blockchains and separate DBs.
     """
 
-    config_overrides = {"full_node.max_sync_wait": 0}
+    config_overrides = {"full_node.max_sync_wait": 0, "full_node.log_coins": True}
     with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
         bt1 = await create_block_tools_async(
             constants=consensus_constants, keychain=keychain1, config_overrides=config_overrides
@@ -121,7 +121,7 @@ async def setup_n_nodes(
     """
     Setup and teardown of n full nodes, with blockchains and separate DBs.
     """
-    config_overrides = {"full_node.max_sync_wait": 0}
+    config_overrides = {"full_node.max_sync_wait": 0, "full_node.log_coins": True}
     with ExitStack() as stack:
         keychains = [stack.enter_context(TempKeyring(populate=True)) for _ in range(n)]
         async with AsyncExitStack() as async_exit_stack:
@@ -246,6 +246,7 @@ async def setup_simulators_and_wallets_inner(
 ) -> AsyncIterator[tuple[list[BlockTools], list[SimulatorFullNodeService], list[WalletService]]]:
     if config_overrides is not None and "full_node.max_sync_wait" not in config_overrides:
         config_overrides["full_node.max_sync_wait"] = 0
+        config_overrides["full_node.log_coins"] = True
     async with AsyncExitStack() as async_exit_stack:
         bt_tools: list[BlockTools] = [
             await create_block_tools_async(consensus_constants, keychain=keychain1, config_overrides=config_overrides)
@@ -360,7 +361,7 @@ async def setup_full_system_inner(
     keychain2: Keychain,
     shared_b_tools: BlockTools,
 ) -> AsyncIterator[FullSystem]:
-    config_overrides = {"full_node.max_sync_wait": 0}
+    config_overrides = {"full_node.max_sync_wait": 0, "full_node.log_coins": True}
     if b_tools is None:
         b_tools = await create_block_tools_async(
             constants=consensus_constants, keychain=keychain1, config_overrides=config_overrides

--- a/chia/_tests/wallet/conftest.py
+++ b/chia/_tests/wallet/conftest.py
@@ -65,7 +65,7 @@ async def ignore_block_validation(
     if "standard_block_tools" in request.keywords:
         return None
 
-    async def validate_block_body(*args: Any) -> Literal[None]:
+    async def validate_block_body(*args: Any, **kwargs: Any) -> Literal[None]:
         return None
 
     def create_wrapper(original_create: Any) -> Any:

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -187,6 +187,8 @@ async def validate_block_body(
     height: uint32,
     conds: Optional[SpendBundleConditions],
     fork_info: ForkInfo,
+    *,
+    log_coins: bool = False,
 ) -> Optional[Err]:
     """
     This assumes the header block has been completely validated.
@@ -474,6 +476,9 @@ async def validate_block_body(
         else:
             look_in_fork.append(unspent.name)
 
+    if log_coins and len(look_in_fork) > 0:
+        log.info("%d coins spent after fork", len(look_in_fork))
+
     if len(unspent_records) != len(removals_from_db):
         # some coins could not be found in the DB. We need to find out which
         # ones and look for them in additions_since_fork
@@ -482,6 +487,9 @@ async def validate_block_body(
             if rem in found:
                 continue
             look_in_fork.append(rem)
+
+    if log_coins and len(look_in_fork) > 0:
+        log.info("coins spent in fork: %s", ",".join([f"{name}"[0:6] for name in look_in_fork]))
 
     for rem in look_in_fork:
         # This coin is not in the current heaviest chain, so it must be in the fork

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -258,6 +258,7 @@ class FullNode:
             start_time = time.monotonic()
             reserved_cores = self.config.get("reserved_cores", 0)
             single_threaded = self.config.get("single_threaded", False)
+            log_coins = self.config.get("log_coins", False)
             multiprocessing_start_method = process_config_start_method(config=self.config, log=self.log)
             self.multiprocessing_context = multiprocessing.get_context(method=multiprocessing_start_method)
             self._blockchain = await Blockchain.create(
@@ -267,6 +268,7 @@ class FullNode:
                 blockchain_dir=self.db_path.parent,
                 reserved_cores=reserved_cores,
                 single_threaded=single_threaded,
+                log_coins=log_coins,
             )
 
             self._mempool_manager = MempoolManager(
@@ -1817,6 +1819,7 @@ class FullNode:
         self.log.info(
             f"🌱 Updated peak to height {record.height}, weight {record.weight}, "
             f"hh {record.header_hash.hex()}, "
+            f"ph {record.prev_hash.hex()}, "
             f"forked at {state_change_summary.fork_height}, rh: {record.reward_infusion_new_challenge.hex()}, "
             f"total iters: {record.total_iters}, "
             f"overflow: {record.overflow}, "

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -361,6 +361,10 @@ full_node:
   # profiled.
   single_threaded: False
 
+  # when enabled, logs coins additions, removals and reorgs at INFO level.
+  # Requires the log level to be INFO or DEBUG as well.
+  log_coins: False
+
   # How often to initiate outbound connections to other full nodes.
   peer_connect_interval: 30
   # How long to wait for a peer connection


### PR DESCRIPTION
### Purpose:

Make it easier (and possible) to track down inconsistencies with the coin table.

### Current Behavior:

We don't log coins additions and removals, so if there's a coin error, it's difficult to know why there was an error.

### New Behavior:

There's a new configuration option to enable logging of additions, removals and reorged coins (only the first 6 hex digits, to save space).

### Testing Notes:

example output:

```
2024-11-19T14:21:52.952 0.0.0 full_node chia.consensus.blockchain: INFO     adding new block to coin_store, 47 spends
2024-11-19T14:21:52.953 0.0.0 full_node chia.consensus.blockchain: INFO     additions: aa4381,6ac924,f5e25c,955af8,04e5c7,b21752,987a59,ba0289,fe1cbe,f2436c,fee746,93b084,4607a9,57c420,3e3627,51e3db,ed60b5,bb0fc8,511477,b81b93,0d9961,797828,a10678,9c4c40,af54bb,ba7d68,8c66f2,3bf4bc,db9c10,59b0f0,b463f7,0cabbd,383210,237d4a,b90a79,c1edd4,6a6999,f63ba9,34f65d,e74f27,004ce5,b6bf5c,d0dbac,9e36a5,135923,e714a2,b9b40d,ec3e6e
2024-11-19T14:21:52.953 0.0.0 full_node chia.consensus.blockchain: INFO     removals: 0aef99,2e6aca,6d8a0d,83a5a2,8d3132,224b72,8f2546,75b407,44d4dc,d655d4,7d085e,cfd5e2,a7e876,b0d1a0,64b73c,8aef7e,2d7f30,77846f,5e6d35,9daed0,813f53,c883af,bc6348,ca15fe,7bd77a,2130d5,7a42cc,2b7d44,79a113,c613df,87af45,8808c9,3fa854,bcf05a,30bd2c,401768,41dc99,d9122b,1b341a,3bfa44,5f570f,33ca55,27785c,b60b08,de1796,eacafc,5d1de6
```