### PR TITLE
CHIA-2383 Revisit items with fast forward related spends on new blocks

### DIFF
--- a/chia/types/mempool_item.py
+++ b/chia/types/mempool_item.py
@@ -17,7 +17,7 @@ from chia.util.streamable import recurse_jsonify
 class BundleCoinSpend:
     coin_spend: CoinSpend
     eligible_for_dedup: bool
-    eligible_for_fast_forward: bool
+    ff_latest_version: Optional[bytes32]
     additions: list[Coin]
     # cost on the specific solution in this item
     cost: Optional[uint64] = None


### PR DESCRIPTION
### Purpose:

Revisits mempool items that have fast forward spends related to any singletons among the spent coins IDs, on new blocks.

If a singleton is melted, the mempool items with spends related to it get removed, otherwise they get updated and revalidated accordingly.

### Current Behavior:

We don't do anything about mempool items that have fast forward spends, on new blocks.

### New Behavior:

We either evict mempool items or update them, depending on their related singletons, on new blocks.