### PR TITLE
convert test_change_pools to WalletTestFramework

### DIFF
--- a/chia/_tests/pools/test_pool_rpc.py
+++ b/chia/_tests/pools/test_pool_rpc.py
@@ -1003,6 +1003,10 @@ class TestPoolWalletRpc:
         await wallet_environments.full_node.farm_blocks_to_puzzlehash(
             count=LOCK_HEIGHT + 2, guarantee_transaction_blocks=True
         )
+        await wallet_environments.full_node.wait_for_wallet_synced(
+            wallet_node=wallet_environments.environments[0].node, timeout=20
+        )
+
         pw_status: PoolWalletInfo = (await wallet_rpc.pw_status(wallet_id))[0]
         assert pw_status.current.state == PoolSingletonState.FARMING_TO_POOL.value
         assert pw_status.current.pool_url == "https://pool-b.org"

--- a/chia/_tests/pools/test_pool_rpc.py
+++ b/chia/_tests/pools/test_pool_rpc.py
@@ -1003,10 +1003,10 @@ class TestPoolWalletRpc:
         await wallet_environments.full_node.farm_blocks_to_puzzlehash(
             count=LOCK_HEIGHT + 2, guarantee_transaction_blocks=True
         )
-        await verify_pool_state(wallet_rpc, wallet_id, PoolSingletonState.FARMING_TO_POOL)
-        await wallet_environments.full_node.wait_for_wallet_synced(
-            wallet_node=wallet_environments.environments[0].node, timeout=20
-        )
+        pw_status: PoolWalletInfo = (await wallet_rpc.pw_status(wallet_id))[0]
+        assert pw_status.current.state == PoolSingletonState.FARMING_TO_POOL.value
+        assert pw_status.current.pool_url == "https://pool-b.org"
+        assert pw_status.current.relative_lock_height == LOCK_HEIGHT
 
     @pytest.mark.anyio
     async def test_change_pools_reorg(self, setup: Setup, fee: uint64, self_hostname: str) -> None:

--- a/chia/_tests/pools/test_pool_rpc.py
+++ b/chia/_tests/pools/test_pool_rpc.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
 from shutil import rmtree
-from typing import Any
+from typing import Any, Union
 
 import pytest
 
@@ -16,6 +16,7 @@ import pytest
 from _pytest.fixtures import SubRequest
 from chia_rs import G1Element
 
+from chia._tests.environments.wallet import WalletStateTransition, WalletTestFramework
 from chia._tests.util.setup_nodes import setup_simulators_and_wallets_service
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.constants import ConsensusConstants
@@ -39,12 +40,17 @@ from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_node import WalletNode
+from chia.wallet.wallet_state_manager import WalletStateManager
 
 # TODO: Compare deducted fees in all tests against reported total_fee
+
+# limit to plain consensus mode for all tests
+pytestmark = [pytest.mark.limit_consensus_modes(reason="irrelevant")]
 
 log = logging.getLogger(__name__)
 FEE_AMOUNT = uint64(29_000)
 MAX_WAIT_SECS = 30  # A high value for WAIT_SECS is useful when paused in the debugger
+LOCK_HEIGHT = uint32(5)
 
 
 def get_pool_plot_dir() -> Path:
@@ -180,6 +186,90 @@ async def setup(
 
     client.close()
     await client.await_closed()
+
+
+async def verify_pool_state(wallet_rpc: WalletRpcClient, w_id: int, expected_state: PoolSingletonState) -> bool:
+    pw_status: PoolWalletInfo = (await wallet_rpc.pw_status(w_id))[0]
+    return pw_status.current.state == expected_state.value
+
+
+async def process_plotnft_create(
+    wallet_test_framework: WalletTestFramework, expected_state: PoolSingletonState, second_nft: bool = False
+) -> int:
+    wallet_rpc: WalletRpcClient = wallet_test_framework.environments[0].rpc_client
+
+    pre_block_balance_updates: dict[Union[int, str], dict[str, int]] = {
+        1: {
+            "confirmed_wallet_balance": 0,
+            "unconfirmed_wallet_balance": -1,
+            "<=#spendable_balance": 1,
+            "<=#max_send_amount": 1,
+            ">=#pending_change": 1,  # any amount increase
+            "pending_coin_removal_count": 1,
+        }
+    }
+
+    post_block_balance_updates: dict[Union[int, str], dict[str, int]] = {
+        1: {
+            "confirmed_wallet_balance": -1,
+            "unconfirmed_wallet_balance": 0,
+            ">=#spendable_balance": 1,
+            ">=#max_send_amount": 1,
+            "<=#pending_change": 1,  # any amount decrease
+            "<=#pending_coin_removal_count": 1,
+        },
+    }
+
+    if second_nft:
+        post_block = post_block_balance_updates | {
+            2: {
+                "set_remainder": True,  # TODO: sometimes this fails with pending_coin_removal_count
+            },
+            3: {"init": True, "unspent_coin_count": 1},
+        }
+    else:
+        post_block = post_block_balance_updates | {2: {"init": True, "unspent_coin_count": 1}}
+
+    await wallet_test_framework.process_pending_states(
+        [
+            WalletStateTransition(
+                pre_block_balance_updates=pre_block_balance_updates,
+                post_block_balance_updates=post_block,
+            )
+        ]
+    )
+
+    summaries_response = await wallet_rpc.get_wallets(WalletType.POOLING_WALLET)
+    assert len(summaries_response) == 2 if second_nft else 1
+    wallet_id: int = summaries_response[-1]["id"]
+
+    await verify_pool_state(wallet_rpc, wallet_id, expected_state=expected_state)
+    return wallet_id
+
+
+async def create_new_plotnft(
+    wallet_test_framework: WalletTestFramework, self_pool: bool = False, second_nft: bool = False
+) -> int:
+    wallet_state_manager: WalletStateManager = wallet_test_framework.environments[0].wallet_state_manager
+    wallet_rpc: WalletRpcClient = wallet_test_framework.environments[0].rpc_client
+
+    our_ph = await wallet_state_manager.main_wallet.get_new_puzzlehash()
+
+    await wallet_rpc.create_new_pool_wallet(
+        target_puzzlehash=our_ph,
+        backup_host="",
+        mode="new",
+        relative_lock_height=uint32(0) if self_pool else LOCK_HEIGHT,
+        state="SELF_POOLING" if self_pool else "FARMING_TO_POOL",
+        pool_url="" if self_pool else "http://pool.example.com",
+        fee=uint64(0),
+    )
+
+    return await process_plotnft_create(
+        wallet_test_framework=wallet_test_framework,
+        expected_state=PoolSingletonState.SELF_POOLING if self_pool else PoolSingletonState.FARMING_TO_POOL,
+        second_nft=second_nft,
+    )
 
 
 class TestPoolWalletRpc:
@@ -868,73 +958,55 @@ class TestPoolWalletRpc:
         await time_out_assert(timeout=MAX_WAIT_SECS, function=status_is_self_pooling)
         assert len(await wallet_node.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(2)) == 0
 
+    @pytest.mark.parametrize(
+        "wallet_environments",
+        [
+            {
+                "num_environments": 1,
+                "blocks_needed": [10],
+            }
+        ],
+        indirect=True,
+    )
     @pytest.mark.anyio
-    async def test_change_pools(self, setup: Setup, fee: uint64, self_hostname: str) -> None:
+    async def test_change_pools(
+        self,
+        fee: uint64,
+        wallet_environments: WalletTestFramework,
+    ) -> None:
         """This tests Pool A -> escaping -> Pool B"""
-        full_node_api, wallet_node, our_ph, _total_block_rewards, client = setup
-        pool_a_ph = bytes32.zeros
-        pool_b_ph = bytes32.zeros
 
-        WAIT_SECS = 200
-        assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
+        wallet_state_manager: WalletStateManager = wallet_environments.environments[0].wallet_state_manager
+        wallet_rpc: WalletRpcClient = wallet_environments.environments[0].rpc_client
 
-        await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
+        wallet_state_manager.config["reuse_public_key_for_change"][
+            str(wallet_state_manager.root_pubkey.get_fingerprint())
+        ] = wallet_environments.tx_config.reuse_puzhash
 
-        creation_tx: TransactionRecord = await client.create_new_pool_wallet(
-            pool_a_ph, "https://pool-a.org", uint32(5), f"{self_hostname}:5000", "new", "FARMING_TO_POOL", fee
-        )
+        # Create a farming plotnft to url http://pool.example.com
+        wallet_id = await create_new_plotnft(wallet_environments)
 
-        await full_node_api.wait_transaction_records_entered_mempool(records=[creation_tx])
-
-        await full_node_api.farm_blocks_to_puzzlehash(count=6, farm_to=our_ph, guarantee_transaction_blocks=True)
-        assert not full_node_api.txs_in_mempool(txs=[creation_tx])
-
-        await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
-
-        summaries_response = await client.get_wallets(WalletType.POOLING_WALLET)
-        assert len(summaries_response) == 1
-        wallet_id: int = summaries_response[0]["id"]
-        status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
-
-        assert status.current.state == PoolSingletonState.FARMING_TO_POOL.value
-        assert status.target is None
-
-        async def status_is_farming_to_pool() -> bool:
-            await full_node_api.farm_blocks_to_puzzlehash(count=1, farm_to=our_ph, guarantee_transaction_blocks=True)
-            pw_status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
-            return pw_status.current.state == PoolSingletonState.FARMING_TO_POOL.value
-
-        await time_out_assert(timeout=WAIT_SECS, function=status_is_farming_to_pool)
-
-        pw_info: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
-        assert pw_info.current.pool_url == "https://pool-a.org"
-        assert pw_info.current.relative_lock_height == 5
-
-        await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
+        # Join a different pool
         join_pool_tx: TransactionRecord = (
-            await client.pw_join_pool(
+            await wallet_rpc.pw_join_pool(
                 wallet_id,
-                pool_b_ph,
+                bytes32.zeros,
                 "https://pool-b.org",
-                uint32(10),
+                LOCK_HEIGHT,
                 uint64(fee),
             )
         )["transaction"]
         assert join_pool_tx is not None
 
-        async def status_is_leaving() -> bool:
-            await full_node_api.farm_blocks_to_puzzlehash(count=1, farm_to=our_ph, guarantee_transaction_blocks=True)
-            pw_status: PoolWalletInfo = (await client.pw_status(wallet_id))[0]
-            return pw_status.current.state == PoolSingletonState.LEAVING_POOL.value
-
-        await time_out_assert(timeout=WAIT_SECS, function=status_is_leaving)
-        pw_info = (await client.pw_status(wallet_id))[0]
-
-        await time_out_assert(timeout=WAIT_SECS, function=status_is_farming_to_pool)
-        pw_info = (await client.pw_status(wallet_id))[0]
-        assert pw_info.current.pool_url == "https://pool-b.org"
-        assert pw_info.current.relative_lock_height == 10
-        assert len(await wallet_node.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(2)) == 0
+        await wallet_environments.full_node.farm_blocks_to_puzzlehash(count=1, guarantee_transaction_blocks=True)
+        await verify_pool_state(wallet_rpc, wallet_id, PoolSingletonState.LEAVING_POOL)
+        await wallet_environments.full_node.farm_blocks_to_puzzlehash(
+            count=LOCK_HEIGHT + 2, guarantee_transaction_blocks=True
+        )
+        await verify_pool_state(wallet_rpc, wallet_id, PoolSingletonState.FARMING_TO_POOL)
+        await wallet_environments.full_node.wait_for_wallet_synced(
+            wallet_node=wallet_environments.environments[0].node, timeout=20
+        )
 
     @pytest.mark.anyio
     async def test_change_pools_reorg(self, setup: Setup, fee: uint64, self_hostname: str) -> None:


### PR DESCRIPTION
Convert flaky `test_change_pools` test to newer WalletTestFramework

Also limit the pool RPC tests to single consensus mode