### PR TITLE
name threads in ThreadPoolExecutor

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -146,6 +146,7 @@ class Blockchain:
             num_workers = max(cpu_count - reserved_cores, 1)
             self.pool = ThreadPoolExecutor(
                 max_workers=num_workers,
+                thread_name_prefix="block-validation-",
             )
             log.info(f"Started {num_workers} processes for block validation")
 

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -205,7 +205,7 @@ class S3Plugin:
             target_diff_path = self.get_s3_target_from_path(store_id, diff_path, group_files_by_store)
 
             try:
-                with concurrent.futures.ThreadPoolExecutor() as pool:
+                with concurrent.futures.ThreadPoolExecutor(thread_name_prefix="s3-upload-") as pool:
                     if full_tree_path is not None:
                         await asyncio.get_running_loop().run_in_executor(
                             pool,
@@ -284,7 +284,7 @@ class S3Plugin:
             # Create folder for parent directory
             target_filename.parent.mkdir(parents=True, exist_ok=True)
             log.info(f"downloading {url} to {target_filename}...")
-            with concurrent.futures.ThreadPoolExecutor() as pool:
+            with concurrent.futures.ThreadPoolExecutor(thread_name_prefix="s3-download-") as pool:
                 await asyncio.get_running_loop().run_in_executor(
                     pool, functools.partial(my_bucket.download_file, filename, str(target_filename))
                 )
@@ -330,7 +330,7 @@ class S3Plugin:
                         log.debug(f"skip {file_name} already in bucket")
                         continue
 
-                    with concurrent.futures.ThreadPoolExecutor() as pool:
+                    with concurrent.futures.ThreadPoolExecutor(thread_name_prefix="s3-missing-") as pool:
                         await asyncio.get_running_loop().run_in_executor(
                             pool,
                             functools.partial(my_bucket.upload_file, file_path, target_file_name),

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -96,7 +96,7 @@ class FullNodeAPI:
     def __init__(self, full_node: FullNode) -> None:
         self.log = logging.getLogger(__name__)
         self.full_node = full_node
-        self.executor = ThreadPoolExecutor(max_workers=1)
+        self.executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="node-api-")
 
     @property
     def server(self) -> ChiaServer:

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -180,7 +180,7 @@ class MempoolManager:
         if single_threaded:
             self.pool = InlineExecutor()
         else:
-            self.pool = ThreadPoolExecutor(max_workers=2)
+            self.pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="mempool-")
 
         # The mempool will correspond to a certain peak
         self.peak: Optional[BlockRecordProtocol] = None

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -94,7 +94,9 @@ class Harvester:
             root_path, refresh_parameter=refresh_parameter, refresh_callback=self._plot_refresh_callback
         )
         self._shut_down = False
-        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=config["num_threads"])
+        self.executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=config["num_threads"], thread_name_prefix="harvester-"
+        )
         self._server = None
         self.constants = constants
         self.state_changed_callback: Optional[StateChangedProtocol] = None

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -241,7 +241,9 @@ def check_plots(
                 )
                 bad_plots_list.append(plot_path)
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, context_count)) as executor:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=max(1, context_count), thread_name_prefix="check-plots-"
+        ) as executor:
             logger_lock = Lock()
             futures = []
             for plot_path, plot_info in plot_manager.plots.items():

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -418,7 +418,7 @@ class PlotManager:
 
             return new_plot_info
 
-        with self, ThreadPoolExecutor() as executor:
+        with self, ThreadPoolExecutor(thread_name_prefix="plot-process-") as executor:
             plots_refreshed: dict[Path, PlotInfo] = {}
             for new_plot in executor.map(process_file, plot_paths):
                 if new_plot is not None:

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -167,6 +167,7 @@ class Timelord:
                 self._executor_shutdown_tempfile = _create_shutdown_file()
                 self.bluebox_pool = ThreadPoolExecutor(
                     max_workers=workers,
+                    thread_name_prefix="blue-box-",
                 )
                 self.main_loop = create_referenced_task(
                     self._start_manage_discriminant_queue_sanitizer_slow(self.bluebox_pool, workers)


### PR DESCRIPTION
### Purpose:

To make it easier to troubleshoot threads pegging the CPU.