### PR TITLE
`create_block_generator` refactor

### DIFF
--- a/benchmarks/mempool.py
+++ b/benchmarks/mempool.py
@@ -228,17 +228,17 @@ async def run_mempool_benchmark() -> None:
         print(f"  time: {stop - start:0.4f}s")
         print(f"  per call: {(stop - start) / total_bundles * 1000:0.2f}ms")
 
-        print("\nProfiling create_bundle_from_mempool()")
+        print("\nProfiling create_block_generator()")
         with enable_profiler(True, f"create-{suffix}"):
             start = monotonic()
-            for _ in range(500):
-                await mempool.create_bundle_from_mempool(
+            for _ in range(50):
+                await mempool.create_block_generator(
                     last_tb_header_hash=rec.header_hash,
                     get_unspent_lineage_info_for_puzzle_hash=get_unspent_lineage_info_for_puzzle_hash,
                 )
             stop = monotonic()
         print(f"  time: {stop - start:0.4f}s")
-        print(f"  per call: {(stop - start) / 500 * 1000:0.2f}ms")
+        print(f"  per call: {(stop - start) / 50 * 1000:0.2f}ms")
 
         print("\nProfiling new_peak() (optimized)")
         blocks: list[tuple[BenchBlockRecord, list[bytes32]]] = []

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -6,7 +6,7 @@ import random
 from typing import Callable, Optional
 
 import pytest
-from chia_rs import G1Element, G2Element, get_flags_for_height_and_constants
+from chia_rs import AugSchemeMPL, G1Element, G2Element, get_flags_for_height_and_constants, run_block_generator2
 from clvm.casts import int_to_bytes
 from clvm_tools import binutils
 from clvm_tools.binutils import assemble
@@ -3093,20 +3093,21 @@ def test_get_items_by_coin_ids(items: list[MempoolItem], coin_ids: list[bytes32]
     assert set(result) == set(expected)
 
 
+def make_test_spendbundle(coin: Coin, *, fee: int = 0, with_higher_cost: bool = False) -> SpendBundle:
+    conditions = []
+    actual_fee = fee
+    if with_higher_cost:
+        conditions.extend([[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, i] for i in range(3)])
+        actual_fee += 3
+    conditions.append([ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, coin.amount - actual_fee])
+    sb = spend_bundle_from_conditions(conditions, coin)
+    return sb
+
+
 @pytest.mark.anyio
 async def test_aggregating_on_a_solution_then_a_more_cost_saving_one_appears() -> None:
     async def get_unspent_lineage_info_for_puzzle_hash(_: bytes32) -> Optional[UnspentLineageInfo]:
         assert False  # pragma: no cover
-
-    def make_test_spendbundle(coin: Coin, *, fee: int = 0, with_higher_cost: bool = False) -> SpendBundle:
-        conditions = []
-        actual_fee = fee
-        if with_higher_cost:
-            conditions.extend([[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, i] for i in range(3)])
-            actual_fee += 3
-        conditions.append([ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, coin.amount - actual_fee])
-        sb = spend_bundle_from_conditions(conditions, coin)
-        return sb
 
     def agg_and_add_sb_returning_cost_info(mempool: Mempool, spend_bundles: list[SpendBundle]) -> uint64:
         sb = SpendBundle.aggregate(spend_bundles)
@@ -3176,6 +3177,67 @@ def test_get_puzzle_and_solution_for_coin_failure() -> None:
         ValueError, match=f"Failed to get puzzle and solution for coin {TEST_COIN}, error: \\('coin not found', '80'\\)"
     ):
         get_puzzle_and_solution_for_coin(BlockGenerator(SerializedProgram.to(None), []), TEST_COIN, 0, test_constants)
+
+
+@pytest.mark.anyio
+async def test_create_block_generator() -> None:
+    async def get_unspent_lineage_info_for_puzzle_hash(_: bytes32) -> Optional[UnspentLineageInfo]:
+        assert False  # pragma: no cover
+
+    mempool_info = MempoolInfo(
+        CLVMCost(uint64(11000000000 * 3)),
+        FeeRate(uint64(1000000)),
+        CLVMCost(uint64(11000000000)),
+    )
+
+    fee_estimator = create_bitcoin_fee_estimator(test_constants.MAX_BLOCK_COST_CLVM)
+    mempool = Mempool(mempool_info, fee_estimator)
+    coins = [
+        Coin(IDENTITY_PUZZLE_HASH, IDENTITY_PUZZLE_HASH, uint64(amount)) for amount in range(2000000000, 2000000020, 2)
+    ]
+
+    spend_bundles = set(make_test_spendbundle(c) for c in coins)
+    expected_additions = set(Coin(c.name(), IDENTITY_PUZZLE_HASH, c.amount) for c in coins)
+    expected_signature = AugSchemeMPL.aggregate([sb.aggregated_signature for sb in spend_bundles])
+
+    for sb in spend_bundles:
+        mi = mempool_item_from_spendbundle(sb)
+        mempool.add_to_pool(mi)
+        invariant_check_mempool(mempool)
+
+    generator, signature, additions = await mempool.create_block_generator(
+        get_unspent_lineage_info_for_puzzle_hash, test_constants, uint32(0)
+    )
+
+    assert set(additions) == expected_additions
+
+    assert len(additions) == len(expected_additions)
+    assert signature == expected_signature
+
+    err, conds = run_block_generator2(
+        bytes(generator.program),
+        generator.generator_refs,
+        test_constants.MAX_BLOCK_COST_CLVM,
+        0,
+        signature,
+        None,
+        test_constants,
+    )
+
+    assert err is None
+    assert conds is not None
+
+    assert len(conds.spends) == len(coins)
+
+    num_additions = 0
+    for spend in conds.spends:
+        assert Coin(spend.parent_id, spend.puzzle_hash, uint64(spend.coin_amount)) in coins
+        for add2 in spend.create_coin:
+            assert Coin(spend.coin_id, add2[0], uint64(add2[1])) in expected_additions
+            num_additions += 1
+
+    assert num_additions == len(additions)
+    invariant_check_mempool(mempool)
 
 
 # TODO: import this from chia_rs once we bump the version we depend on

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -3095,9 +3095,6 @@ def test_get_items_by_coin_ids(items: list[MempoolItem], coin_ids: list[bytes32]
 
 @pytest.mark.anyio
 async def test_aggregating_on_a_solution_then_a_more_cost_saving_one_appears() -> None:
-    def always(_: bytes32) -> bool:
-        return True
-
     async def get_unspent_lineage_info_for_puzzle_hash(_: bytes32) -> Optional[UnspentLineageInfo]:
         assert False  # pragma: no cover
 
@@ -3142,7 +3139,7 @@ async def test_aggregating_on_a_solution_then_a_more_cost_saving_one_appears() -
     saved_cost_on_solution_A = agg_and_add_sb_returning_cost_info(mempool, [sb_A, sb_low_rate])
     invariant_check_mempool(mempool)
     result = await mempool.create_bundle_from_mempool_items(
-        always, get_unspent_lineage_info_for_puzzle_hash, test_constants, uint32(0)
+        get_unspent_lineage_info_for_puzzle_hash, test_constants, uint32(0)
     )
     assert result is not None
     agg, _ = result
@@ -3163,7 +3160,7 @@ async def test_aggregating_on_a_solution_then_a_more_cost_saving_one_appears() -
     # sb_A1 gets picked before them (~10 FPC), so from then on only sb_A2 (~2 FPC)
     # would get picked
     result = await mempool.create_bundle_from_mempool_items(
-        always, get_unspent_lineage_info_for_puzzle_hash, test_constants, uint32(0)
+        get_unspent_lineage_info_for_puzzle_hash, test_constants, uint32(0)
     )
     assert result is not None
     agg, _ = result

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -473,10 +473,10 @@ class Mempool:
 
     async def create_bundle_from_mempool_items(
         self,
-        item_inclusion_filter: Callable[[bytes32], bool],
         get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[Optional[UnspentLineageInfo]]],
         constants: ConsensusConstants,
         height: uint32,
+        item_inclusion_filter: Optional[Callable[[bytes32], bool]] = None,
     ) -> Optional[tuple[SpendBundle, list[Coin]]]:
         cost_sum = 0  # Checks that total cost does not exceed block maximum
         fee_sum = 0  # Checks that total fees don't exceed 64 bits
@@ -506,7 +506,7 @@ class Mempool:
             if current_time - bundle_creation_start > 1:
                 log.info(f"exiting early, already spent {current_time - bundle_creation_start:0.2f} s")
                 break
-            if not item_inclusion_filter(name):
+            if item_inclusion_filter is not None and not item_inclusion_filter(name):
                 continue
             try:
                 assert item.conds is not None

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -9,16 +9,18 @@ from enum import Enum
 from time import monotonic
 from typing import Callable, Optional
 
-from chia_rs import AugSchemeMPL, Coin, G2Element
+from chia_rs import AugSchemeMPL, Coin, G2Element, solution_generator_backrefs
 
 from chia.consensus.constants import ConsensusConstants
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.fee_estimation import FeeMempoolInfo, MempoolInfo, MempoolItemInfo
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
+from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.clvm_cost import CLVMCost
 from chia.types.coin_spend import CoinSpend
 from chia.types.eligible_coin_spends import EligibleCoinSpends, UnspentLineageInfo
+from chia.types.generator_types import BlockGenerator
 from chia.types.internal_mempool_item import InternalMempoolItem
 from chia.types.mempool_item import MempoolItem
 from chia.types.spend_bundle import SpendBundle
@@ -470,6 +472,46 @@ class Mempool:
         """
 
         return self._total_cost + cost > self.mempool_info.max_size_in_cost
+
+    async def create_block_generator(
+        self,
+        get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[Optional[UnspentLineageInfo]]],
+        constants: ConsensusConstants,
+        height: uint32,
+        item_inclusion_filter: Optional[Callable[[bytes32], bool]] = None,
+    ) -> tuple[BlockGenerator, G2Element, list[Coin]]:
+        """
+        height is needed in case we fast-forward a transaction and we need to
+        re-run its puzzle.
+        """
+
+        mempool_bundle = await self.create_bundle_from_mempool_items(
+            get_unspent_lineage_info_for_puzzle_hash, constants, height, item_inclusion_filter
+        )
+        if mempool_bundle is None:
+            return (BlockGenerator(), G2Element(), [])
+
+        spend_bundle, additions = mempool_bundle
+        removals = spend_bundle.removals()
+        log.info(f"Add rem: {len(additions)} {len(removals)}")
+
+        # since the hard fork has activated, block generators are
+        # allowed to be serialized with CLVM back-references. We can do that
+        # unconditionally.
+        start_time = monotonic()
+        spends = [(cs.coin, bytes(cs.puzzle_reveal), bytes(cs.solution)) for cs in spend_bundle.coin_spends]
+        block_program = solution_generator_backrefs(spends)
+
+        duration = monotonic() - start_time
+        log.log(
+            logging.INFO if duration < 1 else logging.WARNING,
+            f"serializing block generator took {duration:0.2f} seconds",
+        )
+        return (
+            BlockGenerator(SerializedProgram.from_bytes(block_program), []),
+            spend_bundle.aggregated_signature,
+            additions,
+        )
 
     async def create_bundle_from_mempool_items(
         self,

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -208,14 +208,8 @@ class MempoolManager:
 
         if self.peak is None or self.peak.header_hash != last_tb_header_hash:
             return None
-        if item_inclusion_filter is None:
-
-            def always(bundle_name: bytes32) -> bool:
-                return True
-
-            item_inclusion_filter = always
         return await self.mempool.create_bundle_from_mempool_items(
-            item_inclusion_filter, get_unspent_lineage_info_for_puzzle_hash, self.constants, self.peak.height
+            get_unspent_lineage_info_for_puzzle_hash, self.constants, self.peak.height, item_inclusion_filter
         )
 
     def get_filter(self) -> bytes:

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -8,7 +8,14 @@ from concurrent.futures import Executor, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Callable, Optional, TypeVar
 
-from chia_rs import ELIGIBLE_FOR_DEDUP, ELIGIBLE_FOR_FF, BLSCache, supports_fast_forward, validate_clvm_and_signature
+from chia_rs import (
+    ELIGIBLE_FOR_DEDUP,
+    ELIGIBLE_FOR_FF,
+    BLSCache,
+    G2Element,
+    supports_fast_forward,
+    validate_clvm_and_signature,
+)
 from chiabip158 import PyBIP158
 
 from chia.consensus.block_record import BlockRecordProtocol
@@ -26,6 +33,7 @@ from chia.types.clvm_cost import CLVMCost
 from chia.types.coin_record import CoinRecord
 from chia.types.eligible_coin_spends import EligibilityAndAdditions, UnspentLineageInfo
 from chia.types.fee_rate import FeeRate
+from chia.types.generator_types import BlockGenerator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.mempool_item import BundleCoinSpend, MempoolItem
 from chia.types.spend_bundle import SpendBundle
@@ -195,6 +203,7 @@ class MempoolManager:
     def shut_down(self) -> None:
         self.pool.shutdown(wait=True)
 
+    # TODO: remove this, use create_generator() instead
     async def create_bundle_from_mempool(
         self,
         last_tb_header_hash: bytes32,
@@ -210,6 +219,25 @@ class MempoolManager:
             return None
         return await self.mempool.create_bundle_from_mempool_items(
             get_unspent_lineage_info_for_puzzle_hash, self.constants, self.peak.height, item_inclusion_filter
+        )
+
+    async def create_block_generator(
+        self,
+        last_tb_header_hash: bytes32,
+        get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[Optional[UnspentLineageInfo]]],
+        item_inclusion_filter: Optional[Callable[[bytes32], bool]] = None,
+    ) -> tuple[BlockGenerator, G2Element, list[Coin]]:
+        """
+        Returns a block generator program, the aggregate signature and all additions, for a new block
+        """
+        if self.peak is None or self.peak.header_hash != last_tb_header_hash:
+            return (BlockGenerator(), G2Element(), [])
+
+        return await self.mempool.create_block_generator(
+            get_unspent_lineage_info_for_puzzle_hash,
+            self.constants,
+            self.peak.height,
+            item_inclusion_filter,
         )
 
     def get_filter(self) -> bytes:

--- a/chia/types/generator_types.py
+++ b/chia/types/generator_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.util.streamable import Streamable, streamable
@@ -9,5 +9,5 @@ from chia.util.streamable import Streamable, streamable
 @streamable
 @dataclass(frozen=True)
 class BlockGenerator(Streamable):
-    program: SerializedProgram
-    generator_refs: list[bytes]
+    program: SerializedProgram = field(default_factory=SerializedProgram.default)
+    generator_refs: list[bytes] = field(default_factory=list)


### PR DESCRIPTION
This PR is best reviewed one commit at a time.

### Purpose:

Change the mempool interface to create a block generator, rather than a large spend bundle (to then be turned into a block generator)

The main reason for this is to prepare for changing the implementation of the block generator creation to use an incrementally compressed block creator, to fill block more effectively.

It has some other benefits I think:

1. The spend bundle is an unnecessary step, skipping it should save some time and space
2. It makes it easier to unit test the block generator creation (which currently requires interacting with `full_node_api`, and probably requires a full simulation environment.

The first commit is only tangentially related, and simplifies the function interface related to mempool item inclusion.

### Current Behavior:

The mempool has a method: `create_bundle_from_mempool_items()`

### New Behavior:

The mempool has a method: `create_block_generator`

### benchmarks

This is not expected to affect performance, but the new function combines picking transactions and serializing the block, so it will take longer than just picking the transactions. The benchmarks are now:

Serializing the block with compression is especially expensive:

before:
```
Profiling create_bundle_from_mempool()
  output written to: mempool-create-mt.png
  time: 4.6944s
  per call: 9.39ms
```

after:
```
Profiling create_block_generator()
  output written to: mempool-create-mt.png
  time: 43.8237s
  per call: 876.47ms
```