### PR TITLE
clean overflow blocks moved to unfinished block cache on reset chain

### DIFF
--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -335,10 +335,13 @@ class Timelord:
                     if self.last_state.get_deficit() < self.constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK:
                         self.iters_to_submit[Chain.INFUSED_CHALLENGE_CHAIN].append(new_block_iters)
                     self.iteration_to_proof_type[new_block_iters] = IterationType.INFUSION_POINT
-                    if block in self.overflow_blocks:
-                        self.overflow_blocks.remove(block)
         # Remove all unfinished blocks that have already passed.
         self.unfinished_blocks = new_unfinished_blocks
+
+        # remove overflow blocks that where moved to unfinished cache
+        for block in new_unfinished_blocks:
+            if block in self.overflow_blocks:
+                self.overflow_blocks.remove(block)
         # Signage points.
         if not only_eos and len(self.signage_point_iters) > 0:
             count_signage = 0

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -338,7 +338,7 @@ class Timelord:
         # Remove all unfinished blocks that have already passed.
         self.unfinished_blocks = new_unfinished_blocks
 
-        # remove overflow blocks that where moved to unfinished cache
+        # remove overflow blocks that were moved to unfinished cache
         for block in new_unfinished_blocks:
             if block in self.overflow_blocks:
                 self.overflow_blocks.remove(block)

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -335,6 +335,8 @@ class Timelord:
                     if self.last_state.get_deficit() < self.constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK:
                         self.iters_to_submit[Chain.INFUSED_CHALLENGE_CHAIN].append(new_block_iters)
                     self.iteration_to_proof_type[new_block_iters] = IterationType.INFUSION_POINT
+                    if block in self.overflow_blocks:
+                        self.overflow_blocks.remove(block)
         # Remove all unfinished blocks that have already passed.
         self.unfinished_blocks = new_unfinished_blocks
         # Signage points.


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
clean redundant blocks from overflow cache
<!-- Does this PR introduce a breaking change? -->

### Current Behavior:
when we call reset_chain we reset the unfinished block cache moving relevant blocks that can be infused from the overflow cache to the unfinished cache, we dont remove the overflow blocks we moved from the overflow cache creating redundant duplication

### New Behavior:
remove the blocks that where moved to the unfinished block cache

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
