### PR TITLE
ignore errors in daemon plotter process cleanup

### DIFF
--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -1131,7 +1131,10 @@ class WebSocketServer:
 
         finally:
             if current_process is not None:
-                self.services[service_name].remove(current_process)
+                try:
+                    self.services[service_name].remove(current_process)
+                except KeyError:
+                    pass
                 current_process.wait()  # prevent zombies
             self._run_next_serial_plotting(loop, queue)
 


### PR DESCRIPTION
Based on some CI failures, the error indicates a key error on the `self.services` dictionary during this `finally` block.

(see https://github.com/Chia-Network/chia-blockchain/actions/runs/12263577030/job/34215480215?pr=19016)

Unclear what timing or code path creates this discrepancy, but I believe we can safely ignore any keyerrors when removing the process tracking. The process will still be waited for, but if the entire tracking list doesn't exist there isn't anything to remove.

Unclear if this is masking some other problem with the test however, so there may be something else hiding behind this. But I think it should be fixed regardless.