### PR TITLE
use undelying height_to_hash to check main chain

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1545,7 +1545,7 @@ class FullNode:
             # we have already validated this block once, no need to do it again.
             # however, if this block is not part of the main chain, we need to
             # update the fork context with its additions and removals
-            if blockchain.height_to_hash(block.height) == header_hash:
+            if self.blockchain.height_to_hash(block.height) == header_hash:
                 # we're on the main chain, just fast-forward the fork height
                 fork_info.reset(block.height, header_hash)
             else:


### PR DESCRIPTION
### Purpose:

Backport fix to check whether a block is in the main chain.

### Current Behavior:

We check against the fork's height-to-hash map

### New Behavior:

We check against the main chain's height-to-hash map

### Testing Notes:
