### PR TITLE
CHIA-2109 Clarify cases when transactions filter is computed with just reward coins

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -4184,3 +4184,19 @@ async def get_fork_info(blockchain: Blockchain, block: FullBlock, peak: BlockRec
     )
 
     return fork_info
+
+
+@pytest.mark.anyio
+async def test_get_header_blocks_in_range_tx_filter_non_tx_block(empty_blockchain: Blockchain, bt: BlockTools) -> None:
+    """
+    Covers the case of calling `get_header_blocks_in_range`, requesting
+    transactions filter, on a non transaction block.
+    """
+    b = empty_blockchain
+    blocks = bt.get_consecutive_blocks(2)
+    for block in blocks:
+        await _validate_and_add_block(b, block)
+    non_tx_block = next(block for block in blocks if not block.is_transaction_block())
+    blocks_with_filter = await b.get_header_blocks_in_range(0, 42, tx_filter=True)
+    empty_tx_filter = b"\x00"
+    assert blocks_with_filter[non_tx_block.header_hash].transactions_filter == empty_tx_filter

--- a/chia/util/generator_tools.py
+++ b/chia/util/generator_tools.py
@@ -14,18 +14,20 @@ from chia.util.ints import uint64
 
 
 def get_block_header(
-    block: FullBlock, additions_and_removals: Optional[tuple[Collection[Coin], Collection[bytes32]]] = None
+    block: FullBlock, removals_and_additions: Optional[tuple[Collection[bytes32], Collection[Coin]]] = None
 ) -> HeaderBlock:
     """
     Returns a HeaderBlock from a FullBlock.
-    If `additions_and_removals` is not None, account for them, as well as
+    If `removals_and_additions` is not None, account for them, as well as
     reward coins, in the creation of the transactions filter, otherwise create
     an empty one.
     """
+    # Guard against passing removals and additions for a non-transaction block.
+    assert removals_and_additions is None or block.is_transaction_block()
     # Create an empty filter to begin with
     byte_array_tx: list[bytearray] = []
-    if additions_and_removals is not None and block.is_transaction_block():
-        tx_addition_coins, removals_names = additions_and_removals
+    if removals_and_additions is not None and block.is_transaction_block():
+        removals_names, tx_addition_coins = removals_and_additions
         for coin in tx_addition_coins:
             byte_array_tx.append(bytearray(coin.puzzle_hash))
         for coin in block.get_included_reward_coins():


### PR DESCRIPTION
### Purpose:

This allows us to request more clearly the computation of a transactions filter, both when the transaction block contains no transactions generator (block with only reward coins) and when it has one.

### Current Behavior:

Requesting a transactions filter on the two cases of transaction blocks (with and without transactions generator) are not separated clearly.

### New Behavior:

There are now two clear paths that requesting a transactions filter on a transaction block would go through.