### PR TITLE
[CHIA-1773] Add better `reuse_puzhash` checking to `WalletTestFramework`

### DIFF
--- a/chia/_tests/wallet/conftest.py
+++ b/chia/_tests/wallet/conftest.py
@@ -16,7 +16,7 @@ from chia_rs import (
     run_block_generator2,
 )
 
-from chia._tests.environments.wallet import WalletEnvironment, WalletState, WalletTestFramework
+from chia._tests.environments.wallet import NewPuzzleHashError, WalletEnvironment, WalletState, WalletTestFramework
 from chia._tests.util.setup_nodes import setup_simulators_and_wallets_service
 from chia._tests.wallet.wallet_block_tools import WalletBlockTools
 from chia.consensus.constants import ConsensusConstants
@@ -160,7 +160,10 @@ def new_action_scope_wrapper(func: Any) -> Any:
         # Finally, check that the number of puzzle hashes did or did not increase by the specified amount
         if action_scope.config.tx_config.reuse_puzhash:
             for wallet_id, ph_index in zip(self.wallets, ph_indexes):
-                assert ph_indexes[wallet_id] == (await self.puzzle_store.get_unused_count(wallet_id))
+                if not ph_indexes[wallet_id] == (await self.puzzle_store.get_unused_count(wallet_id)):
+                    raise NewPuzzleHashError(
+                        f"wallet ID {wallet_id} generated new puzzle hashes while reuse_puzhash was False"
+                    )
 
     return wrapped_new_action_scope
 

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -843,7 +843,7 @@ class TestDIDWallet:
         # Delete the coin and wallet
         coin = await did_wallet.get_coin()
         await wallet_node_0.wallet_state_manager.coin_store.delete_coin_record(coin.name())
-        await wallet_node_0.wallet_state_manager.user_store.delete_wallet(did_wallet.wallet_info.id)
+        await wallet_node_0.wallet_state_manager.delete_wallet(did_wallet.wallet_info.id)
         wallet_node_0.wallet_state_manager.wallets.pop(did_wallet.wallet_info.id)
         assert len(wallet_node_0.wallet_state_manager.wallets) == 1
         # Find lost DID
@@ -857,6 +857,21 @@ class TestDIDWallet:
             )
         )
         did_wallet = wallet_node_0.wallet_state_manager.wallets[did_wallets[0].id]
+        env_0.wallet_aliases["did_found"] = did_wallets[0].id
+        await env_0.change_balances(
+            {
+                "did_found": {
+                    "init": True,
+                    "confirmed_wallet_balance": 101,
+                    "unconfirmed_wallet_balance": 101,
+                    "spendable_balance": 101,
+                    "max_send_amount": 101,
+                    "unspent_coin_count": 1,
+                }
+            }
+        )
+        await env_0.check_balances()
+
         # Spend DID
         recovery_list = [bytes32.fromhex(did_wallet.get_my_DID())]
         await did_wallet.update_recovery_list(recovery_list, uint64(1))
@@ -866,32 +881,20 @@ class TestDIDWallet:
         ) as action_scope:
             await did_wallet.create_update_spend(action_scope)
 
-        env_0.wallet_aliases["did_found"] = 3
-
         await wallet_environments.process_pending_states(
             [
                 WalletStateTransition(
                     pre_block_balance_updates={
                         "did_found": {
-                            "init": True,
-                            "confirmed_wallet_balance": 101,
-                            "unconfirmed_wallet_balance": 202,  # Seems strange
-                            "spendable_balance": 101,
-                            "max_send_amount": 101,
-                            "unspent_coin_count": 1,
-                            "pending_change": 101,
+                            "spendable_balance": -101,
+                            "max_send_amount": -101,
                             "pending_coin_removal_count": 1,
-                            "set_remainder": True,
                         },
                     },
                     post_block_balance_updates={
                         "did_found": {
-                            "confirmed_wallet_balance": 0,
-                            "unconfirmed_wallet_balance": -101,
-                            "spendable_balance": 0,
-                            "max_send_amount": 0,
-                            "unspent_coin_count": 0,
-                            "pending_change": -101,
+                            "spendable_balance": 101,
+                            "max_send_amount": 101,
                             "pending_coin_removal_count": -1,
                         },
                     },
@@ -902,7 +905,7 @@ class TestDIDWallet:
         # Delete the coin and change inner puzzle
         coin = await did_wallet.get_coin()
         await wallet_node_0.wallet_state_manager.coin_store.delete_coin_record(coin.name())
-        new_inner_puzzle = await did_wallet.get_new_did_innerpuz()
+        new_inner_puzzle = await did_wallet.get_did_innerpuz(new=True)
         did_wallet.did_info = dataclasses.replace(did_wallet.did_info, current_inner=new_inner_puzzle)
         # Recovery the coin
         assert did_wallet.did_info.origin_coin is not None  # mypy

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -1056,7 +1056,7 @@ class TestDIDWallet:
                 backup_data,
             )
         env_0.wallet_aliases["did_2"] = 3
-        new_ph = await did_wallet_3.get_new_did_inner_hash()
+        new_ph = await did_wallet_3.get_did_inner_hash(new=True)
         coin = await did_wallet_2.get_coin()
         pubkey = (
             await did_wallet_3.wallet_state_manager.get_unused_derivation_record(did_wallet_3.wallet_info.id)
@@ -1143,7 +1143,7 @@ class TestDIDWallet:
             )
         env_1.wallet_aliases["did_2"] = 3
         coin = await did_wallet.get_coin()
-        new_ph = await did_wallet_4.get_new_did_inner_hash()
+        new_ph = await did_wallet_4.get_did_inner_hash(new=True)
         pubkey = (
             await did_wallet_4.wallet_state_manager.get_unused_derivation_record(did_wallet_4.wallet_info.id)
         ).pubkey

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -888,6 +888,7 @@ class TestDIDWallet:
                         "did_found": {
                             "spendable_balance": -101,
                             "max_send_amount": -101,
+                            "pending_change": 101,
                             "pending_coin_removal_count": 1,
                         },
                     },
@@ -895,6 +896,7 @@ class TestDIDWallet:
                         "did_found": {
                             "spendable_balance": 101,
                             "max_send_amount": 101,
+                            "pending_change": -101,
                             "pending_coin_removal_count": -1,
                         },
                     },

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -2728,10 +2728,11 @@ async def test_split_coins(wallet_environments: WalletTestFramework) -> None:
     )
     assert response == SplitCoinsResponse([], [])
 
-    await env.rpc_client.split_coins(
-        xch_request,
-        wallet_environments.tx_config,
-    )
+    with wallet_environments.new_puzzle_hashes_allowed():
+        await env.rpc_client.split_coins(
+            xch_request,
+            wallet_environments.tx_config,
+        )
 
     await wallet_environments.process_pending_states(
         [
@@ -2797,10 +2798,11 @@ async def test_split_coins(wallet_environments: WalletTestFramework) -> None:
         push=True,
     )
 
-    await env.rpc_client.split_coins(
-        cat_request,
-        wallet_environments.tx_config,
-    )
+    with wallet_environments.new_puzzle_hashes_allowed():
+        await env.rpc_client.split_coins(
+            cat_request,
+            wallet_environments.tx_config,
+        )
 
     await wallet_environments.process_pending_states(
         [

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -2966,7 +2966,7 @@ async def test_combine_coins(wallet_environments: WalletTestFramework) -> None:
     async with env.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         await cat_wallet.generate_signed_transaction(
             [BIG_COIN_AMOUNT, SMALL_COIN_AMOUNT, REALLY_SMALL_COIN_AMOUNT],
-            [await env.xch_wallet.get_puzzle_hash(new=action_scope.config.tx_config.reuse_puzhash)] * 3,
+            [await env.xch_wallet.get_puzzle_hash(new=not action_scope.config.tx_config.reuse_puzhash)] * 3,
             action_scope,
         )
 

--- a/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
@@ -528,16 +528,18 @@ async def test_vc_lifecycle(wallet_environments: WalletTestFramework) -> None:
         )
 
     # Test melting a CRCAT
-    tx = (
-        await client_1.cat_spend(
-            env_1.dealias_wallet_id("crcat"),
-            wallet_environments.tx_config,
-            uint64(20),
-            wallet_1_addr,
-            uint64(0),
-            cat_discrepancy=(-50, Program.to(None), Program.to(None)),
-        )
-    ).transaction
+    # This is intended to trigger an edge case where the output and change are the same forcing a new puzhash
+    with wallet_environments.new_puzzle_hashes_allowed():
+        tx = (
+            await client_1.cat_spend(
+                env_1.dealias_wallet_id("crcat"),
+                wallet_environments.tx_config,
+                uint64(20),
+                wallet_1_addr,
+                uint64(0),
+                cat_discrepancy=(-50, Program.to(None), Program.to(None)),
+            )
+        ).transaction
     [tx] = await wallet_node_1.wallet_state_manager.add_pending_transactions([tx])
     await wallet_environments.process_pending_states(
         [

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -3310,14 +3310,18 @@ class WalletRpcApi:
         if isinstance(royalty_address, str):
             royalty_puzhash = decode_puzzle_hash(royalty_address)
         elif royalty_address is None:
-            royalty_puzhash = await nft_wallet.standard_wallet.get_new_puzzlehash()
+            royalty_puzhash = await nft_wallet.standard_wallet.get_puzzle_hash(
+                new=not action_scope.config.tx_config.reuse_puzhash
+            )
         else:
             royalty_puzhash = royalty_address
         target_address = request.get("target_address")
         if isinstance(target_address, str):
             target_puzhash = decode_puzzle_hash(target_address)
         elif target_address is None:
-            target_puzhash = await nft_wallet.standard_wallet.get_new_puzzlehash()
+            target_puzhash = await nft_wallet.standard_wallet.get_puzzle_hash(
+                new=not action_scope.config.tx_config.reuse_puzhash
+            )
         else:
             target_puzhash = target_address
         if "uris" not in request:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1256,7 +1256,7 @@ class WalletRpcApi:
             primary_output_amount = uint64(primary_output_amount - request.fee)
             await wallet.generate_signed_transaction(
                 primary_output_amount,
-                await wallet.get_puzzle_hash(new=action_scope.config.tx_config.reuse_puzhash),
+                await wallet.get_puzzle_hash(new=not action_scope.config.tx_config.reuse_puzhash),
                 action_scope,
                 request.fee,
                 set(coins),
@@ -1266,7 +1266,7 @@ class WalletRpcApi:
             assert isinstance(wallet, CATWallet)
             await wallet.generate_signed_transaction(
                 [primary_output_amount],
-                [await wallet.get_puzzle_hash(new=action_scope.config.tx_config.reuse_puzhash)],
+                [await wallet.get_puzzle_hash(new=not action_scope.config.tx_config.reuse_puzhash)],
                 action_scope,
                 request.fee,
                 coins=set(coins),

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -144,10 +144,10 @@ class CATWallet:
             )
             assert self.cat_info.limitations_program_hash != empty_bytes
         except Exception:
-            await wallet_state_manager.user_store.delete_wallet(self.id())
+            await wallet_state_manager.delete_wallet(self.id())
             raise
         if spend_bundle is None:
-            await wallet_state_manager.user_store.delete_wallet(self.id())
+            await wallet_state_manager.delete_wallet(self.id())
             raise ValueError("Failed to create spend.")
 
         await self.wallet_state_manager.add_new_wallet(self)

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -422,6 +422,12 @@ class CATWallet:
                         # We also need to make sure there's no record of the transaction
                         await self.wallet_state_manager.tx_store.delete_transaction_record(record.coin.name())
 
+    async def get_inner_puzzle(self, new: bool) -> Program:
+        return await self.standard_wallet.get_puzzle(new=new)
+
+    async def get_inner_puzzle_hash(self, new: bool) -> bytes32:
+        return await self.standard_wallet.get_puzzle_hash(new=new)
+
     async def get_new_inner_hash(self) -> bytes32:
         puzzle = await self.get_new_inner_puzzle()
         return puzzle.get_tree_hash()

--- a/chia/wallet/dao_wallet/dao_wallet.py
+++ b/chia/wallet/dao_wallet/dao_wallet.py
@@ -184,7 +184,7 @@ class DAOWallet:
                 fee_for_cat=fee_for_cat,
             )
         except Exception as e_info:  # pragma: no cover
-            await wallet_state_manager.user_store.delete_wallet(self.id())
+            await wallet_state_manager.delete_wallet(self.id())
             self.log.exception(f"Failed to create dao wallet: {e_info}")
             raise
 

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -316,6 +316,7 @@ class DIDWallet:
 
         for record in unconfirmed_tx:
             our_spend = False
+            # Need to check belonging with hint_dict
             for coin in record.removals:
                 if await self.wallet_state_manager.does_coin_belong_to_wallet(coin, self.id()):
                     our_spend = True
@@ -325,7 +326,12 @@ class DIDWallet:
                 continue
 
             for coin in record.additions:
-                if (await self.wallet_state_manager.does_coin_belong_to_wallet(coin, self.id())) and (
+                hint_dict = {
+                    coin_id: bytes32(memos[0])
+                    for coin_id, memos in record.memos
+                    if len(memos) > 0 and len(memos[0]) == 32
+                }
+                if (await self.wallet_state_manager.does_coin_belong_to_wallet(coin, self.id(), hint_dict)) and (
                     coin not in record.removals
                 ):
                     addition_amount += coin.amount

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -142,7 +142,7 @@ class DIDWallet:
         try:
             await self.generate_new_decentralised_id(amount, action_scope, fee, extra_conditions)
         except Exception:
-            await wallet_state_manager.user_store.delete_wallet(self.id())
+            await wallet_state_manager.delete_wallet(self.id())
             raise
 
         await self.wallet_state_manager.add_new_wallet(self)
@@ -208,7 +208,6 @@ class DIDWallet:
         :param name: Wallet name
         :return: DID wallet
         """
-
         self = DIDWallet()
         self.wallet_state_manager = wallet_state_manager
         if name is None:
@@ -576,7 +575,7 @@ class DIDWallet:
         assert self.did_info.current_inner is not None
         assert self.did_info.origin_coin is not None
         coin = await self.get_coin()
-        new_inner_puzzle = await self.get_new_did_innerpuz()
+        new_inner_puzzle = await self.get_did_innerpuz(new=not action_scope.config.tx_config.reuse_puzhash)
         uncurried = did_wallet_puzzles.uncurry_innerpuz(new_inner_puzzle)
         assert uncurried is not None
         p2_puzzle = uncurried[0]
@@ -1097,6 +1096,12 @@ class DIDWallet:
         )
         await self.save_info(new_did_info)
 
+    async def get_p2_inner_hash(self, new: bool) -> bytes32:
+        return await self.standard_wallet.get_puzzle_hash(new=new)
+
+    async def get_p2_inner_puzzle(self, new: bool) -> Program:
+        return await self.standard_wallet.get_puzzle(new=new)
+
     async def get_new_p2_inner_hash(self) -> bytes32:
         puzzle = await self.get_new_p2_inner_puzzle()
         return puzzle.get_tree_hash()
@@ -1104,7 +1109,7 @@ class DIDWallet:
     async def get_new_p2_inner_puzzle(self) -> Program:
         return await self.standard_wallet.get_new_puzzle()
 
-    async def get_new_did_innerpuz(self, origin_id: Optional[bytes32] = None) -> Program:
+    async def get_did_innerpuz(self, new: bool, origin_id: Optional[bytes32] = None) -> Program:
         if self.did_info.origin_coin is not None:
             launcher_id = self.did_info.origin_coin.name()
         elif origin_id is not None:
@@ -1112,15 +1117,15 @@ class DIDWallet:
         else:
             raise ValueError("must have origin coin")
         return did_wallet_puzzles.create_innerpuz(
-            p2_puzzle_or_hash=await self.get_new_p2_inner_puzzle(),
+            p2_puzzle_or_hash=await self.get_p2_inner_puzzle(new=new),
             recovery_list=self.did_info.backup_ids,
             num_of_backup_ids_needed=self.did_info.num_of_backup_ids_needed,
             launcher_id=launcher_id,
             metadata=did_wallet_puzzles.metadata_to_program(json.loads(self.did_info.metadata)),
         )
 
-    async def get_new_did_inner_hash(self) -> bytes32:
-        innerpuz = await self.get_new_did_innerpuz()
+    async def get_did_inner_hash(self, new: bool) -> bytes32:
+        innerpuz = await self.get_did_innerpuz(new=new)
         return innerpuz.get_tree_hash()
 
     async def get_innerpuz_for_new_innerhash(self, pubkey: G1Element):
@@ -1215,7 +1220,9 @@ class DIDWallet:
         genesis_launcher_puz = SINGLETON_LAUNCHER_PUZZLE
         launcher_coin = Coin(origin.name(), genesis_launcher_puz.get_tree_hash(), amount)
 
-        did_inner: Program = await self.get_new_did_innerpuz(launcher_coin.name())
+        did_inner: Program = await self.get_did_innerpuz(
+            new=not action_scope.config.tx_config.reuse_puzhash, origin_id=launcher_coin.name()
+        )
         did_inner_hash = did_inner.get_tree_hash()
         did_full_puz = create_singleton_puzzle(did_inner, launcher_coin.name())
         did_puzzle_hash = did_full_puz.get_tree_hash()

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -292,7 +292,7 @@ class NFTWallet:
                     if did_wallet_info.origin_coin.name() == self.did_id:
                         return
                 self.log.info(f"No NFT, deleting wallet {self.wallet_info.name} ...")
-                await self.wallet_state_manager.user_store.delete_wallet(self.wallet_info.id)
+                await self.wallet_state_manager.delete_wallet(self.wallet_info.id)
                 self.wallet_state_manager.wallets.pop(self.wallet_info.id)
         else:
             self.log.info("Tried removing NFT coin that doesn't exist: %s", coin.name())

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -97,7 +97,7 @@ class GenesisById(LimitationsProgram):
         origin = coins.copy().pop()
         origin_id = origin.name()
 
-        cat_inner: Program = await wallet.get_new_inner_puzzle()
+        cat_inner: Program = await wallet.get_inner_puzzle(new=not action_scope.config.tx_config.reuse_puzhash)
         tail: Program = cls.construct([Program.to(origin_id)])
 
         wallet.lineage_store = await CATLineageStore.create(

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -343,6 +343,22 @@ class WalletPuzzleStore:
 
         return None
 
+    async def get_unused_derivation_path_for_wallet(self, wallet_id: uint32) -> Optional[uint32]:
+        """
+        Returns the first unused derivation path by derivation_index.
+        """
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            row = await execute_fetchone(
+                conn,
+                "SELECT MIN(derivation_index) FROM derivation_paths WHERE wallet_id=? AND used=0 AND hardened=0;",
+                (wallet_id,),
+            )
+
+        if row is not None and row[0] is not None:
+            return uint32(row[0])
+
+        return None
+
     async def delete_wallet(self, wallet_id: uint32) -> None:
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             # First fetch all puzzle hashes since we need them to drop them from the cache

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -363,3 +363,18 @@ class WalletPuzzleStore:
         except KeyError:
             pass
         self.last_derivation_index = None
+
+    async def get_unused_count(self, wallet_id: uint32) -> int:
+        """
+        Returns a count of unused derivation indexes
+        """
+
+        async with self.db_wrapper.reader_no_transaction() as conn:
+            row = await execute_fetchone(
+                conn,
+                "SELECT COUNT(*) FROM derivation_paths WHERE wallet_id=? AND used=1",
+                (wallet_id,),
+            )
+            row_count = 0 if row is None else row[0]
+
+        return row_count


### PR DESCRIPTION
(reviewing with whitespace changes hidden will be beneficial)

I learned recently that the `WalletTestFramework` testing for the respect of the `reuse_puzhash` parameter in the `WalletActionScope` was subpar in that it would only check for new puzzle hashes being generated as the result of farming a block.  While this is a useful check, it ignored most of where the puzzle hashes get generated which is during spend construction.

This PR is still not perfect, because the only thing it adds is that no puzzle hashes are generated between action scope opening/closing. If the wrong value is fed to an action scope, it can't check for that still, but hopefully as our TX endpoints become more and more standardized, that responsibility can mostly fall to mypy.  Still, this is a massive improvement that identified many bugs that the framework had previously missed.