### PR TITLE
[CHIA-2192] Add singleton records to action scopes

### DIFF
--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -44,7 +44,7 @@ from chia.data_layer.data_layer_util import (
     leaf_hash,
     unspecified,
 )
-from chia.data_layer.data_layer_wallet import DataLayerWallet, Mirror, SingletonRecord, verify_offer
+from chia.data_layer.data_layer_wallet import DataLayerWallet, Mirror, verify_offer
 from chia.data_layer.data_store import DataStore
 from chia.data_layer.download_data import (
     delete_full_file_if_exists,
@@ -53,6 +53,7 @@ from chia.data_layer.download_data import (
     insert_from_delta_file,
     write_files_for_root,
 )
+from chia.data_layer.singleton_record import SingletonRecord
 from chia.rpc.rpc_server import StateChangedProtocol, default_get_connections
 from chia.rpc.wallet_request_types import LogIn
 from chia.rpc.wallet_rpc_client import WalletRpcClient

--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -12,6 +12,7 @@ from typing_extensions import Unpack, final
 from chia.consensus.block_record import BlockRecord
 from chia.data_layer.data_layer_errors import LauncherCoinNotFoundError, OfferIntegrityError
 from chia.data_layer.data_layer_util import OfferStore, ProofOfInclusion, ProofOfInclusionLayer, StoreProofs, leaf_hash
+from chia.data_layer.singleton_record import SingletonRecord
 from chia.protocols.wallet_protocol import CoinState
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin
@@ -21,7 +22,6 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.ints import uint8, uint32, uint64, uint128
-from chia.util.streamable import Streamable, streamable
 from chia.wallet.conditions import (
     AssertAnnouncement,
     AssertCoinAnnouncement,
@@ -67,20 +67,6 @@ from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_state_manager import WalletStateManager
-
-
-@streamable
-@dataclasses.dataclass(frozen=True)
-class SingletonRecord(Streamable):
-    coin_id: bytes32
-    launcher_id: bytes32
-    root: bytes32
-    inner_puzzle_hash: bytes32
-    confirmed: bool
-    confirmed_at_height: uint32
-    lineage_proof: LineageProof
-    generation: uint32
-    timestamp: uint64
 
 
 @dataclasses.dataclass(frozen=True)

--- a/chia/data_layer/dl_wallet_store.py
+++ b/chia/data_layer/dl_wallet_store.py
@@ -5,7 +5,8 @@ from typing import Optional, TypeVar, Union
 
 from aiosqlite import Row
 
-from chia.data_layer.data_layer_wallet import Mirror, SingletonRecord
+from chia.data_layer.data_layer_wallet import Mirror
+from chia.data_layer.singleton_record import SingletonRecord
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.db_wrapper import DBWrapper2, execute_fetchone

--- a/chia/data_layer/singleton_record.py
+++ b/chia/data_layer/singleton_record.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import dataclasses
+
+from chia.types.blockchain_format.sized_bytes import bytes32
+from chia.util.ints import uint32, uint64
+from chia.util.streamable import Streamable, streamable
+from chia.wallet.lineage_proof import LineageProof
+
+
+@streamable
+@dataclasses.dataclass(frozen=True)
+class SingletonRecord(Streamable):
+    coin_id: bytes32
+    launcher_id: bytes32
+    root: bytes32
+    inner_puzzle_hash: bytes32
+    confirmed: bool
+    confirmed_at_height: uint32
+    lineage_proof: LineageProof
+    generation: uint32
+    timestamp: uint64

--- a/chia/rpc/wallet_rpc_client.py
+++ b/chia/rpc/wallet_rpc_client.py
@@ -4,7 +4,8 @@ from collections.abc import Sequence
 from typing import Any, Optional, Union, cast
 
 from chia.data_layer.data_layer_util import DLProof, VerifyProofResponse
-from chia.data_layer.data_layer_wallet import Mirror, SingletonRecord
+from chia.data_layer.data_layer_wallet import Mirror
+from chia.data_layer.singleton_record import SingletonRecord
 from chia.pools.pool_wallet_info import PoolWalletInfo
 from chia.rpc.rpc_client import RpcClient
 from chia.rpc.wallet_request_types import (

--- a/chia/wallet/wallet_action_scope.py
+++ b/chia/wallet/wallet_action_scope.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Optional, cast, final
 
-from chia.data_layer.data_layer_wallet import SingletonRecord
+from chia.data_layer.singleton_record import SingletonRecord
 from chia.types.blockchain_format.coin import Coin
 from chia.util.action_scope import ActionScope
 from chia.util.streamable import Streamable, streamable

--- a/chia/wallet/wallet_action_scope.py
+++ b/chia/wallet/wallet_action_scope.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Optional, cast, final
 
+from chia.data_layer.data_layer_wallet import SingletonRecord
 from chia.types.blockchain_format.coin import Coin
 from chia.util.action_scope import ActionScope
 from chia.util.streamable import Streamable, streamable
@@ -25,6 +26,7 @@ class _StreamableWalletSideEffects(Streamable):
     signing_responses: list[SigningResponse]
     extra_spends: list[WalletSpendBundle]
     selected_coins: list[Coin]
+    singleton_records: list[SingletonRecord]
 
 
 @dataclass
@@ -33,6 +35,7 @@ class WalletSideEffects:
     signing_responses: list[SigningResponse] = field(default_factory=list)
     extra_spends: list[WalletSpendBundle] = field(default_factory=list)
     selected_coins: list[Coin] = field(default_factory=list)
+    singleton_records: list[SingletonRecord] = field(default_factory=list)
 
     def __bytes__(self) -> bytes:
         return bytes(_StreamableWalletSideEffects(**self.__dict__))
@@ -93,4 +96,5 @@ async def new_wallet_action_scope(
         sign=sign,
         additional_signing_responses=self.side_effects.signing_responses,
         extra_spends=self.side_effects.extra_spends,
+        singleton_records=self.side_effects.singleton_records,
     )

--- a/chia/wallet/wallet_protocol.py
+++ b/chia/wallet/wallet_protocol.py
@@ -68,7 +68,6 @@ class GSTOptionalArgs(TypedDict):
     launcher_id: NotRequired[Optional[bytes32]]
     new_root_hash: NotRequired[Optional[bytes32]]
     sign: NotRequired[bool]
-    add_pending_singleton: NotRequired[bool]
     announce_new_state: NotRequired[bool]
     # CATWallet
     cat_discrepancy: NotRequired[Optional[tuple[int, Program, Program]]]

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -18,7 +18,7 @@ from chia_rs import AugSchemeMPL, G1Element, G2Element, PrivateKey
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.coinbase import farmer_parent_id, pool_parent_id
 from chia.consensus.constants import ConsensusConstants
-from chia.data_layer.data_layer_wallet import DataLayerWallet
+from chia.data_layer.data_layer_wallet import DataLayerWallet, SingletonRecord
 from chia.data_layer.dl_wallet_store import DataLayerStore
 from chia.pools.pool_puzzles import (
     SINGLETON_LAUNCHER_HASH,
@@ -2298,6 +2298,7 @@ class WalletStateManager:
         sign: Optional[bool] = None,
         additional_signing_responses: Optional[list[SigningResponse]] = None,
         extra_spends: Optional[list[WalletSpendBundle]] = None,
+        singleton_records: list[SingletonRecord] = [],
     ) -> list[TransactionRecord]:
         """
         Add a list of transactions to be submitted to the full node.
@@ -2343,6 +2344,9 @@ class WalletStateManager:
                     await self.tx_store.add_transaction_record(tx_record)
                     all_coins_names.extend([coin.name() for coin in tx_record.additions])
                     all_coins_names.extend([coin.name() for coin in tx_record.removals])
+
+                for singleton_record in singleton_records:
+                    await self.dl_store.add_singleton_record(singleton_record)
 
             await self.add_interested_coin_ids(all_coins_names)
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -18,8 +18,9 @@ from chia_rs import AugSchemeMPL, G1Element, G2Element, PrivateKey
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.coinbase import farmer_parent_id, pool_parent_id
 from chia.consensus.constants import ConsensusConstants
-from chia.data_layer.data_layer_wallet import DataLayerWallet, SingletonRecord
+from chia.data_layer.data_layer_wallet import DataLayerWallet
 from chia.data_layer.dl_wallet_store import DataLayerStore
+from chia.data_layer.singleton_record import SingletonRecord
 from chia.pools.pool_puzzles import (
     SINGLETON_LAUNCHER_HASH,
     get_most_recent_singleton_coin_from_coin_spend,


### PR DESCRIPTION
The DataLayer wallet was made a while back and we kind of just accepted that this extra piece of database information (`SingletonRecord`s) would sometimes be out of sync with the transactions we had made.  We even have guardrails and recovery paths for this.  This PR _should_ eliminate the need for all of that by ensuring that singleton records only get added to the database if the action succeeds and transactions are pushed etc.