### PR TITLE
stop using `.execute_insert()` when the result row is unused

### DIFF
--- a/chia/_tests/wallet/test_transaction_store.py
+++ b/chia/_tests/wallet/test_transaction_store.py
@@ -863,7 +863,7 @@ async def test_valid_times_migration() -> None:
         )
 
         async with db_wrapper.writer_maybe_transaction() as conn:
-            await conn.execute_insert(
+            await conn.execute(
                 "INSERT OR REPLACE INTO transaction_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     bytes(old_record),

--- a/chia/data_layer/dl_wallet_store.py
+++ b/chia/data_layer/dl_wallet_store.py
@@ -109,7 +109,7 @@ class DataLayerStore:
         """
 
         async with self.db_wrapper.writer_maybe_transaction() as conn:
-            await conn.execute_insert(
+            await conn.execute(
                 "INSERT OR REPLACE INTO singleton_records VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     record.coin_id,
@@ -257,7 +257,7 @@ class DataLayerStore:
         )
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             launcher_id = launcher.name()
-            await conn.execute_insert(
+            await conn.execute(
                 "INSERT OR REPLACE INTO launchers VALUES (?, ?)",
                 (launcher_id, launcher_bytes),
             )
@@ -308,7 +308,7 @@ class DataLayerStore:
         """
 
         async with self.db_wrapper.writer_maybe_transaction() as conn:
-            await conn.execute_insert(
+            await conn.execute(
                 "INSERT OR REPLACE INTO mirrors VALUES (?, ?, ?, ?, ?)",
                 (
                     mirror.coin_id,
@@ -320,7 +320,7 @@ class DataLayerStore:
                     1 if mirror.ours else 0,
                 ),
             )
-            await conn.execute_insert(
+            await conn.execute(
                 "INSERT OR REPLACE INTO mirror_confirmations (coin_id, confirmed_at_height) VALUES (?, ?)",
                 (
                     mirror.coin_id,

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -120,7 +120,7 @@ class WalletCoinStore:
             name = record.name()
         assert record.spent == (record.spent_block_height != 0)
         async with self.db_wrapper.writer_maybe_transaction() as conn:
-            await conn.execute_insert(
+            await conn.execute(
                 "INSERT OR REPLACE INTO coin_record ("
                 "coin_name, confirmed_height, spent_height, spent, coinbase, puzzle_hash, coin_parent, amount, "
                 "wallet_type, wallet_id, coin_type, metadata) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -150,7 +150,7 @@ class WalletCoinStore:
     # Update coin_record to be spent in DB
     async def set_spent(self, coin_name: bytes32, height: uint32) -> None:
         async with self.db_wrapper.writer_maybe_transaction() as conn:
-            await conn.execute_insert(
+            await conn.execute(
                 "UPDATE coin_record SET spent_height=?,spent=? WHERE coin_name=?",
                 (
                     height,

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -156,7 +156,7 @@ class WalletPuzzleStore:
         """
 
         async with self.db_wrapper.writer_maybe_transaction() as conn:
-            await conn.execute_insert(
+            await conn.execute(
                 "UPDATE derivation_paths SET used=1 WHERE derivation_index<=?",
                 (index,),
             )

--- a/chia/wallet/wallet_transaction_store.py
+++ b/chia/wallet/wallet_transaction_store.py
@@ -125,7 +125,7 @@ class WalletTransactionStore:
                 name=record.name,
                 memos=record.memos,
             )
-            await conn.execute_insert(
+            await conn.execute(
                 "INSERT OR REPLACE INTO transaction_record VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     bytes(transaction_record_old),
@@ -142,7 +142,7 @@ class WalletTransactionStore:
                     record.type,
                 ),
             )
-            await conn.execute_insert(
+            await conn.execute(
                 "INSERT OR REPLACE INTO tx_times VALUES (?, ?)", (record.name, bytes(record.valid_times))
             )
             ltx = get_light_transaction_record(record)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
