### PR TITLE
Remove unnecessary action_scope edit

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1511,18 +1511,6 @@ class WalletRpcApi:
                         request.get("force", False),
                         extra_conditions=extra_conditions,
                     )
-                    async with action_scope.use() as interface:
-                        # TODO: editing this is not ideal.  Action scopes should know what coins have been spent.
-                        action_scope._config = dataclasses.replace(
-                            action_scope._config,
-                            tx_config=dataclasses.replace(
-                                action_scope._config.tx_config,
-                                excluded_coin_ids=[
-                                    *action_scope._config.tx_config.excluded_coin_ids,
-                                    *(c.name() for tx in interface.side_effects.transactions for c in tx.removals),
-                                ],
-                            ),
-                        )
                     coins = {}
             except Exception as e:
                 log.error(f"Failed to spend clawback coin {coin_id.hex()}: %s", e)

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1498,6 +1498,7 @@ class WalletRpcApi:
         batch_size = request.get(
             "batch_size", self.service.wallet_state_manager.config.get("auto_claim", {}).get("batch_size", 50)
         )
+        # breakpoint()
         for coin_id, coin_record in coin_records.coin_id_to_record.items():
             try:
                 metadata = coin_record.parsed_metadata()

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1498,7 +1498,6 @@ class WalletRpcApi:
         batch_size = request.get(
             "batch_size", self.service.wallet_state_manager.config.get("auto_claim", {}).get("batch_size", 50)
         )
-        # breakpoint()
         for coin_id, coin_record in coin_records.coin_id_to_record.items():
             try:
                 metadata = coin_record.parsed_metadata()


### PR DESCRIPTION
Action scopes do, in fact, keep track of selected coins now, so we can delete this `TODO`