### PR TITLE
remember recent transactions we've received and don't ask for them again

### DIFF
--- a/chia/_tests/core/util/test_lru_cache.py
+++ b/chia/_tests/core/util/test_lru_cache.py
@@ -10,47 +10,70 @@ class TestLRUCache(unittest.TestCase):
         cache = LRUCache(5)
 
         assert cache.get(b"0") is None
-
+        assert cache.peek() is None
         assert len(cache.cache) == 0
+
         cache.put(b"0", 1)
+        print(list(cache.cache.items()))
+        assert cache.peek() == (b"0", 1)
         assert len(cache.cache) == 1
         assert cache.get(b"0") == 1
         cache.put(b"0", 2)
+        assert cache.peek() == (b"0", 2)
         cache.put(b"0", 3)
+        assert cache.peek() == (b"0", 3)
         cache.put(b"0", 4)
+        assert cache.peek() == (b"0", 4)
         cache.put(b"0", 6)
+        assert cache.peek() == (b"0", 6)
         assert cache.get(b"0") == 6
         assert len(cache.cache) == 1
 
         cache.put(b"1", 1)
+        print(list(cache.cache.items()))
+        assert cache.peek() == (b"0", 6)
         assert len(cache.cache) == 2
         assert cache.get(b"0") == 6
         assert cache.get(b"1") == 1
+
         cache.put(b"2", 2)
+        print(list(cache.cache.items()))
+        assert cache.peek() == (b"0", 6)
         assert len(cache.cache) == 3
         assert cache.get(b"0") == 6
         assert cache.get(b"1") == 1
         assert cache.get(b"2") == 2
+
         cache.put(b"3", 3)
+        print(list(cache.cache.items()))
+        assert cache.peek() == (b"0", 6)
         assert len(cache.cache) == 4
         assert cache.get(b"0") == 6
         assert cache.get(b"1") == 1
         assert cache.get(b"2") == 2
         assert cache.get(b"3") == 3
+
         cache.put(b"4", 4)
+        print(list(cache.cache.items()))
+        assert cache.peek() == (b"0", 6)
         assert len(cache.cache) == 5
         assert cache.get(b"0") == 6
         assert cache.get(b"1") == 1
         assert cache.get(b"2") == 2
         assert cache.get(b"4") == 4
+
         cache.put(b"5", 5)
+        print(list(cache.cache.items()))
+        assert cache.peek() == (b"0", 6)
         assert cache.get(b"5") == 5
         assert len(cache.cache) == 5
-        print(cache.cache)
         assert cache.get(b"3") is None  # 3 is least recently used
         assert cache.get(b"1") == 1
         assert cache.get(b"2") == 2
+
         cache.put(b"7", 7)
+        print(list(cache.cache.items()))
+        assert cache.peek() == (b"4", 4)
         assert len(cache.cache) == 5
         assert cache.get(b"0") is None
         assert cache.get(b"1") == 1

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -276,6 +276,8 @@ class FullNodeAPI:
             await self.full_node.transaction_queue.put(
                 TransactionQueueEntry(tx.transaction, tx_bytes, spend_name, peer, test), peer.peer_node_id
             )
+            self.full_node._recent_txs.put(spend_name, time.monotonic())
+
         except TransactionQueueFull:
             pass  # we can't do anything here, the tx will be dropped. We might do something in the future.
         return None

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -240,6 +240,24 @@ class MempoolManager:
             item_inclusion_filter,
         )
 
+    def get_filter_with_extra(self, extra: set[bytes32]) -> bytes:
+        """
+        Returns the BIP158 filter for the transactions in the mempool plus
+        the specified transaction IDs
+        """
+        all_transactions = extra
+        byte_array_list = []
+        for key in all_transactions:
+            byte_array_list.append(bytearray(key))
+
+        for key in self.mempool.all_item_ids():
+            if key not in all_transactions:
+                all_transactions.add(key)
+                byte_array_list.append(bytearray(key))
+
+        tx_filter: PyBIP158 = PyBIP158(byte_array_list)
+        return bytes(tx_filter.GetEncoded())
+
     def get_filter(self) -> bytes:
         all_transactions: set[bytes32] = set()
         byte_array_list = []

--- a/chia/util/lru_cache.py
+++ b/chia/util/lru_cache.py
@@ -29,3 +29,12 @@ class LRUCache(Generic[K, V]):
 
     def remove(self, key: K) -> None:
         self.cache.pop(key)
+
+    def peek(self) -> Optional[tuple[K, V]]:
+        """
+        Return the oldest (key, value)-pair in the cache, or None if the cache is empty
+        """
+        try:
+            return next(self.cache.items().__iter__())
+        except StopIteration:
+            return None


### PR DESCRIPTION
### Purpose:

Avoid requesting the same mempool transactions multiple time, especially ones that have failed validation.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
