### PR TITLE
explicitly set option parameter name based on field name for cmd classes

### DIFF
--- a/chia/_tests/cmds/test_cmd_framework.py
+++ b/chia/_tests/cmds/test_cmd_framework.py
@@ -99,6 +99,7 @@ def test_option_loading() -> None:
     @chia_command(cmd, "temp_cmd", "blah")
     class TempCMD:
         some_option: int = option("-o", "--some-option", required=True, type=int)
+        choices: list[str] = option("--choice", multiple=True, type=str)
 
         def run(self) -> None:
             print(self.some_option)

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -204,6 +204,7 @@ def _generate_command_parser(cls: type[ChiaCommand]) -> _CommandParsingStage:
             option_decorators.append(
                 click.option(
                     *option_args["param_decls"],
+                    field_name,
                     type=type_arg,
                     **{k: v for k, v in option_args.items() if k not in {"param_decls", "type"}},
                 )


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

support common `multiple=True` situations where the option name doesn't match the attribute name (singular vs. plural)

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
