### PR TITLE
fixup `dont_prompt`

### DIFF
--- a/chia/cmds/plotnft.py
+++ b/chia/cmds/plotnft.py
@@ -93,7 +93,7 @@ class CreatePlotNFTCMD:
         show_default=True,
         required=True,
     )
-    dont_prompt: bool = option("-y", "--yes", "dont_prompt", help="No prompts", is_flag=True)
+    dont_prompt: bool = option("-y", "--yes", help="No prompts", is_flag=True)
 
     async def run(self) -> None:
         from chia.cmds.plotnft_funcs import create
@@ -133,7 +133,7 @@ class JoinPlotNFTCMD:
         show_default=True,
         required=True,
     )
-    dont_prompt: bool = option("-y", "--yes", "dont_prompt", help="No prompts", is_flag=True)
+    dont_prompt: bool = option("-y", "--yes", help="No prompts", is_flag=True)
     id: Optional[int] = option(
         "-i", "--id", help="ID of the wallet to use", default=None, show_default=True, required=False
     )
@@ -160,7 +160,7 @@ class JoinPlotNFTCMD:
 )
 class LeavePlotNFTCMD:
     rpc_info: NeedsWalletRPC  # provides wallet-rpc-port and fingerprint options
-    dont_prompt: bool = option("-y", "--yes", "dont_prompt", help="No prompts", is_flag=True)
+    dont_prompt: bool = option("-y", "--yes", help="No prompts", is_flag=True)
     fee: uint64 = option(
         "-m",
         "--fee",


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

crossed with merging of https://github.com/Chia-Network/chia-blockchain/pull/18926

https://github.com/Chia-Network/chia-blockchain/actions/runs/12146894253/job/33871934640#step:14:7622
```python-traceback
chia/_tests/pools/test_pool_cmdline.py:14: in <module>
    from chia._tests.cmds.cmd_test_utils import TestWalletRpcClient
chia/_tests/cmds/cmd_test_utils.py:15: in <module>
    from chia.cmds.chia import cli as chia_cli
chia/cmds/chia.py:22: in <module>
    from chia.cmds.plotnft import plotnft_cmd
chia/cmds/plotnft.py:77: in <module>
    class CreatePlotNFTCMD:
chia/cmds/cmd_classes.py:249: in _chia_command
    cmd.command(name, short_help=short_help, help=help)(_convert_class_to_function(wrapped_cls))
chia/cmds/cmd_classes.py:225: in _convert_class_to_function
    return command_parser.apply_decorators(command_parser)
chia/cmds/cmd_classes.py:129: in apply_decorators
    cmd_to_return = decorator(cmd_to_return)
.venv/lib/python3.10/site-packages/click/decorators.py:373: in decorator
    _param_memo(f, cls(param_decls, **attrs))
.venv/lib/python3.10/site-packages/click/core.py:2536: in __init__
    super().__init__(param_decls, type=type, multiple=multiple, **attrs)
.venv/lib/python3.10/site-packages/click/core.py:2111: in __init__
    self.name, self.opts, self.secondary_opts = self._parse_decls(
.venv/lib/python3.10/site-packages/click/core.py:2653: in _parse_decls
    raise TypeError(f"Name '{name}' defined twice")
E   TypeError: Name 'dont_prompt' defined twice
```

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
