### PR TITLE
Wrap with writer

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -419,7 +419,7 @@ class Blockchain:
         try:
             # Always add the block to the database
             # This call should be wrapped with a writer to force all coin reads to the same connection.
-            async with self.block_store.db_wrapper.writer():
+            async with self.block_store.db_wrapper.writer_maybe_transaction():
                 # Perform the DB operations to update the state, and rollback if something goes wrong
                 await self.block_store.add_full_block(header_hash, block, block_record)
                 records, state_change_summary = await self._reconsider_peak(block_record, genesis, fork_info)

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -419,7 +419,7 @@ class Blockchain:
         try:
             # Always add the block to the database
             # This call should be wrapped with a writer to force all coin reads to the same connection.
-            async with self.block_store.db_wrapper.writer_maybe_transaction():
+            async with self.block_store.db_wrapper.writer():
                 # Perform the DB operations to update the state, and rollback if something goes wrong
                 await self.block_store.add_full_block(header_hash, block, block_record)
                 records, state_change_summary = await self._reconsider_peak(block_record, genesis, fork_info)

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -418,7 +418,8 @@ class Blockchain:
 
         try:
             # Always add the block to the database
-            async with self.block_store.db_wrapper.writer():
+            # This call should be wrapped with a writer to force all coin reads to the same connection.
+            async with self.block_store.db_wrapper.writer_maybe_transaction():
                 # Perform the DB operations to update the state, and rollback if something goes wrong
                 await self.block_store.add_full_block(header_hash, block, block_record)
                 records, state_change_summary = await self._reconsider_peak(block_record, genesis, fork_info)

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import dataclasses
 import logging
 import sqlite3
@@ -159,9 +158,8 @@ class CoinStore:
         async with self.db_wrapper.reader_no_transaction() as conn:
 
             if conn!=self.db_wrapper._write_connection:
-                task=asyncio.current_task()
                 log.info(
-                    f"get_coin_records not using _current_writer {task.get_name()} {conn}"
+                    f"get_coin_records not using _current_writer {conn}"
                 )
 
             cursors: list[Cursor] = []

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import logging
 import sqlite3
@@ -156,6 +157,13 @@ class CoinStore:
         coins: list[CoinRecord] = []
 
         async with self.db_wrapper.reader_no_transaction() as conn:
+
+            if conn!=self.db_wrapper._write_connection:
+                task=asyncio.current_task()
+                log.info(
+                    f"get_coin_records not using _current_writer {task.get_name()} {conn}"
+                )
+
             cursors: list[Cursor] = []
             for batch in to_batches(names, SQLITE_MAX_VARIABLE_NUMBER):
                 names_db: tuple[Any, ...] = tuple(batch.entries)

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -157,7 +157,7 @@ class CoinStore:
 
         async with self.db_wrapper.reader_no_transaction() as conn:
             if conn != self.db_wrapper._write_connection:
-                log.info(f"get_coin_records not using _current_writer {conn}")
+                log.info(f"get_coin_records not using _write_connection {conn}")
 
             cursors: list[Cursor] = []
             for batch in to_batches(names, SQLITE_MAX_VARIABLE_NUMBER):

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -156,11 +156,8 @@ class CoinStore:
         coins: list[CoinRecord] = []
 
         async with self.db_wrapper.reader_no_transaction() as conn:
-
-            if conn!=self.db_wrapper._write_connection:
-                log.info(
-                    f"get_coin_records not using _current_writer {conn}"
-                )
+            if conn != self.db_wrapper._write_connection:
+                log.info(f"get_coin_records not using _current_writer {conn}")
 
             cursors: list[Cursor] = []
             for batch in to_batches(names, SQLITE_MAX_VARIABLE_NUMBER):
@@ -169,7 +166,7 @@ class CoinStore:
                     await conn.execute(
                         f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                         f"coin_parent, amount, timestamp FROM coin_record "
-                        f'WHERE coin_name in ({",".join(["?"] * len(names_db))}) ',
+                        f"WHERE coin_name in ({','.join(['?'] * len(names_db))}) ",
                         names_db,
                     )
                 )
@@ -277,7 +274,7 @@ class CoinStore:
             async with conn.execute(
                 f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                 f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash "
-                f'WHERE puzzle_hash in ({"?," * (len(puzzle_hashes) - 1)}?) '
+                f"WHERE puzzle_hash in ({'?,' * (len(puzzle_hashes) - 1)}?) "
                 f"AND confirmed_index>=? AND confirmed_index<? "
                 f"{'' if include_spent_coins else 'AND spent_index=0'}",
                 (*puzzle_hashes_db, start_height, end_height),
@@ -303,7 +300,7 @@ class CoinStore:
             async with conn.execute(
                 f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                 f"coin_parent, amount, timestamp FROM coin_record INDEXED BY sqlite_autoindex_coin_record_1 "
-                f'WHERE coin_name in ({"?," * (len(names) - 1)}?) '
+                f"WHERE coin_name in ({'?,' * (len(names) - 1)}?) "
                 f"AND confirmed_index>=? AND confirmed_index<? "
                 f"{'' if include_spent_coins else 'AND spent_index=0'}",
                 [*names, start_height, end_height],
@@ -342,7 +339,7 @@ class CoinStore:
                 async with conn.execute(
                     f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                     f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash "
-                    f'WHERE puzzle_hash in ({"?," * (len(batch.entries) - 1)}?) '
+                    f"WHERE puzzle_hash in ({'?,' * (len(batch.entries) - 1)}?) "
                     f"AND (confirmed_index>=? OR spent_index>=?)"
                     f"{'' if include_spent_coins else 'AND spent_index=0'}"
                     " LIMIT ?",
@@ -373,7 +370,7 @@ class CoinStore:
                 parent_ids_db: tuple[Any, ...] = tuple(batch.entries)
                 async with conn.execute(
                     f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, coin_parent, amount, timestamp "
-                    f'FROM coin_record WHERE coin_parent in ({"?," * (len(batch.entries) - 1)}?) '
+                    f"FROM coin_record WHERE coin_parent in ({'?,' * (len(batch.entries) - 1)}?) "
                     f"AND confirmed_index>=? AND confirmed_index<? "
                     f"{'' if include_spent_coins else 'AND spent_index=0'}",
                     (*parent_ids_db, start_height, end_height),
@@ -407,7 +404,7 @@ class CoinStore:
 
                 async with conn.execute(
                     f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, coin_parent, amount, timestamp "
-                    f'FROM coin_record WHERE coin_name in ({"?," * (len(batch.entries) - 1)}?) '
+                    f"FROM coin_record WHERE coin_name in ({'?,' * (len(batch.entries) - 1)}?) "
                     f"AND (confirmed_index>=? OR spent_index>=?) {max_height_sql}"
                     f"{'' if include_spent_coins else 'AND spent_index=0'}"
                     " LIMIT ?",
@@ -470,7 +467,7 @@ class CoinStore:
             cursor = await conn.execute(
                 f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                 f"coin_parent, amount, timestamp FROM coin_record INDEXED BY coin_puzzle_hash "
-                f'WHERE puzzle_hash in ({"?," * (puzzle_hash_count - 1)}?) '
+                f"WHERE puzzle_hash in ({'?,' * (puzzle_hash_count - 1)}?) "
                 f"AND (confirmed_index>=? OR spent_index>=?) "
                 f"{height_filter} {amount_filter}"
                 f"ORDER BY MAX(confirmed_index, spent_index) ASC "
@@ -492,7 +489,7 @@ class CoinStore:
                     f"SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
                     f"coin_parent, amount, timestamp FROM coin_record INDEXED BY sqlite_autoindex_coin_record_1 "
                     f"WHERE coin_name IN (SELECT coin_id FROM hints "
-                    f'WHERE hint IN ({"?," * (puzzle_hash_count - 1)}?)) '
+                    f"WHERE hint IN ({'?,' * (puzzle_hash_count - 1)}?)) "
                     f"AND (confirmed_index>=? OR spent_index>=?) "
                     f"{height_filter} {amount_filter}"
                     f"ORDER BY MAX(confirmed_index, spent_index) ASC "

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2137,7 +2137,7 @@ class FullNode:
             pre_validation_time = time.monotonic() - validation_start
 
             # Wrap with writer to ensure all writes and reads are on same connection.
-            async with self.block_store.db_wrapper.writer() as conn:
+            async with self.block_store.db_wrapper.writer():
                 try:
                     if pre_validation_result.error is not None:
                         if Err(pre_validation_result.error) == Err.INVALID_PREV_BLOCK_HASH:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -638,7 +638,7 @@ class FullNode:
                     vs = ValidationState(ssi, diff, None)
 
                     # Wrap add_block_batch with writer to ensure all writes and reads are on same connection.
-                    async with self.block_store.db_wrapper.writer() as conn:
+                    async with self.block_store.db_wrapper.writer():
                         success, state_change_summary = await self.add_block_batch(
                             response.blocks, peer_info, fork_info, vs
                         )
@@ -1357,7 +1357,7 @@ class FullNode:
                 pre_validation_results = list(await asyncio.gather(*futures))
 
                 # Wrap add_prevalidated_blocks with writer to ensure all writes and reads are on same connection.
-                async with self.block_store.db_wrapper.writer() as conn:
+                async with self.block_store.db_wrapper.writer():
                     # The ValidationState object (vs) is an in-out parameter. the add_block_batch()
                     # call will update it
                     state_change_summary, err = await self.add_prevalidated_blocks(

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -639,7 +639,7 @@ class FullNode:
 
                     # Wrap add_block_batch with writer to ensure all writes and reads are on same connection.
                     async with self.block_store.db_wrapper.writer() as conn:
-                        log.info(
+                        self.log.info(
                             f"short_sync_batch writer {conn}"
                         )
                         success, state_change_summary = await self.add_block_batch(
@@ -1361,7 +1361,7 @@ class FullNode:
 
                 # Wrap add_prevalidated_blocks with writer to ensure all writes and reads are on same connection.
                 async with self.block_store.db_wrapper.writer() as conn:
-                    log.info(
+                    self.log.info(
                         f"ingest_blocks writer {conn}"
                     )
                     # The ValidationState object (vs) is an in-out parameter. the add_block_batch()
@@ -2106,7 +2106,7 @@ class FullNode:
             self.block_store.db_wrapper.writer() as conn,
             enable_profiler(self.profile_block_validation) as pr,
         ):
-            log.info(
+            self.log.info(
                 f"add_block writer {conn}"
             )
             # After acquiring the lock, check again, because another asyncio thread might have added it

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -638,7 +638,7 @@ class FullNode:
                     vs = ValidationState(ssi, diff, None)
 
                     # Wrap add_block_batch with writer to ensure all writes and reads are on same connection.
-                    async with self.block_store.db_wrapper.writer() as conn:
+                    async with self.block_store.db_wrapper.writer_maybe_transaction() as conn:
                         self.log.info(f"short_sync_batch writer {conn}")
                         success, state_change_summary = await self.add_block_batch(
                             response.blocks, peer_info, fork_info, vs
@@ -1358,7 +1358,7 @@ class FullNode:
                 pre_validation_results = list(await asyncio.gather(*futures))
 
                 # Wrap add_prevalidated_blocks with writer to ensure all writes and reads are on same connection.
-                async with self.block_store.db_wrapper.writer() as conn:
+                async with self.block_store.db_wrapper.writer_maybe_transaction() as conn:
                     self.log.info(f"ingest_blocks writer {conn}")
                     # The ValidationState object (vs) is an in-out parameter. the add_block_batch()
                     # call will update it
@@ -2099,7 +2099,7 @@ class FullNode:
         async with (
             self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high),
             # Wrap with writer to ensure all writes and reads are on same connection.
-            self.block_store.db_wrapper.writer() as conn,
+            self.block_store.db_wrapper.writer_maybe_transaction() as conn,
             enable_profiler(self.profile_block_validation) as pr,
         ):
             self.log.info(f"add_block writer {conn}")

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -638,7 +638,7 @@ class FullNode:
                     vs = ValidationState(ssi, diff, None)
 
                     # Wrap add_block_batch with writer to ensure all writes and reads are on same connection.
-                    async with self.block_store.db_wrapper.writer_maybe_transaction() as conn:
+                    async with self.block_store.db_wrapper.writer() as conn:
                         self.log.info(f"short_sync_batch writer {conn}")
                         success, state_change_summary = await self.add_block_batch(
                             response.blocks, peer_info, fork_info, vs
@@ -1358,7 +1358,7 @@ class FullNode:
                 pre_validation_results = list(await asyncio.gather(*futures))
 
                 # Wrap add_prevalidated_blocks with writer to ensure all writes and reads are on same connection.
-                async with self.block_store.db_wrapper.writer_maybe_transaction() as conn:
+                async with self.block_store.db_wrapper.writer() as conn:
                     self.log.info(f"ingest_blocks writer {conn}")
                     # The ValidationState object (vs) is an in-out parameter. the add_block_batch()
                     # call will update it
@@ -2099,7 +2099,7 @@ class FullNode:
         async with (
             self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high),
             # Wrap with writer to ensure all writes and reads are on same connection.
-            self.block_store.db_wrapper.writer_maybe_transaction() as conn,
+            self.block_store.db_wrapper.writer() as conn,
             enable_profiler(self.profile_block_validation) as pr,
         ):
             self.log.info(f"add_block writer {conn}")

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -638,8 +638,7 @@ class FullNode:
                     vs = ValidationState(ssi, diff, None)
 
                     # Wrap add_block_batch with writer to ensure all writes and reads are on same connection.
-                    async with self.block_store.db_wrapper.writer() as conn:
-                        self.log.info(f"short_sync_batch writer {conn}")
+                    async with self.block_store.db_wrapper.writer():
                         success, state_change_summary = await self.add_block_batch(
                             response.blocks, peer_info, fork_info, vs
                         )
@@ -1358,8 +1357,7 @@ class FullNode:
                 pre_validation_results = list(await asyncio.gather(*futures))
 
                 # Wrap add_prevalidated_blocks with writer to ensure all writes and reads are on same connection.
-                async with self.block_store.db_wrapper.writer() as conn:
-                    self.log.info(f"ingest_blocks writer {conn}")
+                async with self.block_store.db_wrapper.writer():
                     # The ValidationState object (vs) is an in-out parameter. the add_block_batch()
                     # call will update it
                     state_change_summary, err = await self.add_prevalidated_blocks(
@@ -2098,6 +2096,8 @@ class FullNode:
         ppp_result: Optional[PeakPostProcessingResult] = None
         async with (
             self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high),
+            # Wrap with writer to ensure all writes and reads are on same connection.
+            self.block_store.db_wrapper.writer(),
             enable_profiler(self.profile_block_validation) as pr,
         ):
             # After acquiring the lock, check again, because another asyncio thread might have added it
@@ -2135,68 +2135,63 @@ class FullNode:
             pre_validation_result = await future
             added: Optional[AddBlockResult] = None
             pre_validation_time = time.monotonic() - validation_start
-
-            # Wrap with writer to ensure all writes and reads are on same connection.
-            async with self.block_store.db_wrapper.writer():
-                try:
-                    if pre_validation_result.error is not None:
-                        if Err(pre_validation_result.error) == Err.INVALID_PREV_BLOCK_HASH:
-                            added = AddBlockResult.DISCONNECTED_BLOCK
-                            error_code: Optional[Err] = Err.INVALID_PREV_BLOCK_HASH
-                        elif Err(pre_validation_result.error) == Err.TIMESTAMP_TOO_FAR_IN_FUTURE:
-                            raise TimestampError()
-                        else:
-                            raise ValueError(
-                                f"Failed to validate block {header_hash} height "
-                                f"{block.height}: {Err(pre_validation_result.error).name}"
-                            )
+            try:
+                if pre_validation_result.error is not None:
+                    if Err(pre_validation_result.error) == Err.INVALID_PREV_BLOCK_HASH:
+                        added = AddBlockResult.DISCONNECTED_BLOCK
+                        error_code: Optional[Err] = Err.INVALID_PREV_BLOCK_HASH
+                    elif Err(pre_validation_result.error) == Err.TIMESTAMP_TOO_FAR_IN_FUTURE:
+                        raise TimestampError()
                     else:
-                        if fork_info is None:
-                            fork_info = ForkInfo(block.height - 1, block.height - 1, block.prev_header_hash)
-                        (added, error_code, state_change_summary) = await self.blockchain.add_block(
-                            block, pre_validation_result, ssi, fork_info
+                        raise ValueError(
+                            f"Failed to validate block {header_hash} height "
+                            f"{block.height}: {Err(pre_validation_result.error).name}"
                         )
-                    if added == AddBlockResult.ALREADY_HAVE_BLOCK:
-                        return None
-                    elif added == AddBlockResult.INVALID_BLOCK:
-                        assert error_code is not None
-                        self.log.error(
-                            f"Block {header_hash} at height {block.height} is invalid with code {error_code}."
+                else:
+                    if fork_info is None:
+                        fork_info = ForkInfo(block.height - 1, block.height - 1, block.prev_header_hash)
+                    (added, error_code, state_change_summary) = await self.blockchain.add_block(
+                        block, pre_validation_result, ssi, fork_info
+                    )
+                if added == AddBlockResult.ALREADY_HAVE_BLOCK:
+                    return None
+                elif added == AddBlockResult.INVALID_BLOCK:
+                    assert error_code is not None
+                    self.log.error(f"Block {header_hash} at height {block.height} is invalid with code {error_code}.")
+                    raise ConsensusError(error_code, [header_hash])
+                elif added == AddBlockResult.DISCONNECTED_BLOCK:
+                    self.log.info(f"Disconnected block {header_hash} at height {block.height}")
+                    if raise_on_disconnected:
+                        raise RuntimeError("Expected block to be added, received disconnected block.")
+                    return None
+                elif added == AddBlockResult.NEW_PEAK:
+                    # Evict any related BLS cache entries as we no longer need them
+                    if bls_cache is not None and pre_validation_result.conds is not None:
+                        pairs_pks, pairs_msgs = pkm_pairs(
+                            pre_validation_result.conds, self.constants.AGG_SIG_ME_ADDITIONAL_DATA
                         )
-                        raise ConsensusError(error_code, [header_hash])
-                    elif added == AddBlockResult.DISCONNECTED_BLOCK:
-                        self.log.info(f"Disconnected block {header_hash} at height {block.height}")
-                        if raise_on_disconnected:
-                            raise RuntimeError("Expected block to be added, received disconnected block.")
-                        return None
-                    elif added == AddBlockResult.NEW_PEAK:
-                        # Evict any related BLS cache entries as we no longer need them
-                        if bls_cache is not None and pre_validation_result.conds is not None:
-                            pairs_pks, pairs_msgs = pkm_pairs(
-                                pre_validation_result.conds, self.constants.AGG_SIG_ME_ADDITIONAL_DATA
-                            )
-                            bls_cache.evict(pairs_pks, pairs_msgs)
-                        # Only propagate blocks which extend the blockchain (becomes one of the heads)
-                        assert state_change_summary is not None
-                        post_process_time = time.monotonic()
-                        ppp_result = await self.peak_post_processing(block, state_change_summary, peer)
-                        post_process_time = time.monotonic() - post_process_time
+                        bls_cache.evict(pairs_pks, pairs_msgs)
+                    # Only propagate blocks which extend the blockchain (becomes one of the heads)
+                    assert state_change_summary is not None
+                    post_process_time = time.monotonic()
+                    ppp_result = await self.peak_post_processing(block, state_change_summary, peer)
+                    post_process_time = time.monotonic() - post_process_time
 
-                    elif added == AddBlockResult.ADDED_AS_ORPHAN:
-                        self.log.info(
-                            f"Received orphan block of height {block.height} rh {block.reward_chain_block.get_hash()}"
-                        )
-                        post_process_time = 0
-                    else:
-                        # Should never reach here, all the cases are covered
-                        raise RuntimeError(f"Invalid result from add_block {added}")
-                except asyncio.CancelledError:
-                    # We need to make sure to always call this method even when we get a cancel exception, to make sure
-                    # the node stays in sync
-                    if added == AddBlockResult.NEW_PEAK:
-                        assert state_change_summary is not None
-                        await self.peak_post_processing(block, state_change_summary, peer)
-                    raise
+                elif added == AddBlockResult.ADDED_AS_ORPHAN:
+                    self.log.info(
+                        f"Received orphan block of height {block.height} rh {block.reward_chain_block.get_hash()}"
+                    )
+                    post_process_time = 0
+                else:
+                    # Should never reach here, all the cases are covered
+                    raise RuntimeError(f"Invalid result from add_block {added}")
+            except asyncio.CancelledError:
+                # We need to make sure to always call this method even when we get a cancel exception, to make sure
+                # the node stays in sync
+                if added == AddBlockResult.NEW_PEAK:
+                    assert state_change_summary is not None
+                    await self.peak_post_processing(block, state_change_summary, peer)
+                raise
 
             validation_time = time.monotonic() - validation_start
 

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -640,7 +640,7 @@ class FullNode:
                     # Wrap add_block_batch with writer to ensure all writes and reads are on same connection.
                     async with self.block_store.db_wrapper.writer() as conn:
                         log.info(
-                            f"short_sync_batch writer {task.get_name()} {conn}"
+                            f"short_sync_batch writer {conn}"
                         )
                         success, state_change_summary = await self.add_block_batch(
                             response.blocks, peer_info, fork_info, vs
@@ -1362,7 +1362,7 @@ class FullNode:
                 # Wrap add_prevalidated_blocks with writer to ensure all writes and reads are on same connection.
                 async with self.block_store.db_wrapper.writer() as conn:
                     log.info(
-                        f"ingest_blocks writer {task.get_name()} {conn}"
+                        f"ingest_blocks writer {conn}"
                     )
                     # The ValidationState object (vs) is an in-out parameter. the add_block_batch()
                     # call will update it
@@ -2107,7 +2107,7 @@ class FullNode:
             enable_profiler(self.profile_block_validation) as pr,
         ):
             log.info(
-                f"add_block writer {task.get_name()} {conn}"
+                f"add_block writer {conn}"
             )
             # After acquiring the lock, check again, because another asyncio thread might have added it
             if self.blockchain.contains_block(header_hash):

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2160,7 +2160,9 @@ class FullNode:
                         return None
                     elif added == AddBlockResult.INVALID_BLOCK:
                         assert error_code is not None
-                        self.log.error(f"Block {header_hash} at height {block.height} is invalid with code {error_code}.")
+                        self.log.error(
+                            f"Block {header_hash} at height {block.height} is invalid with code {error_code}."
+                        )
                         raise ConsensusError(error_code, [header_hash])
                     elif added == AddBlockResult.DISCONNECTED_BLOCK:
                         self.log.info(f"Disconnected block {header_hash} at height {block.height}")

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2099,10 +2099,8 @@ class FullNode:
         async with (
             self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high),
             # Wrap with writer to ensure all writes and reads are on same connection.
-            self.block_store.db_wrapper.writer() as conn,
             enable_profiler(self.profile_block_validation) as pr,
         ):
-            self.log.info(f"add_block writer {conn}")
             # After acquiring the lock, check again, because another asyncio thread might have added it
             if self.blockchain.contains_block(header_hash):
                 if fork_info is not None:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -639,6 +639,9 @@ class FullNode:
 
                     # Wrap add_block_batch with writer to ensure all writes and reads are on same connection.
                     async with self.block_store.db_wrapper.writer() as conn:
+                        log.info(
+                            f"short_sync_batch writer {task.get_name()} {conn}"
+                        )
                         success, state_change_summary = await self.add_block_batch(
                             response.blocks, peer_info, fork_info, vs
                         )
@@ -1358,6 +1361,9 @@ class FullNode:
 
                 # Wrap add_prevalidated_blocks with writer to ensure all writes and reads are on same connection.
                 async with self.block_store.db_wrapper.writer() as conn:
+                    log.info(
+                        f"ingest_blocks writer {task.get_name()} {conn}"
+                    )
                     # The ValidationState object (vs) is an in-out parameter. the add_block_batch()
                     # call will update it
                     state_change_summary, err = await self.add_prevalidated_blocks(
@@ -2100,6 +2106,9 @@ class FullNode:
             self.block_store.db_wrapper.writer() as conn,
             enable_profiler(self.profile_block_validation) as pr,
         ):
+            log.info(
+                f"add_block writer {task.get_name()} {conn}"
+            )
             # After acquiring the lock, check again, because another asyncio thread might have added it
             if self.blockchain.contains_block(header_hash):
                 if fork_info is not None:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -638,7 +638,7 @@ class FullNode:
                     vs = ValidationState(ssi, diff, None)
 
                     # Wrap add_block_batch with writer to ensure all writes and reads are on same connection.
-                    async with self.block_store.db_wrapper.writer():
+                    async with self.block_store.db_wrapper.writer() as conn:
                         success, state_change_summary = await self.add_block_batch(
                             response.blocks, peer_info, fork_info, vs
                         )
@@ -1357,7 +1357,7 @@ class FullNode:
                 pre_validation_results = list(await asyncio.gather(*futures))
 
                 # Wrap add_prevalidated_blocks with writer to ensure all writes and reads are on same connection.
-                async with self.block_store.db_wrapper.writer():
+                async with self.block_store.db_wrapper.writer() as conn:
                     # The ValidationState object (vs) is an in-out parameter. the add_block_batch()
                     # call will update it
                     state_change_summary, err = await self.add_prevalidated_blocks(
@@ -2097,7 +2097,7 @@ class FullNode:
         async with (
             self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high),
             # Wrap with writer to ensure all writes and reads are on same connection.
-            self.block_store.db_wrapper.writer(),
+            self.block_store.db_wrapper.writer() as conn,
             enable_profiler(self.profile_block_validation) as pr,
         ):
             # After acquiring the lock, check again, because another asyncio thread might have added it

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -639,9 +639,7 @@ class FullNode:
 
                     # Wrap add_block_batch with writer to ensure all writes and reads are on same connection.
                     async with self.block_store.db_wrapper.writer() as conn:
-                        self.log.info(
-                            f"short_sync_batch writer {conn}"
-                        )
+                        self.log.info(f"short_sync_batch writer {conn}")
                         success, state_change_summary = await self.add_block_batch(
                             response.blocks, peer_info, fork_info, vs
                         )
@@ -1361,9 +1359,7 @@ class FullNode:
 
                 # Wrap add_prevalidated_blocks with writer to ensure all writes and reads are on same connection.
                 async with self.block_store.db_wrapper.writer() as conn:
-                    self.log.info(
-                        f"ingest_blocks writer {conn}"
-                    )
+                    self.log.info(f"ingest_blocks writer {conn}")
                     # The ValidationState object (vs) is an in-out parameter. the add_block_batch()
                     # call will update it
                     state_change_summary, err = await self.add_prevalidated_blocks(
@@ -2106,9 +2102,7 @@ class FullNode:
             self.block_store.db_wrapper.writer() as conn,
             enable_profiler(self.profile_block_validation) as pr,
         ):
-            self.log.info(
-                f"add_block writer {conn}"
-            )
+            self.log.info(f"add_block writer {conn}")
             # After acquiring the lock, check again, because another asyncio thread might have added it
             if self.blockchain.contains_block(header_hash):
                 if fork_info is not None:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2403,6 +2403,7 @@ class FullNode:
         async with self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
             # TODO: pre-validate VDFs outside of lock
             validation_start = time.monotonic()
+            self.log.info("validate_unfinished_block")
             validate_result = await self.blockchain.validate_unfinished_block(block, npc_result)
             if validate_result.error is not None:
                 raise ConsensusError(Err(validate_result.error))
@@ -2775,6 +2776,7 @@ class FullNode:
                     return MempoolInclusionStatus.SUCCESS, None
                 if self.mempool_manager.peak is None:
                     return MempoolInclusionStatus.FAILED, Err.MEMPOOL_NOT_INITIALIZED
+                self.log.info("add_spend_bundle")
                 info = await self.mempool_manager.add_spend_bundle(
                     transaction, cost_result, spend_name, self.mempool_manager.peak.height
                 )

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -44,7 +44,7 @@ class _Default:
 
 default = _Default()
 
-timeout_per_block = 7
+timeout_per_block = 10
 
 
 async def wait_for_coins_in_wallet(coins: set[Coin], wallet: Wallet, timeout: Optional[float] = 5):

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -44,7 +44,7 @@ class _Default:
 
 default = _Default()
 
-timeout_per_block = 5
+timeout_per_block = 7
 
 
 async def wait_for_coins_in_wallet(coins: set[Coin], wallet: Wallet, timeout: Optional[float] = 5):

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -44,7 +44,7 @@ class _Default:
 
 default = _Default()
 
-timeout_per_block = 10
+timeout_per_block = 5
 
 
 async def wait_for_coins_in_wallet(coins: set[Coin], wallet: Wallet, timeout: Optional[float] = 5):

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -133,7 +133,10 @@ class FullNodeSimulator(FullNodeAPI):
         While reorgs are preferred, this is also an option
         Note: This does not broadcast the changes, and all wallets will need to be wiped.
         """
-        async with self.full_node.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
+        async with (
+            self.full_node.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high),
+            self.block_store.db_wrapper.writer(),
+        ):
             peak_height: Optional[uint32] = self.full_node.blockchain.get_peak_height()
             if peak_height is None:
                 raise ValueError("We can't revert without any blocks.")
@@ -170,7 +173,10 @@ class FullNodeSimulator(FullNodeAPI):
     ) -> FullBlock:
         ssi = self.full_node.constants.SUB_SLOT_ITERS_STARTING
         diff = self.full_node.constants.DIFFICULTY_STARTING
-        async with self.full_node.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
+        async with (
+            self.full_node.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high),
+            self.block_store.db_wrapper.writer(),
+        ):
             self.log.info("Farming new block!")
             current_blocks = await self.get_all_full_blocks()
             if len(current_blocks) == 0:
@@ -231,7 +237,10 @@ class FullNodeSimulator(FullNodeAPI):
     async def farm_new_block(self, request: FarmNewBlockProtocol, force_wait_for_timestamp: bool = False):
         ssi = self.full_node.constants.SUB_SLOT_ITERS_STARTING
         diff = self.full_node.constants.DIFFICULTY_STARTING
-        async with self.full_node.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
+        async with (
+            self.full_node.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high),
+            self.block_store.db_wrapper.writer(),
+        ):
             self.log.info("Farming new block!")
             current_blocks = await self.get_all_full_blocks()
             if len(current_blocks) == 0:


### PR DESCRIPTION
### Purpose:

The db_wrapper code allows read operations to use the current write connection if it is active.

Currently the syncing operation uses distinct writes and reads which means write operations are on the writer connection and read operations are on one of the read connections across different threads.

To make life easier for sqlite, this PR wraps block syncs within one db_wrapper writer. The block sync db_wrapper operations then will use the write connection whether it is for reading or writing. The write connection always has an up to date view of the DB.

### Current Behavior:

Block sync operations use multiple connections and threads

### New Behavior:

Block sync operations use the writer connection

### Testing Notes:

This may cause a reduction in concurrency because the db_wrapper write has its own lock. Performance would be the main concern here although with less coherency issues things should be faster.