### PR TITLE
cache `get_unspent_lineage_info()`

### DIFF
--- a/benchmarks/mempool.py
+++ b/benchmarks/mempool.py
@@ -245,7 +245,6 @@ async def run_mempool_benchmark() -> None:
             for _ in range(50):
                 await mempool.create_block_generator(
                     last_tb_header_hash=rec.header_hash,
-                    get_unspent_lineage_info_for_puzzle_hash=get_unspent_lineage_info_for_puzzle_hash,
                 )
             stop = monotonic()
         print(f"  time: {stop - start:0.4f}s")

--- a/chia/_tests/blockchain/test_blockchain_transactions.py
+++ b/chia/_tests/blockchain/test_blockchain_transactions.py
@@ -65,9 +65,7 @@ class TestBlockchainTransactions:
         assert sb == spend_bundle
 
         last_block = blocks[-1]
-        result = await full_node_1.mempool_manager.create_bundle_from_mempool(
-            last_block.header_hash, full_node_1.coin_store.get_unspent_lineage_info_for_puzzle_hash
-        )
+        result = await full_node_1.mempool_manager.create_bundle_from_mempool(last_block.header_hash)
         assert result is not None
         next_spendbundle, _ = result
 

--- a/chia/_tests/core/full_node/test_performance.py
+++ b/chia/_tests/core/full_node/test_performance.py
@@ -123,9 +123,7 @@ class TestPerformance:
         curr: BlockRecord = peak
         while not curr.is_transaction_block:
             curr = full_node_1.full_node.blockchain.block_record(curr.prev_hash)
-        mempool_bundle = await full_node_1.full_node.mempool_manager.create_bundle_from_mempool(
-            curr.header_hash, full_node_1.full_node.coin_store.get_unspent_lineage_info_for_puzzle_hash
-        )
+        mempool_bundle = await full_node_1.full_node.mempool_manager.create_bundle_from_mempool(curr.header_hash)
         if mempool_bundle is None:
             spend_bundle = None
         else:

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -1012,9 +1012,6 @@ async def test_total_mempool_fees() -> None:
 @pytest.mark.parametrize("reverse_tx_order", [True, False])
 @pytest.mark.anyio
 async def test_create_bundle_from_mempool(reverse_tx_order: bool) -> None:
-    async def get_unspent_lineage_info_for_puzzle_hash(_: bytes32) -> Optional[UnspentLineageInfo]:
-        assert False  # pragma: no cover
-
     async def make_coin_spends(coins: list[Coin], *, high_fees: bool = True) -> list[CoinSpend]:
         spends_list = []
         for i in range(0, len(coins)):
@@ -1041,9 +1038,7 @@ async def test_create_bundle_from_mempool(reverse_tx_order: bool) -> None:
     spends = low_rate_spends + high_rate_spends if reverse_tx_order else high_rate_spends + low_rate_spends
     await send_spends_to_mempool(spends)
     assert mempool_manager.peak is not None
-    result = await mempool_manager.create_bundle_from_mempool(
-        mempool_manager.peak.header_hash, get_unspent_lineage_info_for_puzzle_hash
-    )
+    result = await mempool_manager.create_bundle_from_mempool(mempool_manager.peak.header_hash)
     assert result is not None
     # Make sure we filled the block with only high rate spends
     assert len([s for s in high_rate_spends if s in result[0].coin_spends]) == len(result[0].coin_spends)
@@ -1061,9 +1056,6 @@ async def test_create_bundle_from_mempool_on_max_cost(num_skipped_items: int, ca
       1. After PRIORITY_TX_THRESHOLD, we skip items with eligible coins.
       2. After skipping MAX_SKIPPED_ITEMS, we stop processing further items.
     """
-
-    async def get_unspent_lineage_info_for_puzzle_hash(_: bytes32) -> Optional[UnspentLineageInfo]:
-        assert False  # pragma: no cover
 
     MAX_BLOCK_CLVM_COST = 550_000_000
 
@@ -1143,9 +1135,7 @@ async def test_create_bundle_from_mempool_on_max_cost(num_skipped_items: int, ca
 
     assert mempool_manager.peak is not None
     caplog.set_level(logging.DEBUG)
-    result = await mempool_manager.create_bundle_from_mempool(
-        mempool_manager.peak.header_hash, get_unspent_lineage_info_for_puzzle_hash
-    )
+    result = await mempool_manager.create_bundle_from_mempool(mempool_manager.peak.header_hash)
     assert result is not None
     agg, additions = result
     skipped_due_to_eligible_coins = sum(

--- a/chia/_tests/core/mempool/test_singleton_fast_forward.py
+++ b/chia/_tests/core/mempool/test_singleton_fast_forward.py
@@ -676,7 +676,6 @@ async def test_mempool_items_immutability_on_ff() -> None:
         # Let's trigger the fast forward by creating a mempool bundle
         result = await sim.mempool_manager.create_bundle_from_mempool(
             sim_client.service.block_records[-1].header_hash,
-            sim_client.service.coin_store.get_unspent_lineage_info_for_puzzle_hash,
         )
         assert result is not None
         bundle, _ = result

--- a/chia/_tests/util/spend_sim.py
+++ b/chia/_tests/util/spend_sim.py
@@ -276,7 +276,6 @@ class SpendSim:
             if peak is not None:
                 result = await self.mempool_manager.create_bundle_from_mempool(
                     last_tb_header_hash=peak.header_hash,
-                    get_unspent_lineage_info_for_puzzle_hash=self.coin_store.get_unspent_lineage_info_for_puzzle_hash,
                     item_inclusion_filter=item_inclusion_filter,
                 )
 

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -863,9 +863,7 @@ class FullNodeAPI:
                     while not curr_l_tb.is_transaction_block:
                         curr_l_tb = self.full_node.blockchain.block_record(curr_l_tb.prev_hash)
                     try:
-                        block = await self.full_node.mempool_manager.create_block_generator(
-                            curr_l_tb.header_hash, self.full_node.coin_store.get_unspent_lineage_info_for_puzzle_hash
-                        )
+                        block = await self.full_node.mempool_manager.create_block_generator(curr_l_tb.header_hash)
                         if block is not None:
                             block_generator, aggregate_signature, additions = block
                     except Exception as e:

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -205,9 +205,7 @@ class FullNodeSimulator(FullNodeAPI):
                     await asyncio.sleep(1)
                 else:
                     current_time = False
-            mempool_bundle = await self.full_node.mempool_manager.create_bundle_from_mempool(
-                curr.header_hash, self.full_node.coin_store.get_unspent_lineage_info_for_puzzle_hash
-            )
+            mempool_bundle = await self.full_node.mempool_manager.create_bundle_from_mempool(curr.header_hash)
             if mempool_bundle is None:
                 spend_bundle = None
             else:
@@ -260,9 +258,7 @@ class FullNodeSimulator(FullNodeAPI):
                     await asyncio.sleep(1)
                 else:
                     current_time = False
-            mempool_bundle = await self.full_node.mempool_manager.create_bundle_from_mempool(
-                curr.header_hash, self.full_node.coin_store.get_unspent_lineage_info_for_puzzle_hash
-            )
+            mempool_bundle = await self.full_node.mempool_manager.create_bundle_from_mempool(curr.header_hash)
             if mempool_bundle is None:
                 spend_bundle = None
             else:


### PR DESCRIPTION
This is best reviewed one commit at a time

### Purpose:

speed up validation of transactions. In between new blocks (and within mempool function calls) the coin set will not change and we can safely cache the result.

### Current Behavior:

If there are multiple fast-forward spends of the same singleton in the mempool, we perform a DB lookup for each of them every time `new_peak()` is called and we take the slow path.

### New Behavior:

in `new_peak()`, the slow path caches results from the DB lookup and reuses it in case there are multiple FF spends for the same singleton in the mempool.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
