### PR TITLE
CHIA-2091 Use boost v1.85 when compiling chiavdf from source on macos-intel

### DIFF
--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -131,7 +131,12 @@ else
     symlink_vdf_bench "$PYTHON_VERSION"
   elif [ -e venv/bin/python ] && test "$MACOS"; then
     echo "Installing chiavdf dependencies for MacOS."
-    brew install --formula --quiet boost cmake gmp
+    # The most recent boost version causes compile errors.
+    brew install --formula --quiet boost@1.85 cmake gmp
+    # boost@1.85 is keg-only, which means it was not symlinked into /usr/local,
+    # because this is an alternate version of another formula.
+    export LDFLAGS="-L/usr/local/opt/boost@1.85/lib"
+    export CPPFLAGS="-I/usr/local/opt/boost@1.85/include"
     echo "Installing chiavdf from source."
     # User needs to provide required packages
     echo venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"


### PR DESCRIPTION
### Purpose:

This allows us to successfully compile chiavdf from source for now, until the underlying issue with newer boost versions is fixed.

### Current Behavior:

CI failure: https://github.com/Chia-Network/chia-blockchain/actions/runs/12378217642/job/34549652480

### New Behavior:

We are able to compile chiavdf from source on macos-intel and CI continues properly.