### PR TITLE
adjust cmd class help parameters

### DIFF
--- a/chia/_tests/cmds/test_cmd_framework.py
+++ b/chia/_tests/cmds/test_cmd_framework.py
@@ -37,7 +37,7 @@ def check_click_parsing(cmd: ChiaCommand, *args: str) -> None:
         dict_compare_with_ignore_context(asdict(cmd), asdict(self))  # type: ignore[call-overload]
 
     setattr(mock_type, "run", new_run)
-    chia_command(_cmd, "_", "")(mock_type)
+    chia_command(_cmd, "_", "", "")(mock_type)
 
     runner = CliRunner()
     result = runner.invoke(_cmd, ["_", *args], catch_exceptions=False)
@@ -49,12 +49,12 @@ def test_cmd_bases() -> None:
     def cmd() -> None:
         pass
 
-    @chia_command(cmd, "temp_cmd", "blah")
+    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
     class TempCMD:
         def run(self) -> None:
             print("syncronous")
 
-    @chia_command(cmd, "temp_cmd_async", "blah")
+    @chia_command(cmd, "temp_cmd_async", "blah", help="n/a")
     class TempCMDAsync:
         async def run(self) -> None:
             print("asyncronous")
@@ -96,14 +96,14 @@ def test_option_loading() -> None:
     def cmd() -> None:
         pass
 
-    @chia_command(cmd, "temp_cmd", "blah")
+    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
     class TempCMD:
         some_option: int = option("-o", "--some-option", required=True, type=int)
 
         def run(self) -> None:
             print(self.some_option)
 
-    @chia_command(cmd, "temp_cmd_2", "blah")
+    @chia_command(cmd, "temp_cmd_2", "blah", help="n/a")
     class TempCMD2:
         some_option: int = option("-o", "--some-option", required=True, type=int, default=13)
 
@@ -145,7 +145,7 @@ def test_context_requirement() -> None:
     def cmd(ctx: click.Context) -> None:
         ctx.obj = {"foo": "bar"}
 
-    @chia_command(cmd, "temp_cmd", "blah")
+    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
     class TempCMD:
         context: Context
 
@@ -163,7 +163,7 @@ def test_context_requirement() -> None:
     # Test that other variables named context are disallowed
     with pytest.raises(ValueError, match="context"):
 
-        @chia_command(cmd, "shouldnt_work", "blah")
+        @chia_command(cmd, "shouldnt_work", "blah", help="n/a")
         class BadCMD:
             context: int
 
@@ -175,7 +175,7 @@ def test_typing() -> None:
     def cmd() -> None:
         pass
 
-    @chia_command(cmd, "temp_cmd", "blah")
+    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
     class TempCMD:
         integer: int = option("--integer", default=1, required=False)
         text: str = option("--text", default="1", required=False)
@@ -207,7 +207,7 @@ def test_typing() -> None:
     )
 
     # Test optional
-    @chia_command(cmd, "temp_cmd_optional", "blah")
+    @chia_command(cmd, "temp_cmd_optional", "blah", help="n/a")
     class TempCMDOptional:
         optional: Optional[int] = option("--optional", required=False)
 
@@ -219,7 +219,7 @@ def test_typing() -> None:
     # Test optional failure
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_optional_bad", "blah")
+        @chia_command(cmd, "temp_cmd_optional_bad", "blah", help="n/a")
         class TempCMDOptionalBad2:
             optional: Optional[int] = option("--optional", required=True)
 
@@ -227,20 +227,20 @@ def test_typing() -> None:
 
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_optional_bad", "blah")
+        @chia_command(cmd, "temp_cmd_optional_bad", "blah", help="n/a")
         class TempCMDOptionalBad3:
             optional: Optional[int] = option("--optional", default="string", required=False)
 
             def run(self) -> None: ...
 
-    @chia_command(cmd, "temp_cmd_optional_fine", "blah")
+    @chia_command(cmd, "temp_cmd_optional_fine", "blah", help="n/a")
     class TempCMDOptionalBad4:
         optional: Optional[int] = option("--optional", default=None, required=False)
 
         def run(self) -> None: ...
 
     # Test multiple
-    @chia_command(cmd, "temp_cmd_sequence", "blah")
+    @chia_command(cmd, "temp_cmd_sequence", "blah", help="n/a")
     class TempCMDSequence:
         sequence: Sequence[int] = option("--sequence", multiple=True)
 
@@ -252,7 +252,7 @@ def test_typing() -> None:
     # Test sequence failure
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_sequence_bad", "blah")
+        @chia_command(cmd, "temp_cmd_sequence_bad", "blah", help="n/a")
         class TempCMDSequenceBad:
             sequence: Sequence[int] = option("--sequence")
 
@@ -260,7 +260,7 @@ def test_typing() -> None:
 
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_sequence_bad", "blah")
+        @chia_command(cmd, "temp_cmd_sequence_bad", "blah", help="n/a")
         class TempCMDSequenceBad2:
             sequence: int = option("--sequence", multiple=True)
 
@@ -268,7 +268,7 @@ def test_typing() -> None:
 
     with pytest.raises(ValueError):
 
-        @chia_command(cmd, "temp_cmd_sequence_bad", "blah")
+        @chia_command(cmd, "temp_cmd_sequence_bad", "blah", help="n/a")
         class TempCMDSequenceBad3:
             sequence: Sequence[int] = option("--sequence", default=[1, 2, 3], multiple=True)
 
@@ -276,7 +276,7 @@ def test_typing() -> None:
 
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_sequence_bad", "blah")
+        @chia_command(cmd, "temp_cmd_sequence_bad", "blah", help="n/a")
         class TempCMDSequenceBad4:
             sequence: Sequence[int] = option("--sequence", default=(1, 2, "3"), multiple=True)
 
@@ -285,7 +285,7 @@ def test_typing() -> None:
     # Test invalid type
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_bad_type", "blah")
+        @chia_command(cmd, "temp_cmd_bad_type", "blah", help="n/a")
         class TempCMDBadType:
             sequence: list[int] = option("--sequence")
 
@@ -294,20 +294,20 @@ def test_typing() -> None:
     # Test invalid default
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_bad_default", "blah")
+        @chia_command(cmd, "temp_cmd_bad_default", "blah", help="n/a")
         class TempCMDBadDefault:
             integer: int = option("--int", default="string")
 
             def run(self) -> None: ...
 
     # Test bytes parsing
-    @chia_command(cmd, "temp_cmd_bad_bytes", "blah")
+    @chia_command(cmd, "temp_cmd_bad_bytes", "blah", help="n/a")
     class TempCMDBadBytes:
         blob: bytes = option("--blob", required=True)
 
         def run(self) -> None: ...
 
-    @chia_command(cmd, "temp_cmd_bad_bytes32", "blah")
+    @chia_command(cmd, "temp_cmd_bad_bytes32", "blah", help="n/a")
     class TempCMDBadBytes32:
         blob32: bytes32 = option("--blob32", required=True)
 
@@ -353,7 +353,7 @@ async def test_wallet_rpc_helper(wallet_environments: WalletTestFramework) -> No
     def cmd() -> None:
         pass
 
-    @chia_command(cmd, "temp_cmd", "blah")
+    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
     class TempCMD:
         rpc_info: NeedsWalletRPC
 

--- a/chia/_tests/wallet/test_signer_protocol.py
+++ b/chia/_tests/wallet/test_signer_protocol.py
@@ -752,7 +752,7 @@ def test_transactions_in() -> None:
     def cmd() -> None:
         pass
 
-    @chia_command(cmd, "temp_cmd", "blah")
+    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
     class TempCMD(TransactionsIn):
         def run(self) -> None:
             assert self.transaction_bundle == TransactionBundle([STD_TX])
@@ -771,7 +771,7 @@ def test_transactions_out() -> None:
     def cmd() -> None:
         pass
 
-    @chia_command(cmd, "temp_cmd", "blah")
+    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
     class TempCMD(TransactionsOut):
         def run(self) -> None:
             self.handle_transaction_output([STD_TX])
@@ -824,7 +824,7 @@ def test_signer_protocol_in(monkeypatch: pytest.MonkeyPatch) -> None:
 
     coin = Coin(bytes32.zeros, bytes32.zeros, uint64(13))
 
-    @chia_command(cmd, "temp_cmd", "blah")
+    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
     class TempCMD(SPIn):
         def run(self) -> None:
             assert self.read_sp_input(Coin) == [coin, coin]
@@ -881,7 +881,7 @@ def test_signer_protocol_out(monkeypatch: pytest.MonkeyPatch) -> None:
     coin = Coin(bytes32.zeros, bytes32.zeros, uint64(0))
     coin_bytes = byte_serialize_clvm_streamable(coin)
 
-    @chia_command(cmd, "temp_cmd", "blah")
+    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
     class TempCMD(SPOut):
         def run(self) -> None:
             self.handle_clvm_output([coin, coin])
@@ -930,7 +930,7 @@ def test_qr_code_display() -> None:
 
     bytes_to_encode = b"foo bar qat qux bam bat"
 
-    @chia_command(cmd, "temp_cmd", "blah")
+    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
     class TempCMD(QrCodeDisplay):
         def run(self) -> None:
             self.display_qr_codes([bytes_to_encode, bytes_to_encode])

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -225,7 +225,12 @@ def _convert_class_to_function(cls: type[ChiaCommand]) -> SyncCmd:
 
 
 @dataclass_transform()
-def chia_command(cmd: click.Group, name: str, help: str) -> Callable[[type[ChiaCommand]], type[ChiaCommand]]:
+def chia_command(
+    cmd: click.Group,
+    name: str,
+    short_help: str,
+    help: str,
+) -> Callable[[type[ChiaCommand]], type[ChiaCommand]]:
     def _chia_command(cls: type[ChiaCommand]) -> type[ChiaCommand]:
         # The type ignores here are largely due to the fact that the class information is not preserved after being
         # passed through the dataclass wrapper.  Not sure what to do about this right now.
@@ -240,7 +245,7 @@ def chia_command(cmd: click.Group, name: str, help: str) -> Callable[[type[ChiaC
                 kw_only=True,
             )(cls)
 
-        cmd.command(name, short_help=help)(_convert_class_to_function(wrapped_cls))
+        cmd.command(name, short_help=short_help, help=help)(_convert_class_to_function(wrapped_cls))
         return wrapped_cls
 
     return _chia_command

--- a/chia/cmds/signer.py
+++ b/chia/cmds/signer.py
@@ -211,6 +211,7 @@ class SPOut(QrCodeDisplay, _SPTranslation):
 @chia_command(
     signer_cmd,
     "gather_signing_info",
+    "gather signer information",
     "Gather the information from a transaction that a signer needs in order to create a signature",
 )
 class GatherSigningInfoCMD:
@@ -232,7 +233,7 @@ class GatherSigningInfoCMD:
             self.sp_out.handle_clvm_output([signing_instructions])
 
 
-@chia_command(signer_cmd, "apply_signatures", "Apply a signer's signatures to a transaction bundle")
+@chia_command(signer_cmd, "apply_signatures", "apply signatures", "Apply a signer's signatures to a transaction bundle")
 class ApplySignaturesCMD:
     txs_out: TransactionsOut
     sp_in: SPIn
@@ -270,7 +271,12 @@ class ApplySignaturesCMD:
             self.txs_out.handle_transaction_output(new_transactions)
 
 
-@chia_command(signer_cmd, "execute_signing_instructions", "Given some signing instructions, return signing responses")
+@chia_command(
+    signer_cmd,
+    "execute_signing_instructions",
+    "execute signing instructions",
+    "Given some signing instructions, return signing responses",
+)
 class ExecuteSigningInstructionsCMD:
     sp_out: SPOut
     sp_in: SPIn
@@ -292,7 +298,12 @@ class ExecuteSigningInstructionsCMD:
             )
 
 
-@chia_command(wallet_cmd, "push_transactions", "Push a transaction bundle to the wallet to send to the network")
+@chia_command(
+    wallet_cmd,
+    "push_transactions",
+    "push transaction bundle",
+    "Push a transaction bundle to the wallet to send to the network",
+)
 class PushTransactionsCMD:
     txs_in: TransactionsIn
     rpc_info: NeedsWalletRPC


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

presently you are only able to specify the click short help message for cmd classes.  this short help is used when you checking `--help` on the group containing the command.  this pr renames the exisitng parameter to `short_help` and adds a new parameter `help` (reusing the existing parameter name).  the help parameter specifies the text used when you do `--help` on the command itself.  both are required parameters.

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
