### PR TITLE
improve sync timeouts by being more conservative the fewer peers we have

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1208,10 +1208,11 @@ class FullNode:
                             new_peers_with_peak[idx][0],
                             new_peers_with_peak[idx][1] + bump,
                         )
-                        response = await peer.call_api(FullNodeAPI.request_blocks, request, timeout=30)
+                        # the fewer peers we have, the more willing we should be
+                        # to wait for them.
+                        timeout = int(30 + 30 / len(new_peers_with_peak))
+                        response = await peer.call_api(FullNodeAPI.request_blocks, request, timeout=timeout)
                         end = time.monotonic()
-                        if end - start > 5:
-                            self.log.info(f"sync pipeline, peer took {end - start:0.2f} to respond to request_blocks")
                         if response is None:
                             self.log.info(f"peer timed out after {end - start:.1f} s")
                             await peer.close()


### PR DESCRIPTION
### Purpose:

This seems to improve my long sync experience on testnet11, where I have few peers and they pften get banned for taking too long to respond to blocks (stalling the sync).

The time it takes for the peer I'm syncing from to respond varies greatly, and sometimes is very close to (and exceeds) the current 30 second timeout.

```
2024-11-19T13:56:23.606 0.0.0 full_node chia.full_node.full_node: INFO     peer took 14.4 s to respond to request_blocks
2024-11-19T13:56:51.399 0.0.0 full_node chia.full_node.full_node: INFO     peer took 27.8 s to respond to request_blocks
2024-11-19T13:57:17.338 0.0.0 full_node chia.full_node.full_node: INFO     peer took 25.9 s to respond to request_blocks
2024-11-19T13:57:29.737 0.0.0 full_node chia.full_node.full_node: INFO     peer took 12.4 s to respond to request_blocks
2024-11-19T13:57:42.373 0.0.0 full_node chia.full_node.full_node: INFO     peer took 12.6 s to respond to request_blocks
2024-11-19T13:57:59.668 0.0.0 full_node chia.full_node.full_node: INFO     peer took 17.3 s to respond to request_blocks
2024-11-19T13:58:17.767 0.0.0 full_node chia.full_node.full_node: INFO     peer took 18.1 s to respond to request_blocks
2024-11-19T13:58:30.263 0.0.0 full_node chia.full_node.full_node: INFO     peer took 12.5 s to respond to request_blocks
2024-11-19T13:58:44.927 0.0.0 full_node chia.full_node.full_node: INFO     peer took 14.7 s to respond to request_blocks
2024-11-19T13:59:01.316 0.0.0 full_node chia.full_node.full_node: INFO     peer took 16.4 s to respond to request_blocks
2024-11-19T13:59:16.394 0.0.0 full_node chia.full_node.full_node: INFO     peer took 15.1 s to respond to request_blocks
2024-11-19T13:59:40.084 0.0.0 full_node chia.full_node.full_node: INFO     peer took 23.7 s to respond to request_blocks
2024-11-19T14:00:01.010 0.0.0 full_node chia.full_node.full_node: INFO     peer took 18.7 s to respond to request_blocks
2024-11-19T14:00:29.726 0.0.0 full_node chia.full_node.full_node: INFO     peer took 28.7 s to respond to request_blocks
2024-11-19T14:01:00.610 0.0.0 full_node chia.full_node.full_node: INFO     peer took 28.7 s to respond to request_blocks
2024-11-19T14:01:35.311 0.0.0 full_node chia.full_node.full_node: INFO     peer took 34.7 s to respond to request_blocks
2024-11-19T14:02:00.978 0.0.0 full_node chia.full_node.full_node: INFO     peer took 23.7 s to respond to request_blocks
2024-11-19T14:02:16.906 0.0.0 full_node chia.full_node.full_node: INFO     peer took 15.9 s to respond to request_blocks
2024-11-19T14:03:01.019 0.0.0 full_node chia.full_node.full_node: INFO     peer took 41.7 s to respond to request_blocks
2024-11-19T14:03:28.853 0.0.0 full_node chia.full_node.full_node: INFO     peer took 27.8 s to respond to request_blocks
2024-11-19T14:04:00.805 0.0.0 full_node chia.full_node.full_node: INFO     peer took 29.8 s to respond to request_blocks
2024-11-19T14:04:28.353 0.0.0 full_node chia.full_node.full_node: INFO     peer took 27.5 s to respond to request_blocks
2024-11-19T14:05:00.975 0.0.0 full_node chia.full_node.full_node: INFO     peer took 30.6 s to respond to request_blocks
2024-11-19T14:05:36.019 0.0.0 full_node chia.full_node.full_node: INFO     peer took 35.0 s to respond to request_blocks
2024-11-19T14:06:01.271 0.0.0 full_node chia.full_node.full_node: INFO     peer took 22.7 s to respond to request_blocks
2024-11-19T14:06:12.676 0.0.0 full_node chia.full_node.full_node: INFO     peer took 11.4 s to respond to request_blocks
2024-11-19T14:07:44.451 0.0.0 full_node chia.full_node.full_node: INFO     peer took 44.2 s to respond to request_blocks
2024-11-19T14:08:09.006 0.0.0 full_node chia.full_node.full_node: INFO     peer took 24.6 s to respond to request_blocks
2024-11-19T14:08:51.648 0.0.0 full_node chia.full_node.full_node: INFO     peer took 42.6 s to respond to request_blocks
2024-11-19T14:09:37.780 0.0.0 full_node chia.full_node.full_node: INFO     peer took 46.1 s to respond to request_blocks
2024-11-19T14:10:27.427 0.0.0 full_node chia.full_node.full_node: INFO     peer took 49.6 s to respond to request_blocks
2024-11-19T14:10:41.919 0.0.0 full_node chia.full_node.full_node: INFO     peer took 14.5 s to respond to request_blocks
2024-11-19T14:11:08.404 0.0.0 full_node chia.full_node.full_node: INFO     peer took 26.5 s to respond to request_blocks
2024-11-19T14:11:31.337 0.0.0 full_node chia.full_node.full_node: INFO     peer took 22.9 s to respond to request_blocks
2024-11-19T14:11:45.543 0.0.0 full_node chia.full_node.full_node: INFO     peer took 14.2 s to respond to request_blocks
```

### Current Behavior:

If the peer doesn't respond to `RequestBlocks` within 30 seconds, we time-out and ban the peer.

### New Behavior:

The timeout is longer the fewer peers we have with the peak. If we only have a single peer, the timeout is 60 seconds, and if we have many, it approaches the current 30 seconds.

### Testing Notes:

Prior to this change, my testnet11 node has a hard time long-syncing faster than real-time. With this change, it appears to be working better.