### PR TITLE
Add skip to exception update

### DIFF
--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -3176,7 +3176,7 @@ async def test_aggregating_on_a_solution_then_a_more_cost_saving_one_appears() -
     # The 3 items got skipped here
     # We ran with solution A and missed bigger savings on solution B
     assert mempool.size() == 5
-    assert [c.coin for c in agg.coin_spends] == [coins[0], coins[1]]
+    assert [c.coin for c in agg.coin_spends] == [coins[0], coins[1], coins[2]]
     invariant_check_mempool(mempool)
 
 

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -45,6 +45,7 @@ from chia.types.eligible_coin_spends import (
     DedupCoinSpend,
     EligibilityAndAdditions,
     EligibleCoinSpends,
+    SkipDedup,
     UnspentLineageInfo,
     run_for_cost,
 )
@@ -1134,10 +1135,7 @@ async def test_create_bundle_from_mempool_on_max_cost(num_skipped_items: int, ca
     assert result is not None
     agg, additions = result
     skipped_due_to_eligible_coins = sum(
-        1
-        for line in caplog.text.split("\n")
-        if "Exception while checking a mempool item for deduplication: Skipping transaction with eligible coin(s)"
-        in line
+        1 for line in caplog.text.split("\n") if "Skipping transaction with dedup or FF spends" in line
     )
     if num_skipped_items == PRIORITY_TX_THRESHOLD:
         # We skipped enough big cost items to reach `PRIORITY_TX_THRESHOLD`,
@@ -1460,7 +1458,7 @@ def test_dedup_info_eligible_but_different_solution() -> None:
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 2]]
     sb = spend_bundle_from_conditions(conditions, TEST_COIN)
     mempool_item = mempool_item_from_spendbundle(sb)
-    with pytest.raises(ValueError, match="Solution is different from what we're deduplicating on"):
+    with pytest.raises(SkipDedup, match="Solution is different from what we're deduplicating on"):
         eligible_coin_spends.get_deduplication_info(
             bundle_coin_spends=mempool_item.bundle_coin_spends, max_cost=mempool_item.conds.cost
         )

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -559,11 +559,17 @@ class Mempool:
                     # we want to keep looking for smaller transactions that
                     # might fit, but we also want to avoid spending too much
                     # time on potentially expensive ones, hence this shortcut.
+                    if any(
+                        map(
+                            lambda spend_data: (spend_data.eligible_for_dedup or spend_data.eligible_for_fast_forward),
+                            item.bundle_coin_spends.values(),
+                        )
+                    ):
+                        continue
+
                     unique_coin_spends = []
                     unique_additions = []
                     for spend_data in item.bundle_coin_spends.values():
-                        if spend_data.eligible_for_dedup or spend_data.eligible_for_fast_forward:
-                            raise Exception(f"Skipping transaction with eligible coin(s): {name.hex()}")
                         unique_coin_spends.append(spend_data.coin_spend)
                         unique_additions.extend(spend_data.additions)
                     cost_saving = 0

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -565,6 +565,7 @@ class Mempool:
                             item.bundle_coin_spends.values(),
                         )
                     ):
+                        log.info("Skipping transaction with dedup or FF spends {item.name}")
                         continue
 
                     unique_coin_spends = []
@@ -617,7 +618,8 @@ class Mempool:
                 # find transactions small enough to fit at this point
                 if self.mempool_info.max_block_clvm_cost - cost_sum < MIN_COST_THRESHOLD:
                     break
-            except SkipDedup:
+            except SkipDedup as e:
+                log.info(f"{e}")
                 continue
             except Exception as e:
                 log.info(f"Exception while checking a mempool item for deduplication: {e}")

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -19,7 +19,7 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.clvm_cost import CLVMCost
 from chia.types.coin_spend import CoinSpend
-from chia.types.eligible_coin_spends import EligibleCoinSpends, UnspentLineageInfo
+from chia.types.eligible_coin_spends import EligibleCoinSpends, SkipDedup, UnspentLineageInfo
 from chia.types.generator_types import BlockGenerator
 from chia.types.internal_mempool_item import InternalMempoolItem
 from chia.types.mempool_item import MempoolItem
@@ -617,6 +617,8 @@ class Mempool:
                 # find transactions small enough to fit at this point
                 if self.mempool_info.max_block_clvm_cost - cost_sum < MIN_COST_THRESHOLD:
                     break
+            except SkipDedup:
+                continue
             except Exception as e:
                 log.info(f"Exception while checking a mempool item for deduplication: {e}")
                 skipped_items += 1

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -142,6 +142,12 @@ def perform_the_fast_forward(
 
 
 @dataclasses.dataclass(frozen=True)
+class SkipDedup(BaseException):
+    msg: str
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
 class EligibleCoinSpends:
     deduplication_spends: dict[bytes32, DedupCoinSpend] = dataclasses.field(default_factory=dict)
     fast_forward_spends: dict[bytes32, UnspentLineageInfo] = dataclasses.field(default_factory=dict)
@@ -198,7 +204,7 @@ class EligibleCoinSpends:
                 # even if they end up saving more cost, as we're going for the first
                 # solution we see from the relatively highest FPC item, to avoid
                 # severe performance and/or time-complexity impact
-                raise ValueError("Solution is different from what we're deduplicating on")
+                raise SkipDedup("Solution is different from what we're deduplicating on")
             # Let's calculate the saved cost if we never did that before
             if duplicate_cost is None:
                 # See first if this mempool item had this cost computed before

--- a/chia/types/eligible_coin_spends.py
+++ b/chia/types/eligible_coin_spends.py
@@ -141,10 +141,9 @@ def perform_the_fast_forward(
     return new_coin_spend, patched_additions
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass
 class SkipDedup(BaseException):
     msg: str
-    pass
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
### Purpose:

restore the test by not treating skipping a dedup spend with different solution as an error

### Current Behavior:

encountering a second dedup spend with a different solution raises an exception that's treated as an error.

### New Behavior:

encountering a second dedup spend with a different solution raises an exception that's *not* treated as an error.
