### PR TITLE
[CHIA-1251] Add puzzle hash generation to action scopes

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -195,7 +195,8 @@ async def test_block_compression(
     _ = await connect_and_get_peer(server_1, server_2, self_hostname)
     _ = await connect_and_get_peer(server_1, server_3, self_hostname)
 
-    ph = await wallet.get_new_puzzlehash()
+    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
 
     for i in range(4):
         await full_node_1.farm_new_transaction_block(FarmNewBlockProtocol(ph))

--- a/chia/_tests/core/full_node/test_transactions.py
+++ b/chia/_tests/core/full_node/test_transactions.py
@@ -25,7 +25,8 @@ async def test_wallet_coinbase(simulator_and_wallet, self_hostname):
     full_node_server = full_node_api.server
     wallet_node, server_2 = wallets[0]
     wallet = wallet_node.wallet_state_manager.main_wallet
-    ph = await wallet.get_new_puzzlehash()
+    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
 
     await server_2.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
     for i in range(num_blocks):
@@ -54,8 +55,10 @@ async def test_tx_propagation(three_nodes_two_wallets, self_hostname, seeded_ran
     full_node_api_2 = full_nodes[2]
     server_2 = full_node_api_2.server
 
-    ph = await wallet_0.wallet_state_manager.main_wallet.get_new_puzzlehash()
-    ph1 = await wallet_1.wallet_state_manager.main_wallet.get_new_puzzlehash()
+    async with wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph = await action_scope.get_puzzle_hash(wallet_0.wallet_state_manager)
+    async with wallet_1.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph1 = await action_scope.get_puzzle_hash(wallet_1.wallet_state_manager)
 
     #
     # wallet0 <-> sever0 <-> server1 <-> server2 <-> wallet1
@@ -134,7 +137,8 @@ async def test_mempool_tx_sync(three_nodes_two_wallets, self_hostname, seeded_ra
     full_node_api_2 = full_nodes[2]
     server_2 = full_node_api_2.server
 
-    ph = await wallet_0.wallet_state_manager.main_wallet.get_new_puzzlehash()
+    async with wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph = await action_scope.get_puzzle_hash(wallet_0.wallet_state_manager)
 
     # wallet0 <-> sever0 <-> server1
 

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -1719,8 +1719,9 @@ async def test_identical_spend_aggregation_e2e(
         full_node_api: FullNodeSimulator, wallet_node: WalletNode
     ) -> tuple[Wallet, list[WalletCoinRecord], bytes32]:
         wallet = wallet_node.wallet_state_manager.main_wallet
-        ph = await wallet.get_new_puzzlehash()
-        phs = [await wallet.get_new_puzzlehash() for _ in range(3)]
+        async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
+            phs = [await action_scope.get_puzzle_hash(wallet.wallet_state_manager) for _ in range(3)]
         for _ in range(2):
             await farm_a_block(full_node_api, wallet_node, ph)
         async with wallet.wallet_state_manager.new_action_scope(

--- a/chia/_tests/core/mempool/test_mempool_performance.py
+++ b/chia/_tests/core/mempool/test_mempool_performance.py
@@ -43,7 +43,8 @@ async def test_mempool_update_performance(
     fee_amount = uint64(2213)
     await time_out_assert(30, wallet_balance_at_least, True, wallet_node, send_amount + fee_amount)
 
-    ph = await wallet.get_new_puzzlehash()
+    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
     async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=False, sign=True) as action_scope:
         await wallet.generate_signed_transaction([send_amount], [ph], action_scope, fee_amount)
     [big_transaction] = action_scope.side_effects.transactions

--- a/chia/_tests/core/test_filter.py
+++ b/chia/_tests/core/test_filter.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import pytest
 from chiabip158 import PyBIP158
 
+from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
+
 
 @pytest.mark.anyio
 async def test_basic_filter_test(simulator_and_wallet):
@@ -11,7 +13,8 @@ async def test_basic_filter_test(simulator_and_wallet):
     wallet = wallet_node.wallet_state_manager.main_wallet
 
     num_blocks = 2
-    ph = await wallet.get_new_puzzlehash()
+    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
     blocks = bt.get_consecutive_blocks(
         10,
         guarantee_transaction_block=True,

--- a/chia/_tests/fee_estimation/test_fee_estimation_rpc.py
+++ b/chia/_tests/fee_estimation/test_fee_estimation_rpc.py
@@ -17,6 +17,7 @@ from chia.simulator.wallet_tools import WalletTool
 from chia.types.aliases import WalletService
 from chia.types.blockchain_format.coin import Coin
 from chia.types.spend_bundle import SpendBundle
+from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 
 
 @pytest.fixture(scope="function")
@@ -37,7 +38,8 @@ async def setup_node_and_rpc(
     )
     full_node_rpc_api = FullNodeRpcApi(full_node_api.full_node)
 
-    ph = await wallet.get_new_puzzlehash()
+    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
 
     for i in range(4):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))

--- a/chia/_tests/pools/test_pool_cmdline.py
+++ b/chia/_tests/pools/test_pool_cmdline.py
@@ -44,6 +44,7 @@ from chia.util.bech32m import encode_puzzle_hash
 from chia.util.config import lock_and_load_config, save_config
 from chia.util.errors import CliRpcConnectionError
 from chia.wallet.util.address_type import AddressType
+from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_state_manager import WalletStateManager
 
@@ -678,7 +679,8 @@ async def test_plotnft_cli_claim(
     wallet_id = await create_new_plotnft(wallet_environments, self_pool=True)
 
     status: PoolWalletInfo = (await wallet_rpc.pw_status(wallet_id))[0]
-    our_ph = await wallet_state_manager.main_wallet.get_new_puzzlehash()
+    async with wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        our_ph = await action_scope.get_puzzle_hash(wallet_state_manager)
     bt = wallet_environments.full_node.bt
 
     async with manage_temporary_pool_plot(bt, status.p2_singleton_puzzle_hash) as pool_plot:

--- a/chia/_tests/pools/test_pool_rpc.py
+++ b/chia/_tests/pools/test_pool_rpc.py
@@ -253,7 +253,8 @@ async def create_new_plotnft(
     wallet_state_manager: WalletStateManager = wallet_test_framework.environments[0].wallet_state_manager
     wallet_rpc: WalletRpcClient = wallet_test_framework.environments[0].rpc_client
 
-    our_ph = await wallet_state_manager.main_wallet.get_new_puzzlehash()
+    async with wallet_state_manager.new_action_scope(wallet_test_framework.tx_config, push=True) as action_scope:
+        our_ph = await action_scope.get_puzzle_hash(wallet_state_manager)
 
     await wallet_rpc.create_new_pool_wallet(
         target_puzzlehash=our_ph,
@@ -283,7 +284,8 @@ class TestPoolWalletRpc:
         client, wallet_node, full_node_api, _total_block_rewards, _ = one_wallet_node_and_rpc
         wallet = wallet_node.wallet_state_manager.main_wallet
 
-        our_ph = await wallet.get_new_puzzlehash()
+        async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            our_ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
         assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
         creation_tx: TransactionRecord = await client.create_new_pool_wallet(
@@ -335,7 +337,8 @@ class TestPoolWalletRpc:
         client, wallet_node, full_node_api, _total_block_rewards, _ = one_wallet_node_and_rpc
         wallet = wallet_node.wallet_state_manager.main_wallet
 
-        our_ph = await wallet.get_new_puzzlehash()
+        async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            our_ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
         assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
 
@@ -390,8 +393,9 @@ class TestPoolWalletRpc:
 
         wallet = wallet_node.wallet_state_manager.main_wallet
 
-        our_ph_1 = await wallet.get_new_puzzlehash()
-        our_ph_2 = await wallet.get_new_puzzlehash()
+        async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            our_ph_1 = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
+            our_ph_2 = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
         assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
 
@@ -500,7 +504,8 @@ class TestPoolWalletRpc:
 
         wallet = wallet_node.wallet_state_manager.main_wallet
 
-        our_ph = await wallet.get_new_puzzlehash()
+        async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            our_ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
         assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
 
@@ -590,7 +595,8 @@ class TestPoolWalletRpc:
 
         wallet = wallet_node.wallet_state_manager.main_wallet
 
-        our_ph = await wallet.get_new_puzzlehash()
+        async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            our_ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
         assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
 
@@ -660,7 +666,8 @@ class TestPoolWalletRpc:
 
         wallet = wallet_node.wallet_state_manager.main_wallet
 
-        our_ph = await wallet.get_new_puzzlehash()
+        async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            our_ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
         assert len(await client.get_wallets(WalletType.POOLING_WALLET)) == 0
         creation_tx: TransactionRecord = await client.create_new_pool_wallet(

--- a/chia/_tests/pools/test_pool_wallet.py
+++ b/chia/_tests/pools/test_pool_wallet.py
@@ -11,6 +11,7 @@ from chia_rs.sized_bytes import bytes32
 
 from chia._tests.util.benchmarks import rand_g1, rand_hash
 from chia.pools.pool_wallet import PoolWallet
+from chia.wallet.wallet_action_scope import WalletActionScope
 
 
 @dataclass
@@ -52,6 +53,14 @@ class MockPoolWalletInfo:
     launcher_id: bytes32
     p2_singleton_puzzle_hash: bytes32
     current: MockPoolState
+
+
+@dataclass
+class MockActionScope:
+    payout_instructions_ph: bytes32
+
+    async def get_puzzle_hash(self, wallet_state_manager: Any) -> bytes32:
+        return self.payout_instructions_ph
 
 
 @pytest.mark.anyio
@@ -108,7 +117,7 @@ async def test_update_pool_config_new_config(monkeypatch: Any) -> None:
         wallet_id=MagicMock(),
     )
 
-    await wallet.update_pool_config()
+    await wallet.update_pool_config(cast(WalletActionScope, MockActionScope(payout_instructions_ph)))
 
     assert len(updated_configs) == 1
     assert updated_configs[0].launcher_id == launcher_id
@@ -191,7 +200,7 @@ async def test_update_pool_config_existing_payout_instructions(monkeypatch: Any)
         wallet_id=MagicMock(),
     )
 
-    await wallet.update_pool_config()
+    await wallet.update_pool_config(MagicMock())
 
     assert len(updated_configs) == 1
     assert updated_configs[0].launcher_id == launcher_id

--- a/chia/_tests/simulation/test_simulator.py
+++ b/chia/_tests/simulation/test_simulator.py
@@ -128,7 +128,7 @@ async def test_wait_transaction_records_entered_mempool(
         async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
             await wallet.generate_signed_transaction(
                 amounts=[uint64(tx_amount)],
-                puzzle_hashes=[await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash()],
+                puzzle_hashes=[await action_scope.get_puzzle_hash(wallet.wallet_state_manager)],
                 action_scope=action_scope,
                 coins={coin},
             )
@@ -164,7 +164,7 @@ async def test_process_transaction_records(
         async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
             await wallet.generate_signed_transaction(
                 amounts=[uint64(tx_amount)],
-                puzzle_hashes=[await wallet_node.wallet_state_manager.main_wallet.get_new_puzzlehash()],
+                puzzle_hashes=[await action_scope.get_puzzle_hash(wallet.wallet_state_manager)],
                 action_scope=action_scope,
                 coins={coin},
             )

--- a/chia/_tests/wallet/clawback/test_clawback_decorator.py
+++ b/chia/_tests/wallet/clawback/test_clawback_decorator.py
@@ -8,6 +8,7 @@ from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.types.peer_info import PeerInfo
 from chia.wallet.puzzles.clawback.puzzle_decorator import ClawbackPuzzleDecorator
 from chia.wallet.util.puzzle_decorator import PuzzleDecoratorManager
+from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.wallet_node import WalletNode
 
 
@@ -74,5 +75,6 @@ async def test_decorator(
     assert isinstance(wallet_node.wallet_state_manager.decorator_manager.decorator_list[0], ClawbackPuzzleDecorator)
     clawback_decorator: ClawbackPuzzleDecorator = wallet_node.wallet_state_manager.decorator_manager.decorator_list[0]
     assert clawback_decorator.time_lock == 3600
-    puzzle = await wallet.get_new_puzzle()
+    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        puzzle = await action_scope.get_puzzle(wallet.wallet_state_manager)
     assert puzzle == wallet_node.wallet_state_manager.decorator_manager.decorate(puzzle)

--- a/chia/_tests/wallet/clawback/test_clawback_metadata.py
+++ b/chia/_tests/wallet/clawback/test_clawback_metadata.py
@@ -11,6 +11,7 @@ from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.types.peer_info import PeerInfo
 from chia.wallet.puzzles.clawback.metadata import ClawbackMetadata
+from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.wallet_node import WalletNode
 
 
@@ -30,8 +31,9 @@ async def test_is_recipient(
     server_1: ChiaServer = full_node_api.full_node.server
     wallet_node, server_2 = wallets[0]
     wallet = wallet_node.wallet_state_manager.main_wallet
-    puzhash_1 = await wallet.get_new_puzzlehash()
-    puzhash_2 = await wallet.get_new_puzzlehash()
+    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        puzhash_1 = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
+        puzhash_2 = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
     await server_2.start_client(PeerInfo(self_hostname, server_1.get_port()), None)
     invalid_data = ClawbackMetadata(uint64(500), bytes32.random(seeded_random), bytes32.random(seeded_random))
     both_data = ClawbackMetadata(uint64(500), puzhash_1, puzhash_2)

--- a/chia/_tests/wallet/db_wallet/test_dl_wallet.py
+++ b/chia/_tests/wallet/db_wallet/test_dl_wallet.py
@@ -101,8 +101,8 @@ class TestDLWallet:
 
             await time_out_assert(15, is_singleton_confirmed, True, dl_wallet, launcher_id)
 
-        new_puz = await dl_wallet.get_new_puzzle()
-        assert new_puz
+        async with dl_wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            await action_scope.get_puzzle(dl_wallet.wallet_state_manager)
 
     @pytest.mark.parametrize(
         "wallet_environments",

--- a/chia/_tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -81,7 +81,8 @@ async def test_nft_offer_sell_nft(
     wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
     wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
 
-    ph_maker = await wallet_maker.get_new_puzzlehash()
+    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     trusted_setup_helper(trusted, wallet_node_maker, wallet_node_taker, full_node_api)
@@ -219,7 +220,8 @@ async def test_nft_offer_request_nft(
     wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
     wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
 
-    ph_taker = await wallet_taker.get_new_puzzlehash()
+    async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_taker = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     trusted_setup_helper(trusted, wallet_node_maker, wallet_node_taker, full_node_api)
@@ -356,7 +358,8 @@ async def test_nft_offer_sell_did_to_did(
     wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
     wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
 
-    ph_maker = await wallet_maker.get_new_puzzlehash()
+    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     trusted_setup_helper(trusted, wallet_node_maker, wallet_node_taker, full_node_api)
@@ -508,7 +511,8 @@ async def test_nft_offer_sell_nft_for_cat(
     wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
     wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
 
-    ph_maker = await wallet_maker.get_new_puzzlehash()
+    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     trusted_setup_helper(trusted, wallet_node_maker, wallet_node_taker, full_node_api)
@@ -607,8 +611,9 @@ async def test_nft_offer_sell_nft_for_cat(
         wallet_node_taker.wallet_state_manager, wallet_taker, cat_wallet_maker.get_asset_id()
     )
 
-    ph_taker_cat_1 = await wallet_taker.get_new_puzzlehash()
-    ph_taker_cat_2 = await wallet_taker.get_new_puzzlehash()
+    async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_taker_cat_1 = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
+        ph_taker_cat_2 = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
     async with cat_wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
         await cat_wallet_maker.generate_signed_transaction(
             [cats_to_trade, cats_to_trade],
@@ -688,7 +693,8 @@ async def test_nft_offer_request_nft_for_cat(
     wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
     wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
 
-    ph_taker = await wallet_taker.get_new_puzzlehash()
+    async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_taker = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     trusted_setup_helper(trusted, wallet_node_maker, wallet_node_taker, full_node_api)
@@ -786,15 +792,18 @@ async def test_nft_offer_request_nft_for_cat(
         wallet_node_taker.wallet_state_manager, wallet_taker, cat_wallet_maker.get_asset_id()
     )
     if test_change:
-        cat_1 = await wallet_maker.get_new_puzzlehash()
-        cat_2 = await wallet_maker.get_new_puzzlehash()
+        async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            cat_1 = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
+            cat_2 = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
     else:
-        cat_1 = await wallet_taker.get_new_puzzlehash()
-        cat_2 = await wallet_taker.get_new_puzzlehash()
+        async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            cat_1 = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
+            cat_2 = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
     puzzle_hashes = [cat_1, cat_2]
     amounts = [cats_to_trade, cats_to_trade]
     if test_change:
-        ph_taker_cat_1 = await wallet_taker.get_new_puzzlehash()
+        async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            ph_taker_cat_1 = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
         extra_change = cats_to_mint - (2 * cats_to_trade)
         amounts.append(uint64(extra_change))
         puzzle_hashes.append(ph_taker_cat_1)
@@ -878,7 +887,8 @@ async def test_nft_offer_sell_cancel(
     wallet_node_maker, server_0 = wallets[0]
     wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
 
-    ph_maker = await wallet_maker.get_new_puzzlehash()
+    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     if trusted:
@@ -989,7 +999,8 @@ async def test_nft_offer_sell_cancel_in_batch(
     wallet_node_maker, server_0 = wallets[0]
     wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
 
-    ph_maker = await wallet_maker.get_new_puzzlehash()
+    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     if trusted:
@@ -1121,8 +1132,10 @@ async def test_complex_nft_offer(
     wallet_maker = wsm_maker.main_wallet
     wallet_taker = wsm_taker.main_wallet
 
-    ph_maker = await wallet_maker.get_new_puzzlehash()
-    ph_taker = await wallet_taker.get_new_puzzlehash()
+    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
+    async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_taker = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     trusted_setup_helper(trusted, wallet_node_maker, wallet_node_taker, full_node_api)

--- a/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -45,7 +45,8 @@ async def test_nft_mint_from_did(
     wallet_node_1, server_1 = wallets[1]
     wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
     wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
-    ph_maker = await wallet_0.get_new_puzzlehash()
+    async with wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_0.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     if trusted:
@@ -106,7 +107,8 @@ async def test_nft_mint_from_did(
         for x in range(mint_total)
     ]
 
-    target_list = [(await wallet_1.get_new_puzzlehash()) for x in range(mint_total)]
+    async with wallet_1.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        target_list = [await action_scope.get_puzzle_hash(wallet_1.wallet_state_manager) for x in range(mint_total)]
 
     async with nft_wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
         await nft_wallet_maker.mint_from_did(
@@ -168,8 +170,10 @@ async def test_nft_mint_from_did_rpc(
     wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
     wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
 
-    ph_maker = await wallet_maker.get_new_puzzlehash()
-    ph_taker = await wallet_taker.get_new_puzzlehash()
+    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
+    async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_taker = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     if trusted:
@@ -360,8 +364,10 @@ async def test_nft_mint_from_did_rpc_no_royalties(
     wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
     wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
 
-    ph_maker = await wallet_maker.get_new_puzzlehash()
-    ph_taker = await wallet_taker.get_new_puzzlehash()
+    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
+    async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_taker = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     if trusted:
@@ -526,8 +532,10 @@ async def test_nft_mint_from_did_multiple_xch(
     wallet_node_1, server_1 = wallets[1]
     wallet_maker = wallet_node_0.wallet_state_manager.main_wallet
     wallet_taker = wallet_node_1.wallet_state_manager.main_wallet
-    ph_maker = await wallet_maker.get_new_puzzlehash()
-    ph_taker = await wallet_taker.get_new_puzzlehash()
+    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
+    async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_taker = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     if trusted:
@@ -638,7 +646,8 @@ async def test_nft_mint_from_xch(
     wallet_node_1, server_1 = wallets[1]
     wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
     wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
-    ph_maker = await wallet_0.get_new_puzzlehash()
+    async with wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_0.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     if trusted:
@@ -699,7 +708,8 @@ async def test_nft_mint_from_xch(
         for x in range(mint_total)
     ]
 
-    target_list = [(await wallet_1.get_new_puzzlehash()) for x in range(mint_total)]
+    async with wallet_1.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        target_list = [await action_scope.get_puzzle_hash(wallet_1.wallet_state_manager) for x in range(mint_total)]
 
     async with nft_wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
         await nft_wallet_maker.mint_from_xch(
@@ -756,8 +766,10 @@ async def test_nft_mint_from_xch_rpc(
     wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
     wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
 
-    ph_maker = await wallet_maker.get_new_puzzlehash()
-    ph_taker = await wallet_taker.get_new_puzzlehash()
+    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
+    async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_taker = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     if trusted:
@@ -930,8 +942,10 @@ async def test_nft_mint_from_xch_multiple_xch(
     wallet_node_1, server_1 = wallets[1]
     wallet_maker = wallet_node_0.wallet_state_manager.main_wallet
     wallet_taker = wallet_node_1.wallet_state_manager.main_wallet
-    ph_maker = await wallet_maker.get_new_puzzlehash()
-    ph_taker = await wallet_taker.get_new_puzzlehash()
+    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
+    async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_taker = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     if trusted:

--- a/chia/_tests/wallet/rpc/test_dl_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_dl_wallet_rpc.py
@@ -18,6 +18,7 @@ from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.peer_info import PeerInfo
 from chia.wallet.db_wallet.db_wallet_puzzles import create_mirror_puzzle
+from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 
 log = logging.getLogger(__name__)
 
@@ -37,7 +38,8 @@ class TestWalletRpc:
         wallet_node_2 = wallet_services[1]._node
         server_3 = wallet_node_2.server
         wallet = wallet_node.wallet_state_manager.main_wallet
-        ph = await wallet.get_new_puzzlehash()
+        async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
 
         if trusted:
             wallet_node.config["trusted_peers"] = {full_node_server.node_id.hex(): full_node_server.node_id.hex()}

--- a/chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -142,7 +142,8 @@ async def test_subscribe_for_ph(simulator_and_wallet: OldSimulatorsAndWallets, s
 
     wallet = wallet_node.wallet_state_manager.wallets[uint32(1)]
     assert isinstance(wallet, Wallet)
-    puzzle_hash = await wallet.get_new_puzzlehash()
+    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        puzzle_hash = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
 
     for i in range(num_blocks):
         if i == num_blocks - 1:
@@ -223,7 +224,8 @@ async def test_subscribe_for_coin_id(simulator_and_wallet: OldSimulatorsAndWalle
     fn_server = full_node_api.full_node.server
     standard_wallet = wallet_node.wallet_state_manager.wallets[uint32(1)]
     assert isinstance(standard_wallet, Wallet)
-    puzzle_hash = await standard_wallet.get_new_puzzlehash()
+    async with standard_wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        puzzle_hash = await action_scope.get_puzzle_hash(standard_wallet.wallet_state_manager)
 
     await server_2.start_client(PeerInfo(self_hostname, fn_server.get_port()), None)
     incoming_queue, peer_id = await add_dummy_connection(fn_server, self_hostname, 12312, NodeType.WALLET)
@@ -325,7 +327,8 @@ async def test_subscribe_for_ph_reorg(simulator_and_wallet: OldSimulatorsAndWall
     fn_server = full_node_api.full_node.server
     standard_wallet = wallet_node.wallet_state_manager.wallets[uint32(1)]
     assert isinstance(standard_wallet, Wallet)
-    puzzle_hash = await standard_wallet.get_new_puzzlehash()
+    async with standard_wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        puzzle_hash = await action_scope.get_puzzle_hash(standard_wallet.wallet_state_manager)
 
     await server_2.start_client(PeerInfo(self_hostname, fn_server.get_port()), None)
     incoming_queue, peer_id = await add_dummy_connection(fn_server, self_hostname, 12312, NodeType.WALLET)
@@ -400,7 +403,8 @@ async def test_subscribe_for_coin_id_reorg(simulator_and_wallet: OldSimulatorsAn
     fn_server = full_node_api.full_node.server
     standard_wallet = wallet_node.wallet_state_manager.wallets[uint32(1)]
     assert isinstance(standard_wallet, Wallet)
-    puzzle_hash = await standard_wallet.get_new_puzzlehash()
+    async with standard_wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        puzzle_hash = await action_scope.get_puzzle_hash(standard_wallet.wallet_state_manager)
 
     await server_2.start_client(PeerInfo(self_hostname, fn_server.get_port()), None)
     incoming_queue, peer_id = await add_dummy_connection(fn_server, self_hostname, 12312, NodeType.WALLET)

--- a/chia/_tests/wallet/test_notifications.py
+++ b/chia/_tests/wallet/test_notifications.py
@@ -65,8 +65,10 @@ async def test_notifications(
     wallet_1 = wsm_1.main_wallet
     wallet_2 = wsm_2.main_wallet
 
-    ph_1 = await wallet_1.get_new_puzzlehash()
-    ph_2 = await wallet_2.get_new_puzzlehash()
+    async with wallet_1.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_1 = await action_scope.get_puzzle_hash(wallet_1.wallet_state_manager)
+    async with wallet_2.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        ph_2 = await action_scope.get_puzzle_hash(wallet_2.wallet_state_manager)
     ph_token = bytes32.random(seeded_random)
 
     if trusted:

--- a/chia/_tests/wallet/test_wallet_action_scope.py
+++ b/chia/_tests/wallet/test_wallet_action_scope.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import pytest
-from chia_rs import G2Element
+from chia_rs import G2Element, Program
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint64
 
@@ -83,6 +83,7 @@ async def test_wallet_action_scope() -> None:
         sign=True,
         additional_signing_responses=[],
         extra_spends=[],
+        puzzle_for_pk=lambda _: Program.to(1),
     ) as action_scope:
         async with action_scope.use() as interface:
             interface.side_effects.transactions = [STD_TX]
@@ -94,7 +95,13 @@ async def test_wallet_action_scope() -> None:
     assert wsm.most_recent_call == ([STD_TX], True, False, True, [], [], [])
 
     async with wsm.new_action_scope(  # type: ignore[attr-defined]
-        DEFAULT_TX_CONFIG, push=False, merge_spends=True, sign=True, additional_signing_responses=[], extra_spends=[]
+        DEFAULT_TX_CONFIG,
+        push=False,
+        merge_spends=True,
+        sign=True,
+        additional_signing_responses=[],
+        extra_spends=[],
+        puzzle_for_pk=lambda _: Program.to(1),
     ) as action_scope:
         async with action_scope.use() as interface:
             interface.side_effects.transactions = []

--- a/chia/_tests/wallet/test_wallet_retry.py
+++ b/chia/_tests/wallet/test_wallet_retry.py
@@ -47,7 +47,8 @@ async def test_wallet_tx_retry(
     wallet_node_1.config["tx_resend_timeout_secs"] = 5
     wallet_server_1 = wallets[0][1]
     wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
-    reward_ph = await wallet_1.get_new_puzzlehash()
+    async with wallet_1.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        reward_ph = await action_scope.get_puzzle_hash(wallet_1.wallet_state_manager)
 
     await wallet_server_1.start_client(PeerInfo(self_hostname, server_1.get_port()), None)
 
@@ -74,7 +75,8 @@ async def test_wallet_tx_retry(
     # Wait some time so wallet will retry
     await asyncio.sleep(2)
 
-    our_ph = await wallet_1.get_new_puzzlehash()
+    async with wallet_1.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        our_ph = await action_scope.get_puzzle_hash(wallet_1.wallet_state_manager)
     await farm_blocks(full_node_1, our_ph, 2)
 
     # Wait for wallet to catch up

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1106,9 +1106,7 @@ class WalletRpcApi:
                 if "initial_target_state" not in request:
                     raise AttributeError("Daemon didn't send `initial_target_state`. Try updating the daemon.")
 
-                owner_puzzle_hash: bytes32 = await self.service.wallet_state_manager.main_wallet.get_puzzle_hash(
-                    new=not action_scope.config.tx_config.reuse_puzhash
-                )
+                owner_puzzle_hash: bytes32 = await action_scope.get_puzzle_hash(self.service.wallet_state_manager)
 
                 from chia.pools.pool_wallet_info import initial_pool_state_from_dict
 
@@ -1274,9 +1272,9 @@ class WalletRpcApi:
 
         outputs = [
             CreateCoin(
-                await wallet.get_puzzle_hash(new=True)
-                if isinstance(wallet, Wallet)
-                else await wallet.standard_wallet.get_puzzle_hash(new=True),
+                await action_scope.get_puzzle_hash(
+                    self.service.wallet_state_manager, override_reuse_puzhash_with=False
+                ),
                 request.amount_per_coin,
             )
             for _ in range(request.number_of_coins)
@@ -1388,13 +1386,10 @@ class WalletRpcApi:
         )
         if isinstance(wallet, Wallet):
             primary_output_amount = uint64(primary_output_amount - request.fee)
-            main_wallet = wallet
-        else:
-            main_wallet = wallet.standard_wallet
 
         await wallet.generate_signed_transaction(
             [primary_output_amount],
-            [await main_wallet.get_puzzle_hash(new=not action_scope.config.tx_config.reuse_puzhash)],
+            [await action_scope.get_puzzle_hash(self.service.wallet_state_manager)],
             action_scope,
             request.fee,
             coins=set(coins),
@@ -1480,13 +1475,13 @@ class WalletRpcApi:
         wallet = self.service.wallet_state_manager.wallets[wallet_id]
         selected = self.service.config["selected_network"]
         prefix = self.service.config["network_overrides"]["config"][selected]["address_prefix"]
-        if wallet.type() == WalletType.STANDARD_WALLET:
-            assert isinstance(wallet, Wallet)
-            raw_puzzle_hash = await wallet.get_puzzle_hash(create_new)
-            address = encode_puzzle_hash(raw_puzzle_hash, prefix)
-        elif wallet.type() in {WalletType.CAT, WalletType.CRCAT}:
-            assert isinstance(wallet, CATWallet)
-            raw_puzzle_hash = await wallet.standard_wallet.get_puzzle_hash(create_new)
+        if wallet.type() in {WalletType.STANDARD_WALLET, WalletType.CAT, WalletType.CRCAT}:
+            async with self.service.wallet_state_manager.new_action_scope(
+                DEFAULT_TX_CONFIG, push=request.get("save_derivations", True)
+            ) as action_scope:
+                raw_puzzle_hash = await action_scope.get_puzzle_hash(
+                    self.service.wallet_state_manager, override_reuse_puzhash_with=not create_new
+                )
             address = encode_puzzle_hash(raw_puzzle_hash, prefix)
         else:
             raise ValueError(f"Wallet type {wallet.type()} cannot create puzzle hashes")
@@ -1828,9 +1823,10 @@ class WalletRpcApi:
         # Since we've bumping the derivation index without having found any new puzzles, we want
         # to preserve the current last used index, so we call create_more_puzzle_hashes with
         # mark_existing_as_used=False
-        await self.service.wallet_state_manager.create_more_puzzle_hashes(
+        result = await self.service.wallet_state_manager.create_more_puzzle_hashes(
             from_zero=False, mark_existing_as_used=False, up_to_index=index, num_additional_phs=0
         )
+        await result.commit(self.service.wallet_state_manager)
 
         updated: Optional[uint32] = await self.service.wallet_state_manager.puzzle_store.get_last_derivation_path()
         updated_index = updated if updated is not None else None
@@ -3017,18 +3013,14 @@ class WalletRpcApi:
         if isinstance(royalty_address, str):
             royalty_puzhash = decode_puzzle_hash(royalty_address)
         elif royalty_address is None:
-            royalty_puzhash = await nft_wallet.standard_wallet.get_puzzle_hash(
-                new=not action_scope.config.tx_config.reuse_puzhash
-            )
+            royalty_puzhash = await action_scope.get_puzzle_hash(self.service.wallet_state_manager)
         else:
             royalty_puzhash = royalty_address
         target_address = request.get("target_address")
         if isinstance(target_address, str):
             target_puzhash = decode_puzzle_hash(target_address)
         elif target_address is None:
-            target_puzhash = await nft_wallet.standard_wallet.get_puzzle_hash(
-                new=not action_scope.config.tx_config.reuse_puzhash
-            )
+            target_puzhash = await action_scope.get_puzzle_hash(self.service.wallet_state_manager)
         else:
             target_puzhash = target_address
         if "uris" not in request:
@@ -3527,7 +3519,7 @@ class WalletRpcApi:
         if isinstance(royalty_address, str) and royalty_address != "":
             royalty_puzhash = decode_puzzle_hash(royalty_address)
         elif royalty_address in {None, ""}:
-            royalty_puzhash = await nft_wallet.standard_wallet.get_new_puzzlehash()
+            royalty_puzhash = await action_scope.get_puzzle_hash(self.service.wallet_state_manager)
         else:
             royalty_puzhash = bytes32.from_hexstr(royalty_address)
         royalty_percentage = request.get("royalty_percentage", None)
@@ -4270,9 +4262,7 @@ class WalletRpcApi:
             [
                 request.new_puzhash
                 if request.new_puzhash is not None
-                else await vc_wallet.standard_wallet.get_puzzle_hash(
-                    new=not action_scope.config.tx_config.reuse_puzhash
-                )
+                else await action_scope.get_puzzle_hash(self.service.wallet_state_manager)
             ],
             action_scope,
             request.fee,

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -369,7 +369,8 @@ class FullNodeSimulator(FullNodeAPI):
             if count == 0:
                 return 0
 
-            target_puzzlehash = await wallet.get_new_puzzlehash()
+            async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+                target_puzzlehash = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
             rewards = 0
 
             block_reward_coins = set()
@@ -687,7 +688,10 @@ class FullNodeSimulator(FullNodeAPI):
             for amount in amounts:
                 # We need unique puzzle hash amount combos so we'll only generate a new puzzle hash when we've already
                 # seen that amount sent to that puzzle hash
-                puzzle_hash = await wallet.get_puzzle_hash(new=amount in amounts_seen)
+                async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+                    puzzle_hash = await action_scope.get_puzzle_hash(
+                        wallet.wallet_state_manager, override_reuse_puzhash_with=amount not in amounts_seen
+                    )
                 outputs.append(CreateCoin(puzzle_hash, amount))
                 amounts_seen.add(amount)
 

--- a/chia/util/action_scope.py
+++ b/chia/util/action_scope.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 from collections.abc import AsyncIterator, Awaitable
 from dataclasses import dataclass, field
-from typing import Callable, Generic, Optional, Protocol, TypeVar, final
+from typing import Callable, Generic, Optional, Protocol, TypeVar
 
 import aiosqlite
 
@@ -87,7 +87,6 @@ _T_SideEffects = TypeVar("_T_SideEffects", bound=SideEffects)
 _T_Config = TypeVar("_T_Config")
 
 
-@final
 @dataclass
 class ActionScope(Generic[_T_SideEffects, _T_Config]):
     """

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -583,7 +583,7 @@ class CATWallet:
                 selected_amount = sum(c.amount for c in chia_coins)
                 await self.standard_wallet.generate_signed_transaction(
                     [uint64(selected_amount + amount_to_claim - fee)],
-                    [(await self.standard_wallet.get_puzzle_hash(not action_scope.config.tx_config.reuse_puzhash))],
+                    [await action_scope.get_puzzle_hash(self.wallet_state_manager)],
                     inner_action_scope,
                     coins=chia_coins,
                     negative_change_allowed=True,
@@ -657,10 +657,12 @@ class CATWallet:
                 for payment in payments:
                     if change_puzhash == payment.puzzle_hash and change == payment.amount:
                         # We cannot create two coins has same id, create a new puzhash for the change
-                        change_puzhash = await self.standard_wallet.get_puzzle_hash(new=True)
+                        change_puzhash = await action_scope.get_puzzle_hash(
+                            self.wallet_state_manager, override_reuse_puzhash_with=False
+                        )
                         break
             else:
-                change_puzhash = await self.standard_wallet.get_puzzle_hash(new=True)
+                change_puzhash = await action_scope.get_puzzle_hash(self.wallet_state_manager)
             primaries.append(CreateCoin(change_puzhash, uint64(change), [change_puzhash]))
 
         # Loop through the coins we've selected and gather the information we need to spend them

--- a/chia/wallet/derivation_record.py
+++ b/chia/wallet/derivation_record.py
@@ -7,6 +7,7 @@ from chia_rs import G1Element
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32
 
+from chia.util.streamable import Streamable, streamable
 from chia.wallet.util.wallet_types import WalletType
 
 
@@ -28,3 +29,35 @@ class DerivationRecord:
     def pubkey(self) -> G1Element:
         assert isinstance(self._pubkey, G1Element)
         return self._pubkey
+
+
+@streamable
+@dataclass(frozen=True)
+class StreamableDerivationRecord(Streamable):
+    index: uint32
+    puzzle_hash: bytes32
+    pubkey: bytes
+    wallet_type: uint32
+    wallet_id: uint32
+    hardened: bool
+
+    @classmethod
+    def from_standard(cls, record: DerivationRecord) -> StreamableDerivationRecord:
+        return cls(
+            record.index,
+            record.puzzle_hash,
+            bytes(record._pubkey),
+            uint32(record.wallet_type.value),
+            record.wallet_id,
+            record.hardened,
+        )
+
+    def to_standard(self) -> DerivationRecord:
+        return DerivationRecord(
+            self.index,
+            self.puzzle_hash,
+            G1Element.from_bytes(self.pubkey),
+            WalletType(self.wallet_type),
+            self.wallet_id,
+            self.hardened,
+        )

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -48,6 +48,7 @@ from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.curry_and_treehash import NIL_TREEHASH, shatree_int, shatree_pair
 from chia.wallet.util.transaction_type import TransactionType
+from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend, fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
@@ -467,63 +468,66 @@ class DIDWallet:
         # full_puz = did_wallet_puzzles.create_fullpuz(innerpuz, origin.name())
         # All additions in this block here:
 
-        new_puzhash = await self.wallet_state_manager.main_wallet.get_puzzle_hash(new=False)
-        new_pubkey = await self.wallet_state_manager.get_public_key(new_puzhash)
-        parent_info = None
-        assert did_info.origin_coin is not None
-        assert did_info.current_inner is not None
-        new_did_inner_puzhash = did_wallet_puzzles.get_inner_puzhash_by_p2(
-            p2_puzhash=new_puzhash,
-            recovery_list=did_info.backup_ids,
-            num_of_backup_ids_needed=did_info.num_of_backup_ids_needed,
-            launcher_id=did_info.origin_coin.name(),
-            metadata=did_wallet_puzzles.metadata_to_program(json.loads(self.did_info.metadata)),
-        )
-        wallet_node = self.wallet_state_manager.wallet_node
-        parent_coin: Coin = did_info.origin_coin
-        while True:
-            peer = wallet_node.get_full_node_peer()
-            children = await wallet_node.fetch_children(parent_coin.name(), peer)
-            if len(children) == 0:
-                break
-
-            children_state: CoinState = children[0]
-            child_coin = children_state.coin
-            assert did_info.current_inner is not None
-            future_parent = LineageProof(
-                parent_name=child_coin.parent_coin_info,
-                inner_puzzle_hash=did_info.current_inner.get_tree_hash(),
-                amount=uint64(child_coin.amount),
+        async with self.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            new_puzhash = await action_scope.get_puzzle_hash(
+                self.wallet_state_manager, override_reuse_puzhash_with=True
             )
-            await self.add_parent(child_coin.name(), future_parent)
-            if children_state.spent_height != children_state.created_height:
-                did_info = DIDInfo(
-                    origin_coin=did_info.origin_coin,
-                    backup_ids=did_info.backup_ids,
-                    num_of_backup_ids_needed=did_info.num_of_backup_ids_needed,
-                    parent_info=self.did_info.parent_info,
-                    current_inner=did_info.current_inner,
-                    temp_coin=child_coin,
-                    temp_puzhash=new_did_inner_puzhash,
-                    temp_pubkey=bytes(new_pubkey),
-                    sent_recovery_transaction=did_info.sent_recovery_transaction,
-                    metadata=did_info.metadata,
-                )
+            new_pubkey = await self.wallet_state_manager.get_public_key(new_puzhash)
+            parent_info = None
+            assert did_info.origin_coin is not None
+            assert did_info.current_inner is not None
+            new_did_inner_puzhash = did_wallet_puzzles.get_inner_puzhash_by_p2(
+                p2_puzhash=new_puzhash,
+                recovery_list=did_info.backup_ids,
+                num_of_backup_ids_needed=did_info.num_of_backup_ids_needed,
+                launcher_id=did_info.origin_coin.name(),
+                metadata=did_wallet_puzzles.metadata_to_program(json.loads(self.did_info.metadata)),
+            )
+            wallet_node = self.wallet_state_manager.wallet_node
+            parent_coin: Coin = did_info.origin_coin
+            while True:
+                peer = wallet_node.get_full_node_peer()
+                children = await wallet_node.fetch_children(parent_coin.name(), peer)
+                if len(children) == 0:
+                    break
 
-                await self.save_info(did_info)
-                assert children_state.created_height
-                parent_spend = await fetch_coin_spend(uint32(children_state.created_height), parent_coin, peer)
-                assert parent_spend is not None
-                parent_innerpuz = get_inner_puzzle_from_singleton(parent_spend.puzzle_reveal)
-                assert parent_innerpuz is not None
-                parent_info = LineageProof(
-                    parent_name=parent_coin.parent_coin_info,
-                    inner_puzzle_hash=parent_innerpuz.get_tree_hash(),
-                    amount=uint64(parent_coin.amount),
+                children_state: CoinState = children[0]
+                child_coin = children_state.coin
+                assert did_info.current_inner is not None
+                future_parent = LineageProof(
+                    parent_name=child_coin.parent_coin_info,
+                    inner_puzzle_hash=did_info.current_inner.get_tree_hash(),
+                    amount=uint64(child_coin.amount),
                 )
-                await self.add_parent(child_coin.parent_coin_info, parent_info)
-            parent_coin = child_coin
-        assert parent_info is not None
+                await self.add_parent(child_coin.name(), future_parent)
+                if children_state.spent_height != children_state.created_height:
+                    did_info = DIDInfo(
+                        origin_coin=did_info.origin_coin,
+                        backup_ids=did_info.backup_ids,
+                        num_of_backup_ids_needed=did_info.num_of_backup_ids_needed,
+                        parent_info=self.did_info.parent_info,
+                        current_inner=did_info.current_inner,
+                        temp_coin=child_coin,
+                        temp_puzhash=new_did_inner_puzhash,
+                        temp_pubkey=bytes(new_pubkey),
+                        sent_recovery_transaction=did_info.sent_recovery_transaction,
+                        metadata=did_info.metadata,
+                    )
+
+                    await self.save_info(did_info)
+                    assert children_state.created_height
+                    parent_spend = await fetch_coin_spend(uint32(children_state.created_height), parent_coin, peer)
+                    assert parent_spend is not None
+                    parent_innerpuz = get_inner_puzzle_from_singleton(parent_spend.puzzle_reveal)
+                    assert parent_innerpuz is not None
+                    parent_info = LineageProof(
+                        parent_name=parent_coin.parent_coin_info,
+                        inner_puzzle_hash=parent_innerpuz.get_tree_hash(),
+                        amount=uint64(parent_coin.amount),
+                    )
+                    await self.add_parent(child_coin.parent_coin_info, parent_info)
+                parent_coin = child_coin
+            assert parent_info is not None
 
     def puzzle_for_pk(self, pubkey: G1Element) -> Program:
         if self.did_info.origin_coin is not None:
@@ -578,7 +582,7 @@ class DIDWallet:
         assert self.did_info.current_inner is not None
         assert self.did_info.origin_coin is not None
         coin = await self.get_coin()
-        new_inner_puzzle = await self.get_did_innerpuz(new=not action_scope.config.tx_config.reuse_puzhash)
+        new_inner_puzzle = await self.get_did_innerpuz(action_scope)
         uncurried = did_wallet_puzzles.uncurry_innerpuz(new_inner_puzzle)
         assert uncurried is not None
         p2_puzzle = uncurried[0]
@@ -646,7 +650,9 @@ class DIDWallet:
         did_record = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
-            to_puzzle_hash=await self.standard_wallet.get_puzzle_hash(False),
+            to_puzzle_hash=await action_scope.get_puzzle_hash(
+                self.wallet_state_manager, override_reuse_puzhash_with=True
+            ),
             amount=uint64(coin.amount),
             fee_amount=uint64(0),
             confirmed=False,
@@ -737,7 +743,9 @@ class DIDWallet:
         did_record = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
-            to_puzzle_hash=await self.standard_wallet.get_puzzle_hash(False),
+            to_puzzle_hash=await action_scope.get_puzzle_hash(
+                self.wallet_state_manager, override_reuse_puzhash_with=True
+            ),
             amount=uint64(coin.amount),
             fee_amount=fee,
             confirmed=False,
@@ -776,20 +784,16 @@ class DIDWallet:
         )
         uncurried = did_wallet_puzzles.uncurry_innerpuz(innerpuz)
         assert uncurried is not None
-        p2_puzzle, id_list_hash, num_of_backup_ids_needed, _, metadata = uncurried
+        _p2_puzzle, id_list_hash, num_of_backup_ids_needed, _, metadata = uncurried
         # Quote message puzzle & solution
-        if action_scope.config.tx_config.reuse_puzhash:
-            new_innerpuzzle_hash = innerpuz.get_tree_hash()
-            p2_ph = p2_puzzle.get_tree_hash()
-        else:
-            p2_ph = await self.standard_wallet.get_puzzle_hash(new=True)
-            new_innerpuzzle_hash = did_wallet_puzzles.get_inner_puzhash_by_p2(
-                p2_puzhash=p2_ph,
-                recovery_list_hash=bytes32(id_list_hash.as_atom()),
-                num_of_backup_ids_needed=uint64(num_of_backup_ids_needed.as_int()),
-                launcher_id=self.did_info.origin_coin.name(),
-                metadata=metadata,
-            )
+        p2_ph = await action_scope.get_puzzle_hash(self.wallet_state_manager)
+        new_innerpuzzle_hash = did_wallet_puzzles.get_inner_puzhash_by_p2(
+            p2_puzhash=p2_ph,
+            recovery_list_hash=bytes32(id_list_hash.as_atom()),
+            num_of_backup_ids_needed=uint64(num_of_backup_ids_needed.as_int()),
+            launcher_id=self.did_info.origin_coin.name(),
+            metadata=metadata,
+        )
         p2_solution = self.standard_wallet.make_solution(
             primaries=[CreateCoin(puzzle_hash=new_innerpuzzle_hash, amount=uint64(coin.amount), memos=[p2_ph])],
             conditions=extra_conditions,
@@ -876,7 +880,9 @@ class DIDWallet:
                 TransactionRecord(
                     confirmed_at_height=uint32(0),
                     created_at_time=uint64(int(time.time())),
-                    to_puzzle_hash=await self.standard_wallet.get_puzzle_hash(False),
+                    to_puzzle_hash=await action_scope.get_puzzle_hash(
+                        self.wallet_state_manager, override_reuse_puzhash_with=True
+                    ),
                     amount=uint64(coin.amount),
                     fee_amount=uint64(0),
                     confirmed=False,
@@ -959,7 +965,9 @@ class DIDWallet:
         did_record = TransactionRecord(
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
-            to_puzzle_hash=await self.standard_wallet.get_puzzle_hash(False),
+            to_puzzle_hash=await action_scope.get_puzzle_hash(
+                self.wallet_state_manager, override_reuse_puzhash_with=True
+            ),
             amount=uint64(coin.amount),
             fee_amount=uint64(0),
             confirmed=False,
@@ -1076,7 +1084,9 @@ class DIDWallet:
                 TransactionRecord(
                     confirmed_at_height=uint32(0),
                     created_at_time=uint64(int(time.time())),
-                    to_puzzle_hash=await self.standard_wallet.get_puzzle_hash(False),
+                    to_puzzle_hash=await action_scope.get_puzzle_hash(
+                        self.wallet_state_manager, override_reuse_puzhash_with=True
+                    ),
                     amount=uint64(coin.amount),
                     fee_amount=uint64(0),
                     confirmed=False,
@@ -1107,13 +1117,12 @@ class DIDWallet:
         )
         await self.save_info(new_did_info)
 
-    async def get_p2_inner_hash(self, new: bool) -> bytes32:
-        return await self.standard_wallet.get_puzzle_hash(new=new)
-
-    async def get_p2_inner_puzzle(self, new: bool) -> Program:
-        return await self.standard_wallet.get_puzzle(new=new)
-
-    async def get_did_innerpuz(self, new: bool, origin_id: Optional[bytes32] = None) -> Program:
+    async def get_did_innerpuz(
+        self,
+        action_scope: WalletActionScope,
+        origin_id: Optional[bytes32] = None,
+        override_reuse_puzhash_with: Optional[bool] = None,
+    ) -> Program:
         if self.did_info.origin_coin is not None:
             launcher_id = self.did_info.origin_coin.name()
         elif origin_id is not None:
@@ -1121,16 +1130,14 @@ class DIDWallet:
         else:
             raise ValueError("must have origin coin")
         return did_wallet_puzzles.create_innerpuz(
-            p2_puzzle_or_hash=await self.get_p2_inner_puzzle(new=new),
+            p2_puzzle_or_hash=await action_scope.get_puzzle(
+                self.wallet_state_manager, override_reuse_puzhash_with=override_reuse_puzhash_with
+            ),
             recovery_list=self.did_info.backup_ids,
             num_of_backup_ids_needed=self.did_info.num_of_backup_ids_needed,
             launcher_id=launcher_id,
             metadata=did_wallet_puzzles.metadata_to_program(json.loads(self.did_info.metadata)),
         )
-
-    async def get_did_inner_hash(self, new: bool) -> bytes32:
-        innerpuz = await self.get_did_innerpuz(new=new)
-        return innerpuz.get_tree_hash()
 
     async def get_innerpuz_for_new_innerhash(self, pubkey: G1Element):
         """
@@ -1224,9 +1231,7 @@ class DIDWallet:
         genesis_launcher_puz = SINGLETON_LAUNCHER_PUZZLE
         launcher_coin = Coin(origin.name(), genesis_launcher_puz.get_tree_hash(), amount)
 
-        did_inner: Program = await self.get_did_innerpuz(
-            new=not action_scope.config.tx_config.reuse_puzhash, origin_id=launcher_coin.name()
-        )
+        did_inner: Program = await self.get_did_innerpuz(action_scope, origin_id=launcher_coin.name())
         did_inner_hash = did_inner.get_tree_hash()
         did_full_puz = create_singleton_puzzle(did_inner, launcher_coin.name())
         did_puzzle_hash = did_full_puz.get_tree_hash()
@@ -1287,7 +1292,9 @@ class DIDWallet:
             confirmed_at_height=uint32(0),
             created_at_time=uint64(int(time.time())),
             amount=uint64(amount),
-            to_puzzle_hash=await self.standard_wallet.get_puzzle_hash(False),
+            to_puzzle_hash=await action_scope.get_puzzle_hash(
+                self.wallet_state_manager, override_reuse_puzhash_with=True
+            ),
             fee_amount=fee,
             confirmed=False,
             sent=uint32(0),

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -358,7 +358,7 @@ class NFTWallet:
         launcher_coin = Coin(origin.name(), SINGLETON_LAUNCHER_PUZZLE_HASH, uint64(amount))
         self.log.debug("Generating NFT with launcher coin %s and metadata: %s", launcher_coin, metadata)
 
-        p2_inner_puzzle = await self.standard_wallet.get_puzzle(new=not action_scope.config.tx_config.reuse_puzhash)
+        p2_inner_puzzle = await action_scope.get_puzzle(self.wallet_state_manager)
         if not target_puzzle_hash:
             target_puzzle_hash = p2_inner_puzzle.get_tree_hash()
         self.log.debug("Attempt to generate a new NFT to %s", target_puzzle_hash.hex())
@@ -820,9 +820,7 @@ class NFTWallet:
                 royalty_payments[asset] = payment_list
 
         # Generate the requested_payments to be notarized
-        p2_ph = await wallet_state_manager.main_wallet.get_puzzle_hash(
-            new=not action_scope.config.tx_config.reuse_puzhash
-        )
+        p2_ph = await action_scope.get_puzzle_hash(wallet_state_manager)
         requested_payments: dict[Optional[bytes32], list[CreateCoin]] = {}
         for asset, amount in offer_dict.items():
             if amount > 0:
@@ -1242,7 +1240,7 @@ class NFTWallet:
         intermediate_coin_spends = []
         launcher_spends = []
         launcher_ids = []
-        p2_inner_puzzle = await self.standard_wallet.get_new_puzzle()
+        p2_inner_puzzle = await action_scope.get_puzzle(self.wallet_state_manager)
         p2_inner_ph = p2_inner_puzzle.get_tree_hash()
 
         # Loop to create each intermediate coin, launcher, eve and (optional) transfer spends
@@ -1348,7 +1346,7 @@ class NFTWallet:
         spend_value = sum(coin.amount for coin in xch_coins)
         change: uint64 = uint64(spend_value - total_amount)
         if xch_change_ph is None:
-            xch_change_ph = await self.standard_wallet.get_new_puzzlehash()
+            xch_change_ph = await action_scope.get_puzzle_hash(self.wallet_state_manager)
         xch_payment = CreateCoin(xch_change_ph, change, [xch_change_ph])
 
         xch_coins_iter = iter(xch_coins)
@@ -1500,7 +1498,7 @@ class NFTWallet:
         intermediate_coin_spends = []
         launcher_spends = []
         launcher_ids = []
-        p2_inner_puzzle = await self.standard_wallet.get_new_puzzle()
+        p2_inner_puzzle = await action_scope.get_puzzle(self.wallet_state_manager)
         p2_inner_ph = p2_inner_puzzle.get_tree_hash()
 
         # Loop to create each intermediate coin, launcher, eve and (optional) transfer spends
@@ -1606,7 +1604,7 @@ class NFTWallet:
         change: uint64 = uint64(spend_value - total_amount)
         xch_spends = []
         if xch_change_ph is None:
-            xch_change_ph = await self.standard_wallet.get_new_puzzlehash()
+            xch_change_ph = await action_scope.get_puzzle_hash(self.wallet_state_manager)
         xch_payment = CreateCoin(xch_change_ph, change, [xch_change_ph])
 
         first = True

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -94,9 +94,7 @@ class GenesisById(LimitationsProgram):
         origin = coins.copy().pop()
         origin_id = origin.name()
 
-        cat_inner: Program = await wallet.standard_wallet.get_puzzle(
-            new=not action_scope.config.tx_config.reuse_puzhash
-        )
+        cat_inner: Program = await action_scope.get_puzzle(wallet.wallet_state_manager)
         tail: Program = cls.construct([Program.to(origin_id)])
 
         wallet.lineage_store = await CATLineageStore.create(

--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -449,19 +449,18 @@ class CRCATWallet(CATWallet):
             if origin_crcat_record is None:
                 raise RuntimeError("A CR-CAT coin was selected that we don't have a record for")  # pragma: no cover
             origin_crcat = self.coin_record_to_crcat(origin_crcat_record)
-            if action_scope.config.tx_config.override(
-                reuse_puzhash=(
-                    True if not add_authorizations_to_cr_cats else action_scope.config.tx_config.reuse_puzhash
-                )
-            ).reuse_puzhash:
-                change_puzhash = origin_crcat.inner_puzzle_hash
-                for payment in payments:
-                    if change_puzhash == payment.puzzle_hash and change == payment.amount:
-                        # We cannot create two coins has same id, create a new puzhash for the change
-                        change_puzhash = await self.standard_wallet.get_puzzle_hash(new=True)
-                        break
+
+            if add_authorizations_to_cr_cats:
+                change_puzhash = await action_scope.get_puzzle_hash(self.wallet_state_manager)
             else:
-                change_puzhash = await self.standard_wallet.get_puzzle_hash(new=True)
+                change_puzhash = origin_crcat.inner_puzzle_hash
+            for payment in payments:
+                if change_puzhash == payment.puzzle_hash and change == payment.amount:
+                    # We cannot create two coins has same id, create a new puzhash for the change
+                    change_puzhash = await action_scope.get_puzzle_hash(
+                        self.wallet_state_manager, override_reuse_puzhash_with=False
+                    )
+                    break
             primaries.append(CreateCoin(change_puzhash, uint64(change), [change_puzhash]))
 
         # Find the VC Wallet
@@ -586,7 +585,7 @@ class CRCATWallet(CATWallet):
         if add_authorizations_to_cr_cats:
             await vc_wallet.generate_signed_transaction(
                 [uint64(1)],
-                [await self.standard_wallet.get_puzzle_hash(new=not action_scope.config.tx_config.reuse_puzhash)],
+                [await action_scope.get_puzzle_hash(self.wallet_state_manager)],
                 action_scope,
                 vc_id=vc.launcher_id,
                 extra_conditions=(
@@ -769,7 +768,7 @@ class CRCATWallet(CATWallet):
         # Make the VC TX
         await vc_wallet.generate_signed_transaction(
             [uint64(1)],
-            [await self.standard_wallet.get_puzzle_hash(new=not action_scope.config.tx_config.reuse_puzhash)],
+            [await action_scope.get_puzzle_hash(self.wallet_state_manager)],
             action_scope,
             vc_id=vc.launcher_id,
             extra_conditions=(
@@ -780,6 +779,7 @@ class CRCATWallet(CATWallet):
             ),
         )
 
+        to_puzzle_hash = await action_scope.get_puzzle_hash(self.wallet_state_manager, override_reuse_puzhash_with=True)
         async with action_scope.use() as interface:
             other_additions: set[Coin] = {rem for tx in interface.side_effects.transactions for rem in tx.additions}
             other_removals: set[Coin] = {rem for tx in interface.side_effects.transactions for rem in tx.removals}
@@ -787,7 +787,7 @@ class CRCATWallet(CATWallet):
                 TransactionRecord(
                     confirmed_at_height=uint32(0),
                     created_at_time=uint64(int(time.time())),
-                    to_puzzle_hash=await self.wallet_state_manager.main_wallet.get_puzzle_hash(False),
+                    to_puzzle_hash=to_puzzle_hash,
                     amount=uint64(sum(c.amount for c in coins)),
                     fee_amount=fee,
                     confirmed=False,

--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -187,9 +187,7 @@ class VCWallet:
         if len(coins) == 0:
             raise ValueError("Cannot find a coin to mint the verified credential.")  # pragma: no cover
         if inner_puzzle_hash is None:  # pragma: no cover
-            inner_puzzle_hash = await self.standard_wallet.get_puzzle_hash(
-                new=not action_scope.config.tx_config.reuse_puzhash
-            )
+            inner_puzzle_hash = await action_scope.get_puzzle_hash(self.wallet_state_manager)
         dpuzs, coin_spends, vc = VerifiedCredential.launch(
             coins,
             provider_did,
@@ -395,7 +393,7 @@ class VCWallet:
         else:
             await self.generate_signed_transaction(
                 [uint64(1)],
-                [await self.standard_wallet.get_puzzle_hash(new=not action_scope.config.tx_config.reuse_puzhash)],
+                [await action_scope.get_puzzle_hash(self.wallet_state_manager)],
                 action_scope,
                 fee,
                 vc_id=vc.launcher_id,
@@ -564,11 +562,7 @@ class VCWallet:
             for launcher_id, vc in vcs.items():
                 await self.generate_signed_transaction(
                     [uint64(1)],
-                    [
-                        await self.standard_wallet.get_puzzle_hash(
-                            new=not inner_action_scope.config.tx_config.reuse_puzhash
-                        )
-                    ],
+                    [await action_scope.get_puzzle_hash(self.wallet_state_manager)],
                     inner_action_scope,
                     vc_id=launcher_id,
                     extra_conditions=(

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -177,38 +177,6 @@ class Wallet:
         public_key = await self.wallet_state_manager.get_public_key(puzzle_hash)
         return puzzle_for_pk(G1Element.from_bytes(public_key))
 
-    async def get_new_puzzle(self) -> Program:
-        dr = await self.wallet_state_manager.get_unused_derivation_record(self.id())
-        puzzle = puzzle_for_pk(dr.pubkey)
-        return puzzle
-
-    async def get_puzzle(self, new: bool) -> Program:
-        if new:
-            return await self.get_new_puzzle()
-        else:
-            record: Optional[
-                DerivationRecord
-            ] = await self.wallet_state_manager.get_current_derivation_record_for_wallet(self.id())
-            if record is None:
-                return await self.get_new_puzzle()  # pragma: no cover
-            puzzle = puzzle_for_pk(record.pubkey)
-            return puzzle
-
-    async def get_puzzle_hash(self, new: bool) -> bytes32:
-        if new:
-            return await self.get_new_puzzlehash()
-        else:
-            record: Optional[
-                DerivationRecord
-            ] = await self.wallet_state_manager.get_current_derivation_record_for_wallet(self.id())
-            if record is None:
-                return await self.get_new_puzzlehash()
-            return record.puzzle_hash
-
-    async def get_new_puzzlehash(self) -> bytes32:
-        puzhash = (await self.wallet_state_manager.get_unused_derivation_record(self.id())).puzzle_hash
-        return puzhash
-
     def make_solution(
         self,
         primaries: list[CreateCoin],
@@ -338,15 +306,14 @@ class Wallet:
                 ]
 
                 if change > 0:
-                    if action_scope.config.tx_config.reuse_puzhash:
-                        change_puzzle_hash: bytes32 = coin.puzzle_hash
-                        for primary in primaries:
-                            if change_puzzle_hash == primary.puzzle_hash and change == primary.amount:
-                                # We cannot create two coins has same id, create a new puzhash for the change:
-                                change_puzzle_hash = await self.get_new_puzzlehash()
-                                break
-                    else:
-                        change_puzzle_hash = await self.get_new_puzzlehash()
+                    change_puzzle_hash = await action_scope.get_puzzle_hash(self.wallet_state_manager)
+                    for primary in primaries:
+                        if change_puzzle_hash == primary.puzzle_hash and change == primary.amount:
+                            # We cannot create two coins has same id, create a new puzhash for the change:
+                            change_puzzle_hash = await action_scope.get_puzzle_hash(
+                                self.wallet_state_manager, override_reuse_puzhash_with=False
+                            )
+                            break
                     primaries.append(CreateCoin(change_puzzle_hash, uint64(change)))
                 message_list: list[bytes32] = [c.name() for c in coins]
                 for primary in primaries:

--- a/chia/wallet/wallet_action_scope.py
+++ b/chia/wallet/wallet_action_scope.py
@@ -3,16 +3,22 @@ from __future__ import annotations
 import contextlib
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Optional, cast, final
+from typing import TYPE_CHECKING, Callable, Optional, cast, final
+
+from chia_rs.chia_rs import G1Element
+from chia_rs.sized_bytes import bytes32
 
 from chia.data_layer.singleton_record import SingletonRecord
 from chia.types.blockchain_format.coin import Coin
+from chia.types.blockchain_format.program import Program
 from chia.util.action_scope import ActionScope
 from chia.util.streamable import Streamable, streamable
+from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.signer_protocol import SigningResponse
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.tx_config import TXConfig
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
+from chia.wallet.wsm_apis import GetUnusedDerivationRecordResult, StreambleGetUnusedDerivationRecordResult
 
 if TYPE_CHECKING:
     # Avoid a circular import here
@@ -27,6 +33,7 @@ class _StreamableWalletSideEffects(Streamable):
     extra_spends: list[WalletSpendBundle]
     selected_coins: list[Coin]
     singleton_records: list[SingletonRecord]
+    get_unused_derivation_record_result: Optional[StreambleGetUnusedDerivationRecordResult]
 
 
 @dataclass
@@ -36,6 +43,7 @@ class WalletSideEffects:
     extra_spends: list[WalletSpendBundle] = field(default_factory=list)
     selected_coins: list[Coin] = field(default_factory=list)
     singleton_records: list[SingletonRecord] = field(default_factory=list)
+    get_unused_derivation_record_result: Optional[StreambleGetUnusedDerivationRecordResult] = None
 
     def __bytes__(self) -> bytes:
         return bytes(_StreamableWalletSideEffects(**self.__dict__))
@@ -54,6 +62,7 @@ class WalletActionConfig:
     additional_signing_responses: list[SigningResponse]
     extra_spends: list[WalletSpendBundle]
     tx_config: TXConfig
+    puzzle_for_pk: Callable[[G1Element], Program]
 
     def adjust_for_side_effects(self, side_effects: WalletSideEffects) -> WalletActionConfig:
         return replace(
@@ -65,7 +74,59 @@ class WalletActionConfig:
         )
 
 
-WalletActionScope = ActionScope[WalletSideEffects, WalletActionConfig]
+class WalletActionScope(ActionScope[WalletSideEffects, WalletActionConfig]):
+    async def _get_unused_derivation_path(
+        self, wallet_state_manager: WalletStateManager
+    ) -> GetUnusedDerivationRecordResult:
+        async with self.use() as interface:
+            result = await wallet_state_manager._get_unused_derivation_record(
+                wallet_state_manager.main_wallet.id(),
+                previous_result=interface.side_effects.get_unused_derivation_record_result.to_standard()
+                if interface.side_effects.get_unused_derivation_record_result is not None
+                else None,
+            )
+            interface.side_effects.get_unused_derivation_record_result = (
+                StreambleGetUnusedDerivationRecordResult.from_standard(result)
+            )
+        return result
+
+    async def _get_new_puzzle(self, wallet_state_manager: WalletStateManager) -> Program:
+        puzzle = self.config.puzzle_for_pk((await self._get_unused_derivation_path(wallet_state_manager)).record.pubkey)
+        return puzzle
+
+    async def _get_new_puzzle_hash(self, wallet_state_manager: WalletStateManager) -> bytes32:
+        return (await self._get_unused_derivation_path(wallet_state_manager)).record.puzzle_hash
+
+    async def get_puzzle(
+        self, wallet_state_manager: WalletStateManager, override_reuse_puzhash_with: Optional[bool] = None
+    ) -> Program:
+        if (
+            self.config.tx_config.reuse_puzhash or override_reuse_puzhash_with is True
+        ) and override_reuse_puzhash_with is not False:
+            record: Optional[DerivationRecord] = await wallet_state_manager.get_current_derivation_record_for_wallet(
+                wallet_state_manager.main_wallet.id()
+            )
+            if record is None:
+                return await self._get_new_puzzle(wallet_state_manager)  # pragma: no cover
+            puzzle = self.config.puzzle_for_pk(record.pubkey)
+            return puzzle
+        else:
+            return await self._get_new_puzzle(wallet_state_manager)
+
+    async def get_puzzle_hash(
+        self, wallet_state_manager: WalletStateManager, override_reuse_puzhash_with: Optional[bool] = None
+    ) -> bytes32:
+        if (
+            self.config.tx_config.reuse_puzhash or override_reuse_puzhash_with is True
+        ) and override_reuse_puzhash_with is not False:
+            record: Optional[DerivationRecord] = await wallet_state_manager.get_current_derivation_record_for_wallet(
+                wallet_state_manager.main_wallet.id()
+            )
+            if record is None:
+                return await self._get_new_puzzle_hash(wallet_state_manager)  # pragma: no cover
+            return record.puzzle_hash
+        else:
+            return await self._get_new_puzzle_hash(wallet_state_manager)
 
 
 @contextlib.asynccontextmanager
@@ -77,10 +138,16 @@ async def new_wallet_action_scope(
     sign: Optional[bool] = None,
     additional_signing_responses: list[SigningResponse] = [],
     extra_spends: list[WalletSpendBundle] = [],
+    puzzle_for_pk: Optional[Callable[[G1Element], Program]] = None,
 ) -> AsyncIterator[WalletActionScope]:
-    async with ActionScope.new_scope(
+    if puzzle_for_pk is None:
+        puzzle_for_pk = wallet_state_manager.main_wallet.puzzle_for_pk
+    assert puzzle_for_pk is not None
+    async with WalletActionScope.new_scope(
         WalletSideEffects,
-        WalletActionConfig(push, merge_spends, sign, additional_signing_responses, extra_spends, tx_config),
+        WalletActionConfig(
+            push, merge_spends, sign, additional_signing_responses, extra_spends, tx_config, puzzle_for_pk
+        ),
     ) as self:
         self = cast(WalletActionScope, self)
         async with self.use() as interface:
@@ -98,3 +165,5 @@ async def new_wallet_action_scope(
         extra_spends=self.side_effects.extra_spends,
         singleton_records=self.side_effects.singleton_records,
     )
+    if self.side_effects.get_unused_derivation_record_result is not None:
+        await self.side_effects.get_unused_derivation_record_result.to_standard().commit(wallet_state_manager)

--- a/chia/wallet/wsm_apis.py
+++ b/chia/wallet/wsm_apis.py
@@ -46,9 +46,9 @@ class StreamableCreateMorePuzzleHashesResult(Streamable):
 class CreateMorePuzzleHashesResult:
     derivation_paths: list[DerivationRecord]
     mark_existing_as_used: bool
-    unused: int
+    unused: int  # The first unusued puzzle hash
     new_unhardened_keys: bool
-    last_index: int
+    last_index: int  # The index we derived up to
 
     async def commit(self, wallet_state_manager: WalletStateManager) -> None:
         if len(self.derivation_paths) > 0:

--- a/chia/wallet/wsm_apis.py
+++ b/chia/wallet/wsm_apis.py
@@ -5,11 +5,41 @@ from typing import TYPE_CHECKING
 
 from chia_rs.sized_ints import uint32
 
-from chia.wallet.derivation_record import DerivationRecord
+from chia.util.streamable import Streamable, streamable
+from chia.wallet.derivation_record import DerivationRecord, StreamableDerivationRecord
 
 if TYPE_CHECKING:
     # avoiding a circular import
     from chia.wallet.wallet_state_manager import WalletStateManager
+
+
+@streamable
+@dataclasses.dataclass(frozen=True)
+class StreamableCreateMorePuzzleHashesResult(Streamable):
+    derivation_paths: list[StreamableDerivationRecord]
+    mark_existing_as_used: bool
+    unused: uint32
+    new_unhardened_keys: bool
+    last_index: uint32
+
+    @classmethod
+    def from_standard(cls, result: CreateMorePuzzleHashesResult) -> StreamableCreateMorePuzzleHashesResult:
+        return cls(
+            [StreamableDerivationRecord.from_standard(path) for path in result.derivation_paths],
+            result.mark_existing_as_used,
+            uint32(result.unused),
+            result.new_unhardened_keys,
+            uint32(result.last_index),
+        )
+
+    def to_standard(self) -> CreateMorePuzzleHashesResult:
+        return CreateMorePuzzleHashesResult(
+            [path.to_standard() for path in self.derivation_paths],
+            self.mark_existing_as_used,
+            self.unused,
+            self.new_unhardened_keys,
+            self.last_index,
+        )
 
 
 @dataclasses.dataclass
@@ -36,6 +66,26 @@ class CreateMorePuzzleHashesResult:
         if self.mark_existing_as_used and self.unused > 0 and self.new_unhardened_keys:
             wallet_state_manager.log.info(f"Updating last used derivation index: {self.unused - 1}")
             await wallet_state_manager.puzzle_store.set_used_up_to(uint32(self.unused - 1))
+
+
+@streamable
+@dataclasses.dataclass(frozen=True)
+class StreambleGetUnusedDerivationRecordResult(Streamable):
+    record: StreamableDerivationRecord
+    create_more_puzzle_hashes_result: StreamableCreateMorePuzzleHashesResult
+
+    @classmethod
+    def from_standard(cls, result: GetUnusedDerivationRecordResult) -> StreambleGetUnusedDerivationRecordResult:
+        return cls(
+            StreamableDerivationRecord.from_standard(result.record),
+            StreamableCreateMorePuzzleHashesResult.from_standard(result.create_more_puzzle_hashes_result),
+        )
+
+    def to_standard(self) -> GetUnusedDerivationRecordResult:
+        return GetUnusedDerivationRecordResult(
+            self.record.to_standard(),
+            self.create_more_puzzle_hashes_result.to_standard(),
+        )
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
(hide whitespace)

This PR moves the endpoints that wallets use for puzzle hash generation into action scopes.  The purpose for this is that requesting a puzzle hash may result in the generation of new puzzle hashes which is a side effect that we would like to discard if the action is also discarded.

An interesting thing that I learned while doing this is that all of the puzzle hash generation is called already from outside of existing `aciton_scope.use()` calls which is a good sign that this is a move in the right direction.  The side effects were already completely separated, they just were committed without a thought as to whether or not the greater action would finish.