### PR TITLE
[CHIA-1933] Remove `get_new` methods from `CATWallet`

### DIFF
--- a/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
@@ -318,7 +318,7 @@ async def test_cat_spend(wallet_environments: WalletTestFramework) -> None:
 
     assert cat_wallet.cat_info.limitations_program_hash == cat_wallet_2.cat_info.limitations_program_hash
 
-    cat_2_hash = await cat_wallet_2.get_new_inner_hash()
+    cat_2_hash = await cat_wallet_2.standard_wallet.get_puzzle_hash(new=False)
     async with cat_wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
         await cat_wallet.generate_signed_transaction([uint64(60)], [cat_2_hash], action_scope, fee=uint64(1))
     tx_id = None
@@ -408,7 +408,7 @@ async def test_cat_spend(wallet_environments: WalletTestFramework) -> None:
     memos = await env_2.rpc_client.get_transaction_memo(GetTransactionMemo(transaction_id=tx_id))
     assert len(memos.coins_with_memos) == 2
     assert memos.coins_with_memos[1].memos[0] == cat_2_hash
-    cat_hash = await cat_wallet.get_new_inner_hash()
+    cat_hash = await cat_wallet.standard_wallet.get_puzzle_hash(new=False)
     async with cat_wallet_2.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
         await cat_wallet_2.generate_signed_transaction([uint64(15)], [cat_hash], action_scope)
 
@@ -610,7 +610,7 @@ async def test_cat_doesnt_see_eve(wallet_environments: WalletTestFramework) -> N
 
     assert cat_wallet.cat_info.limitations_program_hash == cat_wallet_2.cat_info.limitations_program_hash
 
-    cat_2_hash = await cat_wallet_2.get_new_inner_hash()
+    cat_2_hash = await cat_wallet_2.standard_wallet.get_puzzle_hash(new=False)
     async with cat_wallet.wallet_state_manager.new_action_scope(
         wallet_environments.tx_config, push=True
     ) as action_scope:
@@ -684,7 +684,7 @@ async def test_cat_doesnt_see_eve(wallet_environments: WalletTestFramework) -> N
         ]
     )
 
-    cc2_ph = await cat_wallet_2.get_new_cat_puzzle_hash()
+    cc2_ph = await cat_wallet_2.get_cat_puzzle_hash(new=False)
     async with wallet.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         await wallet.wallet_state_manager.main_wallet.generate_signed_transaction(uint64(10), cc2_ph, action_scope)
 
@@ -817,8 +817,8 @@ async def test_cat_spend_multiple(wallet_environments: WalletTestFramework) -> N
     assert cat_wallet_0.cat_info.limitations_program_hash == cat_wallet_1.cat_info.limitations_program_hash
     assert cat_wallet_0.cat_info.limitations_program_hash == cat_wallet_2.cat_info.limitations_program_hash
 
-    cat_1_hash = await cat_wallet_1.get_new_inner_hash()
-    cat_2_hash = await cat_wallet_2.get_new_inner_hash()
+    cat_1_hash = await cat_wallet_1.standard_wallet.get_puzzle_hash(new=False)
+    cat_2_hash = await cat_wallet_2.standard_wallet.get_puzzle_hash(new=False)
 
     async with cat_wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
         await cat_wallet_0.generate_signed_transaction([uint64(60), uint64(20)], [cat_1_hash, cat_2_hash], action_scope)
@@ -900,7 +900,7 @@ async def test_cat_spend_multiple(wallet_environments: WalletTestFramework) -> N
         ]
     )
 
-    cat_hash = await cat_wallet_0.get_new_inner_hash()
+    cat_hash = await cat_wallet_0.standard_wallet.get_puzzle_hash(new=False)
 
     async with cat_wallet_1.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
         await cat_wallet_1.generate_signed_transaction([uint64(15)], [cat_hash], action_scope)
@@ -1107,7 +1107,7 @@ async def test_cat_max_amount_send(wallet_environments: WalletTestFramework) -> 
 
     assert cat_wallet.cat_info.limitations_program_hash is not None
 
-    cat_2 = await cat_wallet.get_new_inner_puzzle()
+    cat_2 = await cat_wallet.standard_wallet.get_puzzle(new=False)
     cat_2_hash = cat_2.get_tree_hash()
     amounts = []
     puzzle_hashes = []
@@ -1382,7 +1382,7 @@ async def test_cat_hint(wallet_environments: WalletTestFramework) -> None:
     cat_wallet_2 = wallet_node_2.wallet_state_manager.wallets[uint32(2)]
     assert isinstance(cat_wallet_2, CATWallet)
 
-    cat_hash = await cat_wallet.get_new_inner_hash()
+    cat_hash = await cat_wallet.standard_wallet.get_puzzle_hash(new=False)
     async with cat_wallet_2.wallet_state_manager.new_action_scope(
         wallet_environments.tx_config, push=True
     ) as action_scope:

--- a/chia/_tests/wallet/dao_wallet/test_dao_wallets.py
+++ b/chia/_tests/wallet/dao_wallet/test_dao_wallets.py
@@ -1032,7 +1032,7 @@ async def test_dao_proposal_partial_vote(
     await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node_0, wallet_node_1], timeout=30)
 
     # Create a mint proposal
-    recipient_puzzle_hash = await cat_wallet_1.get_new_inner_hash()
+    recipient_puzzle_hash = await cat_wallet_1.standard_wallet.get_puzzle_hash(new=False)
     new_mint_amount = uint64(500)
     mint_proposal_inner = await generate_mint_proposal_innerpuz(
         treasury_id,
@@ -1104,7 +1104,7 @@ async def test_dao_proposal_partial_vote(
     await time_out_assert(20, cat_wallet_1.get_spendable_balance, balance + new_mint_amount)
     # Can we spend the newly minted CATs?
     old_balance = await cat_wallet_0.get_spendable_balance()
-    ph_0 = await cat_wallet_0.get_new_inner_hash()
+    ph_0 = await cat_wallet_0.standard_wallet.get_puzzle_hash(new=False)
     async with cat_wallet_1.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
         await cat_wallet_1.generate_signed_transaction([balance + new_mint_amount], [ph_0], action_scope)
     await full_node_api.process_transaction_records(records=action_scope.side_effects.transactions)

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1131,7 +1131,12 @@ class WalletRpcApi:
             raise ValueError("Cannot split coins from non-fungible wallet types")
 
         outputs = [
-            Payment(await wallet.get_puzzle_hash(new=True), request.amount_per_coin)
+            Payment(
+                await wallet.get_puzzle_hash(new=True)
+                if isinstance(wallet, Wallet)
+                else await wallet.standard_wallet.get_puzzle_hash(new=True),
+                request.amount_per_coin,
+            )
             for _ in range(request.number_of_coins)
         ]
         if len(outputs) == 0:
@@ -1266,7 +1271,7 @@ class WalletRpcApi:
             assert isinstance(wallet, CATWallet)
             await wallet.generate_signed_transaction(
                 [primary_output_amount],
-                [await wallet.get_puzzle_hash(new=not action_scope.config.tx_config.reuse_puzhash)],
+                [await wallet.standard_wallet.get_puzzle_hash(new=not action_scope.config.tx_config.reuse_puzhash)],
                 action_scope,
                 request.fee,
                 coins=set(coins),

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -97,7 +97,9 @@ class GenesisById(LimitationsProgram):
         origin = coins.copy().pop()
         origin_id = origin.name()
 
-        cat_inner: Program = await wallet.get_inner_puzzle(new=not action_scope.config.tx_config.reuse_puzhash)
+        cat_inner: Program = await wallet.standard_wallet.get_puzzle(
+            new=not action_scope.config.tx_config.reuse_puzhash
+        )
         tail: Program = cls.construct([Program.to(origin_id)])
 
         wallet.lineage_store = await CATLineageStore.create(

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -266,7 +266,9 @@ class GenesisByIdOrSingleton(LimitationsProgram):
             origin = coins.copy().pop()
             origin_id = origin.name()
 
-        cat_inner: Program = await wallet.get_new_inner_puzzle()
+        cat_inner: Program = await wallet.standard_wallet.get_puzzle(
+            new=not action_scope.config.tx_config.reuse_puzhash
+        )
         # GENESIS_ID
         # TREASURY_SINGLETON_STRUCT  ; (SINGLETON_MOD_HASH, (LAUNCHER_ID, LAUNCHER_PUZZLE_HASH))
         launcher_puzhash = create_cat_launcher_for_singleton_id(tail_info["treasury_id"]).get_tree_hash()

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -506,9 +506,14 @@ class TradeManager:
                         wallet_id = uint32(id)
                         wallet = self.wallet_state_manager.wallets.get(wallet_id)
                         assert isinstance(wallet, (CATWallet, Wallet))
-                        p2_ph: bytes32 = await wallet.get_puzzle_hash(
-                            new=not action_scope.config.tx_config.reuse_puzhash
-                        )
+                        if isinstance(wallet, Wallet):
+                            p2_ph: bytes32 = await wallet.get_puzzle_hash(
+                                new=not action_scope.config.tx_config.reuse_puzhash
+                            )
+                        else:
+                            p2_ph = await wallet.standard_wallet.get_puzzle_hash(
+                                new=not action_scope.config.tx_config.reuse_puzhash
+                            )
                         if wallet.type() != WalletType.STANDARD_WALLET:
                             if callable(getattr(wallet, "get_asset_id", None)):  # ATTENTION: new wallets
                                 assert isinstance(wallet, CATWallet)

--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -458,10 +458,10 @@ class CRCATWallet(CATWallet):
                 for payment in payments:
                     if change_puzhash == payment.puzzle_hash and change == payment.amount:
                         # We cannot create two coins has same id, create a new puzhash for the change
-                        change_puzhash = await self.get_new_inner_hash()
+                        change_puzhash = await self.standard_wallet.get_puzzle_hash(new=True)
                         break
             else:
-                change_puzhash = await self.get_new_inner_hash()
+                change_puzhash = await self.standard_wallet.get_puzzle_hash(new=True)
             primaries.append(Payment(change_puzhash, uint64(change), [change_puzhash]))
 
         # Find the VC Wallet


### PR DESCRIPTION
These methods are a temptation to ignore the reuse puzhash setting and should just be removed.  This decreases duplication and complexity as well.