### PR TITLE
[CHIA-1787] Add ergonomic message condition drivers

### DIFF
--- a/chia/_tests/clvm/test_message_conditions.py
+++ b/chia/_tests/clvm/test_message_conditions.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import pytest
+from chia_rs import Coin, G2Element
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint8, uint64
+
+from chia._tests.util.spend_sim import CostLogger, sim_and_client
+from chia.types.blockchain_format.program import Program
+from chia.types.coin_spend import make_spend
+from chia.types.mempool_inclusion_status import MempoolInclusionStatus
+from chia.util.errors import Err
+from chia.wallet.conditions import MessageParticipant, ReceiveMessage, SendMessage
+from chia.wallet.wallet_spend_bundle import WalletSpendBundle
+
+ACS = Program.to(1)
+ACS_PH = ACS.get_tree_hash()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "mode",
+    [i for i in range(0b001001, 0b111111 + 1) if i % 8 != 0],  # skipping anything ending in 000
+)
+async def test_basic_message_send_receive(mode: int, cost_logger: CostLogger) -> None:
+    async with sim_and_client() as (sim, client):
+        # Farm two ACS coins
+        await sim.farm_block(ACS_PH)
+        [sender_coin, receiver_coin] = await client.get_coin_records_by_puzzle_hash(ACS_PH)
+
+        only_sender = WalletSpendBundle(
+            [
+                make_spend(
+                    sender_coin.coin,
+                    ACS,
+                    Program.to(
+                        [
+                            SendMessage(
+                                b"foo",
+                                mode_integer=uint8(mode),
+                                receiver=MessageParticipant(
+                                    parent_id_committed=receiver_coin.coin.parent_coin_info
+                                    if mode & 0b000100
+                                    else None,
+                                    puzzle_hash_committed=receiver_coin.coin.puzzle_hash if mode & 0b000010 else None,
+                                    amount_committed=receiver_coin.coin.amount if mode & 0b000001 else None,
+                                    coin_id_committed=receiver_coin.coin.name()
+                                    if mode & 0b000111 == 0b000111
+                                    else None,
+                                ),
+                            ).to_program()
+                        ]
+                    ),
+                ),
+            ],
+            G2Element(),
+        )
+        result = await client.push_tx(only_sender)
+        assert result == (MempoolInclusionStatus.FAILED, Err.MESSAGE_NOT_SENT_OR_RECEIVED)
+
+        only_receiver = WalletSpendBundle(
+            [
+                make_spend(
+                    receiver_coin.coin,
+                    ACS,
+                    Program.to(
+                        [
+                            ReceiveMessage(
+                                b"foo",
+                                mode_integer=uint8(mode),
+                                sender=MessageParticipant(
+                                    parent_id_committed=sender_coin.coin.parent_coin_info if mode & 0b100000 else None,
+                                    puzzle_hash_committed=sender_coin.coin.puzzle_hash if mode & 0b010000 else None,
+                                    amount_committed=sender_coin.coin.amount if mode & 0b001000 else None,
+                                    coin_id_committed=sender_coin.coin.name() if mode & 0b111000 == 0b111000 else None,
+                                ),
+                            ).to_program()
+                        ]
+                    ),
+                ),
+            ],
+            G2Element(),
+        )
+        result = await client.push_tx(only_receiver)
+        assert result == (MempoolInclusionStatus.FAILED, Err.MESSAGE_NOT_SENT_OR_RECEIVED)
+
+        result = await client.push_tx(WalletSpendBundle.aggregate([only_sender, only_receiver]))
+        assert result == (MempoolInclusionStatus.SUCCESS, None)
+
+
+def test_message_error_conditions() -> None:
+    with pytest.raises(ValueError, match="Must specify at least one committment"):
+        MessageParticipant()
+
+    test_coin = Coin(bytes32.zeros, bytes32.zeros, uint64(0))
+    with pytest.raises(ValueError, match="You must specify all or none"):
+        MessageParticipant(coin_id_committed=test_coin.name(), parent_id_committed=bytes32.zeros)
+
+    with pytest.raises(AssertionError, match="The value for coin_id_committed must be equal"):
+        MessageParticipant(
+            coin_id_committed=test_coin.name(),
+            parent_id_committed=bytes32.zeros,
+            puzzle_hash_committed=bytes32.zeros,
+            amount_committed=uint64(1),
+        )
+
+    for mode in range(0b001, 0b111 + 1):
+        with pytest.raises(AssertionError, match="If mode_integer is manually specified"):
+            MessageParticipant(
+                mode_integer=uint8(mode),
+                parent_id_committed=test_coin.parent_coin_info if not mode & 0b100 else None,
+                puzzle_hash_committed=test_coin.puzzle_hash if not mode & 0b010 else None,
+                amount_committed=test_coin.amount if (not mode & 0b001) or (mode == 0b111) else None,
+            )
+
+    with pytest.raises(ValueError, match="without committment information"):
+        MessageParticipant(
+            mode_integer=uint8(0b111),
+        ).necessary_args
+
+    with pytest.raises(ValueError, match="Must specify either mode_integer or both sender and reciever"):
+        SendMessage(
+            msg=b"foo",
+            sender=MessageParticipant(coin_id_committed=test_coin.name()),
+        )
+
+    with pytest.raises(ValueError, match="Must specify either mode_integer or both sender and reciever"):
+        SendMessage(
+            msg=b"foo",
+            receiver=MessageParticipant(coin_id_committed=test_coin.name()),
+        )
+
+    with pytest.raises(AssertionError, match="don't match the sender's mode"):
+        SendMessage(
+            msg=b"foo",
+            mode_integer=uint8(0b111111),
+            sender=MessageParticipant(mode_integer=uint8(0b001)),
+        )
+
+    with pytest.raises(AssertionError, match="don't match the receiver's mode"):
+        SendMessage(
+            msg=b"foo",
+            mode_integer=uint8(0b111111),
+            receiver=MessageParticipant(mode_integer=uint8(0b001)),
+        )
+
+    with pytest.raises(ValueError, match="Must specify either var_args or receiver"):
+        SendMessage(
+            msg=b"foo",
+            mode_integer=uint8(0b111111),
+        )
+
+    with pytest.raises(ValueError, match="Must specify either var_args or sender"):
+        ReceiveMessage(
+            msg=b"foo",
+            mode_integer=uint8(0b111111),
+        )
+
+    with pytest.raises(AssertionError, match="do not match the specified arguments"):
+        SendMessage(
+            msg=b"foo",
+            mode_integer=uint8(0b111111),
+            var_args=[Program.to(test_coin.name())],
+            receiver=MessageParticipant(coin_id_committed=bytes32.zeros),
+        )
+
+    with pytest.raises(AssertionError, match="do not match the specified arguments"):
+        ReceiveMessage(
+            msg=b"foo",
+            mode_integer=uint8(0b111111),
+            var_args=[Program.to(test_coin.name())],
+            sender=MessageParticipant(coin_id_committed=bytes32.zeros),
+        )

--- a/chia/_tests/wallet/test_conditions.py
+++ b/chia/_tests/wallet/test_conditions.py
@@ -156,14 +156,26 @@ def test_completeness() -> None:
         ConditionSerializations(
             ConditionOpcode.SEND_MESSAGE,
             Program.to([0x3F, b"foobar", Program.to(HASH)]),
-            ["mode", "msg", "args"],
-            ["63", "0x" + b"foobar".hex(), "a0" + HASH_HEX],
+            ["mode_integer", "msg", "var_args", "sender", "receiver"],
+            [
+                "63",
+                "0x" + b"foobar".hex(),
+                ["a0" + HASH_HEX],
+                {"mode_integer": 0b111},
+                {"mode_integer": 0b111, "coin_id_committed": "0x" + HASH_HEX},
+            ],
         ),
         ConditionSerializations(
             ConditionOpcode.RECEIVE_MESSAGE,
             Program.to([0x3F, b"foobar", Program.to(HASH)]),
-            ["mode", "msg", "args"],
-            ["63", "0x" + b"foobar".hex(), "a0" + HASH_HEX],
+            ["mode_integer", "msg", "var_args", "sender", "receiver"],
+            [
+                "63",
+                "0x" + b"foobar".hex(),
+                ["a0" + HASH_HEX],
+                {"mode_integer": 0b111, "coin_id_committed": "0x" + HASH_HEX},
+                {"mode_integer": 0b111},
+            ],
         ),
     ],
 )

--- a/chia/wallet/conditions.py
+++ b/chia/wallet/conditions.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass, fields, replace
-from typing import Any, Optional, TypeVar, Union, final, get_type_hints
+from typing import Any, ClassVar, Optional, TypeVar, Union, final, get_type_hints
 
-from chia_rs import G1Element
+from chia_rs import Coin, G1Element
 from clvm.casts import int_from_bytes, int_to_bytes
 
 from chia.types.blockchain_format.program import Program
@@ -408,43 +408,227 @@ class CreatePuzzleAnnouncement(Condition):
 @final
 @streamable
 @dataclass(frozen=True)
+class MessageParticipant(Streamable):
+    mode_integer: Optional[uint8] = None
+    parent_id_committed: Optional[bytes32] = None
+    puzzle_hash_committed: Optional[bytes32] = None
+    amount_committed: Optional[uint64] = None
+    coin_id_committed: Optional[bytes32] = None
+
+    def __post_init__(self) -> None:
+        if (
+            self.parent_id_committed is None
+            and self.puzzle_hash_committed is None
+            and self.amount_committed is None
+            and self.coin_id_committed is None
+            and self.mode_integer is None
+        ):
+            raise ValueError("Must specify at least one committment. Anyone-can-send/recieve is not allowed.")
+        if self.coin_id_committed is not None:
+            if self.parent_id_committed is None or self.puzzle_hash_committed is None or self.amount_committed is None:
+                if not (
+                    self.parent_id_committed is None
+                    and self.puzzle_hash_committed is None
+                    and self.amount_committed is None
+                ):
+                    raise ValueError(
+                        "Cannot commit to coin_id and only specify some of the other arguments. "
+                        "You must specify all or none of them."
+                    )
+            else:
+                assert (
+                    Coin(
+                        parent_coin_info=self.parent_id_committed,
+                        puzzle_hash=self.puzzle_hash_committed,
+                        amount=self.amount_committed,
+                    ).name()
+                    == self.coin_id_committed
+                ), "The value for coin_id_committed must be equal to the implied ID of the other three arguments"
+        if self.mode_integer is not None:
+            assert (
+                self.mode == self.mode_integer
+            ), "If mode_integer is manually specified, you must specify committments that match with the mode"
+
+    @property
+    def _nothing_committed(self) -> bool:
+        return (
+            self.coin_id_committed is None
+            and self.parent_id_committed is None
+            and self.puzzle_hash_committed is None
+            and self.amount_committed is None
+        )
+
+    @property
+    def mode(self) -> uint8:
+        if self._nothing_committed:
+            # The non-None-ness of this is asserted by __post_init__
+            return self.mode_integer  # type: ignore[return-value]
+        if self.coin_id_committed is not None:
+            return uint8(0b111)
+
+        def convert_noneness_to_bit(maybe_none: Optional[Any]) -> int:
+            return 1 if maybe_none is not None else 0
+
+        return uint8(
+            (convert_noneness_to_bit(self.parent_id_committed) << 2)
+            | (convert_noneness_to_bit(self.puzzle_hash_committed) << 1)
+            | convert_noneness_to_bit(self.amount_committed)
+        )
+
+    @property
+    def necessary_args(self) -> list[Program]:
+        if self._nothing_committed:
+            raise ValueError("Cannot generate necessary_args for a participant without committment information")
+
+        if self.coin_id_committed:
+            return [Program.to(self.coin_id_committed)]
+
+        condition_args = []
+        if self.parent_id_committed is not None:
+            condition_args.append(Program.to(self.parent_id_committed))
+        if self.puzzle_hash_committed is not None:
+            condition_args.append(Program.to(self.puzzle_hash_committed))
+        if self.amount_committed is not None:
+            condition_args.append(Program.to(self.amount_committed))
+        return condition_args
+
+    @classmethod
+    def from_mode_and_maybe_args(
+        cls, sender: bool, full_mode: uint8, args: Optional[Iterable[Program]] = None
+    ) -> MessageParticipant:
+        if sender:
+            mode = full_mode >> 3
+        else:
+            mode = full_mode & 0b000111
+
+        if args is None:
+            return cls(mode_integer=uint8(mode))
+
+        if mode == 0b111:
+            return cls(mode_integer=uint8(mode), coin_id_committed=next(bytes32(arg.as_atom()) for arg in args))
+
+        parent_id_committed: Optional[bytes32] = None
+        puzzle_hash_committed: Optional[bytes32] = None
+        amount_committed: Optional[uint64] = None
+        # This loop probably looks a little strange
+        # It's trying to account for the fact that the arguments may be any 1 or 2 of these arguments in this order
+        # Not sure of a more elgant way to do it
+        for arg in args:
+            if mode & 0b100:
+                parent_id_committed = bytes32(arg.as_atom())
+                mode &= 0b011
+                continue
+            if mode & 0b010:
+                puzzle_hash_committed = bytes32(arg.as_atom())
+                mode &= 0b101
+                continue
+            if mode & 0b001:
+                amount_committed = uint64(arg.as_int())
+                break
+
+        return cls(
+            mode_integer=uint8(mode),
+            parent_id_committed=parent_id_committed,
+            puzzle_hash_committed=puzzle_hash_committed,
+            amount_committed=amount_committed,
+        )
+
+
+_T_MessageCondition = TypeVar("_T_MessageCondition", bound="SendMessage")
+
+
+@streamable
+@dataclass(frozen=True)
 class SendMessage(Condition):
-    mode: uint8
     msg: bytes
-    args: Program
+    var_args: Optional[list[Program]] = None
+    mode_integer: Optional[uint8] = None
+    sender: Optional[MessageParticipant] = None
+    receiver: Optional[MessageParticipant] = None
+    _other_party_is_receiver: ClassVar[bool] = True
+
+    @property
+    def _other_party(self) -> Optional[MessageParticipant]:
+        return self.receiver
+
+    @property
+    def _opcode(self) -> ConditionOpcode:
+        return ConditionOpcode.SEND_MESSAGE
+
+    def __post_init__(self) -> None:
+        if self.mode_integer is None and (self.sender is None or self.receiver is None):
+            raise ValueError("Must specify either mode_integer or both sender and reciever")
+
+        if self.mode_integer is not None and self.sender is not None:
+            assert (
+                self.mode_integer >> 3 == self.sender.mode
+            ), "The first 3 bits of mode_integer don't match the sender's mode"
+
+        if self.mode_integer is not None and self.receiver is not None:
+            assert (
+                self.mode_integer & 0b000111 == self.receiver.mode
+            ), "The last 3 bits of mode_integer don't match the receiver's mode"
+
+        if self.var_args is None and self._other_party is None:
+            raise ValueError(
+                f"Must specify either var_args or {'receiver' if self._other_party_is_receiver else 'sender'}"
+            )
+
+        if self.var_args is not None and self._other_party is not None and not self._other_party._nothing_committed:
+            assert (
+                self.var_args == self._other_party.necessary_args
+            ), f"The implied arguments for {self._other_party} do not match the specified arguments {self.var_args}"
+
+    @property
+    def args(self) -> list[Program]:
+        if self.var_args is not None:
+            return self.var_args
+
+        # The non-None-ness of this is asserted in __post_init__
+        return self._other_party.necessary_args  # type: ignore[union-attr]
+
+    @property
+    def mode(self) -> uint8:
+        if self.mode_integer is not None:
+            return self.mode_integer
+
+        # The non-None-ness of these are asserted in __post_init__
+        return uint8((self.sender.mode << 3) & self.receiver.mode)  # type: ignore[union-attr]
 
     def to_program(self) -> Program:
-        condition: Program = Program.to([ConditionOpcode.SEND_MESSAGE, self.mode, self.msg, self.args])
+        condition: Program = Program.to([self._opcode, self.mode, self.msg, *self.args])
         return condition
 
     @classmethod
-    def from_program(cls, program: Program) -> SendMessage:
+    def from_program(cls: type[_T_MessageCondition], program: Program) -> _T_MessageCondition:
+        full_mode = uint8(program.at("rf").as_int())
+        var_args = list(program.at("rrr").as_iter())
         return cls(
-            uint8(program.at("rf").as_int()),
             program.at("rrf").as_atom(),
-            program.at("rrrf"),
+            var_args,
+            full_mode,
+            MessageParticipant.from_mode_and_maybe_args(
+                True, full_mode, var_args if not cls._other_party_is_receiver else None
+            ),
+            MessageParticipant.from_mode_and_maybe_args(
+                False, full_mode, var_args if cls._other_party_is_receiver else None
+            ),
         )
 
 
 @final
 @streamable
 @dataclass(frozen=True)
-class ReceiveMessage(Condition):
-    mode: uint8
-    msg: bytes
-    args: Program
+class ReceiveMessage(SendMessage):
+    _other_party_is_receiver: ClassVar[bool] = False
 
-    def to_program(self) -> Program:
-        condition: Program = Program.to([ConditionOpcode.RECEIVE_MESSAGE, self.mode, self.msg, self.args])
-        return condition
+    @property
+    def _other_party(self) -> Optional[MessageParticipant]:
+        return self.sender
 
-    @classmethod
-    def from_program(cls, program: Program) -> ReceiveMessage:
-        return cls(
-            uint8(program.at("rf").as_int()),
-            program.at("rrf").as_atom(),
-            program.at("rrrf"),
-        )
+    @property
+    def _opcode(self) -> ConditionOpcode:
+        return ConditionOpcode.RECEIVE_MESSAGE
 
 
 @final

--- a/chia/wallet/conditions.py
+++ b/chia/wallet/conditions.py
@@ -513,6 +513,7 @@ class MessageParticipant(Streamable):
         # This loop probably looks a little strange
         # It's trying to account for the fact that the arguments may be any 1 or 2 of these arguments in this order
         # Not sure of a more elgant way to do it
+        original_mode = mode
         for arg in args:
             if mode & 0b100:
                 parent_id_committed = bytes32(arg.as_atom())
@@ -527,7 +528,7 @@ class MessageParticipant(Streamable):
                 break
 
         return cls(
-            mode_integer=uint8(mode),
+            mode_integer=uint8(original_mode),
             parent_id_committed=parent_id_committed,
             puzzle_hash_committed=puzzle_hash_committed,
             amount_committed=amount_committed,
@@ -593,7 +594,7 @@ class SendMessage(Condition):
             return self.mode_integer
 
         # The non-None-ness of these are asserted in __post_init__
-        return uint8((self.sender.mode << 3) & self.receiver.mode)  # type: ignore[union-attr]
+        return uint8((self.sender.mode << 3) | self.receiver.mode)  # type: ignore[union-attr]
 
     def to_program(self) -> Program:
         condition: Program = Program.to([self._opcode, self.mode, self.msg, *self.args])


### PR DESCRIPTION
Right now, there's no easy way to work with message conditions when you're constructing spends.  This PR expands on the current drivers to make it much easier to work with.

Worth noting this is _technically_ a breaking change to the `extra_conditions` argument in the RPCs because I changed the naming of some of the fields, but I think it's worth it and would highly doubt that anyone will be affected.