### PR TITLE
CHIA-2020 Simplify add_block_batch

### DIFF
--- a/chia/_tests/util/full_sync.py
+++ b/chia/_tests/util/full_sync.py
@@ -28,7 +28,6 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
 from chia.types.validation_state import ValidationState
-from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.config import load_config
 from chia.util.ints import uint16
 
@@ -212,8 +211,7 @@ async def run_sync_test(
                             )
                             fork_height = block_batch[0].height - 1
                             header_hash = block_batch[0].prev_header_hash
-                            success, summary, _err = await full_node.add_block_batch(
-                                AugmentedBlockchain(full_node.blockchain),
+                            success, summary = await full_node.add_block_batch(
                                 block_batch,
                                 peer_info,
                                 ForkInfo(fork_height, fork_height, header_hash),

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -46,7 +46,6 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
 from chia.types.validation_state import ValidationState
-from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.hash import std_hash
 from chia.util.ints import uint32, uint64, uint128
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
@@ -361,7 +360,6 @@ async def test_long_sync_wallet(
     )
     fork_height = blocks_reorg[-num_blocks - 10].height - 1
     await full_node.add_block_batch(
-        AugmentedBlockchain(full_node.blockchain),
         blocks_reorg[-num_blocks - 10 : -1],
         PeerInfo("0.0.0.0", 0),
         ForkInfo(fork_height, fork_height, blocks_reorg[-num_blocks - 10].prev_header_hash),
@@ -490,7 +488,6 @@ async def test_wallet_reorg_get_coinbase(
         full_node.constants, True, block_record, full_node.blockchain
     )
     await full_node.add_block_batch(
-        AugmentedBlockchain(full_node.blockchain),
         blocks_reorg_2[-44:],
         PeerInfo("0.0.0.0", 0),
         ForkInfo(blocks_reorg_2[-45].height, blocks_reorg_2[-45].height, blocks_reorg_2[-45].header_hash),

--- a/chia/simulator/add_blocks_in_batches.py
+++ b/chia/simulator/add_blocks_in_batches.py
@@ -9,7 +9,6 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.full_block import FullBlock
 from chia.types.peer_info import PeerInfo
 from chia.types.validation_state import ValidationState
-from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.batches import to_batches
 from chia.util.ints import uint32
 
@@ -40,14 +39,9 @@ async def add_blocks_in_batches(
         if (b.height % 128) == 0:
             print(f"main chain: {b.height:4} weight: {b.weight}")
         # vs is updated by the call to add_block_batch()
-        success, state_change_summary, err = await full_node.add_block_batch(
-            AugmentedBlockchain(full_node.blockchain),
-            block_batch.entries,
-            PeerInfo("0.0.0.0", 0),
-            fork_info,
-            vs,
+        success, state_change_summary = await full_node.add_block_batch(
+            block_batch.entries, PeerInfo("0.0.0.0", 0), fork_info, vs
         )
-        assert err is None
         assert success is True
         if state_change_summary is not None:
             peak_fb: Optional[FullBlock] = await full_node.blockchain.get_full_peak()

--- a/tools/test_full_sync.py
+++ b/tools/test_full_sync.py
@@ -21,7 +21,6 @@ from chia.full_node.full_node import FullNode
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.full_block import FullBlock
 from chia.types.validation_state import ValidationState
-from chia.util.augmented_chain import AugmentedBlockchain
 from chia.util.config import load_config
 
 
@@ -165,8 +164,7 @@ async def run_sync_checkpoint(
                 fork_height = block_batch[0].height - 1
                 header_hash = block_batch[0].prev_header_hash
 
-                success, _, _err = await full_node.add_block_batch(
-                    AugmentedBlockchain(full_node.blockchain),
+                success, _ = await full_node.add_block_batch(
                     block_batch,
                     peer_info,
                     ForkInfo(fork_height, fork_height, header_hash),
@@ -189,8 +187,7 @@ async def run_sync_checkpoint(
                 )
                 fork_height = block_batch[0].height - 1
                 fork_header_hash = block_batch[0].prev_header_hash
-                success, _, _err = await full_node.add_block_batch(
-                    AugmentedBlockchain(full_node.blockchain),
+                success, _ = await full_node.add_block_batch(
                     block_batch,
                     peer_info,
                     ForkInfo(fork_height, fork_height, fork_header_hash),


### PR DESCRIPTION
### Purpose:

1. No need to accept `AugmentedBlockchain` and reconstruct it again.
2. No need to return both success and an unused optional error.

### Current Behavior:

1. The `blockchain` parameter is essentially not used.
2. The returned optional error is not used. 

### New Behavior:

1. The `blockchain` parameter is not needed.
2. The returned optional error is not returned.