### PR TITLE
Add simulator to installers

### DIFF
--- a/build_scripts/pyinstaller.spec
+++ b/build_scripts/pyinstaller.spec
@@ -33,7 +33,6 @@ SERVERS = [
     "farmer",
     "introducer",
     "timelord",
-    "simulator",
 ]
 
 if THIS_IS_WINDOWS:
@@ -182,6 +181,7 @@ add_binary("start_seeder", f"{ROOT}/chia/seeder/dns_server.py", COLLECT_ARGS)
 add_binary("start_data_layer_http", f"{ROOT}/chia/data_layer/data_layer_server.py", COLLECT_ARGS)
 add_binary("start_data_layer_s3_plugin", f"{ROOT}/chia/data_layer/s3_plugin_service.py", COLLECT_ARGS)
 add_binary("timelord_launcher", f"{ROOT}/chia/timelord/timelord_launcher.py", COLLECT_ARGS)
+add_binary(f"start_simulator", f"{ROOT}/chia/simulator/start_simulator.py", COLLECT_ARGS)
 
 COLLECT_KWARGS = dict(
     strip=False,

--- a/build_scripts/pyinstaller.spec
+++ b/build_scripts/pyinstaller.spec
@@ -33,6 +33,7 @@ SERVERS = [
     "farmer",
     "introducer",
     "timelord",
+    "simulator",
 ]
 
 if THIS_IS_WINDOWS:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

Enables using the simulator from the installers

### Current Behavior:

start_simulator is missing from the installers, so `chia start simulator` fails with an error in the error logs

### New Behavior:

start_simulator is included in the installers, so `chia start simulator` works

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
