### PR TITLE
put `None` at the end in `Union`s - incoming RUF036

### DIFF
--- a/chia/_tests/core/data_layer/util.py
+++ b/chia/_tests/core/data_layer/util.py
@@ -16,7 +16,7 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 
 # from subprocess.pyi
-_FILE = Union[None, int, IO[Any]]
+_FILE = Union[int, IO[Any], None]
 
 
 if TYPE_CHECKING:

--- a/chia/server/chia_policy.py
+++ b/chia/server/chia_policy.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
         # https://github.com/python/typeshed/pull/5718/files
         def __call__(self) -> asyncio.protocols.BaseProtocol: ...
 
-    _SSLContext: TypeAlias = Union[bool, None, ssl.SSLContext]
+    _SSLContext: TypeAlias = Union[bool, ssl.SSLContext, None]
 
     # https://github.com/python/cpython/blob/v3.10.8/Lib/asyncio/base_events.py#L389
     # https://github.com/python/typeshed/blob/d084079fc3d89a7b51b89095ad67762944e0ace3/stdlib/asyncio/base_events.pyi#L64

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -307,7 +307,7 @@ class FullNodeSimulator(FullNodeAPI):
         count: int,
         farm_to: bytes32 = bytes32.zeros,
         guarantee_transaction_blocks: bool = False,
-        timeout: Union[None, _Default, float] = default,
+        timeout: Union[_Default, float, None] = default,
         _wait_for_synced: bool = True,
     ) -> int:
         """Process the requested number of blocks including farming to the passed puzzle
@@ -351,7 +351,7 @@ class FullNodeSimulator(FullNodeAPI):
         self,
         count: int,
         wallet: Wallet,
-        timeout: Union[None, _Default, float] = default,
+        timeout: Union[_Default, float, None] = default,
         _wait_for_synced: bool = True,
     ) -> int:
         """Farm the requested number of blocks to the passed wallet. This will
@@ -423,7 +423,7 @@ class FullNodeSimulator(FullNodeAPI):
         self,
         amount: int,
         wallet: Wallet,
-        timeout: Union[None, _Default, float] = default,
+        timeout: Union[_Default, float, None] = default,
     ) -> int:
         """Farm at least the requested amount of mojos to the passed wallet. Extra
         mojos will be received based on the block rewards at the present block height.
@@ -464,7 +464,7 @@ class FullNodeSimulator(FullNodeAPI):
     async def wait_transaction_records_entered_mempool(
         self,
         records: Collection[TransactionRecord],
-        timeout: Union[None, float] = 5,
+        timeout: Union[float, None] = 5,
     ) -> None:
         """Wait until the transaction records have entered the mempool.  Transaction
         records with no spend bundle are ignored.
@@ -496,7 +496,7 @@ class FullNodeSimulator(FullNodeAPI):
     async def wait_bundle_ids_in_mempool(
         self,
         bundle_ids: Collection[bytes32],
-        timeout: Union[None, float] = 5,
+        timeout: Union[float, None] = 5,
     ) -> None:
         """Wait until the ids of specific spend bundles have entered the mempool.
 
@@ -523,7 +523,7 @@ class FullNodeSimulator(FullNodeAPI):
         self,
         record_ids: Collection[bytes32],
         wallet_node: WalletNode,
-        timeout: Union[None, float] = 10,
+        timeout: Union[float, None] = 10,
     ) -> None:
         """Wait until the transaction records have been marked that they have made it into the mempool.  Transaction
         records with no spend bundle are ignored.
@@ -550,7 +550,7 @@ class FullNodeSimulator(FullNodeAPI):
     async def process_transaction_records(
         self,
         records: Collection[TransactionRecord],
-        timeout: Union[None, float] = (2 * timeout_per_block) + 5,
+        timeout: Union[float, None] = (2 * timeout_per_block) + 5,
     ) -> None:
         """Process the specified transaction records and wait until they have been
         included in a block.
@@ -575,7 +575,7 @@ class FullNodeSimulator(FullNodeAPI):
     async def process_spend_bundles(
         self,
         bundles: Collection[SpendBundle],
-        timeout: Union[None, float] = (2 * timeout_per_block) + 5,
+        timeout: Union[float, None] = (2 * timeout_per_block) + 5,
     ) -> None:
         """Process the specified spend bundles and wait until they have been included
         in a block.
@@ -591,7 +591,7 @@ class FullNodeSimulator(FullNodeAPI):
     async def process_coin_spends(
         self,
         coins: Collection[Coin],
-        timeout: Union[None, float] = (2 * timeout_per_block) + 5,
+        timeout: Union[float, None] = (2 * timeout_per_block) + 5,
     ) -> None:
         """Process the specified coin names and wait until they have been created in a
         block.
@@ -661,7 +661,7 @@ class FullNodeSimulator(FullNodeAPI):
         amounts: list[uint64],
         wallet: Wallet,
         per_transaction_record_group: int = 50,
-        timeout: Union[None, float] = 15,
+        timeout: Union[float, None] = 15,
     ) -> set[Coin]:
         """Create coins with the requested amount.  This is useful when you need a
         bunch of coins for a test and don't need to farm that many.

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -297,7 +297,7 @@ def recurse_jsonify(
     elif d is None or type(d) is str:
         return d
     elif hasattr(d, "to_json_dict"):
-        ret: Union[list[Any], dict[str, Any], str, None, int] = d.to_json_dict()
+        ret: Union[list[Any], dict[str, Any], str, int, None] = d.to_json_dict()
         return ret
     raise UnsupportedType(f"failed to jsonify {d} (type: {type(d)})")
 

--- a/chia/wallet/nft_wallet/nft_puzzles.py
+++ b/chia/wallet/nft_wallet/nft_puzzles.py
@@ -291,9 +291,9 @@ def recurry_nft_puzzle(unft: UncurriedNFT, solution: Program, new_inner_puzzle: 
     return new_ownership_puzzle
 
 
-def get_new_owner_did(unft: UncurriedNFT, solution: Program) -> Union[None, Literal[b""], bytes32]:
+def get_new_owner_did(unft: UncurriedNFT, solution: Program) -> Union[Literal[b""], bytes32, None]:
     conditions = unft.p2_puzzle.run(unft.get_innermost_solution(solution))
-    new_did_id: Union[None, Literal[b""], bytes32] = None
+    new_did_id: Union[Literal[b""], bytes32, None] = None
     for condition in conditions.as_iter():
         if condition.first().as_int() == -10:
             # this is the change owner magic condition


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

https://docs.astral.sh/ruff/rules/none-not-at-end-of-union/

not otherwise being complained about because it seems to be a new rule since our present 0.7.1 version.  just figured i'd fix them now while i saw them.

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
