### PR TITLE
Set app minimum macos version to 13

### DIFF
--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -69,11 +69,11 @@ else
 fi
 echo "${NPM_PATH}/electron-builder" build --mac "${OPT_ARCH}" \
   --config.productName="$PRODUCT_NAME" \
-  --config.mac.minimumSystemVersion="11" \
+  --config.mac.minimumSystemVersion="13" \
   --config ../../../build_scripts/electron-builder.json
 "${NPM_PATH}/electron-builder" build --mac "${OPT_ARCH}" \
   --config.productName="$PRODUCT_NAME" \
-  --config.mac.minimumSystemVersion="11" \
+  --config.mac.minimumSystemVersion="13" \
   --config ../../../build_scripts/electron-builder.json
 LAST_EXIT_CODE=$?
 ls -l dist/mac*/chia.app/Contents/Resources/app.asar


### PR DESCRIPTION
Set the minimum version for macOS to 13 when we make the app using electron-builder

This should prevent launching the app at all on older macos