### PR TITLE
Fixed an issue where cancelling NFT offer did not cancel other offers…

### DIFF
--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -2545,7 +2545,7 @@ class WalletRpcApi:
         fee: uint64 = uint64(request.get("fee", 0))
         async with self.service.wallet_state_manager.lock:
             await wsm.trade_manager.cancel_pending_offers(
-                [bytes32(trade_id)], action_scope, fee=fee, secure=secure, extra_conditions=extra_conditions
+                [trade_id], action_scope, fee=fee, secure=secure, extra_conditions=extra_conditions
             )
 
         return {"transactions": None}  # tx_endpoint wrapper will take care of this

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -2387,20 +2387,21 @@ class WalletStateManager:
                     trade_coins_removed = set()
                     trades = []
                     for removed_coin in coins_removed:
-                        trade = await self.trade_manager.get_trade_by_coin(removed_coin)
-                        if trade is not None and trade.status in {
-                            TradeStatus.PENDING_CONFIRM.value,
-                            TradeStatus.PENDING_ACCEPT.value,
-                            TradeStatus.PENDING_CANCEL.value,
-                        }:
-                            if trade not in trades:
-                                trades.append(trade)
-                            # offer was tied to these coins, lets subscribe to them to get a confirmation to
-                            # cancel it if it's confirmed
-                            # we send transactions to multiple peers, and in cases when mempool gets
-                            # fragmented, it's safest to wait for confirmation from blockchain before setting
-                            # offer to failed
-                            trade_coins_removed.add(removed_coin.name())
+                        trades_by_coin = await self.trade_manager.get_trades_by_coin(removed_coin)
+                        for trade in trades_by_coin:
+                            if trade is not None and trade.status in {
+                                TradeStatus.PENDING_CONFIRM.value,
+                                TradeStatus.PENDING_ACCEPT.value,
+                                TradeStatus.PENDING_CANCEL.value,
+                            }:
+                                if trade not in trades:
+                                    trades.append(trade)
+                                # offer was tied to these coins, lets subscribe to them to get a confirmation to
+                                # cancel it if it's confirmed
+                                # we send transactions to multiple peers, and in cases when mempool gets
+                                # fragmented, it's safest to wait for confirmation from blockchain before setting
+                                # offer to failed
+                                trade_coins_removed.add(removed_coin.name())
                     if trades != [] and trade_coins_removed != set():
                         if not tx.is_valid():
                             # we've tried to send this transaction to a full node multiple times


### PR DESCRIPTION
Fixing https://github.com/Chia-Network/chia-blockchain-gui/issues/2563

I found that the primary issues of the above case are:
1. Canceling an offer with a NFT in offering-side does not set `PENDING_CANCEL` status for trades which also offers the same NFT.
  - This is because current wallet implementation updates trade status by `trade_id` and not by coins being spent.
2.  Confirming cancellation does not set `CANCELLED` status to the trade records.
  - I understood the root cause. I'll desribe it in the following paragraph.

## Why cancelling multiple NFT offers doesn't work

When confirming the offer cancellation, which means the offering NFT coin was spent but requesting coins were not created, `trade_records` wallet db table in the issue's situation would be like:
|trade_id|status|
|--------|------|
|offer1   | `PENDING_ACCEPT` |
|offer2 | `PENDING_ACCEPT` |
|offer3 | `PENDING_CANCEL`|

(This inconsistent statuses is caused by issue `1.` above.)

Then look at the code below. This code is executed when monitoring coin state has been changed.
For example, the offering coin is spent to cancel.
https://github.com/Chia-Network/chia-blockchain/blob/2.5.0/chia/wallet/trade_manager.py#L154
![image](https://github.com/user-attachments/assets/8343c12f-07be-4d6a-9d46-1df82021b32b)

The target `trade` whose status is expected to be set to `CANCELLED` is acquired by `self.get_trade_by_coin(coin_state.coin)`.
This is the problem.
When this is executed, it gets `offer1` in the above table.
`offer1`'s status is `PENDING_ACCEPT`.
When offer is cancelled, its status must be `PENDING_CANCEL` according to
https://github.com/Chia-Network/chia-blockchain/blob/2.5.0/chia/wallet/trade_manager.py#L204
![image](https://github.com/user-attachments/assets/3f88b056-cfbf-4eec-a169-879c3752a15f)

So the current implementation misses to recognize offer cancellation for NFT.
This is the PR to fix this issue.