### PR TITLE
CHIA-2022: Fix problems with startup timing and the Datalayer processing loop

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -920,10 +920,14 @@ class DataLayer:
             # Need this to make sure we process updates and generate DAT files
             try:
                 owned_stores = await self.get_owned_stores()
-            except ValueError:
+            except (ValueError, aiohttp.client_exceptions.ClientConnectorError):
                 # Sometimes the DL wallet isn't available, so we can't get the owned stores.
                 # We'll try again next time.
                 owned_stores = []
+            except Exception as e:
+                self.log.error(f"Exception while fetching owned stores: {type(e)} {e} {traceback.format_exc()}")
+                owned_stores = []
+
             subscription_store_ids = {subscription.store_id for subscription in subscriptions}
             for record in owned_stores:
                 store_id = record.launcher_id


### PR DESCRIPTION
When starting datalayer and wallet together (this is the default behaviour), the datalayer processing loop can get network errors when quering the wallet for owned stores. These errors have to be ignored in the main DL processing loop otherwise the loop will exit preventing stores from being processed correctly until DL is restarted.

Previously only ValueError exceptions were caught. New code catches all exceptions with some different logging.