### PR TITLE
add some validation of `fork_info` in Blockchain.add_block()

### DIFF
--- a/chia/_tests/blockchain/test_blockchain_transactions.py
+++ b/chia/_tests/blockchain/test_blockchain_transactions.py
@@ -7,6 +7,7 @@ from clvm.casts import int_to_bytes
 
 from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from chia._tests.util.generator_tools_testing import run_and_get_removals_and_additions
+from chia.consensus.blockchain import AddBlockResult
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols import wallet_protocol
 from chia.server.server import ChiaServer
@@ -17,7 +18,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.spend_bundle import SpendBundle, estimate_fees
-from chia.util.errors import ConsensusError, Err
+from chia.util.errors import Err
 from chia.util.ints import uint32, uint64
 from chia.wallet.conditions import AssertCoinAnnouncement, AssertPuzzleAnnouncement
 
@@ -44,8 +45,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block, None)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         spend_block = blocks[2]
         spend_coin = None
@@ -110,8 +110,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         spend_block = blocks[2]
         spend_coin = None
@@ -150,8 +149,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         spend_block = blocks[2]
 
@@ -189,8 +187,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         spend_block = blocks[2]
 
@@ -209,8 +206,7 @@ class TestBlockchainTransactions:
             transaction_data=spend_bundle,
         )
         # Move chain to height 10, with a spend at height 10
-        for block in blocks_spend:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks_spend, full_node_api_1.full_node)
 
         # Reorg at height 5, add up to and including height 12
         new_blocks = bt.get_consecutive_blocks(
@@ -221,8 +217,7 @@ class TestBlockchainTransactions:
             seed=b"another seed",
         )
 
-        for block in new_blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(new_blocks[-7:], full_node_api_1.full_node)
 
         # Spend the same coin in the new reorg chain at height 13
         new_blocks = bt.get_consecutive_blocks(
@@ -257,8 +252,9 @@ class TestBlockchainTransactions:
             transaction_data=spend_bundle,
             seed=b"spend at 12 is ok",
         )
-        for block in new_blocks_reorg:
-            await full_node_api_1.full_node.add_block(block)
+        await _validate_and_add_block(
+            full_node_api_1.full_node.blockchain, new_blocks_reorg[-1], expected_result=AddBlockResult.ADDED_AS_ORPHAN
+        )
 
         # Spend at height 13 is also OK (same height)
         new_blocks_reorg = bt.get_consecutive_blocks(
@@ -269,8 +265,9 @@ class TestBlockchainTransactions:
             transaction_data=spend_bundle,
             seed=b"spend at 13 is ok",
         )
-        for block in new_blocks_reorg:
-            await full_node_api_1.full_node.add_block(block)
+        await _validate_and_add_block(
+            full_node_api_1.full_node.blockchain, new_blocks_reorg[-1], expected_result=AddBlockResult.ADDED_AS_ORPHAN
+        )
 
         # Spend at height 14 is not OK (already spend)
         new_blocks_reorg = bt.get_consecutive_blocks(
@@ -281,9 +278,12 @@ class TestBlockchainTransactions:
             transaction_data=spend_bundle,
             seed=b"spend at 14 is double spend",
         )
-        with pytest.raises(ConsensusError):
-            for block in new_blocks_reorg:
-                await full_node_api_1.full_node.add_block(block)
+        await _validate_and_add_block(
+            full_node_api_1.full_node.blockchain,
+            new_blocks_reorg[-1],
+            expected_result=AddBlockResult.INVALID_BLOCK,
+            expected_error=Err.DOUBLE_SPEND,
+        )
 
     @pytest.mark.anyio
     async def test_validate_blockchain_spend_reorg_coin(
@@ -300,8 +300,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         spend_block = blocks[2]
 
@@ -345,7 +344,7 @@ class TestBlockchainTransactions:
             transaction_data=spend_bundle,
             guarantee_transaction_block=True,
         )
-        await add_blocks_in_batches([new_blocks[-1]], full_node_api_1.full_node, blocks[5].prev_header_hash)
+        await add_blocks_in_batches(new_blocks, full_node_api_1.full_node)
 
         coin_3 = None
         for coin in run_and_get_removals_and_additions(
@@ -369,7 +368,7 @@ class TestBlockchainTransactions:
             transaction_data=spend_bundle,
             guarantee_transaction_block=True,
         )
-        await add_blocks_in_batches([new_blocks[-1]], full_node_api_1.full_node, blocks[5].prev_header_hash)
+        await add_blocks_in_batches(new_blocks, full_node_api_1.full_node)
 
     @pytest.mark.anyio
     async def test_validate_blockchain_spend_reorg_cb_coin(
@@ -392,7 +391,7 @@ class TestBlockchainTransactions:
             guarantee_transaction_block=True,
         )
 
-        await add_blocks_in_batches(new_blocks, full_node_api_1.full_node, blocks[6].prev_header_hash)
+        await add_blocks_in_batches(new_blocks, full_node_api_1.full_node)
 
         spend_block = new_blocks[-1]
         spend_coin = None
@@ -410,7 +409,7 @@ class TestBlockchainTransactions:
             transaction_data=spend_bundle,
             guarantee_transaction_block=True,
         )
-        await add_blocks_in_batches([new_blocks[-1]], full_node_api_1.full_node, blocks[6].prev_header_hash)
+        await add_blocks_in_batches(new_blocks, full_node_api_1.full_node)
 
     @pytest.mark.anyio
     async def test_validate_blockchain_spend_reorg_since_genesis(
@@ -425,8 +424,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         spend_block = blocks[-1]
         spend_coin = None
@@ -439,7 +437,7 @@ class TestBlockchainTransactions:
         new_blocks = bt.get_consecutive_blocks(
             1, blocks, seed=b"", farmer_reward_puzzle_hash=coinbase_puzzlehash, transaction_data=spend_bundle
         )
-        await full_node_api_1.full_node.add_block(new_blocks[-1])
+        await _validate_and_add_block(full_node_api_1.full_node.blockchain, new_blocks[-1])
 
         # Spends a coin in a genesis reorg, that was already spent
         new_blocks = bt.get_consecutive_blocks(
@@ -450,9 +448,6 @@ class TestBlockchainTransactions:
             guarantee_transaction_block=True,
         )
 
-        for block in new_blocks:
-            await full_node_api_1.full_node.add_block(block)
-
         new_blocks = bt.get_consecutive_blocks(
             1,
             new_blocks,
@@ -461,7 +456,7 @@ class TestBlockchainTransactions:
             transaction_data=spend_bundle,
         )
 
-        await full_node_api_1.full_node.add_block(new_blocks[-1])
+        await add_blocks_in_batches(new_blocks, full_node_api_1.full_node)
 
     @pytest.mark.anyio
     async def test_assert_my_coin_id(
@@ -478,8 +473,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         # Coinbase that gets spent
 
@@ -550,8 +544,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         # Coinbase that gets spent
         block1 = blocks[2]
@@ -634,8 +627,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         # Coinbase that gets spent
         block1 = blocks[2]
@@ -718,8 +710,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         # Coinbase that gets spent
         block1 = blocks[2]
@@ -784,8 +775,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         # Coinbase that gets spent
         block1 = blocks[2]
@@ -852,8 +842,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         # Coinbase that gets spent
         block1 = blocks[2]
@@ -897,7 +886,7 @@ class TestBlockchainTransactions:
                 time_per_block=301,
             )
         )
-        await full_node_api_1.full_node.add_block(blocks[-1])
+        await _validate_and_add_block(full_node_1.blockchain, blocks[-1])
 
         valid_new_blocks = bt.get_consecutive_blocks(
             1,
@@ -924,8 +913,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         # Coinbase that gets spent
         block1 = blocks[2]
@@ -971,7 +959,7 @@ class TestBlockchainTransactions:
                 time_per_block=30,
             )
         )
-        await full_node_api_1.full_node.add_block(blocks[-1])
+        await _validate_and_add_block(full_node_1.blockchain, blocks[-1])
 
         valid_new_blocks = bt.get_consecutive_blocks(
             1,
@@ -998,8 +986,7 @@ class TestBlockchainTransactions:
             num_blocks, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
         )
 
-        for block in blocks:
-            await full_node_api_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_api_1.full_node)
 
         # Coinbase that gets spent
         block1 = blocks[2]

--- a/chia/_tests/blockchain/test_blockchain_transactions.py
+++ b/chia/_tests/blockchain/test_blockchain_transactions.py
@@ -320,7 +320,7 @@ class TestBlockchainTransactions:
             transaction_data=spend_bundle,
             guarantee_transaction_block=True,
         )
-        await add_blocks_in_batches([new_blocks[-1]], full_node_api_1.full_node, blocks[5].prev_header_hash)
+        await add_blocks_in_batches([new_blocks[-1]], full_node_api_1.full_node)
 
         coin_2 = None
         for coin in run_and_get_removals_and_additions(

--- a/chia/_tests/core/full_node/stores/test_block_store.py
+++ b/chia/_tests/core/full_node/stores/test_block_store.py
@@ -15,6 +15,7 @@ from clvm.casts import int_to_bytes
 
 from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from chia._tests.util.db_connection import DBConnection, PathDBConnection
+from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.blockchain import AddBlockResult, Blockchain
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.full_block_to_block_record import header_block_to_sub_block_record
@@ -148,9 +149,10 @@ async def test_get_full_blocks_at(
         bc = await Blockchain.create(coin_store, block_store, bt.constants, tmp_dir, 2)
 
         count = 0
+        fork_info = ForkInfo(-1, -1, bt.constants.GENESIS_CHALLENGE)
         for b1, b2 in zip(blocks, alt_blocks):
             await _validate_and_add_block(bc, b1)
-            await _validate_and_add_block(bc, b2, expected_result=AddBlockResult.ADDED_AS_ORPHAN)
+            await _validate_and_add_block(bc, b2, expected_result=AddBlockResult.ADDED_AS_ORPHAN, fork_info=fork_info)
             ret = await block_store.get_full_blocks_at([uint32(count)])
             assert set(ret) == set([b1, b2])
             count += 1
@@ -174,9 +176,10 @@ async def test_get_block_records_in_range(
         bc = await Blockchain.create(coin_store, block_store, bt.constants, tmp_dir, 2)
 
         count = 0
+        fork_info = ForkInfo(-1, -1, bt.constants.GENESIS_CHALLENGE)
         for b1, b2 in zip(blocks, alt_blocks):
             await _validate_and_add_block(bc, b1)
-            await _validate_and_add_block(bc, b2, expected_result=AddBlockResult.ADDED_AS_ORPHAN)
+            await _validate_and_add_block(bc, b2, expected_result=AddBlockResult.ADDED_AS_ORPHAN, fork_info=fork_info)
             # the range is inclusive
             ret = await block_store.get_block_records_in_range(count, count)
             assert len(ret) == 1
@@ -202,9 +205,10 @@ async def test_get_block_bytes_in_range_in_main_chain(
         bc = await Blockchain.create(coin_store, block_store, bt.constants, tmp_dir, 2)
 
         count = 0
+        fork_info = ForkInfo(-1, -1, bt.constants.GENESIS_CHALLENGE)
         for b1, b2 in zip(blocks, alt_blocks):
             await _validate_and_add_block(bc, b1)
-            await _validate_and_add_block(bc, b2, expected_result=AddBlockResult.ADDED_AS_ORPHAN)
+            await _validate_and_add_block(bc, b2, expected_result=AddBlockResult.ADDED_AS_ORPHAN, fork_info=fork_info)
             # the range is inclusive
             ret = await block_store.get_block_bytes_in_range(count, count)
             assert ret == [bytes(b1)]
@@ -261,9 +265,10 @@ async def test_rollback(bt: BlockTools, tmp_dir: Path, use_cache: bool, default_
 
         # insert all blocks
         count = 0
+        fork_info = ForkInfo(-1, -1, bt.constants.GENESIS_CHALLENGE)
         for b1, b2 in zip(blocks, alt_blocks):
             await _validate_and_add_block(bc, b1)
-            await _validate_and_add_block(bc, b2, expected_result=AddBlockResult.ADDED_AS_ORPHAN)
+            await _validate_and_add_block(bc, b2, expected_result=AddBlockResult.ADDED_AS_ORPHAN, fork_info=fork_info)
             count += 1
             ret = await block_store.get_random_not_compactified(count)
             assert len(ret) == count

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -549,8 +549,9 @@ class TestFullNodeProtocol:
 
         assert full_node_1.full_node.blockchain.get_peak().height == 0
 
+        fork_info = ForkInfo(-1, -1, bt.constants.GENESIS_CHALLENGE)
         for block in bt.get_consecutive_blocks(30):
-            await full_node_1.full_node.add_block(block, peer)
+            await full_node_1.full_node.add_block(block, peer, fork_info=fork_info)
 
         assert full_node_1.full_node.blockchain.get_peak().height == 29
 
@@ -2665,8 +2666,7 @@ async def test_eviction_from_bls_cache(one_node_one_block: tuple[FullNodeSimulat
     blocks = bt.get_consecutive_blocks(
         3, guarantee_transaction_block=True, farmer_reward_puzzle_hash=bt.pool_ph, pool_reward_puzzle_hash=bt.pool_ph
     )
-    for block in blocks:
-        await full_node_1.full_node.add_block(block)
+    await add_blocks_in_batches(blocks, full_node_1.full_node)
     wt = bt.get_pool_wallet_tool()
     reward_coins = blocks[-1].get_included_reward_coins()
     # Setup a test block with two pk msg pairs

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1019,7 +1019,7 @@ class TestFullNodeProtocol:
             block_list_input=blocks[:-1],
             guarantee_transaction_block=True,
         )
-        await add_blocks_in_batches(blocks[-2:], full_node_1.full_node, blocks[-2].prev_header_hash)
+        await add_blocks_in_batches(blocks[-2:], full_node_1.full_node)
         # Can now resubmit a transaction after the reorg
         status, err = await full_node_1.full_node.add_transaction(
             successful_bundle, successful_bundle.name(), peer, test=True
@@ -2603,13 +2603,13 @@ async def test_shallow_reorg_nodes(
 
     assert chain_b[-1].total_iters < chain_a[-1].total_iters
 
-    await add_blocks_in_batches(chain_a[-1:], full_node_1.full_node, chain[-1].header_hash)
+    await add_blocks_in_batches(chain_a[-1:], full_node_1.full_node)
 
     await time_out_assert(10, check_nodes_in_sync)
     await validate_coin_set(full_node_1.full_node.blockchain.coin_store, chain_a)
     await validate_coin_set(full_node_2.full_node.blockchain.coin_store, chain_a)
 
-    await add_blocks_in_batches(chain_b[-1:], full_node_1.full_node, chain[-1].header_hash)
+    await add_blocks_in_batches(chain_b[-1:], full_node_1.full_node)
 
     # make sure node 1 reorged onto chain B
     assert full_node_1.full_node.blockchain.get_peak().header_hash == chain_b[-1].header_hash
@@ -2649,7 +2649,7 @@ async def test_shallow_reorg_nodes(
                 all_coins.append(coin)
         spend_bundle = wallet_a.generate_signed_transaction(uint64(1_000), receiver_puzzlehash, all_coins.pop())
 
-    await add_blocks_in_batches(chain[-4:], full_node_1.full_node, chain[-5].header_hash)
+    await add_blocks_in_batches(chain[-4:], full_node_1.full_node)
     await time_out_assert(10, check_nodes_in_sync)
     await validate_coin_set(full_node_1.full_node.blockchain.coin_store, chain)
     await validate_coin_set(full_node_2.full_node.blockchain.coin_store, chain)

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -41,6 +41,7 @@ from chia.server.api_protocol import ApiMetadata
 from chia.server.outbound_message import Message
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
+from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.simulator.block_tools import BlockTools, test_constants
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
@@ -371,8 +372,7 @@ async def next_block(full_node_1: FullNodeSimulator, wallet_a: WalletTool, bt: B
         time_per_block=10,
     )
 
-    for block in blocks:
-        await full_node_1.full_node.add_block(block)
+    await add_blocks_in_batches(blocks, full_node_1.full_node)
 
     await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 1)
     return blocks[-1].get_included_reward_coins()[0]
@@ -567,8 +567,7 @@ class TestMempoolManager:
         )
         peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
-        for block in blocks:
-            await full_node_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_1.full_node)
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
         spend_bundle1 = generate_test_spend_bundle(wallet_a, blocks[-1].get_included_reward_coins()[0])
@@ -613,8 +612,7 @@ class TestMempoolManager:
         )
 
         invariant_check_mempool(full_node_1.full_node.mempool_manager.mempool)
-        for block in blocks:
-            await full_node_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_1.full_node)
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
         coins = iter(blocks[-1].get_included_reward_coins())
@@ -696,8 +694,7 @@ class TestMempoolManager:
             pool_reward_puzzle_hash=reward_ph,
         )
 
-        for block in blocks:
-            await full_node_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_1.full_node)
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
         coins = iter(blocks[-1].get_included_reward_coins())
@@ -741,8 +738,7 @@ class TestMempoolManager:
         else:
             raise Exception("dummy peer not found")
 
-        for block in blocks:
-            await full_node_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_1.full_node)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + num_blocks)
 
@@ -784,8 +780,7 @@ class TestMempoolManager:
         else:
             raise Exception("dummy peer not found")
 
-        for block in blocks:
-            await full_node_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_1.full_node)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
@@ -1738,8 +1733,7 @@ class TestMempoolManager:
 
         peer = await connect_and_get_peer(server_1, server_2, bt.config["self_hostname"])
 
-        for block in blocks:
-            await full_node_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_1.full_node)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 5)
 
@@ -1797,8 +1791,7 @@ class TestMempoolManager:
             pool_reward_puzzle_hash=reward_ph,
         )
 
-        for block in blocks:
-            await full_node_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_1.full_node)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
         # coin = blocks[-1].get_included_reward_coins()[0]
@@ -1846,8 +1839,7 @@ class TestMempoolManager:
             pool_reward_puzzle_hash=reward_ph,
         )
 
-        for block in blocks:
-            await full_node_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_1.full_node)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, start_height + 3)
 
@@ -2852,8 +2844,7 @@ class TestMaliciousGenerators:
             pool_reward_puzzle_hash=reward_ph,
         )
 
-        for block in blocks:
-            await full_node_1.full_node.add_block(block)
+        await add_blocks_in_batches(blocks, full_node_1.full_node)
 
         await time_out_assert(60, node_height_at_least, True, full_node_1, blocks[-1].height)
 

--- a/chia/_tests/pools/test_pool_rpc.py
+++ b/chia/_tests/pools/test_pool_rpc.py
@@ -22,6 +22,7 @@ from chia.consensus.constants import ConsensusConstants
 from chia.pools.pool_puzzles import SINGLETON_LAUNCHER_HASH
 from chia.pools.pool_wallet_info import PoolSingletonState, PoolWalletInfo
 from chia.rpc.wallet_rpc_client import WalletRpcClient
+from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.simulator.block_tools import BlockTools, get_plot_dir
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.simulator_protocol import ReorgProtocol
@@ -432,8 +433,7 @@ class TestPoolWalletRpc:
                 guarantee_transaction_block=True,
             )
 
-            for block in blocks[-3:]:
-                await full_node_api.full_node.add_block(block)
+            await add_blocks_in_batches(blocks[-3:], full_node_api.full_node)
             await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
             bal = await client.get_wallet_balance(2)
@@ -532,8 +532,7 @@ class TestPoolWalletRpc:
             )
 
             block_count = 3
-            for block in blocks[-block_count:]:
-                await full_node_api.full_node.add_block(block)
+            await add_blocks_in_batches(blocks[-block_count:], full_node_api.full_node)
             await full_node_api.farm_blocks_to_puzzlehash(count=1, guarantee_transaction_blocks=True)
             await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
@@ -604,8 +603,7 @@ class TestPoolWalletRpc:
             )
 
             block_count = 3
-            for block in blocks[-block_count:]:
-                await full_node_api.full_node.add_block(block)
+            await add_blocks_in_batches(blocks[-block_count:], full_node_api.full_node)
             await full_node_api.farm_blocks_to_puzzlehash(count=1, guarantee_transaction_blocks=True)
             await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
             # Pooled plots don't have balance
@@ -664,8 +662,7 @@ class TestPoolWalletRpc:
                         block_list_input=blocks,
                         guarantee_transaction_block=True,
                     )
-                    for block in blocks[-2:]:
-                        await full_node_api.full_node.add_block(block)
+                    await add_blocks_in_batches(blocks[-2:], full_node_api.full_node)
                     await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
                     # Absorb the farmed reward
@@ -1007,8 +1004,7 @@ class TestPoolWalletRpc:
             transaction_data=next(tx.spend_bundle for tx in join_pool_txs if tx.spend_bundle is not None),
         )
 
-        for block in more_blocks[-3:]:
-            await full_node_api.full_node.add_block(block)
+        await add_blocks_in_batches(more_blocks[-3:], full_node_api.full_node)
 
         await time_out_assert(timeout=WAIT_SECS, function=status_is_leaving_no_blocks)
 

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -189,7 +189,7 @@ async def test_basic_sync_wallet(
     blocks_reorg = bt.get_consecutive_blocks(num_blocks - 1, block_list_input=default_400_blocks[:-5])
     blocks_reorg = bt.get_consecutive_blocks(1, blocks_reorg, guarantee_transaction_block=True, current_time=True)
 
-    await add_blocks_in_batches(blocks_reorg[1:], full_node, blocks_reorg[0].header_hash)
+    await add_blocks_in_batches(blocks_reorg[1:], full_node)
 
     for wallet_node, wallet_server in wallets:
         await time_out_assert(
@@ -246,9 +246,7 @@ async def test_almost_recent(
         blockchain_constants.WEIGHT_PROOF_RECENT_BLOCKS + 10, block_list_input=all_blocks
     )
 
-    await add_blocks_in_batches(
-        new_blocks[base_num_blocks + 20 :], full_node, new_blocks[base_num_blocks + 19].header_hash
-    )
+    await add_blocks_in_batches(new_blocks[base_num_blocks + 20 :], full_node)
 
     for wallet_node, wallet_server in wallets:
         wallet = wallet_node.wallet_state_manager.main_wallet
@@ -436,7 +434,7 @@ async def test_wallet_reorg_sync(
     num_blocks = 30
     blocks_reorg = bt.get_consecutive_blocks(num_blocks, block_list_input=default_400_blocks[:-5])
 
-    await add_blocks_in_batches(blocks_reorg[-30:], full_node, blocks_reorg[-30].prev_header_hash)
+    await add_blocks_in_batches(blocks_reorg[-30:], full_node)
 
     for wallet_node, wallet_server in wallets:
         wallet = wallet_node.wallet_state_manager.main_wallet

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2007,6 +2007,8 @@ class FullNode:
         # Adds the block to seen, and check if it's seen before (which means header is in memory)
         header_hash = block.header_hash
         if self.blockchain.contains_block(header_hash):
+            if fork_info is not None:
+                await self.blockchain.run_single_block(block, fork_info)
             return None
 
         pre_validation_result: Optional[PreValidationResult] = None
@@ -2079,6 +2081,8 @@ class FullNode:
         ):
             # After acquiring the lock, check again, because another asyncio thread might have added it
             if self.blockchain.contains_block(header_hash):
+                if fork_info is not None:
+                    await self.blockchain.run_single_block(block, fork_info)
                 return None
             validation_start = time.monotonic()
             # Tries to add the block to the blockchain, if we already validated transactions, don't do it again

--- a/chia/simulator/add_blocks_in_batches.py
+++ b/chia/simulator/add_blocks_in_batches.py
@@ -5,7 +5,6 @@ from typing import Optional
 from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
 from chia.full_node.full_node import FullNode, PeakPostProcessingResult
-from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
 from chia.types.validation_state import ValidationState
@@ -17,28 +16,23 @@ from chia.util.ints import uint32
 async def add_blocks_in_batches(
     blocks: list[FullBlock],
     full_node: FullNode,
-    # if we're adding the block to a fork, this is the fork point
-    header_hash: Optional[bytes32] = None,
 ) -> None:
     peak_hash = blocks[0].prev_header_hash
     if blocks[0].height == 0:
         assert peak_hash == full_node.constants.GENESIS_CHALLENGE
         diff = full_node.constants.DIFFICULTY_STARTING
         ssi = full_node.constants.SUB_SLOT_ITERS_STARTING
-        assert header_hash is None or header_hash == peak_hash
         fork_height = -1
     else:
-        # if no fork point is specified, assume it's immediately before the
+        # assume the fork point is immediately before the
         # batch of block we're about to add
-        if header_hash is None:
-            header_hash = blocks[0].prev_header_hash
-        block_record = await full_node.blockchain.get_block_record_from_db(header_hash)
+        block_record = await full_node.blockchain.get_block_record_from_db(peak_hash)
         assert block_record is not None
         ssi, diff = get_next_sub_slot_iters_and_difficulty(
             full_node.constants, True, block_record, full_node.blockchain
         )
         fork_height = block_record.height
-    fork_info = ForkInfo(fork_height, blocks[0].height - 1, blocks[0].prev_header_hash)
+    fork_info = ForkInfo(fork_height, blocks[0].height - 1, peak_hash)
 
     vs = ValidationState(ssi, diff, None)
 

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -300,7 +300,7 @@ class FullNodeSimulator(FullNodeAPI):
             guarantee_transaction_block=True,
             seed=seed,
         )
-        await add_blocks_in_batches(more_blocks, self.full_node, current_blocks[old_index].header_hash)
+        await add_blocks_in_batches(more_blocks[old_index + 1 :], self.full_node, current_blocks[old_index].header_hash)
 
     async def farm_blocks_to_puzzlehash(
         self,

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -300,7 +300,7 @@ class FullNodeSimulator(FullNodeAPI):
             guarantee_transaction_block=True,
             seed=seed,
         )
-        await add_blocks_in_batches(more_blocks[old_index + 1 :], self.full_node, current_blocks[old_index].header_hash)
+        await add_blocks_in_batches(more_blocks[old_index + 1 :], self.full_node)
 
     async def farm_blocks_to_puzzlehash(
         self,


### PR DESCRIPTION
This would have caught the bug introduced in main a while ago.

### Purpose:

Catch problems with invalid `ForkInfo` passed to `add_block()` much earlier.

The main change is in `blockchain.py`, here: https://github.com/Chia-Network/chia-blockchain/pull/18981/files#diff-40409ea13958d9e8cec2be388c12e68da7c3179de55f01879713c5abdb1fed38

All other changes is to correct tests' uses of this function, to pass in correct `ForkInfo`.

This exposed an issue in `FullNode.add_block()` where `fork_info` would not be updated when adding a block that was already in our DB. This issue was also fixed (with `run_single_block()`), here: https://github.com/Chia-Network/chia-blockchain/pull/18981/files#diff-a84a0802b416c9c5a5fdc6d2293c4c7971ca0b1519f246ede123e304a56e540a

### Current Behavior:

Many aspects of `ForkInfo` is allowed to be incorrect, potentially silently corrupting the database.

### New Behavior:

`ForkInfo` is validated (to the extent that;s possible to do cheaply) in `Blockchain.add_block()` to mitigate introducing errors in the future.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
