### PR TITLE
remove redundant block record conversion CHIA-1286

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -283,6 +283,7 @@ class Blockchain:
         sub_slot_iters: uint64,
         fork_info: ForkInfo,
         prev_ses_block: Optional[BlockRecord] = None,
+        block_record: Optional[BlockRecord] = None,
     ) -> tuple[AddBlockResult, Optional[Err], Optional[StateChangeSummary]]:
         """
         This method must be called under the blockchain lock
@@ -336,14 +337,14 @@ class Blockchain:
         if extending_main_chain:
             fork_info.reset(block.height - 1, block.prev_header_hash)
 
-        block_rec = await self.get_block_record_from_db(header_hash)
-        if block_rec is not None:
+        block_rec_from_db = await self.get_block_record_from_db(header_hash)
+        if block_rec_from_db is not None:
             # We have already validated the block, but if it's not part of the
             # main chain, we still need to re-run it to update the additions and
             # removals in fork_info.
             await self.advance_fork_info(block, fork_info)
             fork_info.include_spends(pre_validation_result.conds, block, header_hash)
-            self.add_block_record(block_rec)
+            self.add_block_record(block_rec_from_db)
             return AddBlockResult.ALREADY_HAVE_BLOCK, None, None
 
         if fork_info.peak_hash != block.prev_header_hash:
@@ -378,14 +379,15 @@ class Blockchain:
         if not genesis and prev_block is not None:
             self.add_block_record(prev_block)
 
-        block_record = block_to_block_record(
-            self.constants,
-            self,
-            required_iters,
-            block,
-            sub_slot_iters=sub_slot_iters,
-            prev_ses_block=prev_ses_block,
-        )
+        if block_record is None:
+            block_record = block_to_block_record(
+                self.constants,
+                self,
+                required_iters,
+                block,
+                sub_slot_iters=sub_slot_iters,
+                prev_ses_block=prev_ses_block,
+            )
 
         # in case we fail and need to restore the blockchain state, remember the
         # peak height

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -337,6 +337,8 @@ class Blockchain:
         if extending_main_chain:
             fork_info.reset(block.height - 1, block.prev_header_hash)
 
+        # we dont consider block_record passed in here since it might be from
+        # a current sync process and not yet fully validated and commited to the DB
         block_rec_from_db = await self.get_block_record_from_db(header_hash)
         if block_rec_from_db is not None:
             # We have already validated the block, but if it's not part of the

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1296,7 +1296,6 @@ class FullNode:
                             await self.prevalidate_blocks(
                                 blockchain,
                                 [block],
-                                peer.peer_info,
                                 vs,
                                 summaries,
                             )
@@ -1478,7 +1477,6 @@ class FullNode:
         futures = await self.prevalidate_blocks(
             blockchain,
             blocks_to_validate,
-            peer_info,
             copy.copy(vs),
             wp_summaries,
         )
@@ -1547,7 +1545,6 @@ class FullNode:
         self,
         blockchain: AugmentedBlockchain,
         blocks_to_validate: list[FullBlock],
-        peer_info: PeerInfo,
         vs: ValidationState,
         wp_summaries: Optional[list[SubEpochSummary]] = None,
     ) -> Sequence[Awaitable[PreValidationResult]]:
@@ -1615,8 +1612,14 @@ class FullNode:
                     vs.difficulty = cc_sub_slot.new_difficulty
                     assert expected_sub_slot_iters == vs.ssi
                     assert expected_difficulty == vs.difficulty
+            block_rec = blockchain.block_record(block.header_hash)
             result, error, state_change_summary = await self.blockchain.add_block(
-                block, pre_validation_results[i], vs.ssi, fork_info, prev_ses_block=vs.prev_ses_block
+                block,
+                pre_validation_results[i],
+                vs.ssi,
+                fork_info,
+                prev_ses_block=vs.prev_ses_block,
+                block_record=block_rec,
             )
             if error is None:
                 blockchain.remove_extra_block(header_hash)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1554,7 +1554,6 @@ class FullNode:
         Args:
             blockchain:
             blocks_to_validate:
-            peer_info:
             vs: The ValidationState for the first block in the batch. This is an in-out
                 parameter. It will be updated to be the validation state for the next
                 batch of blocks.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,8 @@
 [pytest]
 ; logging options
-log_cli = True
+log_cli = False
 addopts = --verbose --tb=short -n auto -p no:monitor
-log_level = INFO
+log_level = WARNING
 console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
 markers =

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,8 @@
 [pytest]
 ; logging options
-log_cli = False
+log_cli = True
 addopts = --verbose --tb=short -n auto -p no:monitor
-log_level = WARNING
+log_level = INFO
 console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
 markers =


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
removing a redundant call to block_to_block_record by propegating the converted record into blockchain.add_block
<!-- Does this PR introduce a breaking change? -->
