### PR TITLE
[CHIA-1219] Allow coin selection of 0 value coins

### DIFF
--- a/chia/_tests/wallet/test_coin_selection.py
+++ b/chia/_tests/wallet/test_coin_selection.py
@@ -98,6 +98,24 @@ class TestCoinSelection:
             assert len(result) <= 500
 
     @pytest.mark.anyio
+    async def test_coin_selection_zero_coins(self, a_hash: bytes32) -> None:
+        coin_list: list[WalletCoinRecord] = [
+            WalletCoinRecord(Coin(a_hash, a_hash, uint64(0)), uint32(1), uint32(1), False, True, WalletType(0), 1)
+            for _ in range(0, 100)
+        ]
+
+        result: set[Coin] = await select_coins(
+            uint128(0),
+            DEFAULT_COIN_SELECTION_CONFIG,
+            coin_list,
+            {},
+            logging.getLogger("test"),
+            uint128(0),
+        )
+
+        assert len(result) > 0
+
+    @pytest.mark.anyio
     async def test_coin_selection_with_dust(self, a_hash: bytes32) -> None:
         spendable_amount = uint128(5000000000000 + 10000)
         coin_list: list[WalletCoinRecord] = [

--- a/chia/wallet/coin_selection.py
+++ b/chia/wallet/coin_selection.py
@@ -58,7 +58,7 @@ async def select_coins(
             f"Transaction for {amount} is greater than max spendable balance in a block of {sum_spendable_coins}. "
             "There may be other transactions pending or our minimum coin amount is too high."
         )
-    if amount == 0 and sum_spendable_coins == 0:
+    if amount == 0 and len(spendable_coins) == 0:
         raise ValueError(
             "No coins available to spend, you can not create a coin with an amount of 0,"
             " without already having coins."


### PR DESCRIPTION
There was a bad heuristic in the coin selection algorithm to check for a lack of coins.  This fixes that and adds a test to make sure that 0 value coins can be selected.