### PR TITLE
Add mempool config for minimum block inclusion fee per cost

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -43,7 +43,7 @@ from chia.full_node.full_node_api import FullNodeAPI
 from chia.full_node.full_node_store import FullNodeStore, FullNodeStorePeakResult, UnfinishedBlockEntry
 from chia.full_node.hint_management import get_hints_and_subscription_coin_ids
 from chia.full_node.hint_store import HintStore
-from chia.full_node.mempool import MempoolRemoveInfo
+from chia.full_node.mempool import MempoolConfig, MempoolRemoveInfo
 from chia.full_node.mempool_manager import MempoolManager, NewPeakItem
 from chia.full_node.signage_point import SignagePoint
 from chia.full_node.subscriptions import PeerSubscriptions, peers_for_spend_bundle
@@ -272,11 +272,16 @@ class FullNode:
                 log_coins=log_coins,
             )
 
+            mempool_config: dict[str, Any] = self.config.get("mempool", {})
+
             self._mempool_manager = MempoolManager(
                 get_coin_records=self.coin_store.get_coin_records,
                 get_unspent_lineage_info_for_puzzle_hash=self.coin_store.get_unspent_lineage_info_for_puzzle_hash,
                 consensus_constants=self.constants,
                 single_threaded=single_threaded,
+                mempool_config=MempoolConfig(
+                    minimum_fpc_for_block_inclusion=mempool_config.get("minimum_fpc_for_block_inclusion", 0.0)
+                )
             )
 
             # Transactions go into this queue from the server, and get sent to respond_transaction

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -450,6 +450,9 @@ full_node:
     public_key: "config/ssl/full_node/public_full_node.key"
   use_chia_loop_policy: True
 
+  mempool:
+    minimum_fpc_for_block_inclusion: 0.0
+
 ui:
   # Which port to use to communicate with the full node
   rpc_port: 8555


### PR DESCRIPTION
### Purpose:

This will allow farmers to decide what the minimum fee per cost ratio they want to include in blocks is, which prevents wasting resources building blocks with fee-less transactions (possibly useful on lower end hardware). Also, as was made clear by the recent fast forward mempool bug, it's important to have mempool diversity.

### Current Behavior:

The mempool currently has no configuration options.

### New Behavior:

You can now configure the minimum fee per cost for a transaction to be included into a block. However, lower fee transactions will still be received in the local mempool and propagated throughout the network. Fully blocking them from entering the mempool would have more adverse effects at scale.

### Testing Notes:

Has not been tested yet, hence being in draft for now.