### PR TITLE
sqlite cached_statements workaround

### DIFF
--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -74,7 +74,8 @@ async def _create_connection(
     log_file: Optional[TextIO] = None,
     name: Optional[str] = None,
 ) -> aiosqlite.Connection:
-    connection = await aiosqlite.connect(database=database, uri=uri)
+    # To avoid https://github.com/python/cpython/issues/118172
+    connection = await aiosqlite.connect(database=database, uri=uri, cached_statements=0)
 
     if log_file is not None:
         await connection.set_trace_callback(functools.partial(sql_trace_callback, file=log_file, name=name))


### PR DESCRIPTION
### Purpose:

Newer versions of python return incorrect sqlite results if cached_statements is nonzero. See:

https://github.com/python/cpython/issues/118172

### Current Behavior:

cached_statements is set to default

### New Behavior:

cached_statements is set to 0.  Chia rarely repeats the same sqlite queries so hopefully this does not affect performance.

### Testing Notes:

None
