### PR TITLE
[CHIA-2052] Compressed blocks

### DIFF
--- a/benchmarks/mempool.py
+++ b/benchmarks/mempool.py
@@ -242,13 +242,22 @@ async def run_mempool_benchmark() -> None:
         print("\nProfiling create_block_generator()")
         with enable_profiler(True, f"create-{suffix}"):
             start = monotonic()
-            for _ in range(50):
+            for _ in range(10):
                 await mempool.create_block_generator(
                     last_tb_header_hash=rec.header_hash,
                 )
             stop = monotonic()
         print(f"  time: {stop - start:0.4f}s")
-        print(f"  per call: {(stop - start) / 50 * 1000:0.2f}ms")
+        print(f"  per call: {(stop - start) / 10 * 1000:0.2f}ms")
+
+        print("\nProfiling create_block_generator2()")
+        with enable_profiler(True, f"create2-{suffix}"):
+            start = monotonic()
+            for _ in range(10):
+                await mempool.create_block_generator2(last_tb_header_hash=rec.header_hash)
+            stop = monotonic()
+        print(f"  time: {stop - start:0.4f}s")
+        print(f"  per call: {(stop - start) / 10 * 1000:0.2f}ms")
 
         print("\nProfiling new_peak() (optimized)")
         blocks: list[tuple[BenchBlockRecord, list[bytes32]]] = []

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -2984,9 +2984,8 @@ async def test_timeout(old: bool) -> None:
         add_info = mempool.add_to_pool(item)
         assert add_info.error is None
 
-    async def local_get_unspent_lineage_info(ph: bytes32) -> Optional[UnspentLineageInfo]:  # pragma: no cover
-        assert False
-        return None
+    async def local_get_unspent_lineage_info(ph: bytes32) -> Optional[UnspentLineageInfo]:
+        assert False  # pragma: no cover
 
     create_block = mempool.create_block_generator if old else mempool.create_block_generator2
 

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -2959,7 +2959,7 @@ async def test_skip_error_items(old: bool) -> None:
         raise RuntimeError("failed to find fast forward coin")
 
     create_block = mempool.create_block_generator if old else mempool.create_block_generator2
-    generator = await create_block(local_get_unspent_lineage_info, DEFAULT_CONSTANTS, uint32(10))
+    generator = await create_block(local_get_unspent_lineage_info, DEFAULT_CONSTANTS, uint32(10), 10.0)
     assert generator is not None
 
     assert called == 3
@@ -3250,7 +3250,7 @@ async def test_create_block_generator(old: bool) -> None:
         invariant_check_mempool(mempool)
 
     create_block = mempool.create_block_generator if old else mempool.create_block_generator2
-    generator = await create_block(get_unspent_lineage_info_for_puzzle_hash, test_constants, uint32(0))
+    generator = await create_block(get_unspent_lineage_info_for_puzzle_hash, test_constants, uint32(0), 10.0)
     assert generator is not None
 
     assert set(generator.additions) == expected_additions

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -2934,7 +2934,9 @@ def test_items_by_feerate(items: list[MempoolItem], expected: list[Coin]) -> Non
 
 # make sure that after failing to pick 3 fast-forward spends, we skip
 # FF spends. create_block_generator2() does not stop trying FF spends after 3
-# failures, it keeps going.
+# failures, it keeps going. The new function (create_block_generator2()) does
+# not have a limit on FF and dedup spends so it tries all 5. make_test_coins()
+# only returns 5 coins
 @pytest.mark.anyio
 @pytest.mark.parametrize("old, expected", [(True, 3), (False, 5)])
 async def test_skip_error_items(old: bool, expected: int) -> None:
@@ -2946,8 +2948,8 @@ async def test_skip_error_items(old: bool, expected: int) -> None:
     )
     mempool = Mempool(mempool_info, fee_estimator)
 
-    # all 50 items support fast forward
-    for i in range(50):
+    # all 5 items support fast forward
+    for i in range(5):
         item = mk_item(coins[i : i + 1], flags=[ELIGIBLE_FOR_FF], fee=0, cost=50)
         add_info = mempool.add_to_pool(item)
         assert add_info.error is None
@@ -2982,7 +2984,8 @@ async def test_timeout(old: bool) -> None:
         add_info = mempool.add_to_pool(item)
         assert add_info.error is None
 
-    async def local_get_unspent_lineage_info(ph: bytes32) -> Optional[UnspentLineageInfo]:
+    async def local_get_unspent_lineage_info(ph: bytes32) -> Optional[UnspentLineageInfo]:  # pragma: no cover
+        assert False
         return None
 
     create_block = mempool.create_block_generator if old else mempool.create_block_generator2

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -2933,10 +2933,11 @@ def test_items_by_feerate(items: list[MempoolItem], expected: list[Coin]) -> Non
 
 
 # make sure that after failing to pick 3 fast-forward spends, we skip
-# FF spends
+# FF spends. create_block_generator2() does not stop trying FF spends after 3
+# failures, it keeps going.
 @pytest.mark.anyio
-@pytest.mark.parametrize("old", [True, False])
-async def test_skip_error_items(old: bool) -> None:
+@pytest.mark.parametrize("old, expected", [(True, 3), (False, 5)])
+async def test_skip_error_items(old: bool, expected: int) -> None:
     fee_estimator = create_bitcoin_fee_estimator(uint64(11000000000))
     mempool_info = MempoolInfo(
         CLVMCost(uint64(11000000000 * 3)),
@@ -2962,7 +2963,7 @@ async def test_skip_error_items(old: bool) -> None:
     generator = await create_block(local_get_unspent_lineage_info, DEFAULT_CONSTANTS, uint32(10), 10.0)
     assert generator is not None
 
-    assert called == 3
+    assert called == expected
     assert generator.program == SerializedProgram.from_bytes(bytes.fromhex("ff01ff8080"))
 
 

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -2509,6 +2509,24 @@ async def test_advancing_ff(use_optimization: bool) -> None:
     assert spend.latest_singleton_coin == spend_c.coin.name()
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize("old", [True, False])
+async def test_no_peak(old: bool, transactions_1000: list[SpendBundle]) -> None:
+    bundles = transactions_1000[:10]
+    all_coins = [s.coin for b in bundles for s in b.coin_spends]
+    coins = TestCoins(all_coins, {})
+
+    mempool_manager = MempoolManager(
+        coins.get_coin_records,
+        coins.get_unspent_lineage_info,
+        DEFAULT_CONSTANTS,
+    )
+
+    create_block = mempool_manager.create_block_generator if old else mempool_manager.create_block_generator2
+
+    assert await create_block(bytes32([1] * 32), 10.0) is None
+
+
 @pytest.fixture(name="test_wallet")
 def test_wallet_fixture() -> WalletTool:
     return WalletTool(DEFAULT_CONSTANTS)

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -2594,12 +2594,15 @@ def transactions_1000_fixture(test_wallet: WalletTool, seeded_random: random.Ran
 # if we try to fill the mempool with more than 550, all spends won't
 # necessarily fit in the block, which the test assumes
 @pytest.mark.anyio
-@pytest.mark.parametrize("mempool_size", [1, 2, 100, 300, 400, 550])
+@pytest.mark.parametrize("mempool_size", [1, 2, 100, 300, 400, 550, 740])
 @pytest.mark.parametrize("seed", [0, 1, 2, 3, 4, 5])
 @pytest.mark.parametrize("old", [True, False])
 async def test_create_block_generator(
     mempool_size: int, seed: int, old: bool, transactions_1000: list[SpendBundle]
 ) -> None:
+    if mempool_size == 740 and old:
+        pytest.skip("old function can't fit this many")
+
     bundles = transactions_1000
     all_coins = [s.coin for b in bundles for s in b.coin_spends]
     coins = TestCoins(all_coins, {})

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -860,9 +860,15 @@ class FullNodeAPI:
                     while not curr_l_tb.is_transaction_block:
                         curr_l_tb = self.full_node.blockchain.block_record(curr_l_tb.prev_hash)
                     try:
-                        new_block_gen = await self.full_node.mempool_manager.create_block_generator(
-                            curr_l_tb.header_hash
-                        )
+                        # TODO: once we're confident in the new block creation,
+                        # switch to it by default
+                        if self.full_node.config.get("original_block_creation", True):
+                            create_block = self.full_node.mempool_manager.create_block_generator
+                        else:
+                            create_block = self.full_node.mempool_manager.create_block_generator2
+
+                        new_block_gen = await create_block(curr_l_tb.header_hash)
+
                     except Exception as e:
                         self.log.error(f"Traceback: {traceback.format_exc()}")
                         self.full_node.log.error(f"Error making spend bundle {e} peak: {peak}")

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -9,7 +9,7 @@ from enum import Enum
 from time import monotonic
 from typing import Callable, Optional
 
-from chia_rs import AugSchemeMPL, Coin, ConsensusConstants, G2Element, solution_generator_backrefs
+from chia_rs import AugSchemeMPL, BlockBuilder, Coin, ConsensusConstants, G2Element, solution_generator_backrefs
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
@@ -518,7 +518,8 @@ class Mempool:
         duration = monotonic() - start_time
         log.log(
             logging.INFO if duration < 1 else logging.WARNING,
-            f"serializing block generator took {duration:0.2f} seconds",
+            f"serializing block generator took {duration:0.2f} seconds "
+            f"spends: {len(removals)} additions: {len(additions)}",
         )
         return NewBlockGenerator(
             SerializedProgram.from_bytes(block_program),
@@ -653,3 +654,139 @@ class Mempool:
             f"create_bundle_from_mempool_items took {duration:0.4f} seconds",
         )
         return agg, additions
+
+    async def create_block_generator2(
+        self,
+        get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[Optional[UnspentLineageInfo]]],
+        constants: ConsensusConstants,
+        height: uint32,
+        item_inclusion_filter: Optional[Callable[[bytes32], bool]] = None,
+    ) -> Optional[NewBlockGenerator]:
+        fee_sum = 0  # Checks that total fees don't exceed 64 bits
+        additions: list[Coin] = []
+        removals: list[Coin] = []
+
+        eligible_coin_spends = EligibleCoinSpends()
+        log.info(f"Starting to make block, max cost: {self.mempool_info.max_block_clvm_cost}")
+        generator_creation_start = monotonic()
+        cursor = self._db_conn.execute("SELECT name, fee FROM tx ORDER BY fee_per_cost DESC, seq ASC")
+        builder = BlockBuilder()
+        skipped_items = 0
+        # the total (estimated) cost of the transactions added so far
+        block_cost = 0
+        added_spends = 0
+
+        batch_transactions: list[SpendBundle] = []
+        batch_additions: list[Coin] = []
+        batch_spends = 0
+        # this cost only includes conditions and execution cost, not byte-cost
+        batch_cost = 0
+
+        for row in cursor:
+            current_time = monotonic()
+            if current_time - generator_creation_start > 2:
+                log.info(f"exiting early, already spent {current_time - generator_creation_start:0.2f} s")
+                break
+
+            name = bytes32(row[0])
+            fee = int(row[1])
+            item = self._items[name]
+            try:
+                assert item.conds is not None
+                cost = item.conds.condition_cost + item.conds.execution_cost
+                if skipped_items >= PRIORITY_TX_THRESHOLD:
+                    # If we've encountered `PRIORITY_TX_THRESHOLD` number of
+                    # transactions that don't fit in the remaining block size,
+                    # we want to keep looking for smaller transactions that
+                    # might fit, but we also want to avoid spending too much
+                    # time on potentially expensive ones, hence this shortcut.
+                    unique_coin_spends = []
+                    unique_additions = []
+                    for spend_data in item.bundle_coin_spends.values():
+                        if spend_data.eligible_for_dedup or spend_data.eligible_for_fast_forward:
+                            raise Exception(f"Skipping transaction with eligible coin(s): {name.hex()}")
+                        unique_coin_spends.append(spend_data.coin_spend)
+                        unique_additions.extend(spend_data.additions)
+                    cost_saving = 0
+                else:
+                    await eligible_coin_spends.process_fast_forward_spends(
+                        mempool_item=item,
+                        get_unspent_lineage_info_for_puzzle_hash=get_unspent_lineage_info_for_puzzle_hash,
+                        height=height,
+                        constants=constants,
+                    )
+                    unique_coin_spends, cost_saving, unique_additions = eligible_coin_spends.get_deduplication_info(
+                        bundle_coin_spends=item.bundle_coin_spends, max_cost=cost
+                    )
+                new_fee_sum = fee_sum + fee
+                if new_fee_sum > DEFAULT_CONSTANTS.MAX_COIN_AMOUNT:
+                    # Such a fee is very unlikely to happen but we're defensively
+                    # accounting for it
+                    break  # pragma: no cover
+
+                if block_cost + item.conds.cost - cost_saving > constants.MAX_BLOCK_COST_CLVM:
+                    added, done = builder.add_spend_bundles(batch_transactions, uint64(batch_cost), constants)
+
+                    block_cost = builder.cost()
+                    if added:
+                        added_spends += batch_spends
+                        additions.extend(batch_additions)
+                        removals.extend([cs.coin for sb in batch_transactions for cs in sb.coin_spends])
+                        log.info(
+                            f"adding TX batch, additions: {len(batch_additions)} removals: {batch_spends} "
+                            f"cost: {batch_cost} total cost: {block_cost}"
+                        )
+                    else:
+                        skipped_items += 1
+
+                    batch_cost = 0
+                    batch_transactions = []
+                    batch_additions = []
+                    batch_spends = 0
+                    if done:
+                        break
+
+                batch_cost += cost - cost_saving
+                batch_transactions.append(SpendBundle(unique_coin_spends, item.spend_bundle.aggregated_signature))
+                batch_spends += len(unique_coin_spends)
+                batch_additions.extend(unique_additions)
+                fee_sum = new_fee_sum
+                block_cost += item.conds.cost - cost_saving
+            except SkipDedup as e:
+                log.info(f"{e}")
+                continue
+            except Exception as e:
+                log.info(f"Exception while checking a mempool item for deduplication: {e}")
+                skipped_items += 1
+                continue
+
+        if len(batch_transactions) > 0:
+            added, _ = builder.add_spend_bundles(batch_transactions, uint64(batch_cost), constants)
+
+            if added:
+                added_spends += batch_spends
+                additions.extend(batch_additions)
+                removals.extend([cs.coin for sb in batch_transactions for cs in sb.coin_spends])
+                block_cost = builder.cost()
+                log.info(
+                    f"adding TX batch, additions: {len(batch_additions)} removals: {batch_spends} "
+                    f"cost: {batch_cost} total cost: {block_cost}"
+                )
+
+        generator_creation_end = monotonic()
+        duration = generator_creation_end - generator_creation_start
+        block_program, signature, cost = builder.finalize(constants)
+        log.log(
+            logging.INFO if duration < 2 else logging.WARNING,
+            f"create_block_generator2() took {duration:0.4f} seconds. "
+            f"block cost: {cost} spends: {added_spends} additions: {len(additions)}",
+        )
+
+        return NewBlockGenerator(
+            SerializedProgram.from_bytes(block_program),
+            [],
+            [],
+            signature,
+            additions,
+            removals,
+        )

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -684,7 +684,7 @@ class Mempool:
 
         for row in cursor:
             current_time = monotonic()
-            if current_time - generator_creation_start > 2:
+            if current_time - generator_creation_start > 2:  # pragma: no cover
                 log.info(f"exiting early, already spent {current_time - generator_creation_start:0.2f} s")
                 break
 
@@ -704,7 +704,7 @@ class Mempool:
                     unique_additions = []
                     for spend_data in item.bundle_coin_spends.values():
                         if spend_data.eligible_for_dedup or spend_data.eligible_for_fast_forward:
-                            raise Exception(f"Skipping transaction with eligible coin(s): {name.hex()}")
+                            raise Exception(f"Skipping transaction with fast-forward or dedup coin(s): {name.hex()}")
                         unique_coin_spends.append(spend_data.coin_spend)
                         unique_additions.extend(spend_data.additions)
                     cost_saving = 0
@@ -724,6 +724,9 @@ class Mempool:
                     # accounting for it
                     break  # pragma: no cover
 
+                # if adding item would make us exceed the block cost, commit the
+                # batch we've built up first, to see if more space may be freed
+                # up by the compression
                 if block_cost + item.conds.cost - cost_saving > constants.MAX_BLOCK_COST_CLVM:
                     added, done = builder.add_spend_bundles(batch_transactions, uint64(batch_cost), constants)
 

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -566,7 +566,7 @@ class Mempool:
             item = self._items[name]
 
             current_time = monotonic()
-            if current_time - bundle_creation_start > timeout:
+            if current_time - bundle_creation_start >= timeout:
                 log.info(f"exiting early, already spent {current_time - bundle_creation_start:0.2f} s")
                 break
             try:
@@ -644,7 +644,7 @@ class Mempool:
                 log.info(f"Exception while checking a mempool item for deduplication: {e}")
                 skipped_items += 1
                 continue
-        if processed_spend_bundles == 0:
+        if coin_spends == []:
             return None
         log.info(
             f"Cumulative cost of block (real cost should be less) {cost_sum}. Proportion "
@@ -689,7 +689,7 @@ class Mempool:
 
         for row in cursor:
             current_time = monotonic()
-            if current_time - generator_creation_start > timeout:  # pragma: no cover
+            if current_time - generator_creation_start >= timeout:
                 log.info(f"exiting early, already spent {current_time - generator_creation_start:0.2f} s")
                 break
 
@@ -765,6 +765,9 @@ class Mempool:
                     f"adding TX batch, additions: {len(batch_additions)} removals: {batch_spends} "
                     f"cost: {batch_cost} total cost: {block_cost}"
                 )
+
+        if removals == []:
+            return None
 
         generator_creation_end = monotonic()
         duration = generator_creation_end - generator_creation_start

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -243,6 +243,7 @@ class MempoolManager:
     async def create_block_generator(
         self,
         last_tb_header_hash: bytes32,
+        timeout: float = 2.0,
     ) -> Optional[NewBlockGenerator]:
         """
         Returns a block generator program, the aggregate signature and all additions and removals, for a new block
@@ -253,13 +254,16 @@ class MempoolManager:
         lineage_cache = LineageInfoCache(self.get_unspent_lineage_info_for_puzzle_hash)
 
         return await self.mempool.create_block_generator(
-            lineage_cache.get_unspent_lineage_info, self.constants, self.peak.height
+            lineage_cache.get_unspent_lineage_info,
+            self.constants,
+            self.peak.height,
+            timeout,
         )
 
     async def create_block_generator2(
         self,
         last_tb_header_hash: bytes32,
-        item_inclusion_filter: Optional[Callable[[bytes32], bool]] = None,
+        timeout: float = 2.0,
     ) -> Optional[NewBlockGenerator]:
         """
         Returns a block generator program, the aggregate signature and all additions, for a new block
@@ -273,7 +277,7 @@ class MempoolManager:
             lineage_cache.get_unspent_lineage_info,
             self.constants,
             self.peak.height,
-            item_inclusion_filter,
+            timeout,
         )
 
     def get_filter(self) -> bytes:

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -256,6 +256,26 @@ class MempoolManager:
             lineage_cache.get_unspent_lineage_info, self.constants, self.peak.height
         )
 
+    async def create_block_generator2(
+        self,
+        last_tb_header_hash: bytes32,
+        item_inclusion_filter: Optional[Callable[[bytes32], bool]] = None,
+    ) -> Optional[NewBlockGenerator]:
+        """
+        Returns a block generator program, the aggregate signature and all additions, for a new block
+        """
+        if self.peak is None or self.peak.header_hash != last_tb_header_hash:
+            return None
+
+        lineage_cache = LineageInfoCache(self.get_unspent_lineage_info_for_puzzle_hash)
+
+        return await self.mempool.create_block_generator2(
+            lineage_cache.get_unspent_lineage_info,
+            self.constants,
+            self.peak.height,
+            item_inclusion_filter,
+        )
+
     def get_filter(self) -> bytes:
         all_transactions: set[bytes32] = set()
         byte_array_list = []

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -863,7 +863,7 @@ class FullNodeRpcApi:
             start_time = time.monotonic()
 
             try:
-                maybe_gen = await self.service.mempool_manager.create_block_generator(curr_l_tb.header_hash)
+                maybe_gen = await self.service.mempool_manager.create_block_generator2(curr_l_tb.header_hash)
                 if maybe_gen is None:
                     self.service.log.error(f"failed to create block generator, peak: {peak}")
                 else:


### PR DESCRIPTION
### Purpose:

Farm blocks with as many transactions as possible.

### Current Behavior:

We first fill the block with transactions, then we compress it. We don't attempt to fit more transactions after compression, leaving blocks under utilized.

### New Behavior:

This patch doesn't change the default behavior, it adds a (temporary) configuration option to opt-in to a new block creation algorithm.

The new block creation function (`create_block_generator2()`) uses the `BlockBuilder` class from `chia_rs`. This class allows building and compressing a block incrementally. So we start with a batch of transactions that add up to the block cost limit and serialize and compress that. Then we keep building batches to add to the block and serialize and compress those until we reach the cost limit, or run out of time.

### Testing Notes:

The new algorithm is slower, because it serializes more transactions into the block, but also because it needs to checkpoint the serializer state in case it exceeds the limit and has to revert.

Here's how it measures up against the existing block creation (which is also bottle-necked by serialization and compression):

(MacBook M1)
```
Profiling create_block_generator()
  output written to: mempool-create-st.png
  time: 8.3498s
  per call: 834.98ms

Profiling create_block_generator2()
  output written to: mempool-create2-st.png
  time: 17.4403s
  per call: 1744.03ms
```

(RPi-5)
```
Profiling create_block_generator()
  output written to: mempool-create-st.png
  time: 46.4750s
  per call: 4647.50ms

Profiling create_block_generator2()
  output written to: mempool-create2-st.png
  time: 50.0050s
  per call: 5000.50ms
```

This is one reason this is not enabled by default yet. There are optimizations of the compression/serialization logic in the works, [here](https://github.com/Chia-Network/clvm_rs/pull/562).

This will significantly speed up compression (see benchmarks in that PR).

Including this new algorithm early gives us a chance to use it on testnet for longer, and maybe even farmers in the wild, before we switch over to it.

## manual tests

On rapsberry PI 5, running a testnet11 node I used the new RPC to create a block generator with the following log output:

```
full_node chia.full_node.full_node: INFO     Beginning simulated block construction from mempool
full_node chia.full_node.mempool  : INFO     Starting to make block, max cost: 10999975980
full_node chia.full_node.mempool  : INFO     adding TX batch, additions: 9 removals: 8 cost: 29549118 total cost: 10914077138
full_node chia.full_node.mempool  : INFO     adding TX batch, additions: 1 removals: 1 cost: 3039460 total cost: 10954508598
full_node chia.full_node.mempool  : INFO     adding TX batch, additions: 1 removals: 1 cost: 3039460 total cost: 10994916058
full_node chia.full_node.mempool  : INFO     create_block_generator2() took 0.0154 seconds. block cost: 10994916058 spends: 10 additions: 11
full_node chia.full_node.full_node: INFO     Simulated block constructed in 0.02 seconds
```

## future performance

Running the mempool benchmark on RPi-5, with the CLVM optimization patch applied, give these results:

```
Profiling create_block_generator()
  output written to: mempool-create-st.png
  time: 49.7158s
  per call: 4971.58ms

Profiling create_block_generator2()
  output written to: mempool-create2-st.png
  time: 21.0602s
  per call: 2106.02ms
```