### PR TITLE
fix wrong param in prevalidate

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1616,7 +1616,7 @@ class FullNode:
                 cc_sub_slot = block.finished_sub_slots[0].challenge_chain
                 if cc_sub_slot.new_sub_slot_iters is not None or cc_sub_slot.new_difficulty is not None:
                     expected_sub_slot_iters, expected_difficulty = get_next_sub_slot_iters_and_difficulty(
-                        self.constants, True, block_record, self.blockchain
+                        self.constants, True, block_record, blockchain
                     )
                     assert cc_sub_slot.new_sub_slot_iters is not None
                     vs.ssi = cc_sub_slot.new_sub_slot_iters


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

fix a bug where we pass the wrong blockchain data structure into get_next_sub_slot_iters_and_difficulty
### Current Behavior:
we pass self.blockchain instead of the AugmentedBlockchain param passed into get_next_sub_slot_iters_and_difficulty
this means that we rely on having the blocks in the cache, which now happens when we call add blocks but is redundant since we also use AugmentedBlockchain to stage the new blocks before we switch to the new fork
### New Behavior:

pass the correct parameter 

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
