### PR TITLE
[CHIA-2041] Simplify action scopes and add support for nesting

### DIFF
--- a/chia/_tests/util/test_action_scope.py
+++ b/chia/_tests/util/test_action_scope.py
@@ -143,7 +143,9 @@ async def test_nested_use(action_scope: ActionScope[TestSideEffects, TestConfig]
                 raise NotImplementedError("Should not get here")  # pragma: no cover
 
         assert interface.side_effects.buf == b""
+        interface.side_effects.buf = b"qat"
         async with action_scope.use(interface) as nested_interface:
+            assert nested_interface.side_effects.buf == b"qat"
             nested_interface.side_effects.buf = b"foo"
 
         assert interface.side_effects.buf == b"foo"

--- a/chia/_tests/wallet/test_wallet_action_scope.py
+++ b/chia/_tests/wallet/test_wallet_action_scope.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Optional
 
@@ -33,11 +35,19 @@ def test_back_and_forth_serialization() -> None:
     ) == WalletSideEffects([STD_TX, STD_TX], [MOCK_SR, MOCK_SR], [MOCK_SB, MOCK_SB], [MOCK_COIN, MOCK_COIN])
 
 
+@dataclass(frozen=True)
+class MockDBWrapper:
+    @asynccontextmanager
+    async def writer(self) -> AsyncIterator[None]:
+        yield
+
+
 @dataclass
 class MockWalletStateManager:
     most_recent_call: Optional[
         tuple[list[TransactionRecord], bool, bool, bool, list[SigningResponse], list[WalletSpendBundle]]
     ] = None
+    db_wrapper: object = MockDBWrapper()
 
     async def add_pending_transactions(
         self,

--- a/chia/util/action_scope.py
+++ b/chia/util/action_scope.py
@@ -4,7 +4,7 @@ import contextlib
 import copy
 from collections.abc import AsyncIterator, Awaitable
 from dataclasses import dataclass, field
-from typing import Any, AsyncContextManager, Callable, Generic, Optional, Protocol, TypeVar, final
+from typing import Any, Callable, Generic, Optional, Protocol, TypeVar, final
 
 
 class SideEffects(Protocol):
@@ -30,7 +30,7 @@ class ActionScope(Generic[_T_SideEffects, _T_Config]):
     from interfering with each other.
     """
 
-    _lock: Callable[..., AsyncContextManager[Any]]
+    _lock: Callable[..., contextlib.AbstractAsyncContextManager[Any]]
     _active_interface: StateInterface[_T_SideEffects]
     _config: _T_Config  # An object not intended to be mutated during the lifetime of the scope
     _final_side_effects: Optional[_T_SideEffects] = field(init=False, default=None)
@@ -53,7 +53,7 @@ class ActionScope(Generic[_T_SideEffects, _T_Config]):
     @contextlib.asynccontextmanager
     async def new_scope(
         cls,
-        lock: Callable[..., AsyncContextManager[Any]],
+        lock: Callable[..., contextlib.AbstractAsyncContextManager[Any]],
         initial_side_effects: _T_SideEffects,
         # I want a default here in case a use case doesn't want to take advantage of the config but no default seems to
         # satisfy the type hint _T_Config so we'll just ignore this.

--- a/chia/util/action_scope.py
+++ b/chia/util/action_scope.py
@@ -58,6 +58,8 @@ class SQLiteResourceManager:
         async with self._db.writer() as conn:
             if self._active_writer is not None and current_interface is None:
                 raise RuntimeError("Must pass `current_interface` when doing nested transactions")
+            elif current_interface is not None:
+                await self.save_resource(current_interface.side_effects)
             previous_writer = self._active_writer
             self._active_writer = conn
             try:

--- a/chia/wallet/wallet_action_scope.py
+++ b/chia/wallet/wallet_action_scope.py
@@ -76,7 +76,8 @@ async def new_wallet_action_scope(
     extra_spends: list[WalletSpendBundle] = [],
 ) -> AsyncIterator[WalletActionScope]:
     async with ActionScope.new_scope(
-        WalletSideEffects,
+        wallet_state_manager.db_wrapper.writer,
+        WalletSideEffects(),
         WalletActionConfig(push, merge_spends, sign, additional_signing_responses, extra_spends, tx_config),
     ) as self:
         self = cast(WalletActionScope, self)


### PR DESCRIPTION
(hide whitespace to review)

This PR tries to drastically simplify the action scope primitive and remove the sqlite dependency.  The motivation behind this was to support nested scopes, but that's not really _why_ this had to happen, it was moreso discovered along the way.

Reviewing the test changes as a diff makes sense, but it might make sense to just review the new `action_scope.py` file manually since the diff is really a conceptual one rather than a line-by-line one.

The idea now is, instead of using serialization into a sqlite DB as a protection against unexpected edits, we just pay more attention to the references we're handing out.  The process basically goes as follows when you want to "check out" the mutable object that is held at the top level:
1)  create a deepcopy of the top level object
2)  store the current top level object in a new location
3)  replace the top level object with the new copy and hand it to the caller
4)  If the operation with the copy finishes successfully, edit (not replace) the old object
5)  Whether or not the old operation is successful, put the old object back into the top level spot

There's also an additional change that was made along the way which is somewhat unrelated but is actually a feature _improvement_ on action scopes.  They now require a lock acquisition function (like `DBWrapper.writer`) when being constructed and will acquire that lock when opening the scope and release it when closing the scope.  This should enforce consistent usage of the idea behind `WalletStateManager.lock` (to prevent concurrent actions) and eliminate any need for it.