### PR TITLE
CHIA-1945 Avoid computing a transactions filter with just reward coins when the filter is not requested from get_block_header

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -170,7 +170,7 @@ class TestBlockHeaderValidation:
                 block_bad = recursive_replace(
                     block, "finished_sub_slots", [new_finished_ss] + block.finished_sub_slots[1:]
                 )
-                header_block_bad = get_block_header(block_bad, [], [])
+                header_block_bad = get_block_header(block_bad)
                 # TODO: Inspect these block values as they are currently None
                 expected_difficulty = block.finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
                 expected_sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
@@ -195,7 +195,7 @@ class TestBlockHeaderValidation:
                     block, "finished_sub_slots", [new_finished_ss_2] + block.finished_sub_slots[1:]
                 )
 
-                header_block_bad_2 = get_block_header(block_bad_2, [], [])
+                header_block_bad_2 = get_block_header(block_bad_2)
                 # TODO: Inspect these block values as they are currently None
                 expected_difficulty = block.finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
                 expected_sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
@@ -225,7 +225,7 @@ class TestBlockHeaderValidation:
                 log.warning(f"Number of slots: {len(block.finished_sub_slots)}")
                 block_bad_3 = recursive_replace(block, "finished_sub_slots", [new_finished_ss_3])
 
-                header_block_bad_3 = get_block_header(block_bad_3, [], [])
+                header_block_bad_3 = get_block_header(block_bad_3)
                 # TODO: Inspect these block values as they are currently None
                 expected_difficulty = block.finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
                 expected_sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
@@ -254,7 +254,7 @@ class TestBlockHeaderValidation:
                 )
                 block_bad_4 = recursive_replace(block, "finished_sub_slots", [new_finished_ss_4])
 
-                header_block_bad_4 = get_block_header(block_bad_4, [], [])
+                header_block_bad_4 = get_block_header(block_bad_4)
                 # TODO: Inspect these block values as they are currently None
                 expected_difficulty = block.finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
                 expected_sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
@@ -510,7 +510,7 @@ class TestBlockHeaderValidation:
             blocks[0], "finished_sub_slots", [new_finished_ss] + blocks[0].finished_sub_slots[1:]
         )
 
-        header_block_bad = get_block_header(block_0_bad, [], [])
+        header_block_bad = get_block_header(block_0_bad)
         expected_vs = ValidationState(
             empty_blockchain.constants.SUB_SLOT_ITERS_STARTING, empty_blockchain.constants.DIFFICULTY_STARTING, None
         )
@@ -539,7 +539,7 @@ class TestBlockHeaderValidation:
         )
 
         await _validate_and_add_block(empty_blockchain, blocks[0])
-        header_block_bad = get_block_header(block_1_bad, [], [])
+        header_block_bad = get_block_header(block_1_bad)
         # TODO: Inspect these block values as they are currently None
         expected_difficulty = blocks[1].finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
         expected_sub_slot_iters = blocks[1].finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
@@ -566,7 +566,7 @@ class TestBlockHeaderValidation:
         )
         await _validate_and_add_block(empty_blockchain, blocks[0])
 
-        header_block_bad = get_block_header(block_1_bad, [], [])
+        header_block_bad = get_block_header(block_1_bad)
         # TODO: Inspect these block values as they are currently None
         expected_difficulty = blocks[1].finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
         expected_sub_slot_iters = blocks[1].finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
@@ -721,7 +721,7 @@ class TestBlockHeaderValidation:
                     block, "finished_sub_slots", block.finished_sub_slots[:-1] + [new_finished_ss]
                 )
 
-                header_block_bad = get_block_header(block_bad, [], [])
+                header_block_bad = get_block_header(block_bad)
                 # TODO: Inspect these block values as they are currently None
                 expected_difficulty = block.finished_sub_slots[0].challenge_chain.new_difficulty or uint64(0)
                 expected_sub_slot_iters = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters or uint64(0)
@@ -792,7 +792,7 @@ class TestBlockHeaderValidation:
             blocks[-1], "finished_sub_slots", blocks[-1].finished_sub_slots[:-1] + [new_finished_ss]
         )
 
-        header_block_bad = get_block_header(block_bad, [], [])
+        header_block_bad = get_block_header(block_bad)
         expected_vs = ValidationState(
             empty_blockchain.constants.SUB_SLOT_ITERS_STARTING, empty_blockchain.constants.DIFFICULTY_STARTING, None
         )

--- a/chia/_tests/util/test_full_block_utils.py
+++ b/chia/_tests/util/test_full_block_utils.py
@@ -274,6 +274,6 @@ async def test_parser():
 @pytest.mark.skip("This test is expensive and has already convinced us the parser works")
 async def test_header_block():
     for block in get_full_blocks():
-        hb: HeaderBlock = get_block_header(block, [], [])
+        hb: HeaderBlock = get_block_header(block)
         hb_bytes = header_block_from_block(memoryview(bytes(block)))
         assert HeaderBlock.from_bytes(hb_bytes) == hb

--- a/chia/_tests/wallet/test_wallet_blockchain.py
+++ b/chia/_tests/wallet/test_wallet_blockchain.py
@@ -75,7 +75,7 @@ async def test_wallet_blockchain(
 
         header_blocks: list[HeaderBlock] = []
         for block in default_1000_blocks:
-            header_block = get_block_header(block, [], [])
+            header_block = get_block_header(block)
             header_blocks.append(header_block)
 
         res, err = await chain.add_block(header_blocks[50])

--- a/chia/_tests/weight_proof/test_weight_proof.py
+++ b/chia/_tests/weight_proof/test_weight_proof.py
@@ -74,7 +74,7 @@ async def load_blocks_dont_validate(
         )
         sub_blocks[block.header_hash] = sub_block
         height_to_hash[block.height] = block.header_hash
-        header_cache[block.header_hash] = get_block_header(block, [], [])
+        header_cache[block.header_hash] = get_block_header(block)
         if sub_block.sub_epoch_summary_included is not None:
             sub_epoch_summaries[block.height] = sub_block.sub_epoch_summary_included
         prev_block = block

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -897,11 +897,11 @@ class Blockchain:
             if self.height_to_hash(block.height) != block.header_hash:
                 raise ValueError(f"Block at {block.header_hash} is no longer in the blockchain (it's in a fork)")
             if tx_filter is False:
-                header = get_block_header(block, [], [])
+                header = get_block_header(block)
             elif block.transactions_generator is None:
                 # There is no point in getting additions and removals for
                 # blocks that do not have transactions.
-                header = get_block_header(block, [], [])
+                header = get_block_header(block)
             else:
                 added_coins_records, removed_coins_records = await asyncio.gather(
                     self.coin_store.get_coins_added_at_height(block.height),
@@ -909,7 +909,7 @@ class Blockchain:
                 )
                 tx_additions = [cr.coin for cr in added_coins_records if not cr.coinbase]
                 removed = [cr.coin.name() for cr in removed_coins_records]
-                header = get_block_header(block, tx_additions, removed)
+                header = get_block_header(block, (tx_additions, removed))
             header_blocks[header.header_hash] = header
 
         return header_blocks

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -121,7 +121,7 @@ def _pre_validate_block(
             removals, tx_additions = tx_removals_and_additions(conds)
 
         assert conds is None or conds.validated_signature is True
-        header_block = get_block_header(block, tx_additions, removals)
+        header_block = get_block_header(block, (tx_additions, removals))
         required_iters, error = validate_finished_header_block(
             constants,
             blockchain,

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1237,7 +1237,7 @@ class FullNodeAPI:
             tx_additions = [add[0] for add in additions]
             tx_removals = [rem.name() for rem in removals]
 
-        header_block = get_block_header(block, tx_additions, tx_removals)
+        header_block = get_block_header(block, (tx_additions, tx_removals))
         msg = make_msg(
             ProtocolMessageTypes.respond_block_header,
             wallet_protocol.RespondBlockHeader(header_block),
@@ -1529,7 +1529,7 @@ class FullNodeAPI:
             )
             added_coins = [record.coin for record in added_coins_records if not record.coinbase]
             removal_names = [record.coin.name() for record in removed_coins_records]
-            header_block = get_block_header(block, added_coins, removal_names)
+            header_block = get_block_header(block, (added_coins, removal_names))
             header_blocks.append(header_block)
 
         msg = make_msg(

--- a/chia/util/generator_tools.py
+++ b/chia/util/generator_tools.py
@@ -14,11 +14,18 @@ from chia.util.ints import uint64
 
 
 def get_block_header(
-    block: FullBlock, tx_addition_coins: Collection[Coin], removals_names: Collection[bytes32]
+    block: FullBlock, additions_and_removals: Optional[tuple[Collection[Coin], Collection[bytes32]]] = None
 ) -> HeaderBlock:
-    # Create filter
+    """
+    Returns a HeaderBlock from a FullBlock.
+    If `additions_and_removals` is not None, account for them, as well as
+    reward coins, in the creation of the transactions filter, otherwise create
+    an empty one.
+    """
+    # Create an empty filter to begin with
     byte_array_tx: list[bytearray] = []
-    if block.is_transaction_block():
+    if additions_and_removals is not None and block.is_transaction_block():
+        tx_addition_coins, removals_names = additions_and_removals
         for coin in tx_addition_coins:
             byte_array_tx.append(bytearray(coin.puzzle_hash))
         for coin in block.get_included_reward_coins():


### PR DESCRIPTION
### Purpose:

We tend to use `get_block_header` in paths where we don't care about the transactions filter, by passing empty additions and removals, yet when a transaction block contains reward coins, we end up computing a non-empty one. Now make it explicit that we care about the transactions filter by sending a tuple of additions and removals.

### Current Behavior:

We generate a non-empty transactions filter when we get called with a transaction block that has reward coins, even if we pass empty additions and removals, which we usually do to signal not caring about the filter.

### New Behavior:

We generate an empty transactions filter unless we're passed a tuple of additions and removals, in which case we account for them, as well as reward coins, in the computation of the transactions filter.