### PR TITLE
CHIA-2367 Separate height to hash and sub epoch summaries files by networks

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -130,6 +130,7 @@ class Blockchain:
         *,
         single_threaded: bool = False,
         log_coins: bool = False,
+        selected_network: Optional[str] = None,
     ) -> Blockchain:
         """
         Initializes a blockchain with the BlockRecords from disk, assuming they have all been
@@ -157,7 +158,7 @@ class Blockchain:
         self.coin_store = coin_store
         self.block_store = block_store
         self._shut_down = False
-        await self._load_chain_from_store(blockchain_dir)
+        await self._load_chain_from_store(blockchain_dir, selected_network)
         self._seen_compact_proofs = set()
         return self
 
@@ -165,11 +166,11 @@ class Blockchain:
         self._shut_down = True
         self.pool.shutdown(wait=True)
 
-    async def _load_chain_from_store(self, blockchain_dir: Path) -> None:
+    async def _load_chain_from_store(self, blockchain_dir: Path, selected_network: Optional[str] = None) -> None:
         """
         Initializes the state of the Blockchain class from the database.
         """
-        self.__height_map = await BlockHeightMap.create(blockchain_dir, self.block_store.db_wrapper)
+        self.__height_map = await BlockHeightMap.create(blockchain_dir, self.block_store.db_wrapper, selected_network)
         self.__block_records = {}
         self.__heights_in_cache = {}
         block_records, peak = await self.block_store.get_block_records_close_to_peak(self.constants.BLOCKS_CACHE_SIZE)

--- a/chia/full_node/block_height_map.py
+++ b/chia/full_node/block_height_map.py
@@ -56,7 +56,9 @@ class BlockHeightMap:
     __ses_filename: Path
 
     @classmethod
-    async def create(cls, blockchain_dir: Path, db: DBWrapper2) -> BlockHeightMap:
+    async def create(
+        cls, blockchain_dir: Path, db: DBWrapper2, selected_network: Optional[str] = None
+    ) -> BlockHeightMap:
         if db.db_version != 2:
             raise RuntimeError(f"BlockHeightMap does not support database schema v{db.db_version}")
         self = BlockHeightMap()
@@ -66,8 +68,9 @@ class BlockHeightMap:
         self.__first_dirty = 0
         self.__height_to_hash = bytearray()
         self.__sub_epoch_summaries = {}
-        self.__height_to_hash_filename = blockchain_dir / "height-to-hash"
-        self.__ses_filename = blockchain_dir / "sub-epoch-summaries"
+        suffix = "" if (selected_network is None or selected_network == "mainnet") else f"-{selected_network}"
+        self.__height_to_hash_filename = blockchain_dir / f"height-to-hash{suffix}"
+        self.__ses_filename = blockchain_dir / f"sub-epoch-summaries{suffix}"
 
         async with self.db.reader_no_transaction() as conn:
             async with conn.execute("SELECT hash FROM current_peak WHERE key = 0") as cursor:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -270,6 +270,7 @@ class FullNode:
                 reserved_cores=reserved_cores,
                 single_threaded=single_threaded,
                 log_coins=log_coins,
+                selected_network=self.config.get("selected_network"),
             )
 
             self._mempool_manager = MempoolManager(


### PR DESCRIPTION
### Purpose:

While we currently separate the blockchain database and the peers file by networks, the height to hash and sub epoch summaries files are not. This creates/reuses the files in question regardless of which network is selected.

### Current Behavior:

Switching from a network to another ends up picking unrelated data w.r.t. these files.

### New Behavior:

Switching from a network to another properly picks up its related files, separate from other networks.