### PR TITLE
add a feature to log spend bundles being added to the mempool

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2743,6 +2743,15 @@ class FullNode:
                 self.mempool_manager.remove_seen(spend_name)
                 raise
 
+            if self.config.get("log_mempool", False):  # pragma: no cover
+                try:
+                    mempool_dir = path_from_root(self.root_path, "mempool-log") / f"{self.blockchain.get_peak_height()}"
+                    mempool_dir.mkdir(parents=True, exist_ok=True)
+                    with open(mempool_dir / f"{spend_name}.bundle", "wb+") as f:
+                        f.write(bytes(transaction))
+                except Exception:
+                    self.log.exception(f"Failed to log mempool item: {spend_name}")
+
             async with self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.low):
                 if self.mempool_manager.get_spendbundle(spend_name) is not None:
                     self.mempool_manager.remove_seen(spend_name)

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -410,6 +410,10 @@ full_node:
 
   enable_memory_profiler: False
 
+  # this is a debug/auditing facility that saves all spend bundles added to the
+  # mempool, organized by peak height at the time
+  log_mempool: false
+
   # this is a debug and profiling facility that logs all SQLite commands to a
   # separate log file (under logging/sql.log).
   log_sqlite_cmds: False


### PR DESCRIPTION
### Purpose:

This is a test/audit facility to log spend bundles that are added to the mempool.
These spend bundles can be used for testing the mempool, block creation, fuzzing and evaluating the fee estimator (together with the blockchain itself).

### Current Behavior:

### New Behavior:

A new configuration option (off by default) to save spend bundles as they arrive.

### Testing Notes:

Manual testing on testnet11