### PR TITLE
first pass at using `@chia_command` without a group

### DIFF
--- a/chia/_tests/cmds/test_cmd_framework.py
+++ b/chia/_tests/cmds/test_cmd_framework.py
@@ -37,7 +37,7 @@ def check_click_parsing(cmd: ChiaCommand, *args: str, obj: Optional[Any] = None)
         dict_compare_with_ignore_context(asdict(cmd), asdict(self))  # type: ignore[call-overload]
 
     setattr(mock_type, "run", new_run)
-    chia_command(_cmd, "_", "", "")(mock_type)
+    chia_command(group=_cmd, name="_", short_help="", help="")(mock_type)
 
     runner = CliRunner()
     result = runner.invoke(_cmd, ["_", *args], catch_exceptions=False, obj=obj)
@@ -49,12 +49,12 @@ def test_cmd_bases() -> None:
     def cmd() -> None:
         pass
 
-    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd", short_help="blah", help="n/a")
     class TempCMD:
         def run(self) -> None:
             print("syncronous")
 
-    @chia_command(cmd, "temp_cmd_async", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd_async", short_help="blah", help="n/a")
     class TempCMDAsync:
         async def run(self) -> None:
             print("asyncronous")
@@ -96,7 +96,7 @@ def test_option_loading() -> None:
     def cmd() -> None:
         pass
 
-    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd", short_help="blah", help="n/a")
     class TempCMD:
         some_option: int = option("-o", "--some-option", required=True, type=int)
         choices: list[str] = option("--choice", multiple=True, type=str)
@@ -104,7 +104,7 @@ def test_option_loading() -> None:
         def run(self) -> None:
             print(self.some_option)
 
-    @chia_command(cmd, "temp_cmd_2", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd_2", short_help="blah", help="n/a")
     class TempCMD2:
         some_option: int = option("-o", "--some-option", required=True, type=int, default=13)
 
@@ -146,7 +146,7 @@ def test_context_requirement() -> None:
     def cmd(ctx: click.Context) -> None:
         ctx.obj = {"foo": "bar"}
 
-    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd", short_help="blah", help="n/a")
     class TempCMD:
         context: Context
 
@@ -164,7 +164,7 @@ def test_context_requirement() -> None:
     # Test that other variables named context are disallowed
     with pytest.raises(ValueError, match="context"):
 
-        @chia_command(cmd, "shouldnt_work", "blah", help="n/a")
+        @chia_command(group=cmd, name="shouldnt_work", short_help="blah", help="n/a")
         class BadCMD:
             context: int
 
@@ -176,7 +176,7 @@ def test_typing() -> None:
     def cmd() -> None:
         pass
 
-    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd", short_help="blah", help="n/a")
     class TempCMD:
         integer: int = option("--integer", default=1, required=False)
         text: str = option("--text", default="1", required=False)
@@ -208,7 +208,7 @@ def test_typing() -> None:
     )
 
     # Test optional
-    @chia_command(cmd, "temp_cmd_optional", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd_optional", short_help="blah", help="n/a")
     class TempCMDOptional:
         optional: Optional[int] = option("--optional", required=False)
 
@@ -220,7 +220,7 @@ def test_typing() -> None:
     # Test optional failure
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_optional_bad", "blah", help="n/a")
+        @chia_command(group=cmd, name="temp_cmd_optional_bad", short_help="blah", help="n/a")
         class TempCMDOptionalBad2:
             optional: Optional[int] = option("--optional", required=True)
 
@@ -228,20 +228,20 @@ def test_typing() -> None:
 
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_optional_bad", "blah", help="n/a")
+        @chia_command(group=cmd, name="temp_cmd_optional_bad", short_help="blah", help="n/a")
         class TempCMDOptionalBad3:
             optional: Optional[int] = option("--optional", default="string", required=False)
 
             def run(self) -> None: ...
 
-    @chia_command(cmd, "temp_cmd_optional_fine", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd_optional_fine", short_help="blah", help="n/a")
     class TempCMDOptionalBad4:
         optional: Optional[int] = option("--optional", default=None, required=False)
 
         def run(self) -> None: ...
 
     # Test multiple
-    @chia_command(cmd, "temp_cmd_sequence", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd_sequence", short_help="blah", help="n/a")
     class TempCMDSequence:
         sequence: Sequence[int] = option("--sequence", multiple=True)
 
@@ -253,7 +253,7 @@ def test_typing() -> None:
     # Test sequence failure
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_sequence_bad", "blah", help="n/a")
+        @chia_command(group=cmd, name="temp_cmd_sequence_bad", short_help="blah", help="n/a")
         class TempCMDSequenceBad:
             sequence: Sequence[int] = option("--sequence")
 
@@ -261,7 +261,7 @@ def test_typing() -> None:
 
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_sequence_bad", "blah", help="n/a")
+        @chia_command(group=cmd, name="temp_cmd_sequence_bad", short_help="blah", help="n/a")
         class TempCMDSequenceBad2:
             sequence: int = option("--sequence", multiple=True)
 
@@ -269,7 +269,7 @@ def test_typing() -> None:
 
     with pytest.raises(ValueError):
 
-        @chia_command(cmd, "temp_cmd_sequence_bad", "blah", help="n/a")
+        @chia_command(group=cmd, name="temp_cmd_sequence_bad", short_help="blah", help="n/a")
         class TempCMDSequenceBad3:
             sequence: Sequence[int] = option("--sequence", default=[1, 2, 3], multiple=True)
 
@@ -277,7 +277,7 @@ def test_typing() -> None:
 
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_sequence_bad", "blah", help="n/a")
+        @chia_command(group=cmd, name="temp_cmd_sequence_bad", short_help="blah", help="n/a")
         class TempCMDSequenceBad4:
             sequence: Sequence[int] = option("--sequence", default=(1, 2, "3"), multiple=True)
 
@@ -286,7 +286,7 @@ def test_typing() -> None:
     # Test invalid type
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_bad_type", "blah", help="n/a")
+        @chia_command(group=cmd, name="temp_cmd_bad_type", short_help="blah", help="n/a")
         class TempCMDBadType:
             sequence: list[int] = option("--sequence")
 
@@ -295,20 +295,20 @@ def test_typing() -> None:
     # Test invalid default
     with pytest.raises(TypeError):
 
-        @chia_command(cmd, "temp_cmd_bad_default", "blah", help="n/a")
+        @chia_command(group=cmd, name="temp_cmd_bad_default", short_help="blah", help="n/a")
         class TempCMDBadDefault:
             integer: int = option("--int", default="string")
 
             def run(self) -> None: ...
 
     # Test bytes parsing
-    @chia_command(cmd, "temp_cmd_bad_bytes", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd_bad_bytes", short_help="blah", help="n/a")
     class TempCMDBadBytes:
         blob: bytes = option("--blob", required=True)
 
         def run(self) -> None: ...
 
-    @chia_command(cmd, "temp_cmd_bad_bytes32", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd_bad_bytes32", short_help="blah", help="n/a")
     class TempCMDBadBytes32:
         blob32: bytes32 = option("--blob32", required=True)
 
@@ -354,7 +354,7 @@ async def test_wallet_rpc_helper(wallet_environments: WalletTestFramework) -> No
     def cmd() -> None:
         pass
 
-    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd", short_help="blah", help="n/a")
     class TempCMD:
         rpc_info: NeedsWalletRPC
 

--- a/chia/_tests/wallet/test_signer_protocol.py
+++ b/chia/_tests/wallet/test_signer_protocol.py
@@ -752,7 +752,7 @@ def test_transactions_in() -> None:
     def cmd() -> None:
         pass
 
-    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd", short_help="blah", help="n/a")
     class TempCMD(TransactionsIn):
         def run(self) -> None:
             assert self.transaction_bundle == TransactionBundle([STD_TX])
@@ -771,7 +771,7 @@ def test_transactions_out() -> None:
     def cmd() -> None:
         pass
 
-    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd", short_help="blah", help="n/a")
     class TempCMD(TransactionsOut):
         def run(self) -> None:
             self.handle_transaction_output([STD_TX])
@@ -824,7 +824,7 @@ def test_signer_protocol_in(monkeypatch: pytest.MonkeyPatch) -> None:
 
     coin = Coin(bytes32.zeros, bytes32.zeros, uint64(13))
 
-    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd", short_help="blah", help="n/a")
     class TempCMD(SPIn):
         def run(self) -> None:
             assert self.read_sp_input(Coin) == [coin, coin]
@@ -881,7 +881,7 @@ def test_signer_protocol_out(monkeypatch: pytest.MonkeyPatch) -> None:
     coin = Coin(bytes32.zeros, bytes32.zeros, uint64(0))
     coin_bytes = byte_serialize_clvm_streamable(coin)
 
-    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd", short_help="blah", help="n/a")
     class TempCMD(SPOut):
         def run(self) -> None:
             self.handle_clvm_output([coin, coin])
@@ -930,7 +930,7 @@ def test_qr_code_display() -> None:
 
     bytes_to_encode = b"foo bar qat qux bam bat"
 
-    @chia_command(cmd, "temp_cmd", "blah", help="n/a")
+    @chia_command(group=cmd, name="temp_cmd", short_help="blah", help="n/a")
     class TempCMD(QrCodeDisplay):
         def run(self) -> None:
             self.display_qr_codes([bytes_to_encode, bytes_to_encode])

--- a/chia/cmds/chia.py
+++ b/chia/cmds/chia.py
@@ -143,8 +143,6 @@ cli.add_command(dev_cmd)
 
 
 def main() -> None:
-    import chia.cmds.signer  # noqa
-
     cli()
 
 

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -267,7 +267,7 @@ def chia_command(
 _chia_command_metadata_attribute = f"_{__name__.replace('.', '_')}_{chia_command.__qualname__}_metadata"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class Metadata:
     command: click.Command
 

--- a/chia/cmds/plotnft.py
+++ b/chia/cmds/plotnft.py
@@ -24,9 +24,9 @@ def plotnft_cmd(ctx: click.Context) -> None:
 
 
 @chia_command(
-    plotnft_cmd,
-    "show",
-    "Show plotnft information",
+    group=plotnft_cmd,
+    name="show",
+    short_help="Show plotnft information",
     help="Show plotnft information",
 )
 class ShowPlotNFTCMD:
@@ -48,8 +48,8 @@ class ShowPlotNFTCMD:
 
 
 @chia_command(
-    plotnft_cmd,
-    "get_login_link",
+    group=plotnft_cmd,
+    name="get_login_link",
     short_help="Create a login link for a pool",
     help="Create a login link for a pool. The farmer must be running. Use 'plotnft show' to get the launcher id.",
 )
@@ -69,8 +69,8 @@ class GetLoginLinkCMD:
 # They will therefore not work with observer-only functionality
 # NOTE: tx_endpoint  (This creates wallet transactions and should be parametrized by relevant options)
 @chia_command(
-    plotnft_cmd,
-    "create",
+    group=plotnft_cmd,
+    name="create",
     short_help="Create a plot NFT",
     help="Create a plot NFT.",
 )
@@ -116,8 +116,8 @@ class CreatePlotNFTCMD:
 
 # NOTE: tx_endpoint
 @chia_command(
-    plotnft_cmd,
-    "join",
+    group=plotnft_cmd,
+    name="join",
     short_help="Join a plot NFT to a Pool",
     help="Join a plot NFT to a Pool.",
 )
@@ -153,8 +153,8 @@ class JoinPlotNFTCMD:
 
 # NOTE: tx_endpoint
 @chia_command(
-    plotnft_cmd,
-    "leave",
+    group=plotnft_cmd,
+    name="leave",
     short_help="Leave a pool and return to self-farming",
     help="Leave a pool and return to self-farming.",
 )
@@ -187,8 +187,8 @@ class LeavePlotNFTCMD:
 
 
 @chia_command(
-    plotnft_cmd,
-    "inspect",
+    group=plotnft_cmd,
+    name="inspect",
     short_help="Get Detailed plotnft information as JSON",
     help="Get Detailed plotnft information as JSON",
 )
@@ -207,8 +207,8 @@ class InspectPlotNFTCMD:
 
 # NOTE: tx_endpoint
 @chia_command(
-    plotnft_cmd,
-    "claim",
+    group=plotnft_cmd,
+    name="claim",
     short_help="Claim rewards from a plot NFT",
     help="Claim rewards from a plot NFT",
 )
@@ -239,8 +239,8 @@ class ClaimPlotNFTCMD:
 
 
 @chia_command(
-    plotnft_cmd,
-    "change_payout_instructions",
+    group=plotnft_cmd,
+    name="change_payout_instructions",
     short_help="Change the payout instructions for a pool.",
     help="Change the payout instructions for a pool. Use 'plotnft show' to get the launcher id.",
 )

--- a/chia/cmds/signer.py
+++ b/chia/cmds/signer.py
@@ -17,7 +17,6 @@ from segno import QRCode, make_qr
 
 from chia.cmds.cmd_classes import NeedsWalletRPC, chia_command, command_helper, option
 from chia.cmds.cmds_util import TransactionBundle
-from chia.cmds.wallet import wallet_cmd
 from chia.rpc.util import ALL_TRANSLATION_LAYERS
 from chia.rpc.wallet_request_types import (
     ApplySignatures,
@@ -38,7 +37,7 @@ def _clear_screen() -> None:
     os.system("cls" if os.name == "nt" else "clear")
 
 
-@wallet_cmd.group("signer", help="Get information for an external signer")
+@click.group("signer", help="Get information for an external signer")
 def signer_cmd() -> None:
     pass  # pragma: no cover
 
@@ -209,10 +208,10 @@ class SPOut(QrCodeDisplay, _SPTranslation):
 
 
 @chia_command(
-    signer_cmd,
-    "gather_signing_info",
-    "gather signer information",
-    "Gather the information from a transaction that a signer needs in order to create a signature",
+    group=signer_cmd,
+    name="gather_signing_info",
+    short_help="gather signer information",
+    help="Gather the information from a transaction that a signer needs in order to create a signature",
 )
 class GatherSigningInfoCMD:
     sp_out: SPOut
@@ -233,7 +232,12 @@ class GatherSigningInfoCMD:
             self.sp_out.handle_clvm_output([signing_instructions])
 
 
-@chia_command(signer_cmd, "apply_signatures", "apply signatures", "Apply a signer's signatures to a transaction bundle")
+@chia_command(
+    group=signer_cmd,
+    name="apply_signatures",
+    short_help="apply signatures",
+    help="Apply a signer's signatures to a transaction bundle",
+)
 class ApplySignaturesCMD:
     txs_out: TransactionsOut
     sp_in: SPIn
@@ -272,10 +276,10 @@ class ApplySignaturesCMD:
 
 
 @chia_command(
-    signer_cmd,
-    "execute_signing_instructions",
-    "execute signing instructions",
-    "Given some signing instructions, return signing responses",
+    group=signer_cmd,
+    name="execute_signing_instructions",
+    short_help="execute signing instructions",
+    help="Given some signing instructions, return signing responses",
 )
 class ExecuteSigningInstructionsCMD:
     sp_out: SPOut
@@ -299,10 +303,9 @@ class ExecuteSigningInstructionsCMD:
 
 
 @chia_command(
-    wallet_cmd,
-    "push_transactions",
-    "push transaction bundle",
-    "Push a transaction bundle to the wallet to send to the network",
+    name="push_transactions",
+    short_help="push transaction bundle",
+    help="Push a transaction bundle to the wallet to send to the network",
 )
 class PushTransactionsCMD:
     txs_in: TransactionsIn

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -9,6 +9,7 @@ import click
 
 from chia.cmds import options
 from chia.cmds.check_wallet_db import help_text as check_help_text
+from chia.cmds.cmd_classes import get_chia_command_metadata
 from chia.cmds.cmds_util import timelock_args, tx_out_cmd
 from chia.cmds.coins import coins_cmd
 from chia.cmds.param_types import (
@@ -19,6 +20,7 @@ from chia.cmds.param_types import (
     CliAmount,
     cli_amount_none,
 )
+from chia.cmds.signer import PushTransactionsCMD, signer_cmd
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.ints import uint32, uint64
 from chia.wallet.conditions import ConditionValidTimes
@@ -32,6 +34,10 @@ from chia.wallet.util.wallet_types import WalletType
 @click.pass_context
 def wallet_cmd(ctx: click.Context) -> None:
     pass
+
+
+wallet_cmd.add_command(signer_cmd)
+wallet_cmd.add_command(get_chia_command_metadata(PushTransactionsCMD).command)
 
 
 @wallet_cmd.command("get_transaction", help="Get a transaction")


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

with click you can both `@some_group.command()` to add a new command or `some_group.add_command()`.  This makes it possible to code both with a command -> group dependency or a group -> command dependency depending on the situation.  this pr makes the second pattern possible via the new `get_chia_command_metadata()` function.  it is also applied to the `chia.cmds.signer` module to eliminate a circular dependency with the `chia.cmds.wallet` module.

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
