### PR TITLE
some cleanup of exception handling

### DIFF
--- a/chia/cmds/cmds_util.py
+++ b/chia/cmds/cmds_util.py
@@ -141,9 +141,12 @@ async def get_any_service_client(
 
             if tb is not None:
                 print(f"Traceback:\n{tb}")
+        except (click.ClickException, click.Abort):
+            # this includes CliRpcConnectionError which is a subbclass of click.ClickException
+            # raising here allows click to do it's normal click error handling
+            raise
         except Exception as e:  # this is only here to make the errors more user-friendly.
-            if not consume_errors or isinstance(e, (CliRpcConnectionError, click.Abort)):
-                # CliRpcConnectionError will be handled by click.
+            if not consume_errors:
                 raise
             print(f"Exception from '{node_type}' {e}:\n{traceback.format_exc()}")
 

--- a/chia/cmds/cmds_util.py
+++ b/chia/cmds/cmds_util.py
@@ -142,7 +142,7 @@ async def get_any_service_client(
             if tb is not None:
                 print(f"Traceback:\n{tb}")
         except (click.ClickException, click.Abort):
-            # this includes CliRpcConnectionError which is a subbclass of click.ClickException
+            # this includes CliRpcConnectionError which is a subclass of click.ClickException
             # raising here allows click to do it's normal click error handling
             raise
         except Exception as e:  # this is only here to make the errors more user-friendly.


### PR DESCRIPTION
Expand the handling of errors to all click.ClickException to allow using `ClickException` for things where otherwise `CliRpcConnectionError` might be abused
Also edit for clarity
