### PR TITLE
Add override for dependency license

### DIFF
--- a/.repo-content-updater.yml
+++ b/.repo-content-updater.yml
@@ -1,3 +1,4 @@
 var_overrides:
   DEPENDABOT_ACTIONS_REVIEWERS: '["cmmarslender", "altendky"]'
   DEPENDABOT_PIP_REBASE_STRATEGY: disabled
+  DEPENDENCY_REVIEW_ALLOW_DEPENDENCIES_LICENSES: pkg:pypi/pyinstaller, pkg:pypi/mypy


### PR DESCRIPTION
Add an override for the dependency licenses. The default is currently `pkg:pypi/pyinstaller`

Added in `pkg:pypi/mypy` due to the following action bug: https://github.com/actions/dependency-review-action/issues/839