### PR TITLE
Re-enable arch install test

### DIFF
--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -194,11 +194,8 @@ jobs:
         exclude:
           - distribution:
               type: arch
-          # TODO: arch brought in glibc 2.41 which became more sensitive around execstack
-          #       which is enabled in libbladebit.  fixes will be made to main and this
-          #       should be re-enabled then.
-          #    arch:
-          #      matrix: arm
+            arch:
+              matrix: arm
 
     steps:
       - name: Prepare Amazon Linux


### PR DESCRIPTION
Re-enable arch install test

(depends on update to chiapos 2.0.9)