### PR TITLE
skip simulator terminates on signal test for now

### DIFF
--- a/chia/_tests/core/services/test_services.py
+++ b/chia/_tests/core/services/test_services.py
@@ -104,7 +104,8 @@ async def test_daemon_terminates(signal_number: signal.Signals, chia_root: ChiaR
                 reason="windows is not supported by the timelord launcher",
             ),
         ),
-        [None, "chia.simulator.start_simulator", "simulator"],
+        # TODO: fails...  starts creating plots etc
+        # [None, "chia.simulator.start_simulator", "simulator"],
         # TODO: fails...  make it not do that
         # [None, "chia.data_layer.data_layer_server", "data_layer"],
     ],


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

was failing on 3.11 and 3.12 on non-windows anyways so maybe there's something there that we care about.  but, the setup is a bit more complicated what with it creating plots and expecting a different size and number than the test cache provides etc.

explored a bit in https://github.com/Chia-Network/chia-blockchain/compare/main...simulator_shutdown

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
