### PR TITLE
Include plotNFT rewards in get_farmed_amount

### DIFF
--- a/chia/_tests/cmds/test_farm_cmd.py
+++ b/chia/_tests/cmds/test_farm_cmd.py
@@ -56,18 +56,43 @@ async def test_farm_summary_command(
     )
 
     captured = capsys.readouterr()
-    match = re.search(r"^.+(Farming status:.+)$", captured.out, re.DOTALL)
+    match = re.search(r"(Farming status:.*)", captured.out, re.DOTALL)
     assert match is not None
-    lines = match.group(1).split("\n")
+    output = match.group(1)
 
-    assert lines[0] == "Farming status: Not synced or not connected to peers"
-    assert "Total chia farmed:" in lines[1]
-    assert "User transaction fees:" in lines[2]
-    assert "Block rewards:" in lines[3]
-    assert "Last height farmed:" in lines[4]
-    assert lines[5] == "Local Harvester"
-    assert "e (effective)" in lines[6]
-    assert "Plot count for all harvesters:" in lines[7]
-    assert "e (effective)" in lines[8]
-    assert "Estimated network space:" in lines[9]
-    assert "Expected time to win:" in lines[10]
+    assert "Farming status:" in output
+    assert "Total chia farmed:" in output
+    assert "User transaction fees:" in output
+    assert "Block rewards:" in output
+    assert "Last height farmed:" in output
+    assert "Local Harvester" in output
+    assert "e (effective)" in output
+    assert "Plot count for all harvesters:" in output
+    assert "Estimated network space:" in output
+    assert "Expected time to win:" in output
+
+    await summary(
+        rpc_port=full_node_rpc_port,
+        wallet_rpc_port=wallet_rpc_port,
+        harvester_rpc_port=None,
+        farmer_rpc_port=farmer_rpc_port,
+        include_pool_rewards=True,
+        root_path=bt.root_path,
+    )
+
+    captured = capsys.readouterr()
+    match = re.search(r"(Farming status:.*)", captured.out, re.DOTALL)
+    assert match is not None
+    output = match.group(1)
+
+    assert "Farming status:" in output
+    assert "Total chia farmed:" in output
+    assert "User transaction fees:" in output
+    assert "Farmer rewards:" in output
+    assert "Pool rewards:" in output
+    assert "Total rewards:" in output
+    assert "Local Harvester" in output
+    assert "e (effective)" in output
+    assert "Plot count for all harvesters:" in output
+    assert "Estimated network space:" in output
+    assert "Expected time to win:" in output

--- a/chia/_tests/cmds/test_farm_cmd.py
+++ b/chia/_tests/cmds/test_farm_cmd.py
@@ -51,7 +51,7 @@ async def test_farm_summary_command(
         wallet_rpc_port=wallet_rpc_port,
         harvester_rpc_port=None,
         farmer_rpc_port=farmer_rpc_port,
-        include_pool_rewards=True,
+        include_pool_rewards=False,
         root_path=bt.root_path,
     )
 

--- a/chia/_tests/cmds/test_farm_cmd.py
+++ b/chia/_tests/cmds/test_farm_cmd.py
@@ -84,11 +84,10 @@ async def test_farm_summary_command(
     )
 
     captured = capsys.readouterr()
-    # grab the output
     match = re.search(r"Farming status:.*", captured.out, re.DOTALL)
     assert match, "no 'Farming status:' line"
     output = match.group(0).strip()
-    lines = [l.strip() for l in output.splitlines()]
+    lines = [line.strip() for line in output.splitlines()]
 
     # always check these first six lines
     assert lines[0].startswith("Farming status:")
@@ -100,7 +99,7 @@ async def test_farm_summary_command(
 
     # decide where the harvester section starts
     if "Current/Last height farmed:" in output:
-        # we saw the height‐farmed block, so it occupies lines[6–8]
+        # we saw the height-farmed block, so it occupies lines[6-8]
         assert lines[6].startswith("Current/Last height farmed:")
         assert lines[7].startswith("Blocks since last farmed:")
         assert lines[8].startswith("Time since last farmed:")

--- a/chia/_tests/cmds/test_farm_cmd.py
+++ b/chia/_tests/cmds/test_farm_cmd.py
@@ -46,7 +46,14 @@ async def test_farm_summary_command(
     wallet_rpc_port = wallet_service.rpc_server.webserver.listen_port
     farmer_rpc_port = farmer_service.rpc_server.webserver.listen_port
 
-    await summary(full_node_rpc_port, wallet_rpc_port, None, farmer_rpc_port, bt.root_path)
+    await summary(
+        rpc_port=full_node_rpc_port,
+        wallet_rpc_port=wallet_rpc_port,
+        harvester_rpc_port=None,
+        farmer_rpc_port=farmer_rpc_port,
+        include_pool_rewards=False,
+        root_path=bt.root_path,
+    )
 
     captured = capsys.readouterr()
     match = re.search(r"^.+(Farming status:.+)$", captured.out, re.DOTALL)

--- a/chia/_tests/cmds/test_farm_cmd.py
+++ b/chia/_tests/cmds/test_farm_cmd.py
@@ -51,7 +51,7 @@ async def test_farm_summary_command(
         wallet_rpc_port=wallet_rpc_port,
         harvester_rpc_port=None,
         farmer_rpc_port=farmer_rpc_port,
-        include_pool_rewards=False,
+        include_pool_rewards=True,
         root_path=bt.root_path,
     )
 

--- a/chia/cmds/farm.py
+++ b/chia/cmds/farm.py
@@ -50,6 +50,7 @@ def farm_cmd() -> None:
     show_default=True,
 )
 @click.option(
+    "-i",
     "--include-pool-rewards",
     help="Include pool farming rewards in the total farmed amount",
     is_flag=True,

--- a/chia/cmds/farm.py
+++ b/chia/cmds/farm.py
@@ -49,6 +49,12 @@ def farm_cmd() -> None:
     default=None,
     show_default=True,
 )
+@click.option(
+    "--include-pool-rewards",
+    help="Include pool farming rewards in the total farmed amount",
+    is_flag=True,
+    default=False,
+)
 @click.pass_context
 def summary_cmd(
     ctx: click.Context,
@@ -56,6 +62,7 @@ def summary_cmd(
     wallet_rpc_port: Optional[int],
     harvester_rpc_port: Optional[int],
     farmer_rpc_port: Optional[int],
+    include_pool_rewards: bool,
 ) -> None:
     import asyncio
 
@@ -67,6 +74,7 @@ def summary_cmd(
             wallet_rpc_port,
             harvester_rpc_port,
             farmer_rpc_port,
+            include_pool_rewards,
             root_path=ChiaCliContext.set_default(ctx).root_path,
         )
     )

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -127,6 +127,10 @@ async def summary(
         print(f"User transaction fees: {amounts['fee_amount'] / units['chia']}")
         print(f"Block rewards: {(amounts['farmer_reward_amount'] + amounts['pool_reward_amount']) / units['chia']}")
         print(f"Last height farmed: {amounts['last_height_farmed']}")
+        if blockchain_state is not None and blockchain_state["peak"] is not None:
+            peak_height = blockchain_state["peak"].height
+            blocks_since_last_farm = peak_height - amounts['last_height_farmed']
+            print(f"Blocks since last farmed: {blocks_since_last_farm}")
 
     class PlotStats:
         total_plot_size = 0

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -125,10 +125,10 @@ async def summary(
     if amounts is not None:
         print(f"Total chia farmed: {amounts['farmed_amount'] / units['chia']}")
         print(f"User transaction fees: {amounts['fee_amount'] / units['chia']}")
-        print(f"Block rewards: {(amounts['farmer_reward_amount'] + amounts['pool_reward_amount']) / units['chia']}")
         if include_pool_rewards:
-            print(f"├─ Farmer rewards: {amounts['farmer_reward_amount'] / units['chia']}")
-            print(f"└─ Pool rewards: {amounts['pool_reward_amount'] / units['chia']}")
+            print(f"Farmer rewards: {amounts['farmer_reward_amount'] / units['chia']}")
+            print(f"Pool rewards: {amounts['pool_reward_amount'] / units['chia']}")
+            print(f"Total rewards: {(amounts['farmer_reward_amount'] + amounts['pool_reward_amount']) / units['chia']}")
             if blockchain_state is not None and blockchain_state["peak"] is not None:
                 peak_height = blockchain_state["peak"].height
                 blocks_since_last_farm = peak_height - amounts['last_height_farmed']
@@ -136,6 +136,7 @@ async def summary(
                 print(f"Blocks since last farmed: {blocks_since_last_farm}")
                 print(f"Time since last farmed: {format_minutes(int((blocks_since_last_farm * SECONDS_PER_BLOCK) / 60))}")
         else:
+            print(f"Block rewards: {(amounts['farmer_reward_amount'] + amounts['pool_reward_amount']) / units['chia']}")
             print(f"Last height farmed: {amounts['last_height_farmed']}")
 
     class PlotStats:

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -126,11 +126,19 @@ async def summary(
         print(f"Total chia farmed: {amounts['farmed_amount'] / units['chia']}")
         print(f"User transaction fees: {amounts['fee_amount'] / units['chia']}")
         print(f"Block rewards: {(amounts['farmer_reward_amount'] + amounts['pool_reward_amount']) / units['chia']}")
+        if include_pool_rewards:
+            print(f"  └─ Farmer rewards: {amounts['farmer_reward_amount'] / units['chia']}")
+            print(f"  └─ Pool rewards: {amounts['pool_reward_amount'] / units['chia']}")
         print(f"Last height farmed: {amounts['last_height_farmed']}")
-        if blockchain_state is not None and blockchain_state["peak"] is not None:
+        
+        # Show additional information only when include_pool_rewards is True
+        if include_pool_rewards and blockchain_state is not None and blockchain_state["peak"] is not None:
             peak_height = blockchain_state["peak"].height
             blocks_since_last_farm = peak_height - amounts['last_height_farmed']
+            print(f"\nDetailed farming information:")
+            print(f"Current height: {peak_height}")
             print(f"Blocks since last farmed: {blocks_since_last_farm}")
+            print(f"Time since last farmed: {format_minutes(int((blocks_since_last_farm * SECONDS_PER_BLOCK) / 60))}")
 
     class PlotStats:
         total_plot_size = 0

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -127,18 +127,16 @@ async def summary(
         print(f"User transaction fees: {amounts['fee_amount'] / units['chia']}")
         print(f"Block rewards: {(amounts['farmer_reward_amount'] + amounts['pool_reward_amount']) / units['chia']}")
         if include_pool_rewards:
-            print(f"  └─ Farmer rewards: {amounts['farmer_reward_amount'] / units['chia']}")
-            print(f"  └─ Pool rewards: {amounts['pool_reward_amount'] / units['chia']}")
-        print(f"Last height farmed: {amounts['last_height_farmed']}")
-        
-        # Show additional information only when include_pool_rewards is True
-        if include_pool_rewards and blockchain_state is not None and blockchain_state["peak"] is not None:
-            peak_height = blockchain_state["peak"].height
-            blocks_since_last_farm = peak_height - amounts['last_height_farmed']
-            print(f"\nDetailed farming information:")
-            print(f"Current height: {peak_height}")
-            print(f"Blocks since last farmed: {blocks_since_last_farm}")
-            print(f"Time since last farmed: {format_minutes(int((blocks_since_last_farm * SECONDS_PER_BLOCK) / 60))}")
+            print(f"├─ Farmer rewards: {amounts['farmer_reward_amount'] / units['chia']}")
+            print(f"└─ Pool rewards: {amounts['pool_reward_amount'] / units['chia']}")
+            if blockchain_state is not None and blockchain_state["peak"] is not None:
+                peak_height = blockchain_state["peak"].height
+                blocks_since_last_farm = peak_height - amounts['last_height_farmed']
+                print(f"Current/Last height farmed: {peak_height}/{amounts['last_height_farmed']}")
+                print(f"Blocks since last farmed: {blocks_since_last_farm}")
+                print(f"Time since last farmed: {format_minutes(int((blocks_since_last_farm * SECONDS_PER_BLOCK) / 60))}")
+        else:
+            print(f"Last height farmed: {amounts['last_height_farmed']}")
 
     class PlotStats:
         total_plot_size = 0

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -49,9 +49,13 @@ async def get_average_block_time(rpc_port: Optional[int], root_path: Path) -> fl
         return (curr.timestamp - past_curr.timestamp) / (curr.height - past_curr.height)
 
 
-async def get_wallets_stats(wallet_rpc_port: Optional[int], root_path: Path) -> Optional[dict[str, Any]]:
+async def get_wallets_stats(
+    wallet_rpc_port: Optional[int],
+    root_path: Path,
+    include_pool_rewards: bool,
+) -> Optional[dict[str, Any]]:
     async with get_any_service_client(WalletRpcClient, root_path, wallet_rpc_port) as (wallet_client, _):
-        return await wallet_client.get_farmed_amount()
+        return await wallet_client.get_farmed_amount(include_pool_rewards)
 
 
 async def get_challenges(root_path: Path, farmer_rpc_port: Optional[int]) -> Optional[list[dict[str, Any]]]:
@@ -80,6 +84,7 @@ async def summary(
     wallet_rpc_port: Optional[int],
     harvester_rpc_port: Optional[int],
     farmer_rpc_port: Optional[int],
+    include_pool_rewards: bool,
     root_path: Path,
 ) -> None:
     harvesters_summary = await get_harvesters_summary(farmer_rpc_port, root_path)
@@ -97,7 +102,7 @@ async def summary(
     wallet_not_ready: bool = False
     amounts = None
     try:
-        amounts = await get_wallets_stats(wallet_rpc_port, root_path)
+        amounts = await get_wallets_stats(wallet_rpc_port, root_path, include_pool_rewards)
     except CliRpcConnectionError:
         wallet_not_ready = True
     except Exception:

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -131,10 +131,12 @@ async def summary(
             print(f"Total rewards: {(amounts['farmer_reward_amount'] + amounts['pool_reward_amount']) / units['chia']}")
             if blockchain_state is not None and blockchain_state["peak"] is not None:
                 peak_height = blockchain_state["peak"].height
-                blocks_since_last_farm = peak_height - amounts['last_height_farmed']
+                blocks_since_last_farm = peak_height - amounts["last_height_farmed"]
                 print(f"Current/Last height farmed: {peak_height}/{amounts['last_height_farmed']}")
                 print(f"Blocks since last farmed: {blocks_since_last_farm}")
-                print(f"Time since last farmed: {format_minutes(int((blocks_since_last_farm * SECONDS_PER_BLOCK) / 60))}")
+                print(
+                    f"Time since last farmed: {format_minutes(int((blocks_since_last_farm * SECONDS_PER_BLOCK) / 60))}"
+                )
         else:
             print(f"Block rewards: {(amounts['farmer_reward_amount'] + amounts['pool_reward_amount']) / units['chia']}")
             print(f"Last height farmed: {amounts['last_height_farmed']}")

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -3671,7 +3671,10 @@ class WalletRpcApi:
             if record.wallet_id not in self.service.wallet_state_manager.wallets:
                 continue
             if record.type == TransactionType.COINBASE_REWARD.value:
-                if not include_pool_rewards and self.service.wallet_state_manager.wallets[record.wallet_id].type() == WalletType.POOLING_WALLET:
+                if (
+                    not include_pool_rewards
+                    and self.service.wallet_state_manager.wallets[record.wallet_id].type() == WalletType.POOLING_WALLET
+                ):
                     # Don't add pool rewards for pool wallets unless explicitly requested
                     continue
                 pool_reward_amount += record.amount

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -3664,10 +3664,16 @@ class WalletRpcApi:
         fee_amount = 0
         blocks_won = 0
         last_height_farmed = uint32(0)
+
+        include_pool_rewards = request.get("include_pool_rewards", False)
+
         for record in tx_records:
             if record.wallet_id not in self.service.wallet_state_manager.wallets:
                 continue
             if record.type == TransactionType.COINBASE_REWARD.value:
+                if not include_pool_rewards and self.service.wallet_state_manager.wallets[record.wallet_id].type() == WalletType.POOLING_WALLET:
+                    # Don't add pool rewards for pool wallets unless explicitly requested
+                    continue
                 pool_reward_amount += record.amount
             height = record.height_farmed(self.service.constants.GENESIS_CHALLENGE)
             # .get_farming_rewards() above queries for only confirmed records.  This

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -3668,9 +3668,6 @@ class WalletRpcApi:
             if record.wallet_id not in self.service.wallet_state_manager.wallets:
                 continue
             if record.type == TransactionType.COINBASE_REWARD.value:
-                if self.service.wallet_state_manager.wallets[record.wallet_id].type() == WalletType.POOLING_WALLET:
-                    # Don't add pool rewards for pool wallets.
-                    continue
                 pool_reward_amount += record.amount
             height = record.height_farmed(self.service.constants.GENESIS_CHALLENGE)
             # .get_farming_rewards() above queries for only confirmed records.  This

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -427,8 +427,8 @@ class WalletRpcClient(RpcClient):
         updated_index = response["index"]
         return str(updated_index)
 
-    async def get_farmed_amount(self) -> dict[str, Any]:
-        return await self.fetch("get_farmed_amount", {})
+    async def get_farmed_amount(self, include_pool_rewards: bool = False) -> dict[str, Any]:
+        return await self.fetch("get_farmed_amount", {"include_pool_rewards": include_pool_rewards})
 
     async def create_signed_transactions(
         self,


### PR DESCRIPTION
### Purpose:

`chia get farm summary` currently only returns values for OG plots.
Since the majority of people have long since switched to plotNFT plots, I'm not sure why pooling wallets are being excluded from this calculation.

### Current Behavior:

`chia rpc wallet get_farmed_amount`

```
{
  "blocks_won": 114,
  "farmed_amount": 96752754128478,
  "farmer_reward_amount": 28500000000000,
  "fee_amount": 2754128478,
  "last_height_farmed": 3810216,
  "last_time_farmed": 1686871581,
  "pool_reward_amount": 68250000000000,
  "success": true
}
```

`chia farm summary`
```
Farming status: Farming
Total chia farmed: 96.752754128478
User transaction fees: 0.002754128478
Block rewards: 96.75
Last height farmed: 3810216
...
```

### New Behavior:

`chia rpc wallet get_farmed_amount`
```
{
  "blocks_won": 114,
  "farmed_amount": 284002754128478,
  "farmer_reward_amount": 28500000000000,
  "fee_amount": 2754128478,
  "last_height_farmed": 6609397,
  "last_time_farmed": 1739076254,
  "pool_reward_amount": 255500000000000,
  "success": true
}
```

`chia farm summary`
```
Farming status: Farming
Total chia farmed: 284.002754128478
User transaction fees: 0.002754128478
Block rewards: 284.0
Last height farmed: 6609397
...
```

### Testing Notes:

I don't know if the changed calculations here would result in some negative behavior elsewhere, like in the GUI.
