### PR TITLE
add a time-out of adding more transactions to blocks

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -878,10 +878,17 @@ class FullNodeAPI:
                         # when the hard fork activates, block generators are
                         # allowed to be serialized with the improved CLVM
                         # serialization format, supporting back-references
+                        start_time = time.monotonic()
                         if peak.height >= self.full_node.constants.HARD_FORK_HEIGHT:
                             block_generator = simple_solution_generator_backrefs(spend_bundle)
                         else:
                             block_generator = simple_solution_generator(spend_bundle)
+                        end_time = time.monotonic()
+                        duration = end_time - start_time
+                        self.log.log(
+                            logging.INFO if duration < 1 else logging.WARNING,
+                            f"serializing block generator took {duration:0.2f} seconds",
+                        )
 
             def get_plot_sig(to_sign: bytes32, _extra: G1Element) -> G2Element:
                 if to_sign == request.challenge_chain_sp:

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -501,6 +501,11 @@ class Mempool:
             name = bytes32(row[0])
             fee = int(row[1])
             item = self._items[name]
+
+            current_time = monotonic()
+            if current_time - bundle_creation_start > 1:
+                log.info(f"exiting early, already spent {current_time - bundle_creation_start:0.2f} s")
+                break
             if not item_inclusion_filter(name):
                 continue
             try:


### PR DESCRIPTION
### Purpose:

This to make sure we don't spend too much time doing that.
Also log how long serialization takes.

As we've removed the fill rate limit (allowing full blocks) we may spend more time creating and serializing blocks. This mitigates some potential problems and highlights the serialization time in a warning log in case it takes more than 1 second.

### Current Behavior:

We can potentially spend a long time creating the spend bundle for a new block.

### New Behavior:

Once we've spent 1 second, we stop and just use the spend bundle we have so far.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
