### PR TITLE
avoid asyncio bug in 3.12.8

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -96,6 +96,8 @@ jobs:
               main: True
           - name: "3.12"
             file_name: "3.12"
+            # TODO: https://github.com/python/cpython/issues/128479
+            #       return to just `3.12` after presumably 3.12.9 becomes available with the fix
             action: "3.12.7"
             apt: "3.12"
             install_sh: "3.12"

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -97,7 +97,7 @@ jobs:
           - name: "3.12"
             file_name: "3.12"
             action: "3.12.7"
-            apt: "3.12.7"
+            apt: "3.12"
             install_sh: "3.12"
             matrix: "3.12"
             exclude_from:

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -96,7 +96,7 @@ jobs:
               main: True
           - name: "3.12"
             file_name: "3.12"
-            action: "3.12"
+            action: "3.12.7"
             apt: "3.12.7"
             install_sh: "3.12"
             matrix: "3.12"

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -97,7 +97,7 @@ jobs:
           - name: "3.12"
             file_name: "3.12"
             action: "3.12"
-            apt: "3.12"
+            apt: "3.12.7"
             install_sh: "3.12"
             matrix: "3.12"
             exclude_from:


### PR DESCRIPTION
### Purpose:

Avoid the following asyncio bug, introduced in python 3.12.8:
```
.venv/lib/python3.12/site-packages/anyio/pytest_plugin.py:160: in pytest_pyfunc_call
    runner.run_test(pyfuncitem.obj, testargs)
.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py:2316: in run_test
    self._raise_async_exceptions()
.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py:2220: in _raise_async_exceptions
    raise exceptions[0]
/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/staggered.py:108: in run_one_coro
    exceptions[this_index] = e
E   NameError: cannot access free variable 'exceptions' where it is not associated with a value in enclosing scope
```
https://github.com/python/cpython/issues/128479

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
