### PR TITLE
remove the block fill rate limit of 70% when farming a block

### DIFF
--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -1081,7 +1081,7 @@ async def test_create_bundle_from_mempool_on_max_cost(num_skipped_items: int, ca
         g1 = sk.get_g1()
         sig = AugSchemeMPL.sign(sk, IDENTITY_PUZZLE_HASH, g1)
         aggsig = G2Element()
-        for _ in range(169):
+        for _ in range(242):
             conditions.append([ConditionOpcode.AGG_SIG_UNSAFE, g1, IDENTITY_PUZZLE_HASH])
             aggsig += sig
         conditions.append([ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, coin.amount - 10_000_000])

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -2045,9 +2045,7 @@ async def test_fill_rate_block_validation(
         # and without them we won't be able to get the test bundle in.
         # This defaults to `MAX_BLOCK_COST_CLVM // 2`
         full_node_api.full_node._mempool_manager.max_tx_clvm_cost = max_block_clvm_cost
-        # This defaults to `MAX_BLOCK_COST_CLVM * BLOCK_SIZE_LIMIT_FACTOR`
-        # TODO: Revisit this when we eventually raise the fille rate to 100%
-        # and `BLOCK_SIZE_LIMIT_FACTOR` is no longer relevant.
+        # This defaults to `MAX_BLOCK_COST_CLVM - BLOCK_OVERHEAD`
         full_node_api.full_node._mempool_manager.mempool.mempool_info = dataclasses.replace(
             full_node_api.full_node._mempool_manager.mempool.mempool_info,
             max_block_clvm_cost=CLVMCost(max_block_clvm_cost),

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -162,12 +162,11 @@ class MempoolManager:
         # spends.
         self.nonzero_fee_minimum_fpc = 5
 
-        BLOCK_SIZE_LIMIT_FACTOR = 0.7
         # We need to deduct the block overhead, which consists of the wrapping
         # quote opcode's bytes cost as well as its execution cost.
         BLOCK_OVERHEAD = QUOTE_BYTES * self.constants.COST_PER_BYTE + QUOTE_EXECUTION_COST
 
-        self.max_block_clvm_cost = uint64(self.constants.MAX_BLOCK_COST_CLVM * BLOCK_SIZE_LIMIT_FACTOR - BLOCK_OVERHEAD)
+        self.max_block_clvm_cost = uint64(self.constants.MAX_BLOCK_COST_CLVM - BLOCK_OVERHEAD)
         self.max_tx_clvm_cost = (
             max_tx_clvm_cost if max_tx_clvm_cost is not None else uint64(self.constants.MAX_BLOCK_COST_CLVM // 2)
         )


### PR DESCRIPTION
### Purpose:

to increase transaction rate

### Current Behavior:

Farmers only fill blocks to 70% full

### New Behavior:

Farmers fill blocks all the way. But blocks are compressed and have potential to fit more transactions.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
