### PR TITLE
Update .repo-content-updater.yml to use default rebase setting

### DIFF
--- a/.repo-content-updater.yml
+++ b/.repo-content-updater.yml
@@ -1,3 +1,4 @@
 var_overrides:
   DEPENDABOT_ACTIONS_REVIEWERS: '["cmmarslender", "altendky"]'
   DEPENDENCY_REVIEW_ALLOW_DEPENDENCIES_LICENSES: pkg:pypi/pyinstaller, pkg:pypi/mypy
+  

--- a/.repo-content-updater.yml
+++ b/.repo-content-updater.yml
@@ -1,3 +1,2 @@
 var_overrides:
   DEPENDABOT_ACTIONS_REVIEWERS: '["cmmarslender", "altendky"]'
-  DEPENDABOT_PIP_REBASE_STRATEGY: disabled

--- a/.repo-content-updater.yml
+++ b/.repo-content-updater.yml
@@ -1,4 +1,3 @@
 var_overrides:
   DEPENDABOT_ACTIONS_REVIEWERS: '["cmmarslender", "altendky"]'
   DEPENDENCY_REVIEW_ALLOW_DEPENDENCIES_LICENSES: pkg:pypi/pyinstaller, pkg:pypi/mypy
-  


### PR DESCRIPTION
Dependabot should conflict less now with recent changes to version locking in the toml file so hopefully this will be ok to turn back to the default (which is auto)