### PR TITLE
CHIA-2220 Fix a typo when picking the best unfinished block in test_request_unfinished_block2

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1634,7 +1634,7 @@ async def test_request_unfinished_block2(wallet_nodes, self_hostname):
         if best_unf is None:
             best_unf = unf
         elif (
-            unf.foliage.foliage_transaction_block_hash is not None
+            best_unf.foliage.foliage_transaction_block_hash is not None
             and unf.foliage.foliage_transaction_block_hash < best_unf.foliage.foliage_transaction_block_hash
         ):
             best_unf = unf


### PR DESCRIPTION
At this point, we already know that `unf.foliage.foliage_transaction_block_hash` is not `None`, but in order to compare it with our current best unfinished block, `best_unf.foliage.foliage_transaction_block_hash` must not be `None` as well.