### PR TITLE
CHIA-2381 Validate fast forward spends before adding their spend bundle to the mempool

### DIFF
--- a/benchmarks/mempool-long-lived.py
+++ b/benchmarks/mempool-long-lived.py
@@ -17,6 +17,7 @@ from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend
 from chia.types.condition_opcodes import ConditionOpcode
+from chia.types.eligible_coin_spends import UnspentLineageInfo
 from chia.types.spend_bundle import SpendBundle
 from chia.util.ints import uint32, uint64
 
@@ -90,9 +91,15 @@ async def run_mempool_benchmark() -> None:
                 ret.append(r)
         return ret
 
+    # We currently don't need to keep track of these for our purpose
+    async def get_unspent_lineage_info_for_puzzle_hash(_: bytes32) -> Optional[UnspentLineageInfo]:
+        assert False
+
     timestamp = uint64(1631794488)
 
-    mempool = MempoolManager(get_coin_record, DEFAULT_CONSTANTS, single_threaded=True)
+    mempool = MempoolManager(
+        get_coin_record, get_unspent_lineage_info_for_puzzle_hash, DEFAULT_CONSTANTS, single_threaded=True
+    )
 
     print("\nrunning add_spend_bundle() + new_peak()")
 

--- a/benchmarks/mempool.py
+++ b/benchmarks/mempool.py
@@ -166,7 +166,12 @@ async def run_mempool_benchmark() -> None:
         else:
             print("\n== Multi-threaded")
 
-        mempool = MempoolManager(get_coin_records, DEFAULT_CONSTANTS, single_threaded=single_threaded)
+        mempool = MempoolManager(
+            get_coin_records,
+            get_unspent_lineage_info_for_puzzle_hash,
+            DEFAULT_CONSTANTS,
+            single_threaded=single_threaded,
+        )
 
         height = start_height
         rec = fake_block_record(height, timestamp)
@@ -196,7 +201,12 @@ async def run_mempool_benchmark() -> None:
         print(f"  time: {stop - start:0.4f}s")
         print(f"  per call: {(stop - start) / total_bundles * 1000:0.2f}ms")
 
-        mempool = MempoolManager(get_coin_records, DEFAULT_CONSTANTS, single_threaded=single_threaded)
+        mempool = MempoolManager(
+            get_coin_records,
+            get_unspent_lineage_info_for_puzzle_hash,
+            DEFAULT_CONSTANTS,
+            single_threaded=single_threaded,
+        )
 
         height = start_height
         rec = fake_block_record(height, timestamp)

--- a/chia/_tests/core/mempool/test_mempool_fee_estimator.py
+++ b/chia/_tests/core/mempool/test_mempool_fee_estimator.py
@@ -63,7 +63,9 @@ async def test_basics() -> None:
 async def test_fee_increase() -> None:
     async with DBConnection(db_version=2) as db_wrapper:
         coin_store = await CoinStore.create(db_wrapper)
-        mempool_manager = MempoolManager(coin_store.get_coin_records, test_constants)
+        mempool_manager = MempoolManager(
+            coin_store.get_coin_records, coin_store.get_unspent_lineage_info_for_puzzle_hash, test_constants
+        )
         assert test_constants.MAX_BLOCK_COST_CLVM == mempool_manager.constants.MAX_BLOCK_COST_CLVM
         btc_fee_estimator: BitcoinFeeEstimator = mempool_manager.mempool.fee_estimator  # type: ignore
         fee_tracker = btc_fee_estimator.get_tracker()

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -103,6 +103,10 @@ async def zero_calls_get_coin_records(coin_ids: Collection[bytes32]) -> list[Coi
     return []
 
 
+async def zero_calls_get_unspent_lineage_info_for_puzzle_hash(_puzzle_hash: bytes32) -> Optional[UnspentLineageInfo]:
+    assert False  # pragma no cover
+
+
 async def get_coin_records_for_test_coins(coin_ids: Collection[bytes32]) -> list[CoinRecord]:
     test_coin_records = {
         TEST_COIN_ID: TEST_COIN_RECORD,
@@ -140,7 +144,12 @@ async def instantiate_mempool_manager(
     constants: ConsensusConstants = DEFAULT_CONSTANTS,
     max_tx_clvm_cost: Optional[uint64] = None,
 ) -> MempoolManager:
-    mempool_manager = MempoolManager(get_coin_records, constants, max_tx_clvm_cost=max_tx_clvm_cost)
+    mempool_manager = MempoolManager(
+        get_coin_records,
+        zero_calls_get_unspent_lineage_info_for_puzzle_hash,
+        constants,
+        max_tx_clvm_cost=max_tx_clvm_cost,
+    )
     test_block_record = create_test_block_record(height=block_height, timestamp=block_timestamp)
     await mempool_manager.new_peak(test_block_record, None)
     invariant_check_mempool(mempool_manager.mempool)
@@ -427,18 +436,18 @@ def make_bundle_spends_map_and_fee(
         eligibility_and_additions[coin_id] = EligibilityAndAdditions(
             is_eligible_for_dedup=bool(spend.flags & ELIGIBLE_FOR_DEDUP),
             spend_additions=spend_additions,
-            is_eligible_for_ff=bool(spend.flags & ELIGIBLE_FOR_FF),
+            ff_puzzle_hash=bytes32(spend.puzzle_hash) if bool(spend.flags & ELIGIBLE_FOR_FF) else None,
         )
     for coin_spend in spend_bundle.coin_spends:
         coin_id = coin_spend.coin.name()
         removals_amount += coin_spend.coin.amount
         eligibility_info = eligibility_and_additions.get(
-            coin_id, EligibilityAndAdditions(is_eligible_for_dedup=False, spend_additions=[], is_eligible_for_ff=False)
+            coin_id, EligibilityAndAdditions(is_eligible_for_dedup=False, spend_additions=[], ff_puzzle_hash=None)
         )
         bundle_coin_spends[coin_id] = BundleCoinSpend(
             coin_spend=coin_spend,
             eligible_for_dedup=eligibility_info.is_eligible_for_dedup,
-            eligible_for_fast_forward=eligibility_info.is_eligible_for_ff,
+            eligible_for_fast_forward=eligibility_info.ff_puzzle_hash is not None,
             additions=eligibility_info.spend_additions,
         )
     fee = uint64(removals_amount - additions_amount)

--- a/chia/_tests/util/spend_sim.py
+++ b/chia/_tests/util/spend_sim.py
@@ -165,7 +165,9 @@ class SpendSim:
         async with DBWrapper2.managed(database=uri, uri=True, reader_count=1, db_version=2) as self.db_wrapper:
             self.coin_store = await CoinStore.create(self.db_wrapper)
             self.hint_store = await HintStore.create(self.db_wrapper)
-            self.mempool_manager = MempoolManager(self.coin_store.get_coin_records, defaults)
+            self.mempool_manager = MempoolManager(
+                self.coin_store.get_coin_records, self.coin_store.get_unspent_lineage_info_for_puzzle_hash, defaults
+            )
             self.defaults = defaults
 
             # Load the next data if there is any

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -274,6 +274,7 @@ class FullNode:
 
             self._mempool_manager = MempoolManager(
                 get_coin_records=self.coin_store.get_coin_records,
+                get_unspent_lineage_info_for_puzzle_hash=self.coin_store.get_unspent_lineage_info_for_puzzle_hash,
                 consensus_constants=self.constants,
                 single_threaded=single_threaded,
             )

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -129,6 +129,7 @@ class MempoolManager:
     constants: ConsensusConstants
     seen_bundle_hashes: dict[bytes32, bytes32]
     get_coin_records: Callable[[Collection[bytes32]], Awaitable[list[CoinRecord]]]
+    get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[Optional[UnspentLineageInfo]]]
     nonzero_fee_minimum_fpc: int
     mempool_max_total_cost: int
     # a cache of MempoolItems that conflict with existing items in the pool
@@ -145,6 +146,7 @@ class MempoolManager:
     def __init__(
         self,
         get_coin_records: Callable[[Collection[bytes32]], Awaitable[list[CoinRecord]]],
+        get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[Optional[UnspentLineageInfo]]],
         consensus_constants: ConsensusConstants,
         *,
         single_threaded: bool = False,
@@ -156,6 +158,7 @@ class MempoolManager:
         self.seen_bundle_hashes: dict[bytes32, bytes32] = {}
 
         self.get_coin_records = get_coin_records
+        self.get_unspent_lineage_info_for_puzzle_hash = get_unspent_lineage_info_for_puzzle_hash
 
         # The fee per cost must be above this amount to consider the fee "nonzero", and thus able to kick out other
         # transactions. This prevents spam. This is equivalent to 0.055 XCH per block, or about 0.00005 XCH for two
@@ -349,6 +352,7 @@ class MempoolManager:
             spend_name,
             first_added_height,
             get_coin_records,
+            self.get_unspent_lineage_info_for_puzzle_hash,
         )
         if err is None:
             # No error, immediately add to mempool, after removing conflicting TXs.
@@ -379,6 +383,7 @@ class MempoolManager:
         spend_name: bytes32,
         first_added_height: uint32,
         get_coin_records: Callable[[Collection[bytes32]], Awaitable[list[CoinRecord]]],
+        get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[Optional[UnspentLineageInfo]]],
     ) -> tuple[Optional[Err], Optional[MempoolItem], list[bytes32]]:
         """
         Validates new_spend with the given NPCResult, and spend_name, and the current mempool. The mempool should
@@ -423,7 +428,7 @@ class MempoolManager:
             eligibility_and_additions[coin_id] = EligibilityAndAdditions(
                 is_eligible_for_dedup=is_eligible_for_dedup,
                 spend_additions=spend_additions,
-                is_eligible_for_ff=is_eligible_for_ff,
+                ff_puzzle_hash=bytes32(spend.puzzle_hash) if is_eligible_for_ff else None,
             )
         removal_names_from_coin_spends: set[bytes32] = set()
         fast_forward_coin_ids: set[bytes32] = set()
@@ -433,14 +438,20 @@ class MempoolManager:
             removal_names_from_coin_spends.add(coin_id)
             eligibility_info = eligibility_and_additions.get(
                 coin_id,
-                EligibilityAndAdditions(is_eligible_for_dedup=False, spend_additions=[], is_eligible_for_ff=False),
+                EligibilityAndAdditions(is_eligible_for_dedup=False, spend_additions=[], ff_puzzle_hash=None),
             )
-            mark_as_fast_forward = eligibility_info.is_eligible_for_ff and supports_fast_forward(coin_spend)
+            mark_as_fast_forward = eligibility_info.ff_puzzle_hash is not None and supports_fast_forward(coin_spend)
+            if mark_as_fast_forward:
+                # Make sure the fast forward spend still has a version that is
+                # still unspent, because if the singleton has been melted, the
+                # fast forward spend will never become valid.
+                assert eligibility_info.ff_puzzle_hash is not None
+                if await get_unspent_lineage_info_for_puzzle_hash(eligibility_info.ff_puzzle_hash) is None:
+                    return Err.DOUBLE_SPEND, None, []
+                fast_forward_coin_ids.add(coin_id)
             # We are now able to check eligibility of both dedup and fast forward
             if not (eligibility_info.is_eligible_for_dedup or mark_as_fast_forward):
                 non_eligible_coin_ids.append(coin_id)
-            if mark_as_fast_forward:
-                fast_forward_coin_ids.add(coin_id)
             bundle_coin_spends[coin_id] = BundleCoinSpend(
                 coin_spend=coin_spend,
                 eligible_for_dedup=eligibility_info.is_eligible_for_dedup,

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -24,7 +24,10 @@ from chia.util.ints import uint32, uint64
 class EligibilityAndAdditions:
     is_eligible_for_dedup: bool
     spend_additions: list[Coin]
-    is_eligible_for_ff: bool
+    # This is the spend puzzle hash. It's set to `None` if the spend is not
+    # eligible for fast forward. When the spend is eligible, we use its puzzle
+    # hash to check if the singleton has an unspent coin or not.
+    ff_puzzle_hash: Optional[bytes32] = None
 
 
 def run_for_cost(


### PR DESCRIPTION
### Purpose:

Make sure that all fast forward spends of a spend bundle would still have unspent coins.

### Current Behavior:

We can accept a spend bundle with fast forward spends that do not currently have latest unspent coins.

### New Behavior:

We reject spend bundles like that with `DOUBLE_SPEND` error.