### PR TITLE
Add fallback for introducer.

### DIFF
--- a/chia/_tests/simulation/test_simulation.py
+++ b/chia/_tests/simulation/test_simulation.py
@@ -519,8 +519,7 @@ class TestSimulation:
     @pytest.mark.anyio
     async def test_introducer_fallback_to_dns(self, simulation):
         full_system: FullSystem
-        bt: BlockTools
-        full_system, bt = simulation
+        full_system, _ = simulation
         introducer = full_system.introducer
         introducer.introducer.dns_servers = ["127.0.0.1"]
         introducer.introducer.resolver = FakeDNSResolver()

--- a/chia/_tests/simulation/test_simulation.py
+++ b/chia/_tests/simulation/test_simulation.py
@@ -5,6 +5,10 @@ import json
 from collections.abc import AsyncIterator
 
 import aiohttp
+import dns.rdataclass
+import dns.rdatatype
+import dns.rdtypes.IN.A
+import dns.rdtypes.IN.AAAA
 import pytest
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64
 
@@ -62,6 +66,17 @@ async def extra_node(self_hostname) -> AsyncIterator[FullNodeAPI | FullNodeSimul
             db_version=2,
         ) as service:
             yield service._api
+
+
+class FakeDNSResolver:
+    async def resolve(self, qname, rdtype, lifetime):
+        if rdtype == "A":
+            record = dns.rdtypes.IN.A.A(dns.rdataclass.IN, dns.rdatatype.A, "1.2.3.4")
+            return [record]
+        elif rdtype == "AAAA":
+            record = dns.rdtypes.IN.AAAA.AAAA(dns.rdataclass.IN, dns.rdatatype.AAAA, "::1")
+            return [record]
+        return []
 
 
 class TestSimulation:
@@ -499,3 +514,17 @@ class TestSimulation:
 
         with pytest.raises(Exception, match="Coins must have a positive value"):
             await full_node_api.create_coins_with_amounts(amounts=amounts, wallet=wallet)
+
+    @pytest.mark.limit_consensus_modes(reason="This test only supports one running at a time.")
+    @pytest.mark.anyio
+    async def test_introducer_fallback_to_dns(self, simulation):
+        full_system: FullSystem
+        bt: BlockTools
+        full_system, bt = simulation
+        introducer = full_system.introducer
+        introducer.introducer.dns_servers = ["127.0.0.1"]
+        introducer.introducer.resolver = FakeDNSResolver()
+        peers = await introducer.introducer.get_peers_from_dns(num_peers=10)
+        assert len(peers) == 2
+        assert any(peer.host == "1.2.3.4" for peer in peers)
+        assert any(peer.host == "::1" for peer in peers)

--- a/chia/_tests/util/setup_nodes.py
+++ b/chia/_tests/util/setup_nodes.py
@@ -390,6 +390,7 @@ async def setup_full_system_inner(
         introducer_service = await async_exit_stack.enter_async_context(setup_introducer(shared_b_tools, uint16(0)))
         introducer = introducer_service._api
         introducer_server = introducer_service._node.server
+        introducer.introducer.dns_servers = []
 
         # Then start the full node so we can use the port for the farmer and timelord
         node_1 = await async_exit_stack.enter_async_context(

--- a/chia/introducer/introducer.py
+++ b/chia/introducer/introducer.py
@@ -2,18 +2,21 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import dns.asyncresolver
 import logging
+import random
 import time
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
-from chia_rs.sized_ints import uint64
+from chia_rs.sized_ints import uint16, uint64
 
 from chia.rpc.rpc_server import StateChangedProtocol, default_get_connections
 from chia.server.introducer_peers import VettedPeer
 from chia.server.outbound_message import NodeType
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
+from chia.types.peer_info import TimestampedPeerInfo
 from chia.util.task_referencer import create_referenced_task
 
 
@@ -32,9 +35,12 @@ class Introducer:
 
         return self._server
 
-    def __init__(self, max_peers_to_send: int, recent_peer_threshold: int):
+    def __init__(self, max_peers_to_send: int, recent_peer_threshold: int, default_port: int, dns_servers: List[str]):
         self.max_peers_to_send = max_peers_to_send
         self.recent_peer_threshold = recent_peer_threshold
+        self.default_port = uint16(default_port)
+        self.dns_servers = dns_servers
+        self.resolver = dns.asyncresolver.Resolver()
         self._shut_down = False
         self._server: Optional[ChiaServer] = None
         self.log = logging.getLogger(__name__)
@@ -121,3 +127,24 @@ class Introducer:
                     peer.vetted = max(peer.vetted + 1, 1)
             except Exception as e:
                 self.log.error(e)
+
+    async def get_peers_from_dns(self, num_peers: int) -> list[TimestampedPeerInfo]:
+        if len(self.dns_servers) == 0:
+            return []
+
+        peers: list[TimestampedPeerInfo] = []
+        dns_address = random.choice(self.dns_servers)
+        for rdtype in ("A", "AAAA"):
+            result = await self.resolver.resolve(qname=dns_address, rdtype=rdtype, lifetime=30)
+            for ip in result:
+                peers.append(
+                    TimestampedPeerInfo(
+                        ip.to_text(),
+                        self.default_port,
+                        uint64(0),
+                    )
+                )
+            if len(peers) > num_peers:
+                break
+
+        return peers

--- a/chia/introducer/introducer.py
+++ b/chia/introducer/introducer.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import dns.asyncresolver
 import logging
 import random
 import time
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
+import dns.asyncresolver
 from chia_rs.sized_ints import uint16, uint64
 
 from chia.rpc.rpc_server import StateChangedProtocol, default_get_connections

--- a/chia/introducer/introducer.py
+++ b/chia/introducer/introducer.py
@@ -35,7 +35,7 @@ class Introducer:
 
         return self._server
 
-    def __init__(self, max_peers_to_send: int, recent_peer_threshold: int, default_port: int, dns_servers: List[str]):
+    def __init__(self, max_peers_to_send: int, recent_peer_threshold: int, default_port: int, dns_servers: list[str]):
         self.max_peers_to_send = max_peers_to_send
         self.recent_peer_threshold = recent_peer_threshold
         self.default_port = uint16(default_port)

--- a/chia/introducer/introducer_api.py
+++ b/chia/introducer/introducer_api.py
@@ -65,6 +65,13 @@ class IntroducerAPI:
             if len(peers) >= max_peers:
                 break
 
+        if len(peers) < max_peers:
+            peers_needed = max_peers - len(peers)
+            self.introducer.log.info(f"Querying dns servers for {peers_needed} peers")
+            extra_peers = await self.introducer.get_peers_from_dns(peers_needed)
+            self.introducer.log.info(f"Received {len(extra_peers)} peers from dns server")
+            peers.extend(extra_peers)
+
         self.introducer.log.info(f"Sending vetted {peers}")
 
         msg = make_msg(ProtocolMessageTypes.respond_peers_introducer, RespondPeersIntroducer(peers))

--- a/chia/server/start_introducer.py
+++ b/chia/server/start_introducer.py
@@ -37,12 +37,12 @@ def create_introducer_service(
         advertised_port = service_config["port"]
 
     try:
-        default_port = self.service_config["network_overrides"]["config"][network_name]["default_full_node_port"]
+        default_port = service_config["network_overrides"]["config"][network_id]["default_full_node_port"]
     except KeyError:
         raise Exception(f"Specify default_full_node_port for network {network_id}")
 
     dns_servers = service_config.get("dns_servers", [])
-    if dns_servers == [] and network_name == "mainnet":
+    if dns_servers == [] and network_id == "mainnet":
         dns_servers.append("dns-introducer.chia.net")
     
     node = Introducer(

--- a/chia/server/start_introducer.py
+++ b/chia/server/start_introducer.py
@@ -36,7 +36,18 @@ def create_introducer_service(
     if advertised_port is None:
         advertised_port = service_config["port"]
 
-    node = Introducer(service_config["max_peers_to_send"], service_config["recent_peer_threshold"])
+    try:
+        default_port = self.service_config["network_overrides"]["config"][network_name]["default_full_node_port"]
+    except KeyError:
+        raise Exception(f"Specify default_full_node_port for network {network_id}")
+
+    dns_servers = service_config.get("dns_servers", [])
+    if dns_servers == [] and network_name == "mainnet":
+        dns_servers.append("dns-introducer.chia.net")
+    
+    node = Introducer(
+        service_config["max_peers_to_send"], service_config["recent_peer_threshold"], default_port, dns_servers
+    )
     peer_api = IntroducerAPI(node)
 
     return Service(

--- a/chia/server/start_introducer.py
+++ b/chia/server/start_introducer.py
@@ -44,7 +44,7 @@ def create_introducer_service(
     dns_servers = service_config.get("dns_servers", [])
     if dns_servers == [] and network_id == "mainnet":
         dns_servers.append("dns-introducer.chia.net")
-    
+
     node = Introducer(
         service_config["max_peers_to_send"], service_config["recent_peer_threshold"], default_port, dns_servers
     )

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -478,6 +478,7 @@ introducer:
   logging: *logging
   network_overrides: *network_overrides
   selected_network: *selected_network
+  dns_servers: *dns_servers
 
   ssl:
     public_crt: "config/ssl/full_node/public_full_node.crt"


### PR DESCRIPTION
Use a DNS query as a fallback for introducer in case it doesn't have enough peers in its reply.