### PR TITLE
Import `pot_iterations` and `pos_quality` from chia_rs

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -10,7 +10,7 @@ from dataclasses import replace
 from typing import Optional
 
 import pytest
-from chia_rs import AugSchemeMPL, ConsensusConstants, G2Element, MerkleSet, TransactionsInfo
+from chia_rs import AugSchemeMPL, ConsensusConstants, G2Element, MerkleSet, TransactionsInfo, is_overflow_block
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
 from clvm.casts import int_to_bytes
@@ -35,7 +35,6 @@ from chia.consensus.find_fork_point import lookup_fork_chain
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.get_block_generator import get_block_generator
 from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_block
-from chia.consensus.pot_iterations import is_overflow_block
 from chia.simulator.block_tools import BlockTools, create_block_tools_async
 from chia.simulator.keyring import TempKeyring
 from chia.simulator.wallet_tools import WalletTool
@@ -851,7 +850,11 @@ class TestBlockHeaderValidation:
             block = blocks[-1]
             if (
                 len(block.finished_sub_slots)
-                and is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index)
+                and is_overflow_block(
+                    bt.constants.NUM_SPS_SUB_SLOT,
+                    bt.constants.NUM_SP_INTERVALS_EXTRA,
+                    block.reward_chain_block.signage_point_index,
+                )
                 and block.finished_sub_slots[-1].challenge_chain.challenge_chain_end_of_slot_vdf.output
                 != ClassgroupElement.get_default_element()
             ):
@@ -1098,7 +1101,9 @@ class TestBlockHeaderValidation:
         while True:
             blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
             if len(blocks[-1].finished_sub_slots) > 0 and is_overflow_block(
-                bt.constants, blocks[-1].reward_chain_block.signage_point_index
+                bt.constants.NUM_SPS_SUB_SLOT,
+                bt.constants.NUM_SP_INTERVALS_EXTRA,
+                blocks[-1].reward_chain_block.signage_point_index,
             ):
                 new_finished_ss: EndOfSubSlotBundle = recursive_replace(
                     blocks[-1].finished_sub_slots[0],
@@ -1203,7 +1208,11 @@ class TestBlockHeaderValidation:
                 block_bad = recursive_replace(blocks[-1], "reward_chain_block.signage_point_index", uint8(1))
                 await _validate_and_add_block(empty_blockchain, block_bad, expected_error=Err.INVALID_SP_INDEX)
 
-            elif not is_overflow_block(bt.constants, blocks[-1].reward_chain_block.signage_point_index):
+            elif not is_overflow_block(
+                bt.constants.NUM_SPS_SUB_SLOT,
+                bt.constants.NUM_SP_INTERVALS_EXTRA,
+                blocks[-1].reward_chain_block.signage_point_index,
+            ):
                 case_2 = True
                 block_bad = recursive_replace(blocks[-1], "reward_chain_block.signage_point_index", uint8(0))
                 await _validate_and_add_block_multi_error(

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -853,7 +853,7 @@ class TestBlockHeaderValidation:
                 and is_overflow_block(
                     bt.constants.NUM_SPS_SUB_SLOT,
                     bt.constants.NUM_SP_INTERVALS_EXTRA,
-                    block.reward_chain_block.signage_point_index,
+                    uint32(block.reward_chain_block.signage_point_index),
                 )
                 and block.finished_sub_slots[-1].challenge_chain.challenge_chain_end_of_slot_vdf.output
                 != ClassgroupElement.get_default_element()
@@ -1103,7 +1103,7 @@ class TestBlockHeaderValidation:
             if len(blocks[-1].finished_sub_slots) > 0 and is_overflow_block(
                 bt.constants.NUM_SPS_SUB_SLOT,
                 bt.constants.NUM_SP_INTERVALS_EXTRA,
-                blocks[-1].reward_chain_block.signage_point_index,
+                uint32(blocks[-1].reward_chain_block.signage_point_index),
             ):
                 new_finished_ss: EndOfSubSlotBundle = recursive_replace(
                     blocks[-1].finished_sub_slots[0],
@@ -1211,7 +1211,7 @@ class TestBlockHeaderValidation:
             elif not is_overflow_block(
                 bt.constants.NUM_SPS_SUB_SLOT,
                 bt.constants.NUM_SP_INTERVALS_EXTRA,
-                blocks[-1].reward_chain_block.signage_point_index,
+                uint32(blocks[-1].reward_chain_block.signage_point_index),
             ):
                 case_2 = True
                 block_bad = recursive_replace(blocks[-1], "reward_chain_block.signage_point_index", uint8(0))

--- a/chia/_tests/core/consensus/test_pot_iterations.py
+++ b/chia/_tests/core/consensus/test_pot_iterations.py
@@ -107,6 +107,13 @@ class TestPotIterations:
         assert ip_iters == (sp_iters + test_constants.NUM_SP_INTERVALS_EXTRA * sp_interval_iters + required_iters) % ssi
         assert sp_iters > ip_iters
 
+    def test_expected_plot_size(self):
+        assert _expected_plot_size(32) == uint64(139586437120)
+        assert _expected_plot_size(33) == uint64(287762808832)
+        assert _expected_plot_size(34) == uint64(592705486848)
+        assert _expected_plot_size(35) == uint64(1219770712064)
+        assert _expected_plot_size(36) == uint64(2508260900864)
+
     def test_win_percentage(self):
         """
         Tests that the percentage of blocks won is proportional to the space of each farmer,

--- a/chia/_tests/core/consensus/test_pot_iterations.py
+++ b/chia/_tests/core/consensus/test_pot_iterations.py
@@ -40,7 +40,9 @@ class TestPotIterations:
 
         with raises(ValueError):
             # Invalid signage point index
-            calculate_ip_iters(test_constants.NUM_SPS_SUB_SLOT, test_constants.NUM_SP_INTERVALS_EXTRA, ssi, uint8(123), uint64(100000))
+            calculate_ip_iters(
+                test_constants.NUM_SPS_SUB_SLOT, test_constants.NUM_SP_INTERVALS_EXTRA, ssi, uint8(123), uint64(100000)
+            )
 
         sp_iters = sp_interval_iters * 13
 

--- a/chia/_tests/core/consensus/test_pot_iterations.py
+++ b/chia/_tests/core/consensus/test_pot_iterations.py
@@ -6,10 +6,10 @@ from chia_rs import (
     calculate_sp_iters,
     is_overflow_block,
 )
+from chia_rs import expected_plot_size as _expected_plot_size
 from pytest import raises
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
-from chia.consensus.pos_quality import _expected_plot_size
 from chia.consensus.pot_iterations import (
     calculate_iterations_quality,
 )

--- a/chia/_tests/core/consensus/test_pot_iterations.py
+++ b/chia/_tests/core/consensus/test_pot_iterations.py
@@ -40,7 +40,7 @@ class TestPotIterations:
 
         with raises(ValueError):
             # Invalid signage point index
-            calculate_ip_iters(test_constants, ssi, uint8(123), uint64(100000))
+            calculate_ip_iters(test_constants.NUM_SPS_SUB_SLOT, test_constants.NUM_SP_INTERVALS_EXTRA, ssi, uint8(123), uint64(100000))
 
         sp_iters = sp_interval_iters * 13
 

--- a/chia/_tests/core/consensus/test_pot_iterations.py
+++ b/chia/_tests/core/consensus/test_pot_iterations.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
+from chia_rs import (
+    calculate_ip_iters,
+    calculate_sp_iters,
+    is_overflow_block,
+)
 from pytest import raises
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.pos_quality import _expected_plot_size
 from chia.consensus.pot_iterations import (
-    calculate_ip_iters,
     calculate_iterations_quality,
-    calculate_sp_iters,
-    is_overflow_block,
 )
 from chia.util.hash import std_hash
 
@@ -18,19 +20,19 @@ test_constants = DEFAULT_CONSTANTS.replace(NUM_SPS_SUB_SLOT=uint32(32), SUB_SLOT
 
 class TestPotIterations:
     def test_is_overflow_block(self):
-        assert not is_overflow_block(test_constants, uint8(27))
-        assert not is_overflow_block(test_constants, uint8(28))
-        assert is_overflow_block(test_constants, uint8(29))
-        assert is_overflow_block(test_constants, uint8(30))
-        assert is_overflow_block(test_constants, uint8(31))
+        assert not is_overflow_block(test_constants.NUM_SPS_SUB_SLOT, test_constants.NUM_SP_INTERVALS_EXTRA, uint8(27))
+        assert not is_overflow_block(test_constants.NUM_SPS_SUB_SLOT, test_constants.NUM_SP_INTERVALS_EXTRA, uint8(28))
+        assert is_overflow_block(test_constants.NUM_SPS_SUB_SLOT, test_constants.NUM_SP_INTERVALS_EXTRA, uint8(29))
+        assert is_overflow_block(test_constants.NUM_SPS_SUB_SLOT, test_constants.NUM_SP_INTERVALS_EXTRA, uint8(30))
+        assert is_overflow_block(test_constants.NUM_SPS_SUB_SLOT, test_constants.NUM_SP_INTERVALS_EXTRA, uint8(31))
         with raises(ValueError):
-            assert is_overflow_block(test_constants, uint8(32))
+            assert is_overflow_block(test_constants.NUM_SPS_SUB_SLOT, test_constants.NUM_SP_INTERVALS_EXTRA, uint8(32))
 
     def test_calculate_sp_iters(self):
         ssi: uint64 = uint64(100001 * 64 * 4)
         with raises(ValueError):
-            calculate_sp_iters(test_constants, ssi, uint8(32))
-        calculate_sp_iters(test_constants, ssi, uint8(31))
+            calculate_sp_iters(test_constants.NUM_SPS_SUB_SLOT, ssi, uint8(32))
+        calculate_sp_iters(test_constants.NUM_SPS_SUB_SLOT, ssi, uint8(31))
 
     def test_calculate_ip_iters(self):
         ssi: uint64 = uint64(100001 * 64 * 4)
@@ -44,33 +46,58 @@ class TestPotIterations:
 
         with raises(ValueError):
             # required_iters too high
-            calculate_ip_iters(test_constants, ssi, sp_interval_iters, sp_interval_iters)
+            calculate_ip_iters(
+                test_constants.NUM_SPS_SUB_SLOT,
+                test_constants.NUM_SP_INTERVALS_EXTRA,
+                ssi,
+                sp_interval_iters,
+                sp_interval_iters,
+            )
 
         with raises(ValueError):
             # required_iters too high
-            calculate_ip_iters(test_constants, ssi, sp_interval_iters, sp_interval_iters * 12)
+            calculate_ip_iters(
+                test_constants.NUM_SPS_SUB_SLOT,
+                test_constants.NUM_SP_INTERVALS_EXTRA,
+                ssi,
+                sp_interval_iters,
+                sp_interval_iters * 12,
+            )
 
         with raises(ValueError):
             # required_iters too low (0)
-            calculate_ip_iters(test_constants, ssi, sp_interval_iters, uint64(0))
+            calculate_ip_iters(
+                test_constants.NUM_SPS_SUB_SLOT,
+                test_constants.NUM_SP_INTERVALS_EXTRA,
+                ssi,
+                sp_interval_iters,
+                uint64(0),
+            )
 
         required_iters = sp_interval_iters - 1
-        ip_iters = calculate_ip_iters(test_constants, ssi, uint8(13), required_iters)
+        ip_iters = calculate_ip_iters(
+            test_constants.NUM_SPS_SUB_SLOT, test_constants.NUM_SP_INTERVALS_EXTRA, ssi, uint8(13), required_iters
+        )
         assert ip_iters == sp_iters + test_constants.NUM_SP_INTERVALS_EXTRA * sp_interval_iters + required_iters
 
         required_iters = uint64(1)
-        ip_iters = calculate_ip_iters(test_constants, ssi, uint8(13), required_iters)
+        ip_iters = calculate_ip_iters(
+            test_constants.NUM_SPS_SUB_SLOT, test_constants.NUM_SP_INTERVALS_EXTRA, ssi, uint8(13), required_iters
+        )
         assert ip_iters == sp_iters + test_constants.NUM_SP_INTERVALS_EXTRA * sp_interval_iters + required_iters
 
         required_iters = uint64(int(ssi * 4 / 300))
-        ip_iters = calculate_ip_iters(test_constants, ssi, uint8(13), required_iters)
+        ip_iters = calculate_ip_iters(
+            test_constants.NUM_SPS_SUB_SLOT, test_constants.NUM_SP_INTERVALS_EXTRA, ssi, uint8(13), required_iters
+        )
         assert ip_iters == sp_iters + test_constants.NUM_SP_INTERVALS_EXTRA * sp_interval_iters + required_iters
         assert sp_iters < ip_iters
 
         # Overflow
         sp_iters = sp_interval_iters * (test_constants.NUM_SPS_SUB_SLOT - 1)
         ip_iters = calculate_ip_iters(
-            test_constants,
+            test_constants.NUM_SPS_SUB_SLOT,
+            test_constants.NUM_SP_INTERVALS_EXTRA,
             ssi,
             uint8(test_constants.NUM_SPS_SUB_SLOT - 1),
             required_iters,

--- a/chia/_tests/core/consensus/test_pot_iterations.py
+++ b/chia/_tests/core/consensus/test_pot_iterations.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
 from chia_rs import (
     calculate_ip_iters,
     calculate_sp_iters,
     is_overflow_block,
 )
 from chia_rs import expected_plot_size as _expected_plot_size
+from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
 from pytest import raises
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS

--- a/chia/_tests/core/full_node/stores/test_full_node_store.py
+++ b/chia/_tests/core/full_node/stores/test_full_node_store.py
@@ -1014,8 +1014,8 @@ async def test_basic_store(
         i1 = blocks[-1].reward_chain_block.signage_point_index
         if (
             len(blocks[-2].finished_sub_slots) == len(blocks[-1].finished_sub_slots) == 0
-            and not is_overflow_block(custom_block_tools.constants, signage_point_index=i2)
-            and not is_overflow_block(custom_block_tools.constants, signage_point_index=i1)
+            and not is_overflow_block(custom_block_tools.constants.NUM_SPS_SUB_SLOT, custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA, signage_point_index=i2)
+            and not is_overflow_block(custom_block_tools.constants.NUM_SPS_SUB_SLOT, custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA, signage_point_index=i1)
             and i2 > i3 + 3
             and i1 > (i2 + 3)
         ):
@@ -1069,7 +1069,7 @@ async def test_basic_store(
                 assert_sp_none(i1 + 4, True)
 
             for i in range(i2, custom_block_tools.constants.NUM_SPS_SUB_SLOT):
-                if is_overflow_block(custom_block_tools.constants, uint8(i)):
+                if is_overflow_block(custom_block_tools.constants.NUM_SPS_SUB_SLOT, custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA, uint8(i)):
                     blocks_alt = custom_block_tools.get_consecutive_blocks(
                         1, block_list_input=blocks[:-1], skip_slots=1
                     )

--- a/chia/_tests/core/full_node/stores/test_full_node_store.py
+++ b/chia/_tests/core/full_node/stores/test_full_node_store.py
@@ -1014,8 +1014,16 @@ async def test_basic_store(
         i1 = blocks[-1].reward_chain_block.signage_point_index
         if (
             len(blocks[-2].finished_sub_slots) == len(blocks[-1].finished_sub_slots) == 0
-            and not is_overflow_block(custom_block_tools.constants.NUM_SPS_SUB_SLOT, custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA, signage_point_index=i2)
-            and not is_overflow_block(custom_block_tools.constants.NUM_SPS_SUB_SLOT, custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA, signage_point_index=i1)
+            and not is_overflow_block(
+                custom_block_tools.constants.NUM_SPS_SUB_SLOT,
+                custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA,
+                signage_point_index=i2,
+            )
+            and not is_overflow_block(
+                custom_block_tools.constants.NUM_SPS_SUB_SLOT,
+                custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA,
+                signage_point_index=i1,
+            )
             and i2 > i3 + 3
             and i1 > (i2 + 3)
         ):
@@ -1069,7 +1077,11 @@ async def test_basic_store(
                 assert_sp_none(i1 + 4, True)
 
             for i in range(i2, custom_block_tools.constants.NUM_SPS_SUB_SLOT):
-                if is_overflow_block(custom_block_tools.constants.NUM_SPS_SUB_SLOT, custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA, uint8(i)):
+                if is_overflow_block(
+                    custom_block_tools.constants.NUM_SPS_SUB_SLOT,
+                    custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA,
+                    uint8(i),
+                ):
                     blocks_alt = custom_block_tools.get_consecutive_blocks(
                         1, block_list_input=blocks[:-1], skip_slots=1
                     )

--- a/chia/_tests/core/full_node/stores/test_full_node_store.py
+++ b/chia/_tests/core/full_node/stores/test_full_node_store.py
@@ -817,7 +817,9 @@ async def test_basic_store(
         custom_block_tools.constants.NUM_SPS_SUB_SLOT,
     ):
         if is_overflow_block(
-            custom_block_tools.constants.NUM_SPS_SUB_SLOT, custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA, uint8(i)
+            custom_block_tools.constants.NUM_SPS_SUB_SLOT,
+            custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA,
+            uint32(i),
         ):
             finished_sub_slots = blocks_5[-1].finished_sub_slots
         else:
@@ -1017,12 +1019,12 @@ async def test_basic_store(
             and not is_overflow_block(
                 custom_block_tools.constants.NUM_SPS_SUB_SLOT,
                 custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA,
-                signage_point_index=i2,
+                signage_point_index=uint32(i2),
             )
             and not is_overflow_block(
                 custom_block_tools.constants.NUM_SPS_SUB_SLOT,
                 custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA,
-                signage_point_index=i1,
+                signage_point_index=uint32(i1),
             )
             and i2 > i3 + 3
             and i1 > (i2 + 3)
@@ -1080,7 +1082,7 @@ async def test_basic_store(
                 if is_overflow_block(
                     custom_block_tools.constants.NUM_SPS_SUB_SLOT,
                     custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA,
-                    uint8(i),
+                    uint32(i),
                 ):
                     blocks_alt = custom_block_tools.get_consecutive_blocks(
                         1, block_list_input=blocks[:-1], skip_slots=1

--- a/chia/_tests/core/full_node/stores/test_full_node_store.py
+++ b/chia/_tests/core/full_node/stores/test_full_node_store.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 import pytest
 from chia_rs import ConsensusConstants
+from chia_rs import is_overflow_block
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
 
@@ -19,7 +20,6 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
 from chia.consensus.find_fork_point import find_fork_point_in_chain
 from chia.consensus.multiprocess_validation import PreValidationResult
-from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.full_node_store import FullNodeStore, UnfinishedBlockEntry, find_best_block
 from chia.full_node.signage_point import SignagePoint
 from chia.protocols import timelord_protocol
@@ -817,7 +817,9 @@ async def test_basic_store(
         sb.signage_point_index + custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA,
         custom_block_tools.constants.NUM_SPS_SUB_SLOT,
     ):
-        if is_overflow_block(custom_block_tools.constants, uint8(i)):
+        if is_overflow_block(
+            custom_block_tools.constants.NUM_SPS_SUB_SLOT, custom_block_tools.constants.NUM_SP_INTERVALS_EXTRA, uint8(i)
+        ):
             finished_sub_slots = blocks_5[-1].finished_sub_slots
         else:
             finished_sub_slots = []

--- a/chia/_tests/core/full_node/stores/test_full_node_store.py
+++ b/chia/_tests/core/full_node/stores/test_full_node_store.py
@@ -6,8 +6,7 @@ from collections.abc import AsyncIterator
 from typing import Optional
 
 import pytest
-from chia_rs import ConsensusConstants
-from chia_rs import is_overflow_block
+from chia_rs import ConsensusConstants, is_overflow_block
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
 

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1527,7 +1527,9 @@ async def test_unfinished_block_with_replaced_generator(
     blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
     block: FullBlock = blocks[0]
     overflow = is_overflow_block(
-        bt.constants.NUM_SPS_SUB_SLOT, bt.constants.NUM_SP_INTERVALS_EXTRA, block.reward_chain_block.signage_point_index
+        bt.constants.NUM_SPS_SUB_SLOT,
+        bt.constants.NUM_SP_INTERVALS_EXTRA,
+        uint32(block.reward_chain_block.signage_point_index),
     )
 
     replaced_generator = SerializedProgram.from_bytes(b"\x80")

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -21,6 +21,7 @@ from chia_rs import (
     TransactionsInfo,
     additions_and_removals,
     get_flags_for_height_and_constants,
+    is_overflow_block,
 )
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
@@ -39,7 +40,6 @@ from chia._tests.util.time_out_assert import time_out_assert, time_out_assert_cu
 from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.blockchain import Blockchain
 from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_block
-from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.full_node import WalletUpdate
 from chia.full_node.full_node_api import FullNodeAPI
@@ -1526,7 +1526,9 @@ async def test_unfinished_block_with_replaced_generator(
 
     blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
     block: FullBlock = blocks[0]
-    overflow = is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index)
+    overflow = is_overflow_block(
+        bt.constants.NUM_SPS_SUB_SLOT, bt.constants.NUM_SP_INTERVALS_EXTRA, block.reward_chain_block.signage_point_index
+    )
 
     replaced_generator = SerializedProgram.from_bytes(b"\x80")
 

--- a/chia/_tests/core/full_node/test_performance.py
+++ b/chia/_tests/core/full_node/test_performance.py
@@ -5,6 +5,7 @@ import random
 
 import pytest
 from chia_rs.sized_ints import uint64
+from chia_rs import is_overflow_block
 from clvm.casts import int_to_bytes
 
 from chia._tests.connection_utils import add_dummy_connection
@@ -13,7 +14,6 @@ from chia._tests.core.node_height import node_height_at_least
 from chia._tests.util.misc import BenchmarkRunner
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.block_record import BlockRecord
-from chia.consensus.pot_iterations import is_overflow_block
 from chia.protocols import full_node_protocol as fnp
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
@@ -137,7 +137,11 @@ class TestPerformance:
             guarantee_transaction_block=True,
         )
         block = blocks[-1]
-        if is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index):
+        if is_overflow_block(
+            bt.constants.NUM_SPS_SUB_SLOT,
+            bt.constants.NUM_SP_INTERVALS_EXTRA,
+            block.reward_chain_block.signage_point_index,
+        ):
             sub_slots = block.finished_sub_slots[:-1]
         else:
             sub_slots = block.finished_sub_slots

--- a/chia/_tests/core/full_node/test_performance.py
+++ b/chia/_tests/core/full_node/test_performance.py
@@ -4,8 +4,8 @@ import logging
 import random
 
 import pytest
-from chia_rs.sized_ints import uint64
 from chia_rs import is_overflow_block
+from chia_rs.sized_ints import uint64
 from clvm.casts import int_to_bytes
 
 from chia._tests.connection_utils import add_dummy_connection

--- a/chia/_tests/core/test_full_node_rpc.py
+++ b/chia/_tests/core/test_full_node_rpc.py
@@ -62,7 +62,7 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
         for block in blocks:
             if is_overflow_block(
                 bt.constants.NUM_SPS_SUB_SLOT,
-                bt.constants.NUM_SP_INTERVAL_EXTRA,
+                bt.constants.NUM_SP_INTERVALS_EXTRA,
                 block.reward_chain_block.signage_point_index,
             ):
                 finished_ss = block.finished_sub_slots[:-1]

--- a/chia/_tests/core/test_full_node_rpc.py
+++ b/chia/_tests/core/test_full_node_rpc.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from chia_rs import AugSchemeMPL
+from chia_rs import AugSchemeMPL, is_overflow_block
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8
 from clvm.casts import int_to_bytes
@@ -12,7 +12,6 @@ from chia._tests.connection_utils import connect_and_get_peer
 from chia._tests.util.rpc import validate_get_routes
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.block_record import BlockRecord
-from chia.consensus.pot_iterations import is_overflow_block
 from chia.full_node.signage_point import SignagePoint
 from chia.protocols import full_node_protocol
 from chia.rpc.full_node_rpc_api import get_average_block_time, get_nearest_transaction_block
@@ -61,7 +60,11 @@ async def test1(two_nodes_sim_and_wallets_services, self_hostname, consensus_mod
         assert len(await client.get_unfinished_block_headers()) == 0
         assert len(await client.get_block_records(0, 100)) == 0
         for block in blocks:
-            if is_overflow_block(bt.constants, block.reward_chain_block.signage_point_index):
+            if is_overflow_block(
+                bt.constants.NUM_SPS_SUB_SLOT,
+                bt.constants.NUM_SP_INTERVAL_EXTRA,
+                block.reward_chain_block.signage_point_index,
+            ):
                 finished_ss = block.finished_sub_slots[:-1]
             else:
                 finished_ss = block.finished_sub_slots

--- a/chia/_tests/plot_sync/test_receiver.py
+++ b/chia/_tests/plot_sync/test_receiver.py
@@ -8,9 +8,9 @@ from typing import Any, Callable, Union
 
 import pytest
 from chia_rs import G1Element
+from chia_rs import expected_plot_size as _expected_plot_size
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
-from chia_rs import expected_plot_size as _expected_plot_size
 
 from chia._tests.plot_sync.util import get_dummy_connection
 from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR

--- a/chia/_tests/plot_sync/test_receiver.py
+++ b/chia/_tests/plot_sync/test_receiver.py
@@ -10,9 +10,10 @@ import pytest
 from chia_rs import G1Element
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
+from chia_rs import expected_plot_size as _expected_plot_size
 
 from chia._tests.plot_sync.util import get_dummy_connection
-from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR, _expected_plot_size
+from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR
 from chia.plot_sync.delta import Delta
 from chia.plot_sync.receiver import Receiver, Sync, get_list_or_len
 from chia.plot_sync.util import ErrorCodes, State

--- a/chia/_tests/wallet/conftest.py
+++ b/chia/_tests/wallet/conftest.py
@@ -125,13 +125,13 @@ async def ignore_block_validation(
     )
     monkeypatch.setattr("chia.consensus.block_record.BlockRecord.sp_total_iters", lambda *_: uint128(0))
     monkeypatch.setattr("chia.consensus.block_record.BlockRecord.ip_sub_slot_total_iters", lambda *_: uint128(0))
-    monkeypatch.setattr("chia_rs.calculate_sp_iters", lambda *_: uint64(0))
-    monkeypatch.setattr("chia_rs.calculate_ip_iters", lambda *_: uint64(0))
+    # monkeypatch.setattr("chia_rs.calculate_sp_iters", lambda *_: uint64(0))
+    # monkeypatch.setattr("chia_rs.calculate_ip_iters", lambda *_: uint64(0))
     monkeypatch.setattr("chia.consensus.difficulty_adjustment._get_next_sub_slot_iters", lambda *_: uint64(1))
     monkeypatch.setattr("chia.consensus.difficulty_adjustment._get_next_difficulty", lambda *_: uint64(1))
     monkeypatch.setattr("chia.full_node.full_node_store.calculate_sp_interval_iters", lambda *_: uint64(1))
-    monkeypatch.setattr("chia_rs.calculate_sp_interval_iters", lambda *_: uint64(1))
-    monkeypatch.setattr("chia_rs.calculate_ip_iters", lambda *_: uint64(1))
+    # monkeypatch.setattr("chia_rs.calculate_sp_interval_iters", lambda *_: uint64(1))
+    # monkeypatch.setattr("chia_rs.calculate_ip_iters", lambda *_: uint64(1))
     monkeypatch.setattr("chia.consensus.block_record.BlockRecord.sp_sub_slot_total_iters", lambda *_: uint64(1))
 
 

--- a/chia/_tests/wallet/conftest.py
+++ b/chia/_tests/wallet/conftest.py
@@ -125,13 +125,13 @@ async def ignore_block_validation(
     )
     monkeypatch.setattr("chia.consensus.block_record.BlockRecord.sp_total_iters", lambda *_: uint128(0))
     monkeypatch.setattr("chia.consensus.block_record.BlockRecord.ip_sub_slot_total_iters", lambda *_: uint128(0))
-    monkeypatch.setattr("chia.consensus.make_sub_epoch_summary.calculate_sp_iters", lambda *_: uint64(0))
-    monkeypatch.setattr("chia.consensus.make_sub_epoch_summary.calculate_ip_iters", lambda *_: uint64(0))
+    monkeypatch.setattr("chia_rs.calculate_sp_iters", lambda *_: uint64(0))
+    monkeypatch.setattr("chia_rs.calculate_ip_iters", lambda *_: uint64(0))
     monkeypatch.setattr("chia.consensus.difficulty_adjustment._get_next_sub_slot_iters", lambda *_: uint64(1))
     monkeypatch.setattr("chia.consensus.difficulty_adjustment._get_next_difficulty", lambda *_: uint64(1))
     monkeypatch.setattr("chia.full_node.full_node_store.calculate_sp_interval_iters", lambda *_: uint64(1))
-    monkeypatch.setattr("chia.consensus.pot_iterations.calculate_sp_interval_iters", lambda *_: uint64(1))
-    monkeypatch.setattr("chia.consensus.pot_iterations.calculate_ip_iters", lambda *_: uint64(1))
+    monkeypatch.setattr("chia_rs.calculate_sp_interval_iters", lambda *_: uint64(1))
+    monkeypatch.setattr("chia_rs.calculate_ip_iters", lambda *_: uint64(1))
     monkeypatch.setattr("chia.consensus.block_record.BlockRecord.sp_sub_slot_total_iters", lambda *_: uint64(1))
 
 

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -69,7 +69,7 @@ def validate_unfinished_header_block(
     overflow = is_overflow_block(
         constants.NUM_SPS_SUB_SLOT,
         constants.NUM_SP_INTERVALS_EXTRA,
-        header_block.reward_chain_block.signage_point_index,
+        uint32(header_block.reward_chain_block.signage_point_index),
     )
     if skip_overflow_last_ss_validation and overflow:
         if final_eos_is_already_included(header_block, blocks, expected_vs.ssi):
@@ -530,14 +530,14 @@ def validate_unfinished_header_block(
     sp_iters: uint64 = calculate_sp_iters(
         constants.NUM_SPS_SUB_SLOT,
         expected_vs.ssi,
-        header_block.reward_chain_block.signage_point_index,
+        uint32(header_block.reward_chain_block.signage_point_index),
     )
 
     ip_iters: uint64 = calculate_ip_iters(
         constants.NUM_SPS_SUB_SLOT,
         constants.NUM_SP_INTERVALS_EXTRA,
         expected_vs.ssi,
-        header_block.reward_chain_block.signage_point_index,
+        uint32(header_block.reward_chain_block.signage_point_index),
         required_iters,
     )
     if header_block.reward_chain_block.challenge_chain_sp_vdf is None:
@@ -882,7 +882,7 @@ def validate_finished_header_block(
         constants.NUM_SPS_SUB_SLOT,
         constants.NUM_SP_INTERVALS_EXTRA,
         expected_vs.ssi,
-        header_block.reward_chain_block.signage_point_index,
+        uint32(header_block.reward_chain_block.signage_point_index),
         required_iters,
     )
     if not genesis_block:
@@ -992,7 +992,7 @@ def validate_finished_header_block(
         overflow = is_overflow_block(
             constants.NUM_SPS_SUB_SLOT,
             constants.NUM_SP_INTERVALS_EXTRA,
-            header_block.reward_chain_block.signage_point_index,
+            uint32(header_block.reward_chain_block.signage_point_index),
         )
         deficit = calculate_deficit(
             constants,

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -4,7 +4,14 @@ import logging
 import time
 from typing import Optional
 
-from chia_rs import AugSchemeMPL, ConsensusConstants
+from chia_rs import (
+    AugSchemeMPL,
+    ConsensusConstants,
+    calculate_ip_iters,
+    calculate_sp_interval_iters,
+    calculate_sp_iters,
+    is_overflow_block,
+)
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64, uint128
 
@@ -14,13 +21,7 @@ from chia.consensus.deficit import calculate_deficit
 from chia.consensus.difficulty_adjustment import can_finish_sub_and_full_epoch
 from chia.consensus.get_block_challenge import final_eos_is_already_included, get_block_challenge
 from chia.consensus.make_sub_epoch_summary import make_sub_epoch_summary
-from chia.consensus.pot_iterations import (
-    calculate_ip_iters,
-    calculate_iterations_quality,
-    calculate_sp_interval_iters,
-    calculate_sp_iters,
-    is_overflow_block,
-)
+from chia.consensus.pot_iterations import calculate_iterations_quality
 from chia.consensus.vdf_info_computation import get_signage_point_vdf_info
 from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
@@ -65,7 +66,11 @@ def validate_unfinished_header_block(
     if genesis_block and header_block.prev_header_hash != constants.GENESIS_CHALLENGE:
         return None, ValidationError(Err.INVALID_PREV_BLOCK_HASH)
 
-    overflow = is_overflow_block(constants, header_block.reward_chain_block.signage_point_index)
+    overflow = is_overflow_block(
+        constants.NUM_SPS_SUB_SLOT,
+        constants.NUM_SP_INTERVALS_EXTRA,
+        header_block.reward_chain_block.signage_point_index,
+    )
     if skip_overflow_last_ss_validation and overflow:
         if final_eos_is_already_included(header_block, blocks, expected_vs.ssi):
             skip_overflow_last_ss_validation = False
@@ -507,7 +512,7 @@ def validate_unfinished_header_block(
     )
 
     # 7. check required iters
-    if required_iters >= calculate_sp_interval_iters(constants, expected_vs.ssi):
+    if required_iters >= calculate_sp_interval_iters(constants.NUM_SPS_SUB_SLOT, expected_vs.ssi):
         return None, ValidationError(Err.INVALID_REQUIRED_ITERS)
 
     # 8a. check signage point index 0 has no cc sp
@@ -523,13 +528,14 @@ def validate_unfinished_header_block(
         return None, ValidationError(Err.INVALID_SP_INDEX)
 
     sp_iters: uint64 = calculate_sp_iters(
-        constants,
+        constants.NUM_SPS_SUB_SLOT,
         expected_vs.ssi,
         header_block.reward_chain_block.signage_point_index,
     )
 
     ip_iters: uint64 = calculate_ip_iters(
-        constants,
+        constants.NUM_SPS_SUB_SLOT,
+        constants.NUM_SP_INTERVALS_EXTRA,
         expected_vs.ssi,
         header_block.reward_chain_block.signage_point_index,
         required_iters,
@@ -873,7 +879,8 @@ def validate_finished_header_block(
     new_sub_slot: bool = len(header_block.finished_sub_slots) > 0
 
     ip_iters: uint64 = calculate_ip_iters(
-        constants,
+        constants.NUM_SPS_SUB_SLOT,
+        constants.NUM_SP_INTERVALS_EXTRA,
         expected_vs.ssi,
         header_block.reward_chain_block.signage_point_index,
         required_iters,

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -989,7 +989,11 @@ def validate_finished_header_block(
 
     # 31. Check infused challenge chain infusion point VDF
     if not genesis_block:
-        overflow = is_overflow_block(constants, header_block.reward_chain_block.signage_point_index)
+        overflow = is_overflow_block(
+            constants.NUM_SPS_SUB_SLOT,
+            constants.NUM_SP_INTERVALS_EXTRA,
+            header_block.reward_chain_block.signage_point_index,
+        )
         deficit = calculate_deficit(
             constants,
             header_block.height,

--- a/chia/consensus/full_block_to_block_record.py
+++ b/chia/consensus/full_block_to_block_record.py
@@ -35,7 +35,9 @@ def block_to_block_record(
             constants, len(block.finished_sub_slots) > 0, prev_b, blocks
         )
     overflow = is_overflow_block(
-        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, block.reward_chain_block.signage_point_index
+        constants.NUM_SPS_SUB_SLOT,
+        constants.NUM_SP_INTERVALS_EXTRA,
+        uint32(block.reward_chain_block.signage_point_index),
     )
     deficit = calculate_deficit(
         constants,

--- a/chia/consensus/full_block_to_block_record.py
+++ b/chia/consensus/full_block_to_block_record.py
@@ -5,13 +5,13 @@ from typing import Optional, Union
 from chia_rs import ConsensusConstants
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
+from chia_rs import is_overflow_block
 
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.deficit import calculate_deficit
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
 from chia.consensus.make_sub_epoch_summary import make_sub_epoch_summary
-from chia.consensus.pot_iterations import is_overflow_block
 from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.slots import ChallengeBlockInfo
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
@@ -35,7 +35,9 @@ def block_to_block_record(
         sub_slot_iters, _ = get_next_sub_slot_iters_and_difficulty(
             constants, len(block.finished_sub_slots) > 0, prev_b, blocks
         )
-    overflow = is_overflow_block(constants, block.reward_chain_block.signage_point_index)
+    overflow = is_overflow_block(
+        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, block.reward_chain_block.signage_point_index
+    )
     deficit = calculate_deficit(
         constants,
         block.height,

--- a/chia/consensus/full_block_to_block_record.py
+++ b/chia/consensus/full_block_to_block_record.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from chia_rs import ConsensusConstants
+from chia_rs import ConsensusConstants, is_overflow_block
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
-from chia_rs import is_overflow_block
 
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain_interface import BlockRecordsProtocol

--- a/chia/consensus/make_sub_epoch_summary.py
+++ b/chia/consensus/make_sub_epoch_summary.py
@@ -119,7 +119,9 @@ def next_sub_epoch_summary(
     sub_slot_iters = get_next_sub_slot_iters_and_difficulty(
         constants, len(block.finished_sub_slots) > 0, prev_b, blocks
     )[0]
-    overflow = is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, signage_point_index)
+    overflow = is_overflow_block(
+        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, uint32(signage_point_index)
+    )
 
     if (
         len(block.finished_sub_slots) > 0
@@ -177,12 +179,12 @@ def next_sub_epoch_summary(
 
     # if can finish epoch, new difficulty and ssi
     if can_finish_epoch:
-        sp_iters = calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, signage_point_index)
+        sp_iters = calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, uint32(signage_point_index))
         ip_iters = calculate_ip_iters(
             constants.NUM_SPS_SUB_SLOT,
             constants.NUM_SP_INTERVALS_EXTRA,
             sub_slot_iters,
-            signage_point_index,
+            uint32(signage_point_index),
             required_iters,
         )
 

--- a/chia/consensus/make_sub_epoch_summary.py
+++ b/chia/consensus/make_sub_epoch_summary.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Optional, Union
 
-from chia_rs import ConsensusConstants
 from chia_rs import (
+    ConsensusConstants,
     calculate_ip_iters,
     calculate_sp_iters,
     is_overflow_block,

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -207,7 +207,9 @@ async def pre_validate_block(
         if block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters is not None:
             vs.ssi = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters
     overflow = is_overflow_block(
-        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, block.reward_chain_block.signage_point_index
+        constants.NUM_SPS_SUB_SLOT,
+        constants.NUM_SP_INTERVALS_EXTRA,
+        uint32(block.reward_chain_block.signage_point_index),
     )
     challenge = get_block_challenge(constants, block, blockchain, prev_b is None, overflow, False)
     if block.reward_chain_block.challenge_chain_sp_vdf is None:

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -14,6 +14,7 @@ from chia_rs import (
     ConsensusConstants,
     SpendBundleConditions,
     get_flags_for_height_and_constants,
+    is_overflow_block,
     run_block_generator,
     run_block_generator2,
 )
@@ -26,7 +27,7 @@ from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.get_block_challenge import get_block_challenge
 from chia.consensus.get_block_generator import get_block_generator
-from chia.consensus.pot_iterations import calculate_iterations_quality, is_overflow_block
+from chia.consensus.pot_iterations import calculate_iterations_quality
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
 from chia.types.blockchain_format.sub_epoch_summary import SubEpochSummary
@@ -205,7 +206,9 @@ async def pre_validate_block(
             vs.difficulty = block.finished_sub_slots[0].challenge_chain.new_difficulty
         if block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters is not None:
             vs.ssi = block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters
-    overflow = is_overflow_block(constants, block.reward_chain_block.signage_point_index)
+    overflow = is_overflow_block(
+        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, block.reward_chain_block.signage_point_index
+    )
     challenge = get_block_challenge(constants, block, blockchain, prev_b is None, overflow, False)
     if block.reward_chain_block.challenge_chain_sp_vdf is None:
         cc_sp_hash: bytes32 = challenge

--- a/chia/consensus/pos_quality.py
+++ b/chia/consensus/pos_quality.py
@@ -1,19 +1,5 @@
 from __future__ import annotations
 
-from chia_rs.sized_ints import uint64
-
 # The actual space in bytes of a plot, is _expected_plot_size(k) * UI_ACTUAL_SPACE_CONSTANT_FACTO
 # This is not used in consensus, only for display purposes
 UI_ACTUAL_SPACE_CONSTANT_FACTOR = 0.78
-
-
-def _expected_plot_size(k: int) -> uint64:
-    """
-    Given the plot size parameter k (which is between 32 and 59), computes the
-    expected size of the plot in bytes (times a constant factor). This is based on efficient encoding
-    of the plot, and aims to be scale agnostic, so larger plots don't
-    necessarily get more rewards per byte. The +1 is added to give half a bit more space per entry, which
-    is necessary to store the entries in the plot.
-    """
-
-    return uint64(((2 * k) + 1) * (2 ** (k - 1)))

--- a/chia/consensus/pot_iterations.py
+++ b/chia/consensus/pot_iterations.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from chia_rs import expected_plot_size as _expected_plot_size
 
-from chia.types.blockchain_format.sized_bytes import bytes32
+from chia_rs.sized_bytes import bytes32
 from chia.util.hash import std_hash
-from chia.util.ints import uint64, uint128
+from chia_rs.sized_ints import uint64, uint128
 
 
 def calculate_iterations_quality(

--- a/chia/consensus/pot_iterations.py
+++ b/chia/consensus/pot_iterations.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from chia_rs import expected_plot_size as _expected_plot_size
-
 from chia_rs.sized_bytes import bytes32
-from chia.util.hash import std_hash
 from chia_rs.sized_ints import uint64, uint128
+
+from chia.util.hash import std_hash
 
 
 def calculate_iterations_quality(

--- a/chia/consensus/pot_iterations.py
+++ b/chia/consensus/pot_iterations.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from chia.consensus.pos_quality import _expected_plot_size
+from chia_rs import expected_plot_size as _expected_plot_size
+
+from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.util.hash import std_hash
 from chia.util.ints import uint64, uint128
 

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -6,12 +6,12 @@ import time
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union, cast
 
 import aiohttp
-from chia_rs import AugSchemeMPL, G2Element, PoolTarget, PrivateKey
+from chia_rs import AugSchemeMPL, G2Element, PoolTarget, PrivateKey, calculate_sp_interval_iters
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64
 
 from chia import __version__
-from chia.consensus.pot_iterations import calculate_iterations_quality, calculate_sp_interval_iters
+from chia.consensus.pot_iterations import calculate_iterations_quality
 from chia.farmer.farmer import Farmer, increment_pool_stats, strip_old_entries
 from chia.harvester.harvester_api import HarvesterAPI
 from chia.protocols import farmer_protocol, harvester_protocol
@@ -118,7 +118,7 @@ class FarmerAPI:
             )
 
             # If the iters are good enough to make a block, proceed with the block making flow
-            if required_iters < calculate_sp_interval_iters(self.farmer.constants, sp.sub_slot_iters):
+            if required_iters < calculate_sp_interval_iters(self.farmer.constants.NUM_SPS_SUB_SLOT, sp.sub_slot_iters):
                 if new_proof_of_space.farmer_reward_address_override is not None:
                     self.farmer.notify_farmer_reward_taken_by_harvester_as_fee(sp, new_proof_of_space)
 
@@ -224,7 +224,7 @@ class FarmerAPI:
                     new_proof_of_space.sp_hash,
                 )
                 if required_iters >= calculate_sp_interval_iters(
-                    self.farmer.constants, self.farmer.constants.POOL_SUB_SLOT_ITERS
+                    self.farmer.constants.NUM_SPS_SUB_SLOT, self.farmer.constants.POOL_SUB_SLOT_ITERS
                 ):
                     self.farmer.log.info(
                         f"Proof of space not good enough for pool {pool_url}: {pool_state_dict['current_difficulty']}"

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2600,7 +2600,7 @@ class FullNode:
             + calculate_sp_iters(
                 self.constants.NUM_SPS_SUB_SLOT,
                 sub_slot_iters,
-                unfinished_block.reward_chain_block.signage_point_index,
+                uint32(unfinished_block.reward_chain_block.signage_point_index),
             )
         )
 

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -20,6 +20,7 @@ from chia_rs import (
     BLSCache,
     ConsensusConstants,
     PoolTarget,
+    calculate_sp_iters,
     get_flags_for_height_and_constants,
     run_block_generator,
     run_block_generator2,
@@ -37,7 +38,6 @@ from chia.consensus.cost_calculator import NPCResult
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
 from chia.consensus.make_sub_epoch_summary import next_sub_epoch_summary
 from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_block
-from chia.consensus.pot_iterations import calculate_sp_iters
 from chia.full_node.block_store import BlockStore
 from chia.full_node.check_fork_next_block import check_fork_next_block
 from chia.full_node.coin_store import CoinStore
@@ -2598,7 +2598,7 @@ class FullNode:
         sp_total_iters = uint128(
             sub_slot_start_iters
             + calculate_sp_iters(
-                self.constants,
+                self.constants.NUM_SPS_SUB_SLOT,
                 sub_slot_iters,
                 unfinished_block.reward_chain_block.signage_point_index,
             )

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -978,13 +978,13 @@ class FullNodeAPI:
                 request.challenge_chain_sp,
             )
             sp_iters: uint64 = calculate_sp_iters(
-                self.full_node.constants.NUM_SPS_SUB_SLOT, sub_slot_iters, request.signage_point_index
+                self.full_node.constants.NUM_SPS_SUB_SLOT, sub_slot_iters, uint32(request.signage_point_index)
             )
             ip_iters: uint64 = calculate_ip_iters(
                 self.full_node.constants.NUM_SPS_SUB_SLOT,
                 self.full_node.constants.NUM_SP_INTERVALS_EXTRA,
                 sub_slot_iters,
-                request.signage_point_index,
+                uint32(request.signage_point_index),
                 required_iters,
             )
 

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -32,8 +32,7 @@ from chia.consensus.block_creation import create_unfinished_block
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain import BlockchainMutexPriority
 from chia.consensus.get_block_generator import get_block_generator
-from chia.consensus.pot_iterations import calculate_ip_iters, calculate_iterations_quality, calculate_sp_iters
-from chia.full_node.bundle_tools import simple_solution_generator, simple_solution_generator_backrefs
+from chia.consensus.pot_iterations import calculate_iterations_quality
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.fee_estimate import FeeEstimate, FeeEstimateGroup, fee_rate_v2_to_v1
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -20,6 +20,8 @@ from chia_rs import (
     PoolTarget,
     RewardChainBlockUnfinished,
     additions_and_removals,
+    calculate_ip_iters,
+    calculate_sp_iters,
     get_flags_for_height_and_constants,
 )
 from chia_rs.sized_bytes import bytes32
@@ -31,6 +33,7 @@ from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain import BlockchainMutexPriority
 from chia.consensus.get_block_generator import get_block_generator
 from chia.consensus.pot_iterations import calculate_ip_iters, calculate_iterations_quality, calculate_sp_iters
+from chia.full_node.bundle_tools import simple_solution_generator, simple_solution_generator_backrefs
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.fee_estimate import FeeEstimate, FeeEstimateGroup, fee_rate_v2_to_v1
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
@@ -975,9 +978,12 @@ class FullNodeAPI:
                 difficulty,
                 request.challenge_chain_sp,
             )
-            sp_iters: uint64 = calculate_sp_iters(self.full_node.constants, sub_slot_iters, request.signage_point_index)
+            sp_iters: uint64 = calculate_sp_iters(
+                self.full_node.constants.NUM_SPS_SUB_SLOT, sub_slot_iters, request.signage_point_index
+            )
             ip_iters: uint64 = calculate_ip_iters(
-                self.full_node.constants,
+                self.full_node.constants.NUM_SPS_SUB_SLOT,
+                self.full_node.constants.NUM_SP_INTERVALS_EXTRA,
                 sub_slot_iters,
                 request.signage_point_index,
                 required_iters,

--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -9,13 +9,13 @@ from typing import Optional
 from chia_rs import ConsensusConstants
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64, uint128
+from chia_rs import calculate_sp_interval_iters
 
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.difficulty_adjustment import can_finish_sub_and_full_epoch
 from chia.consensus.make_sub_epoch_summary import make_sub_epoch_summary
 from chia.consensus.multiprocess_validation import PreValidationResult
-from chia.consensus.pot_iterations import calculate_sp_interval_iters
 from chia.full_node.signage_point import SignagePoint
 from chia.protocols import timelord_protocol
 from chia.server.outbound_message import Message
@@ -912,7 +912,7 @@ class FullNodeStore:
                 # If there was a reorg and a difficulty adjustment, just clear all the slots
                 self.clear_slots()
             else:
-                interval_iters = calculate_sp_interval_iters(self.constants, peak.sub_slot_iters)
+                interval_iters = calculate_sp_interval_iters(self.constants.NUM_SPS_SUB_SLOT, peak.sub_slot_iters)
                 # If it's not a reorg, or there is a reorg on the same difficulty, we can keep signage points
                 # that we had before, in the cache
                 for index, (sub_slot, sps, total_iters) in enumerate(self.finished_sub_slots):

--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -6,10 +6,9 @@ import logging
 import time
 from typing import Optional
 
-from chia_rs import ConsensusConstants
+from chia_rs import ConsensusConstants, calculate_sp_interval_iters
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64, uint128
-from chia_rs import calculate_sp_interval_iters
 
 from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain_interface import BlockRecordsProtocol

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1115,7 +1115,7 @@ def _validate_sub_slot_data(
             assert sub_slot_data.cc_sp_vdf_info
             input = ClassgroupElement.get_default_element()
             if not sub_slot_data.cc_signage_point.normalized_to_identity:
-                is_overflow = is_overflow_block(constants, sub_slot_data.signage_point_index)
+                is_overflow = is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, sub_slot_data.signage_point_index)
                 input = sub_slot_data_vdf_input(
                     constants, sub_slot_data, sub_slot_idx, sub_slots, is_overflow, prev_ssd.is_end_of_slot(), ssi
                 )
@@ -1252,7 +1252,7 @@ def validate_recent_blocks(
                 diff = sub_slot.challenge_chain.new_difficulty
 
         if (challenge is not None) and (prev_challenge is not None):
-            overflow = is_overflow_block(constants, block.reward_chain_block.signage_point_index)
+            overflow = is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, block.reward_chain_block.signage_point_index)
             if not adjusted:
                 assert prev_block_record is not None
                 prev_block_record = prev_block_record.replace(
@@ -1358,7 +1358,7 @@ def __validate_pospace(
 
     sub_slot_data: SubSlotData = segment.sub_slots[idx]
 
-    if sub_slot_data.signage_point_index and is_overflow_block(constants, sub_slot_data.signage_point_index):
+    if sub_slot_data.signage_point_index and is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, sub_slot_data.signage_point_index):
         curr_slot = segment.sub_slots[idx - 1]
         assert curr_slot.cc_slot_end_info
         challenge = curr_slot.cc_slot_end_info.challenge
@@ -1415,14 +1415,14 @@ def __get_rc_sub_slot(
     slots_n = 1
     assert first
     assert first.signage_point_index is not None
-    if is_overflow_block(constants, first.signage_point_index):
+    if is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, first.signage_point_index):
         if idx >= 2 and slots[idx - 2].cc_slot_end is None:
             slots_n = 2
 
     new_diff = None if ses is None else ses.new_difficulty
     new_ssi = None if ses is None else ses.new_sub_slot_iters
     ses_hash: Optional[bytes32] = None if ses is None else ses.get_hash()
-    overflow = is_overflow_block(constants, first.signage_point_index)
+    overflow = is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, first.signage_point_index)
     if overflow:
         if idx >= 2 and slots[idx - 2].cc_slot_end is not None and slots[idx - 1].cc_slot_end is not None:
             ses_hash = None

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1007,7 +1007,7 @@ def _validate_segment(
                 constants.NUM_SPS_SUB_SLOT,
                 constants.NUM_SP_INTERVALS_EXTRA,
                 curr_ssi,
-                sub_slot_data.signage_point_index,
+                uint32(sub_slot_data.signage_point_index),
                 required_iters,
             )
             vdf_list = _get_challenge_block_vdfs(constants, idx, segment.sub_slots, curr_ssi)
@@ -1036,7 +1036,7 @@ def _get_challenge_block_vdfs(
         sp_input = ClassgroupElement.get_default_element()
         if not sub_slot_data.cc_signage_point.normalized_to_identity and sub_slot_idx >= 1:
             is_overflow = is_overflow_block(
-                constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, sub_slot_data.signage_point_index
+                constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, uint32(sub_slot_data.signage_point_index)
             )
             prev_ssd = sub_slots[sub_slot_idx - 1]
             sp_input = sub_slot_data_vdf_input(
@@ -1116,7 +1116,9 @@ def _validate_sub_slot_data(
             input = ClassgroupElement.get_default_element()
             if not sub_slot_data.cc_signage_point.normalized_to_identity:
                 is_overflow = is_overflow_block(
-                    constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, sub_slot_data.signage_point_index
+                    constants.NUM_SPS_SUB_SLOT,
+                    constants.NUM_SP_INTERVALS_EXTRA,
+                    uint32(sub_slot_data.signage_point_index),
                 )
                 input = sub_slot_data_vdf_input(
                     constants, sub_slot_data, sub_slot_idx, sub_slots, is_overflow, prev_ssd.is_end_of_slot(), ssi
@@ -1257,7 +1259,7 @@ def validate_recent_blocks(
             overflow = is_overflow_block(
                 constants.NUM_SPS_SUB_SLOT,
                 constants.NUM_SP_INTERVALS_EXTRA,
-                block.reward_chain_block.signage_point_index,
+                uint32(block.reward_chain_block.signage_point_index),
             )
             if not adjusted:
                 assert prev_block_record is not None
@@ -1365,7 +1367,7 @@ def __validate_pospace(
     sub_slot_data: SubSlotData = segment.sub_slots[idx]
 
     if sub_slot_data.signage_point_index and is_overflow_block(
-        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, sub_slot_data.signage_point_index
+        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, uint32(sub_slot_data.signage_point_index)
     ):
         curr_slot = segment.sub_slots[idx - 1]
         assert curr_slot.cc_slot_end_info
@@ -1423,7 +1425,9 @@ def __get_rc_sub_slot(
     slots_n = 1
     assert first
     assert first.signage_point_index is not None
-    if is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, first.signage_point_index):
+    if is_overflow_block(
+        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, uint32(first.signage_point_index)
+    ):
         if idx >= 2 and slots[idx - 2].cc_slot_end is None:
             slots_n = 2
 
@@ -1431,7 +1435,7 @@ def __get_rc_sub_slot(
     new_ssi = None if ses is None else ses.new_sub_slot_iters
     ses_hash: Optional[bytes32] = None if ses is None else ses.get_hash()
     overflow = is_overflow_block(
-        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, first.signage_point_index
+        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, uint32(first.signage_point_index)
     )
     if overflow:
         if idx >= 2 and slots[idx - 2].cc_slot_end is not None and slots[idx - 1].cc_slot_end is not None:
@@ -1592,7 +1596,7 @@ def get_sp_total_iters(
     assert sub_slot_data.cc_ip_vdf_info is not None
     assert sub_slot_data.total_iters is not None
     assert sub_slot_data.signage_point_index is not None
-    sp_iters = calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, ssi, sub_slot_data.signage_point_index)
+    sp_iters = calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, ssi, uint32(sub_slot_data.signage_point_index))
     ip_iters = sub_slot_data.cc_ip_vdf_info.number_of_iterations
     sp_sub_slot_total_iters = uint128(sub_slot_data.total_iters - ip_iters)
     if is_overflow:

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -11,6 +11,11 @@ from multiprocessing.context import BaseContext
 from typing import IO, Optional
 
 from chia_rs import ConsensusConstants, SubEpochChallengeSegment, SubEpochData, SubEpochSegments, SubSlotData
+from chia_rs import (
+    calculate_ip_iters,
+    calculate_sp_iters,
+    is_overflow_block,
+)
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64, uint128
 
@@ -19,12 +24,7 @@ from chia.consensus.block_record import BlockRecord
 from chia.consensus.blockchain_interface import BlockchainInterface
 from chia.consensus.deficit import calculate_deficit
 from chia.consensus.full_block_to_block_record import header_block_to_sub_block_record
-from chia.consensus.pot_iterations import (
-    calculate_ip_iters,
-    calculate_iterations_quality,
-    calculate_sp_iters,
-    is_overflow_block,
-)
+from chia.consensus.pot_iterations import calculate_iterations_quality
 from chia.consensus.vdf_info_computation import get_signage_point_vdf_info
 from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
@@ -999,7 +999,13 @@ def _validate_segment(
             if required_iters is None:
                 return False, uint64(0), uint64(0), uint64(0), []
             assert sub_slot_data.signage_point_index is not None
-            ip_iters += calculate_ip_iters(constants, curr_ssi, sub_slot_data.signage_point_index, required_iters)
+            ip_iters += calculate_ip_iters(
+                constants.NUM_SPS_SUB_SLOT,
+                constants.NUM_SP_INTERVALS_EXTRA,
+                curr_ssi,
+                sub_slot_data.signage_point_index,
+                required_iters,
+            )
             vdf_list = _get_challenge_block_vdfs(constants, idx, segment.sub_slots, curr_ssi)
             to_validate.extend(vdf_list)
         elif sampled and after_challenge:
@@ -1025,7 +1031,9 @@ def _get_challenge_block_vdfs(
         assert sub_slot_data.signage_point_index
         sp_input = ClassgroupElement.get_default_element()
         if not sub_slot_data.cc_signage_point.normalized_to_identity and sub_slot_idx >= 1:
-            is_overflow = is_overflow_block(constants, sub_slot_data.signage_point_index)
+            is_overflow = is_overflow_block(
+                constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, sub_slot_data.signage_point_index
+            )
             prev_ssd = sub_slots[sub_slot_idx - 1]
             sp_input = sub_slot_data_vdf_input(
                 constants, sub_slot_data, sub_slot_idx, sub_slots, is_overflow, prev_ssd.is_end_of_slot(), ssi
@@ -1570,7 +1578,7 @@ def get_sp_total_iters(
     assert sub_slot_data.cc_ip_vdf_info is not None
     assert sub_slot_data.total_iters is not None
     assert sub_slot_data.signage_point_index is not None
-    sp_iters = calculate_sp_iters(constants, ssi, sub_slot_data.signage_point_index)
+    sp_iters = calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, ssi, sub_slot_data.signage_point_index)
     ip_iters = sub_slot_data.cc_ip_vdf_info.number_of_iterations
     sp_sub_slot_total_iters = uint128(sub_slot_data.total_iters - ip_iters)
     if is_overflow:

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -10,8 +10,12 @@ from concurrent.futures.process import ProcessPoolExecutor
 from multiprocessing.context import BaseContext
 from typing import IO, Optional
 
-from chia_rs import ConsensusConstants, SubEpochChallengeSegment, SubEpochData, SubEpochSegments, SubSlotData
 from chia_rs import (
+    ConsensusConstants,
+    SubEpochChallengeSegment,
+    SubEpochData,
+    SubEpochSegments,
+    SubSlotData,
     calculate_ip_iters,
     calculate_sp_iters,
     is_overflow_block,

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1115,7 +1115,9 @@ def _validate_sub_slot_data(
             assert sub_slot_data.cc_sp_vdf_info
             input = ClassgroupElement.get_default_element()
             if not sub_slot_data.cc_signage_point.normalized_to_identity:
-                is_overflow = is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, sub_slot_data.signage_point_index)
+                is_overflow = is_overflow_block(
+                    constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, sub_slot_data.signage_point_index
+                )
                 input = sub_slot_data_vdf_input(
                     constants, sub_slot_data, sub_slot_idx, sub_slots, is_overflow, prev_ssd.is_end_of_slot(), ssi
                 )
@@ -1252,7 +1254,11 @@ def validate_recent_blocks(
                 diff = sub_slot.challenge_chain.new_difficulty
 
         if (challenge is not None) and (prev_challenge is not None):
-            overflow = is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, block.reward_chain_block.signage_point_index)
+            overflow = is_overflow_block(
+                constants.NUM_SPS_SUB_SLOT,
+                constants.NUM_SP_INTERVALS_EXTRA,
+                block.reward_chain_block.signage_point_index,
+            )
             if not adjusted:
                 assert prev_block_record is not None
                 prev_block_record = prev_block_record.replace(
@@ -1358,7 +1364,9 @@ def __validate_pospace(
 
     sub_slot_data: SubSlotData = segment.sub_slots[idx]
 
-    if sub_slot_data.signage_point_index and is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, sub_slot_data.signage_point_index):
+    if sub_slot_data.signage_point_index and is_overflow_block(
+        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, sub_slot_data.signage_point_index
+    ):
         curr_slot = segment.sub_slots[idx - 1]
         assert curr_slot.cc_slot_end_info
         challenge = curr_slot.cc_slot_end_info.challenge
@@ -1422,7 +1430,9 @@ def __get_rc_sub_slot(
     new_diff = None if ses is None else ses.new_difficulty
     new_ssi = None if ses is None else ses.new_sub_slot_iters
     ses_hash: Optional[bytes32] = None if ses is None else ses.get_hash()
-    overflow = is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, first.signage_point_index)
+    overflow = is_overflow_block(
+        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, first.signage_point_index
+    )
     if overflow:
         if idx >= 2 and slots[idx - 2].cc_slot_end is not None and slots[idx - 1].cc_slot_end is not None:
             ses_hash = None

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -6,11 +6,11 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Optional, cast
 
-from chia_rs import AugSchemeMPL, G1Element, G2Element
+from chia_rs import AugSchemeMPL, G1Element, G2Element, calculate_sp_interval_iters
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
 
-from chia.consensus.pot_iterations import calculate_iterations_quality, calculate_sp_interval_iters
+from chia.consensus.pot_iterations import calculate_iterations_quality
 from chia.harvester.harvester import Harvester
 from chia.plotting.util import PlotInfo, parse_plot_info
 from chia.protocols import harvester_protocol
@@ -151,7 +151,9 @@ class HarvesterAPI:
                             difficulty,
                             new_challenge.sp_hash,
                         )
-                        sp_interval_iters = calculate_sp_interval_iters(self.harvester.constants, sub_slot_iters)
+                        sp_interval_iters = calculate_sp_interval_iters(
+                            self.harvester.constants.NUM_SPS_SUB_SLOT, sub_slot_iters
+                        )
                         if required_iters < sp_interval_iters:
                             # Found a very good proof of space! will fetch the whole proof from disk,
                             # then send to farmer

--- a/chia/plot_sync/receiver.py
+++ b/chia/plot_sync/receiver.py
@@ -6,9 +6,9 @@ from collections.abc import Awaitable, Collection, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional, Union
 
+from chia_rs import expected_plot_size as _expected_plot_size
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import int16, uint32, uint64
-from chia_rs import expected_plot_size as _expected_plot_size
 from typing_extensions import Protocol
 
 from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR

--- a/chia/plot_sync/receiver.py
+++ b/chia/plot_sync/receiver.py
@@ -8,9 +8,10 @@ from typing import Any, Callable, Optional, Union
 
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import int16, uint32, uint64
+from chia_rs import expected_plot_size as _expected_plot_size
 from typing_extensions import Protocol
 
-from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR, _expected_plot_size
+from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR
 from chia.plot_sync.delta import Delta, PathListDelta, PlotListDelta
 from chia.plot_sync.exceptions import (
     InvalidIdentifierError,

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -9,9 +9,10 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from chia_rs import G1Element
+from chia_rs import expected_plot_size as _expected_plot_size
 from chiapos import DiskProver, decompressor_context_queue
 
-from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR, _expected_plot_size
+from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR
 from chia.plotting.cache import Cache, CacheEntry
 from chia.plotting.util import (
     HarvestingMode,

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -754,7 +754,7 @@ class BlockTools:
                 for signage_point_index in range(0, constants.NUM_SPS_SUB_SLOT - constants.NUM_SP_INTERVALS_EXTRA):
                     curr = latest_block
                     while curr.total_iters > sub_slot_start_total_iters + calculate_sp_iters(
-                        constants.NUM_SPS_SUB_SLOT, sub_slot_iters, uint8(signage_point_index)
+                        constants.NUM_SPS_SUB_SLOT, sub_slot_iters, uint32(signage_point_index)
                     ):
                         if curr.height == 0:
                             break
@@ -1356,17 +1356,17 @@ class BlockTools:
                     sp_iters: uint64 = calculate_sp_iters(
                         constants.NUM_SPS_SUB_SLOT,
                         uint64(constants.SUB_SLOT_ITERS_STARTING),
-                        uint8(signage_point_index),
+                        uint32(signage_point_index),
                     )
                     ip_iters = calculate_ip_iters(
                         constants.NUM_SPS_SUB_SLOT,
                         constants.NUM_SP_INTERVALS_EXTRA,
                         uint64(constants.SUB_SLOT_ITERS_STARTING),
-                        uint8(signage_point_index),
+                        uint32(signage_point_index),
                         required_iters,
                     )
                     is_overflow = is_overflow_block(
-                        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, uint8(signage_point_index)
+                        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, uint32(signage_point_index)
                     )
                     if force_overflow and not is_overflow:
                         continue
@@ -1472,7 +1472,7 @@ class BlockTools:
                         + calculate_sp_iters(
                             self.constants.NUM_SPS_SUB_SLOT,
                             self.constants.SUB_SLOT_ITERS_STARTING,
-                            unfinished_block.reward_chain_block.signage_point_index,
+                            uint32(unfinished_block.reward_chain_block.signage_point_index),
                         )
                     )
                     return unfinished_block_to_full_block(
@@ -1568,10 +1568,13 @@ def get_signage_point(
 ) -> SignagePoint:
     if signage_point_index == 0:
         return SignagePoint(None, None, None, None)
-    sp_iters = calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, signage_point_index)
-    overflow = is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, signage_point_index)
+    sp_iters = calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, uint32(signage_point_index))
+    overflow = is_overflow_block(
+        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, uint32(signage_point_index)
+    )
     sp_total_iters = uint128(
-        sub_slot_start_total_iters + calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, signage_point_index)
+        sub_slot_start_total_iters
+        + calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, uint32(signage_point_index))
     )
 
     (
@@ -1632,7 +1635,9 @@ def finish_block(
     difficulty: uint64,
     normalized_to_identity_cc_ip: bool = False,
 ) -> tuple[FullBlock, BlockRecord]:
-    is_overflow = is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, signage_point_index)
+    is_overflow = is_overflow_block(
+        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, uint32(signage_point_index)
+    )
     cc_vdf_challenge = slot_cc_challenge
     if len(finished_sub_slots) == 0:
         new_ip_iters = uint64(unfinished_block.total_iters - latest_block.total_iters)
@@ -1683,7 +1688,8 @@ def finish_block(
     )
     assert unfinished_block is not None
     sp_total_iters = uint128(
-        sub_slot_start_total_iters + calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, signage_point_index)
+        sub_slot_start_total_iters
+        + calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, uint32(signage_point_index))
     )
     full_block: FullBlock = unfinished_block_to_full_block(
         unfinished_block,
@@ -1890,12 +1896,12 @@ def get_full_block_and_block_record(
         timestamp = max(int(time.time()), last_timestamp + time_per_block)
     else:
         timestamp = last_timestamp + time_per_block
-    sp_iters = calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, signage_point_index)
+    sp_iters = calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, uint32(signage_point_index))
     ip_iters = calculate_ip_iters(
         constants.NUM_SPS_SUB_SLOT,
         constants.NUM_SP_INTERVALS_EXTRA,
         sub_slot_iters,
-        signage_point_index,
+        uint32(signage_point_index),
         required_iters,
     )
 
@@ -2077,7 +2083,9 @@ def make_unfinished_block(
     block: FullBlock, constants: ConsensusConstants, *, force_overflow: bool = False
 ) -> UnfinishedBlock:
     if force_overflow or is_overflow_block(
-        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, block.reward_chain_block.signage_point_index
+        constants.NUM_SPS_SUB_SLOT,
+        constants.NUM_SP_INTERVALS_EXTRA,
+        uint32(block.reward_chain_block.signage_point_index),
     ):
         finished_ss = block.finished_sub_slots[:-1]
     else:

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -26,6 +26,10 @@ from chia_rs import (
     G2Element,
     PoolTarget,
     PrivateKey,
+    calculate_ip_iters,
+    calculate_sp_interval_iters,
+    calculate_sp_iters,
+    is_overflow_block,
     solution_generator,
 )
 from chia_rs.sized_bytes import bytes32
@@ -41,13 +45,7 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.deficit import calculate_deficit
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.make_sub_epoch_summary import next_sub_epoch_summary
-from chia.consensus.pot_iterations import (
-    calculate_ip_iters,
-    calculate_iterations_quality,
-    calculate_sp_interval_iters,
-    calculate_sp_iters,
-    is_overflow_block,
-)
+from chia.consensus.pot_iterations import calculate_iterations_quality
 from chia.consensus.vdf_info_computation import get_signage_point_vdf_info
 from chia.daemon.keychain_proxy import KeychainProxy, connect_to_keychain_and_validate, wrap_local_keychain
 from chia.full_node.bundle_tools import simple_solution_generator, simple_solution_generator_backrefs
@@ -756,7 +754,7 @@ class BlockTools:
                 for signage_point_index in range(0, constants.NUM_SPS_SUB_SLOT - constants.NUM_SP_INTERVALS_EXTRA):
                     curr = latest_block
                     while curr.total_iters > sub_slot_start_total_iters + calculate_sp_iters(
-                        constants, sub_slot_iters, uint8(signage_point_index)
+                        constants.NUM_SPS_SUB_SLOT, sub_slot_iters, uint8(signage_point_index)
                     ):
                         if curr.height == 0:
                             break
@@ -1356,17 +1354,20 @@ class BlockTools:
                 # Try each of the proofs of space
                 for required_iters, proof_of_space in qualified_proofs:
                     sp_iters: uint64 = calculate_sp_iters(
-                        constants,
+                        constants.NUM_SPS_SUB_SLOT,
                         uint64(constants.SUB_SLOT_ITERS_STARTING),
                         uint8(signage_point_index),
                     )
                     ip_iters = calculate_ip_iters(
-                        constants,
+                        constants.NUM_SPS_SUB_SLOT,
+                        constants.NUM_SP_INTERVALS_EXTRA,
                         uint64(constants.SUB_SLOT_ITERS_STARTING),
                         uint8(signage_point_index),
                         required_iters,
                     )
-                    is_overflow = is_overflow_block(constants, uint8(signage_point_index))
+                    is_overflow = is_overflow_block(
+                        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, uint8(signage_point_index)
+                    )
                     if force_overflow and not is_overflow:
                         continue
                     if len(finished_sub_slots) < skip_slots:
@@ -1469,7 +1470,7 @@ class BlockTools:
                     total_iters_sp = uint128(
                         sub_slot_total_iters
                         + calculate_sp_iters(
-                            self.constants,
+                            self.constants.NUM_SPS_SUB_SLOT,
                             self.constants.SUB_SLOT_ITERS_STARTING,
                             unfinished_block.reward_chain_block.signage_point_index,
                         )
@@ -1521,7 +1522,7 @@ class BlockTools:
                         difficulty,
                         signage_point,
                     )
-                    if required_iters < calculate_sp_interval_iters(constants, sub_slot_iters):
+                    if required_iters < calculate_sp_interval_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters):
                         proof_xs: bytes = plot_info.prover.get_full_proof(new_challenge, proof_index)
 
                         # Look up local_sk from plot to save locked memory
@@ -1567,10 +1568,10 @@ def get_signage_point(
 ) -> SignagePoint:
     if signage_point_index == 0:
         return SignagePoint(None, None, None, None)
-    sp_iters = calculate_sp_iters(constants, sub_slot_iters, signage_point_index)
-    overflow = is_overflow_block(constants, signage_point_index)
+    sp_iters = calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, signage_point_index)
+    overflow = is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, signage_point_index)
     sp_total_iters = uint128(
-        sub_slot_start_total_iters + calculate_sp_iters(constants, sub_slot_iters, signage_point_index)
+        sub_slot_start_total_iters + calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, signage_point_index)
     )
 
     (
@@ -1631,7 +1632,7 @@ def finish_block(
     difficulty: uint64,
     normalized_to_identity_cc_ip: bool = False,
 ) -> tuple[FullBlock, BlockRecord]:
-    is_overflow = is_overflow_block(constants, signage_point_index)
+    is_overflow = is_overflow_block(constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, signage_point_index)
     cc_vdf_challenge = slot_cc_challenge
     if len(finished_sub_slots) == 0:
         new_ip_iters = uint64(unfinished_block.total_iters - latest_block.total_iters)
@@ -1682,7 +1683,7 @@ def finish_block(
     )
     assert unfinished_block is not None
     sp_total_iters = uint128(
-        sub_slot_start_total_iters + calculate_sp_iters(constants, sub_slot_iters, signage_point_index)
+        sub_slot_start_total_iters + calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, signage_point_index)
     )
     full_block: FullBlock = unfinished_block_to_full_block(
         unfinished_block,
@@ -1889,8 +1890,14 @@ def get_full_block_and_block_record(
         timestamp = max(int(time.time()), last_timestamp + time_per_block)
     else:
         timestamp = last_timestamp + time_per_block
-    sp_iters = calculate_sp_iters(constants, sub_slot_iters, signage_point_index)
-    ip_iters = calculate_ip_iters(constants, sub_slot_iters, signage_point_index, required_iters)
+    sp_iters = calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, signage_point_index)
+    ip_iters = calculate_ip_iters(
+        constants.NUM_SPS_SUB_SLOT,
+        constants.NUM_SP_INTERVALS_EXTRA,
+        sub_slot_iters,
+        signage_point_index,
+        required_iters,
+    )
 
     unfinished_block = create_unfinished_block(
         constants,
@@ -2069,7 +2076,9 @@ def create_block_tools(
 def make_unfinished_block(
     block: FullBlock, constants: ConsensusConstants, *, force_overflow: bool = False
 ) -> UnfinishedBlock:
-    if force_overflow or is_overflow_block(constants, block.reward_chain_block.signage_point_index):
+    if force_overflow or is_overflow_block(
+        constants.NUM_SPS_SUB_SLOT, constants.NUM_SP_INTERVALS_EXTRA, block.reward_chain_block.signage_point_index
+    ):
         finished_ss = block.finished_sub_slots[:-1]
     else:
         finished_ss = block.finished_sub_slots

--- a/chia/timelord/iters_from_block.py
+++ b/chia/timelord/iters_from_block.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from chia_rs import ConsensusConstants, RewardChainBlock, RewardChainBlockUnfinished
 from chia_rs import (
+    ConsensusConstants,
+    RewardChainBlock,
+    RewardChainBlockUnfinished,
     calculate_ip_iters,
     calculate_sp_iters,
 )

--- a/chia/timelord/iters_from_block.py
+++ b/chia/timelord/iters_from_block.py
@@ -46,12 +46,12 @@ def iters_from_block(
         cc_sp,
     )
     return (
-        calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, reward_chain_block.signage_point_index),
+        calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, uint32(reward_chain_block.signage_point_index)),
         calculate_ip_iters(
             constants.NUM_SPS_SUB_SLOT,
             constants.NUM_SP_INTERVALS_EXTRA,
             sub_slot_iters,
-            reward_chain_block.signage_point_index,
+            uint32(reward_chain_block.signage_point_index),
             required_iters,
         ),
     )

--- a/chia/timelord/iters_from_block.py
+++ b/chia/timelord/iters_from_block.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 from typing import Optional, Union
 
 from chia_rs import ConsensusConstants, RewardChainBlock, RewardChainBlockUnfinished
+from chia_rs import (
+    calculate_ip_iters,
+    calculate_sp_iters,
+)
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
-from chia.consensus.pot_iterations import calculate_ip_iters, calculate_iterations_quality, calculate_sp_iters
+from chia.consensus.pot_iterations import calculate_iterations_quality
 from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
 
 
@@ -40,9 +44,10 @@ def iters_from_block(
         cc_sp,
     )
     return (
-        calculate_sp_iters(constants, sub_slot_iters, reward_chain_block.signage_point_index),
+        calculate_sp_iters(constants.NUM_SPS_SUB_SLOT, sub_slot_iters, reward_chain_block.signage_point_index),
         calculate_ip_iters(
-            constants,
+            constants.NUM_SPS_SUB_SLOT,
+            constants.NUM_SP_INTERVALS_EXTRA,
             sub_slot_iters,
             reward_chain_block.signage_point_index,
             required_iters,

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -15,13 +15,11 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, ClassVar, Optional, cast
 
-from chia_rs import ConsensusConstants, RewardChainBlock
+from chia_rs import ConsensusConstants, RewardChainBlock, calculate_sp_iters, is_overflow_block
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
-from chia_rs import calculate_sp_iters, is_overflow_block
 from chiavdf import create_discriminant, prove
 
-from chia.consensus.pot_iterations import calculate_sp_iters, is_overflow_block
 from chia.protocols import timelord_protocol
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.rpc.rpc_server import StateChangedProtocol, default_get_connections

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -260,7 +260,7 @@ class Timelord:
         if is_overflow_block(
             self.constants.NUM_SPS_SUB_SLOT,
             self.constants.NUM_SP_INTERVALS_EXTRA,
-            block.reward_chain_block.signage_point_index,
+            uint32(block.reward_chain_block.signage_point_index),
         ):
             block_sp_total_iters -= self.last_state.get_sub_slot_iters()
         found_index = -1
@@ -284,7 +284,11 @@ class Timelord:
                 )
                 return None
             if self.last_state.reward_challenge_cache[found_index][1] > block_sp_total_iters:
-                if not is_overflow_block(self.constants, block.reward_chain_block.signage_point_index):
+                if not is_overflow_block(
+                    self.constants.NUM_SPS_SUB_SLOT,
+                    self.constants.NUM_SP_INTERVALS_EXTRA,
+                    uint32(block.reward_chain_block.signage_point_index),
+                ):
                     log.error(
                         f"Will not infuse unfinished block {block.rc_prev}, sp total iters: {block_sp_total_iters}, "
                         f"because its iters are too low"
@@ -603,7 +607,11 @@ class Timelord:
                     self.last_active_time = time.time()
                     log.debug(f"Generated infusion point for challenge: {challenge} iterations: {iteration}.")
 
-                    overflow = is_overflow_block(self.constants, block.reward_chain_block.signage_point_index)
+                    overflow = is_overflow_block(
+                        self.constants.NUM_SPS_SUB_SLOT,
+                        self.constants.NUM_SP_INTERVALS_EXTRA,
+                        uint32(block.reward_chain_block.signage_point_index),
+                    )
 
                     if not self.last_state.can_infuse_block(overflow):
                         log.warning("Too many blocks, or overflow in new epoch, cannot infuse, discarding")
@@ -638,7 +646,7 @@ class Timelord:
                         + calculate_sp_iters(
                             self.constants.NUM_SPS_SUB_SLOT,
                             block.sub_slot_iters,
-                            block.reward_chain_block.signage_point_index,
+                            uint32(block.reward_chain_block.signage_point_index),
                         )
                         - (block.sub_slot_iters if overflow else 0)
                     )


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

As part of the effort to remove a dependency on chia-blockchain from chia_rs the code that previously lived in pot_iterations.py and pos_quality.py has been ported to Rust. 
This PR changes the code here to use the Rust version of pot_iterations and pos_quality.

### Testing Notes:

I have kept the tests here, but using the new Rust versions instead. This should prove parity with the old code.
