### PR TITLE
Add seeder.xchseeder.com to dns_servers in config.yaml

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -440,6 +440,7 @@ full_node:
     - "seeder.dexie.space"
     - "chia.hoffmang.com"
     - "seeder.xchpool.org"
+    - "seeder.xchseeder.com"
   introducer_peer:
     host: introducer.chia.net # Chia AWS introducer IPv4/IPv6
     port: 8444


### PR DESCRIPTION
I am now running a seeder for Chia at `seeder.xchseeder.com`.  Full details are at [https://xchseeder.com](https://xchseeder.com).

### Purpose:
Add a new seeder into the options of seeder for the config.yaml file. The seeder is at `seeder.xchseeder.com` and was setup and is run by me. It does support both IPv4 and IPv6. I do have some monitors setup on Uptime Robot to ensure it stays healthy and provides a status page for the service. I do have a landing page at `xchseeder.com`.

### Current Behavior:
n/a

### New Behavior:
Another seeder option in the `config.yaml` file.

### Testing Notes:

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
![image](https://github.com/user-attachments/assets/adc6cf3d-38e5-460c-8724-1898007512bc)

![image](https://github.com/user-attachments/assets/50c9cdc5-6513-4e41-9a1b-cbfd23729270)

![image](https://github.com/user-attachments/assets/3e1e7644-6c44-455c-a69b-126dd20bdd35)

![image](https://github.com/user-attachments/assets/a9809a86-680a-45cc-80ca-dd976087b0f3)