### PR TITLE
set `wallet.rpc` test job timeout to 35 minutes

### DIFF
--- a/chia/_tests/wallet/rpc/config.py
+++ b/chia/_tests/wallet/rpc/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
 checkout_blocks_and_plots = True
-job_timeout = 90
+job_timeout = 35


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

seeing 25% hang rate and top successful time of 22 minutes so let's fail a bit quicker on the hangs.

https://github.com/Chia-Network/chia-blockchain/actions/runs/12712771698/usage

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
