### PR TITLE
mypy annotation for `test_dos.py`

### DIFF
--- a/chia/_tests/core/full_node/test_performance.py
+++ b/chia/_tests/core/full_node/test_performance.py
@@ -14,23 +14,12 @@ from chia._tests.util.misc import BenchmarkRunner
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.pot_iterations import is_overflow_block
-from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols import full_node_protocol as fnp
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.unfinished_block import UnfinishedBlock
 
 log = logging.getLogger(__name__)
-
-
-async def get_block_path(full_node: FullNodeAPI):
-    blocks_list = [await full_node.full_node.blockchain.get_full_peak()]
-    assert blocks_list[0] is not None
-    while blocks_list[0].height != 0:
-        b = await full_node.full_node.block_store.get_full_block(blocks_list[0].prev_header_hash)
-        assert b is not None
-        blocks_list.insert(0, b)
-    return blocks_list
 
 
 class TestPerformance:

--- a/chia/_tests/core/server/test_dos.py
+++ b/chia/_tests/core/server/test_dos.py
@@ -11,7 +11,6 @@ from chia_rs.sized_ints import uint64
 
 import chia.server.server
 from chia._tests.util.time_out_assert import time_out_assert
-from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols import full_node_protocol
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.shared_protocol import Handshake
@@ -31,16 +30,6 @@ log = logging.getLogger(__name__)
 
 def not_localhost(host: str) -> bool:
     return False
-
-
-async def get_block_path(full_node: FullNodeAPI):
-    blocks_list = [await full_node.full_node.blockchain.get_full_peak()]
-    assert blocks_list[0] is not None
-    while blocks_list[0].height != 0:
-        b = await full_node.full_node.block_store.get_full_block(blocks_list[0].prev_header_hash)
-        assert b is not None
-        blocks_list.insert(0, b)
-    return blocks_list
 
 
 class FakeRateLimiter:

--- a/chia/_tests/core/server/test_dos.py
+++ b/chia/_tests/core/server/test_dos.py
@@ -7,13 +7,14 @@ from typing import Optional
 
 import pytest
 from aiohttp import ClientSession, ClientTimeout, WSCloseCode, WSMessage, WSMsgType, WSServerHandshakeError
-from chia_rs.sized_ints import uint64
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint8, uint16, uint64
 
 import chia.server.server
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.protocols import full_node_protocol
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
-from chia.protocols.shared_protocol import Handshake
+from chia.protocols.shared_protocol import Capability, Handshake
 from chia.server.outbound_message import Message, make_msg
 from chia.server.rate_limits import RateLimiter
 from chia.server.server import ChiaServer
@@ -33,7 +34,9 @@ def not_localhost(host: str) -> bool:
 
 
 class FakeRateLimiter:
-    def process_msg_and_check(self, msg, capa, capb) -> Optional[str]:
+    def process_msg_and_check(
+        self, message: Message, our_capabilities: list[Capability], peer_capabilities: list[Capability]
+    ) -> Optional[str]:
         return None
 
 
@@ -131,7 +134,11 @@ class TestDos:
         await ws.close()
 
     @pytest.mark.anyio
-    async def test_invalid_protocol_handshake(self, setup_two_nodes_fixture, self_hostname):
+    async def test_invalid_protocol_handshake(
+        self,
+        setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+        self_hostname: str,
+    ) -> None:
         nodes, _, _ = setup_two_nodes_fixture
         server_1 = nodes[0].full_node.server
         server_2 = nodes[1].full_node.server
@@ -148,8 +155,8 @@ class TestDos:
         )
 
         # Construct an otherwise valid handshake message
-        handshake: Handshake = Handshake("test", "0.0.32", "1.0.0.0", 3456, 1, [(1, "1")])
-        outbound_handshake: Message = Message(2, None, bytes(handshake))  # 2 is an invalid ProtocolType
+        handshake: Handshake = Handshake("test", "0.0.32", "1.0.0.0", uint16(3456), uint8(1), [(uint16(1), "1")])
+        outbound_handshake: Message = Message(uint8(2), None, bytes(handshake))  # 2 is an invalid ProtocolType
         await ws.send_bytes(bytes(outbound_handshake))
 
         response: WSMessage = await ws.receive()
@@ -162,7 +169,11 @@ class TestDos:
         await asyncio.sleep(1)  # give some time for cleanup to work
 
     @pytest.mark.anyio
-    async def test_spam_tx(self, setup_two_nodes_fixture, self_hostname):
+    async def test_spam_tx(
+        self,
+        setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+        self_hostname: str,
+    ) -> None:
         nodes, _, _ = setup_two_nodes_fixture
         _full_node_1, full_node_2 = nodes
         server_1 = nodes[0].full_node.server
@@ -180,7 +191,7 @@ class TestDos:
 
         new_tx_message = make_msg(
             ProtocolMessageTypes.new_transaction,
-            full_node_protocol.NewTransaction(bytes([9] * 32), uint64(0), uint64(0)),
+            full_node_protocol.NewTransaction(bytes32([9] * 32), uint64(0), uint64(0)),
         )
         for i in range(4000):
             await ws_con._send_message(new_tx_message)
@@ -204,20 +215,24 @@ class TestDos:
                 await asyncio.sleep(0)
         await asyncio.sleep(1)
 
-        def is_closed():
+        def is_closed() -> bool:
             return ws_con.closed
 
         await time_out_assert(15, is_closed)
 
         assert ws_con.closed
 
-        def is_banned():
+        def is_banned() -> bool:
             return "1.2.3.4" in server_2.banned_peers
 
         await time_out_assert(15, is_banned)
 
     @pytest.mark.anyio
-    async def test_spam_message_non_tx(self, setup_two_nodes_fixture, self_hostname):
+    async def test_spam_message_non_tx(
+        self,
+        setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+        self_hostname: str,
+    ) -> None:
         nodes, _, _ = setup_two_nodes_fixture
         _full_node_1, full_node_2 = nodes
         server_1 = nodes[0].full_node.server
@@ -233,7 +248,7 @@ class TestDos:
         ws_con.peer_info = PeerInfo("1.2.3.4", ws_con.peer_info.port)
         ws_con_2.peer_info = PeerInfo("1.2.3.4", ws_con_2.peer_info.port)
 
-        def is_closed():
+        def is_closed() -> bool:
             return ws_con.closed
 
         new_message = make_msg(
@@ -260,13 +275,17 @@ class TestDos:
         await time_out_assert(15, is_closed)
 
         # Banned
-        def is_banned():
+        def is_banned() -> bool:
             return "1.2.3.4" in server_2.banned_peers
 
         await time_out_assert(15, is_banned)
 
     @pytest.mark.anyio
-    async def test_spam_message_too_large(self, setup_two_nodes_fixture, self_hostname):
+    async def test_spam_message_too_large(
+        self,
+        setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+        self_hostname: str,
+    ) -> None:
         nodes, _, _ = setup_two_nodes_fixture
         _full_node_1, full_node_2 = nodes
         server_1 = nodes[0].full_node.server
@@ -282,7 +301,7 @@ class TestDos:
         ws_con.peer_info = PeerInfo("1.2.3.4", ws_con.peer_info.port)
         ws_con_2.peer_info = PeerInfo("1.2.3.4", ws_con_2.peer_info.port)
 
-        def is_closed():
+        def is_closed() -> bool:
             return ws_con.closed
 
         new_message = make_msg(
@@ -296,13 +315,13 @@ class TestDos:
         assert not ws_con.closed
 
         # Remove outbound rate limiter to test inbound limits
-        ws_con.outbound_rate_limiter = FakeRateLimiter()
+        ws_con.outbound_rate_limiter = FakeRateLimiter()  # type: ignore[assignment]
 
         await ws_con._send_message(new_message)
         await time_out_assert(15, is_closed)
 
         # Banned
-        def is_banned():
+        def is_banned() -> bool:
             return "1.2.3.4" in server_2.banned_peers
 
         await time_out_assert(15, is_banned)

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -59,7 +59,6 @@ chia._tests.core.full_node.test_address_manager
 chia._tests.core.full_node.test_node_load
 chia._tests.core.full_node.test_performance
 chia._tests.core.full_node.test_transactions
-chia._tests.core.server.test_dos
 chia._tests.core.server.test_rate_limits
 chia._tests.core.ssl.test_ssl
 chia._tests.core.test_crawler_rpc


### PR DESCRIPTION
### Purpose:

Remove unused code and introduce stricter type checking of `test_dos.py`, gradually getting closer to full mypy coverage.

### Current Behavior:

`test_dos.py` does not have full mypy coverage.

There are 3 copies of an unused function, `get_block_path()`.

### New Behavior:

`test_dos.py` has full mypy coverage (the the extent our repo is configured).

Unused function `get_block_path()` has been removed.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
