### PR TITLE
[CHIA-2224] Add some extra safety into `create_message_spend`

### DIFF
--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -765,20 +765,28 @@ class DIDWallet:
         assert self.did_info.origin_coin is not None
         coin = await self.get_coin()
         innerpuz: Program = self.did_info.current_inner
+        assert (
+            create_singleton_puzzle(
+                innerpuz,
+                self.did_info.origin_coin.name(),
+            ).get_tree_hash()
+            == coin.puzzle_hash
+        )
+        uncurried = did_wallet_puzzles.uncurry_innerpuz(innerpuz)
+        assert uncurried is not None
+        p2_puzzle, id_list, num_of_backup_ids_needed, _, metadata = uncurried
         # Quote message puzzle & solution
         if action_scope.config.tx_config.reuse_puzhash:
             new_innerpuzzle_hash = innerpuz.get_tree_hash()
-            uncurried = did_wallet_puzzles.uncurry_innerpuz(innerpuz)
-            assert uncurried is not None
-            p2_ph = uncurried[0].get_tree_hash()
+            p2_ph = p2_puzzle.get_tree_hash()
         else:
             p2_ph = await self.standard_wallet.get_puzzle_hash(new=True)
             new_innerpuzzle_hash = did_wallet_puzzles.get_inner_puzhash_by_p2(
                 p2_puzhash=p2_ph,
-                recovery_list=self.did_info.backup_ids,
-                num_of_backup_ids_needed=self.did_info.num_of_backup_ids_needed,
+                recovery_list=[bytes32(id.as_atom()) for id in id_list.as_iter()],
+                num_of_backup_ids_needed=uint64(num_of_backup_ids_needed.as_int()),
                 launcher_id=self.did_info.origin_coin.name(),
-                metadata=did_wallet_puzzles.metadata_to_program(json.loads(self.did_info.metadata)),
+                metadata=metadata,
             )
         p2_solution = self.standard_wallet.make_solution(
             primaries=[Payment(puzzle_hash=new_innerpuzzle_hash, amount=uint64(coin.amount), memos=[p2_ph])],

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -774,7 +774,7 @@ class DIDWallet:
         )
         uncurried = did_wallet_puzzles.uncurry_innerpuz(innerpuz)
         assert uncurried is not None
-        p2_puzzle, id_list, num_of_backup_ids_needed, _, metadata = uncurried
+        p2_puzzle, id_list_hash, num_of_backup_ids_needed, _, metadata = uncurried
         # Quote message puzzle & solution
         if action_scope.config.tx_config.reuse_puzhash:
             new_innerpuzzle_hash = innerpuz.get_tree_hash()
@@ -783,7 +783,7 @@ class DIDWallet:
             p2_ph = await self.standard_wallet.get_puzzle_hash(new=True)
             new_innerpuzzle_hash = did_wallet_puzzles.get_inner_puzhash_by_p2(
                 p2_puzhash=p2_ph,
-                recovery_list=[bytes32(id.as_atom()) for id in id_list.as_iter()],
+                recovery_list_hash=bytes32(id_list_hash.as_atom()),
                 num_of_backup_ids_needed=uint64(num_of_backup_ids_needed.as_int()),
                 launcher_id=self.did_info.origin_coin.name(),
                 metadata=metadata,

--- a/chia/wallet/did_wallet/did_wallet_puzzles.py
+++ b/chia/wallet/did_wallet/did_wallet_puzzles.py
@@ -70,10 +70,11 @@ def create_innerpuz(
 
 def get_inner_puzhash_by_p2(
     p2_puzhash: bytes32,
-    recovery_list: list[bytes32],
     num_of_backup_ids_needed: uint64,
     launcher_id: bytes32,
     metadata: Program = Program.to([]),
+    recovery_list: Optional[list[bytes32]] = None,
+    recovery_list_hash: Optional[bytes32] = None,
 ) -> bytes32:
     """
     Calculate DID inner puzzle hash based on a P2 puzzle hash
@@ -85,7 +86,16 @@ def get_inner_puzhash_by_p2(
     :return: DID inner puzzle hash
     """
 
-    backup_ids_hash = shatree_atom_list(recovery_list)
+    if recovery_list is None and recovery_list_hash is None:
+        raise ValueError("Cannot construct DID inner puzzle without information about recovery list")
+    if recovery_list is not None and recovery_list_hash is not None:
+        raise ValueError("Must only specify recovery information a single way to construct DID inner puzzle")
+
+    if recovery_list is not None:
+        backup_ids_hash = shatree_atom_list(recovery_list)
+    else:
+        assert recovery_list_hash is not None
+        backup_ids_hash = recovery_list_hash
 
     # singleton_struct = (MOD_HASH . (LAUNCHER_ID . LAUNCHER_PUZZLE_HASH))
     singleton_struct = shatree_pair(


### PR DESCRIPTION
Related to an issue #19152 where recovery information was accidentally cleared during a routine message spend.  There's no reliable reproduction for this issue so it's tough to say if this will fix it, but my best guess is that the `self.did_info` was not fully in sync before the user was allowed to submit a transaction that uses that information.  This is a big architectural problem with the DID wallet but without a complete overhaul, I'm not sure how we can fix it.  This PR is a small step that should add some extra safety by ensuring that the inner puzzle we think we have does actually match what is in the coin and then using the information directly from that inner puzzle to create the new one.  It should be impossible with these changes to do a message spend where any recovery or otherwise metadata can change during the creation of the spend.