### PR TITLE
use height to hash in short sync

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2098,8 +2098,6 @@ class FullNode:
             prev_ses_block = None
             if block.height > 0:
                 prev_b = await self.blockchain.get_block_record_from_db(block.prev_header_hash)
-                if prev_b is None:
-                    self.log.info(f"height is {block.height}")
                 assert prev_b is not None
                 curr = prev_b
                 while curr.height > 0 and curr.sub_epoch_summary_included is None:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -597,7 +597,7 @@ class FullNode:
                 return False
             hash = self.blockchain.height_to_hash(first.block.height - 1)
             assert hash is not None
-            if not hash == first.block.prev_header_hash:
+            if hash != first.block.prev_header_hash:
                 self.log.info("Batch syncing stopped, this is a deep chain")
                 self.sync_store.batch_syncing.remove(peer.peer_node_id)
                 # First sb not connected to our blockchain, do a long sync instead


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

dont use the cache to locate the forkpoint

### Current Behavior:
 
we use the block records cache to determine fork point even though the cache may contain orphan blocks, this can cause us to use a wrong fork point while syncing

### New Behavior:

use height to hash which is more correct 

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
