### PR TITLE
Change delta format

### DIFF
--- a/chia/_tests/core/data_layer/test_data_store.py
+++ b/chia/_tests/core/data_layer/test_data_store.py
@@ -11,7 +11,7 @@ from collections.abc import Awaitable
 from dataclasses import dataclass
 from pathlib import Path
 from random import Random
-from typing import Any, Callable, Optional
+from typing import Any, BinaryIO, Callable, Optional
 
 import aiohttp
 import pytest
@@ -41,7 +41,7 @@ from chia.data_layer.data_layer_util import (
 from chia.data_layer.data_store import DataStore
 from chia.data_layer.download_data import insert_from_delta_file, write_files_for_root
 from chia.data_layer.util.benchmark import generate_datastore
-from chia.data_layer.util.merkle_blob import RawInternalMerkleNode, RawLeafMerkleNode
+from chia.data_layer.util.merkle_blob import MerkleBlob, RawInternalMerkleNode, RawLeafMerkleNode, TreeIndex
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
@@ -1362,11 +1362,9 @@ async def test_data_server_files(
             root = await data_store_server.get_tree_root(store_id)
             await data_store_server.add_node_hashes(store_id)
             if test_delta == "old":
-                filename = get_delta_filename_path(
-                    tmp_path, store_id, root.node_hash, root.generation, group_files_by_store
-                )
-                filename.parent.mkdir(parents=True, exist_ok=True)
                 node_hash = root.node_hash if root.node_hash is not None else bytes32.zeros
+                filename = get_delta_filename_path(tmp_path, store_id, node_hash, root.generation, group_files_by_store)
+                filename.parent.mkdir(parents=True, exist_ok=True)
                 with open(filename, "xb") as writer:
                     await write_tree_to_file_old_format(data_store_server, root, node_hash, store_id, writer)
             else:

--- a/chia/_tests/core/data_layer/test_data_store.py
+++ b/chia/_tests/core/data_layer/test_data_store.py
@@ -27,6 +27,7 @@ from chia.data_layer.data_layer_util import (
     ProofOfInclusion,
     ProofOfInclusionLayer,
     Root,
+    SerializedNode,
     ServerInfo,
     Side,
     Status,
@@ -40,7 +41,7 @@ from chia.data_layer.data_layer_util import (
 from chia.data_layer.data_store import DataStore
 from chia.data_layer.download_data import insert_from_delta_file, write_files_for_root
 from chia.data_layer.util.benchmark import generate_datastore
-from chia.data_layer.util.merkle_blob import RawLeafMerkleNode
+from chia.data_layer.util.merkle_blob import RawInternalMerkleNode, RawLeafMerkleNode
 from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.byte_types import hexstr_to_bytes
@@ -1279,16 +1280,55 @@ async def test_server_http_ban(
     assert sinfo.ignore_till == start_timestamp  # we don't increase on second failure
 
 
-@pytest.mark.parametrize(
-    "test_delta",
-    [True, False],
-)
+async def write_tree_to_file_old_format(
+    data_store: DataStore,
+    root: Root,
+    node_hash: bytes32,
+    store_id: bytes32,
+    writer: BinaryIO,
+    merkle_blob: Optional[MerkleBlob] = None,
+    hash_to_index: Optional[dict[bytes32, TreeIndex]] = None,
+) -> None:
+    if node_hash == bytes32.zeros:
+        return
+
+    if merkle_blob is None:
+        merkle_blob = await data_store.get_merkle_blob(root.node_hash)
+    if hash_to_index is None:
+        hash_to_index = merkle_blob.get_hashes_indexes()
+
+    generation = await data_store.get_first_generation(node_hash, store_id)
+    # Root's generation is not the first time we see this hash, so it's not a new delta.
+    if root.generation != generation:
+        return
+
+    raw_index = hash_to_index[node_hash]
+    raw_node = merkle_blob.get_raw_node(raw_index)
+
+    to_write = b""
+    if isinstance(raw_node, RawInternalMerkleNode):
+        left_hash = merkle_blob.get_hash_at_index(raw_node.left)
+        right_hash = merkle_blob.get_hash_at_index(raw_node.right)
+        await write_tree_to_file_old_format(data_store, root, left_hash, store_id, writer, merkle_blob, hash_to_index)
+        await write_tree_to_file_old_format(data_store, root, right_hash, store_id, writer, merkle_blob, hash_to_index)
+        to_write = bytes(SerializedNode(False, bytes(left_hash), bytes(right_hash)))
+    elif isinstance(raw_node, RawLeafMerkleNode):
+        node = await data_store.get_terminal_node(raw_node.key, raw_node.value, store_id)
+        to_write = bytes(SerializedNode(True, node.key, node.value))
+    else:
+        raise Exception(f"Node is neither InternalNode nor TerminalNode: {raw_node}")
+
+    writer.write(len(to_write).to_bytes(4, byteorder="big"))
+    writer.write(to_write)
+
+
+@pytest.mark.parametrize(argnames="test_delta", argvalues=["full", "delta", "old"])
 @boolean_datacases(name="group_files_by_store", false="group by singleton", true="don't group by singleton")
 @pytest.mark.anyio
 async def test_data_server_files(
     data_store: DataStore,
     store_id: bytes32,
-    test_delta: bool,
+    test_delta: str,
     group_files_by_store: bool,
     tmp_path: Path,
 ) -> None:
@@ -1321,16 +1361,25 @@ async def test_data_server_files(
             await data_store_server.insert_batch(store_id, changelist, status=Status.COMMITTED)
             root = await data_store_server.get_tree_root(store_id)
             await data_store_server.add_node_hashes(store_id)
-            await write_files_for_root(
-                data_store_server, store_id, root, tmp_path, 0, group_by_store=group_files_by_store
-            )
+            if test_delta == "old":
+                filename = get_delta_filename_path(
+                    tmp_path, store_id, root.node_hash, root.generation, group_files_by_store
+                )
+                filename.parent.mkdir(parents=True, exist_ok=True)
+                node_hash = root.node_hash if root.node_hash is not None else bytes32.zeros
+                with open(filename, "xb") as writer:
+                    await write_tree_to_file_old_format(data_store_server, root, node_hash, store_id, writer)
+            else:
+                await write_files_for_root(
+                    data_store_server, store_id, root, tmp_path, 0, group_by_store=group_files_by_store
+                )
             roots.append(root)
 
     generation = 1
     assert len(roots) == num_batches
     for root in roots:
         assert root.node_hash is not None
-        if not test_delta:
+        if test_delta == "full":
             filename = get_full_tree_filename_path(tmp_path, store_id, root.node_hash, generation, group_files_by_store)
             assert filename.exists()
         else:

--- a/chia/_tests/core/data_layer/test_data_store.py
+++ b/chia/_tests/core/data_layer/test_data_store.py
@@ -1346,6 +1346,7 @@ async def test_data_server_files(
         counter = 0
         num_repeats = 2
 
+        # Repeat twice to guarantee there will be hashes from the old file format
         for _ in range(num_repeats):
             for batch in range(num_batches):
                 changelist: list[dict[str, Any]] = []

--- a/chia/data_layer/data_layer_util.py
+++ b/chia/data_layer/data_layer_util.py
@@ -49,6 +49,7 @@ def key_hash(key: bytes) -> bytes32:
     return bytes32(sha256(b"\1" + key).digest())
 
 
+# TODO: allow Optional[bytes32] for `node_hash` and resolve the filenames here
 def get_full_tree_filename(store_id: bytes32, node_hash: bytes32, generation: int, group_by_store: bool = False) -> str:
     if group_by_store:
         return f"{store_id}/{node_hash}-full-{generation}-v1.0.dat"

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -1458,7 +1458,7 @@ class DataStore:
             hash_to_index = merkle_blob.get_hashes_indexes()
         if existing_hashes is None:
             if root.generation == 0:
-                existing_hashes = {}
+                existing_hashes = set()
             else:
                 previous_root = await self.get_tree_root(store_id=store_id, generation=root.generation - 1)
                 previous_merkle_blob = await self.get_merkle_blob(previous_root.node_hash)

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -239,7 +239,7 @@ class DataStore:
 
         root = await self.get_tree_root(store_id=store_id)
         latest_blob = await self.get_merkle_blob(root.node_hash, read_only=True)
-        known_hashes = {}
+        known_hashes: dict[bytes32, TreeIndex] = {}
         if not latest_blob.empty():
             nodes = latest_blob.get_nodes_with_indexes()
             known_hashes = {node.hash: index for index, node in nodes}
@@ -247,7 +247,7 @@ class DataStore:
         new_missing_hashes: list[bytes32] = []
         for hash in missing_hashes:
             if hash in known_hashes:
-                assert root.node_hash is not None
+                assert root.node_hash is not None, "if root.node_hash were None then known_hashes would be empty"
                 merkle_blob_queries[root.node_hash].append(known_hashes[hash])
             else:
                 new_missing_hashes.append(hash)

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -256,7 +256,8 @@ class DataStore:
         if missing_hashes:
             async with self.db_wrapper.reader() as reader:
                 cursor = await reader.execute(
-                    "SELECT MAX(generation) FROM nodes WHERE store_id = ?", (store_id,),
+                    "SELECT MAX(generation) FROM nodes WHERE store_id = ?",
+                    (store_id,),
                 )
                 row = await cursor.fetchone()
                 if row is None or row[0] is None:

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -153,9 +153,7 @@ class DataStore:
                         kid INTEGER,
                         vid INTEGER,
                         store_id BLOB NOT NULL CHECK(length(store_id) == 32),
-                        PRIMARY KEY(store_id, hash),
-                        FOREIGN KEY (kid) REFERENCES ids(kv_id),
-                        FOREIGN KEY (vid) REFERENCES ids(kv_id)
+                        PRIMARY KEY(store_id, hash)
                     )
                     """
                 )

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -237,6 +237,7 @@ class DataStore:
                 if node_hash not in internal_nodes and node_hash not in terminal_nodes:
                     missing_hashes.append(node_hash)
 
+        # TODO: consider adding transactions aroud this code
         root = await self.get_tree_root(store_id=store_id)
         latest_blob = await self.get_merkle_blob(root.node_hash, read_only=True)
         known_hashes: dict[bytes32, TreeIndex] = {}

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -237,7 +237,7 @@ class DataStore:
                 if node_hash not in internal_nodes and node_hash not in terminal_nodes:
                     missing_hashes.append(node_hash)
 
-        # TODO: consider adding transactions aroud this code
+        # TODO: consider adding transactions around this code
         root = await self.get_tree_root(store_id=store_id)
         latest_blob = await self.get_merkle_blob(root.node_hash, read_only=True)
         known_hashes: dict[bytes32, TreeIndex] = {}


### PR DESCRIPTION
Change the delta file format to diff only against the previous generation, as opposed to all existing generations. This maintains backwards compatibility for now, but adds to the DB only the minimum amount of hashes so we can sync. Once all clients update to this new delta format, it will no longer be needed to store all the hashes into the DB.