### PR TITLE
Update systemd templates to check if RPCs are up by using the chia rpc commands instead of nc

### DIFF
--- a/build_scripts/assets/systemd/chia-daemon@.service
+++ b/build_scripts/assets/systemd/chia-daemon@.service
@@ -6,7 +6,7 @@ StopWhenUnneeded=true
 Type=simple
 Environment=CHIA_ROOT=/home/%i/.chia/mainnet
 ExecStart=/opt/chia/daemon
-ExecStartPost=/bin/bash -c '(while ! nc -z -v -w1 localhost 55400 2>/dev/null; do echo "Waiting for the daemon to listen on port 55400..."; sleep 1; done); sleep 1'
+ExecStartPost=/bin/bash -c '(while ! /opt/chia/chia rpc daemon get_version 2>/dev/null; do echo "Waiting for the daemon to listen on port 55400..."; sleep 1; done); sleep 1'
 User=%i
 Group=%i
 LimitNOFILE=1048576

--- a/build_scripts/assets/systemd/chia-wallet@.service
+++ b/build_scripts/assets/systemd/chia-wallet@.service
@@ -7,7 +7,7 @@ After=chia-daemon@%i.service
 Type=simple
 Environment=CHIA_ROOT=/home/%i/.chia/mainnet
 ExecStart=/opt/chia/start_wallet
-ExecStartPost=/bin/bash -c '(while ! nc -z -v -w1 localhost 9256 2>/dev/null; do echo "Waiting for the wallet to listen on port 9256..."; sleep 1; done); sleep 1'
+ExecStartPost=/bin/bash -c '(while ! /opt/chia/chia rpc wallet get_version 2>/dev/null; do echo "Waiting for the wallet to listen on port 9256..."; sleep 1; done); sleep 1'
 User=%i
 Group=%i
 LimitNOFILE=1048576


### PR DESCRIPTION
### Purpose:

Fixes a bug where systemd thinks the services haven't started on systems without `nc` available
