### PR TITLE
[CHIA-2546] Refactor and add test for WSM puzzle hash endpoints

### DIFF
--- a/chia/_tests/environments/wallet.py
+++ b/chia/_tests/environments/wallet.py
@@ -355,7 +355,7 @@ class WalletTestFramework:
             for env in self.environments:
                 ph_indexes: dict[uint32, int] = {}
                 for wallet_id in env.wallet_state_manager.wallets:
-                    ph_indexes[wallet_id] = await env.wallet_state_manager.puzzle_store.get_unused_count(wallet_id)
+                    ph_indexes[wallet_id] = await env.wallet_state_manager.puzzle_store.get_used_count(wallet_id)
                 puzzle_hash_indexes.append(ph_indexes)
 
         pending_txs: list[list[LightTransactionRecord]] = []
@@ -426,5 +426,5 @@ class WalletTestFramework:
             for env, ph_indexes_before in zip(self.environments, puzzle_hash_indexes):
                 for wallet_id, ph_index in zip(env.wallet_state_manager.wallets, ph_indexes_before):
                     assert ph_indexes_before[wallet_id] == (
-                        await env.wallet_state_manager.puzzle_store.get_unused_count(wallet_id)
+                        await env.wallet_state_manager.puzzle_store.get_used_count(wallet_id)
                     )

--- a/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
@@ -1818,8 +1818,6 @@ async def test_cat_puzzle_hashes(wallet_environments: WalletTestFramework) -> No
         await env.wallet_state_manager.puzzle_store.add_derivation_paths([dr])
 
     # Then we make sure that even though we asked for a used puzzle hash, it still gives us an unused one
-    unused_count = await env.wallet_state_manager.puzzle_store.get_unused_count(uint32(env.wallet_aliases["cat"]))
+    unused_count = await env.wallet_state_manager.puzzle_store.get_used_count(uint32(env.wallet_aliases["cat"]))
     await cat_wallet.get_cat_puzzle_hash(new=False)
-    assert unused_count < await env.wallet_state_manager.puzzle_store.get_unused_count(
-        uint32(env.wallet_aliases["cat"])
-    )
+    assert unused_count < await env.wallet_state_manager.puzzle_store.get_used_count(uint32(env.wallet_aliases["cat"]))

--- a/chia/_tests/wallet/conftest.py
+++ b/chia/_tests/wallet/conftest.py
@@ -152,7 +152,7 @@ def new_action_scope_wrapper(func: Any) -> Any:
         # Take note of the number of puzzle hashes if we're supposed to be reusing
         ph_indexes: dict[uint32, int] = {}
         for wallet_id in self.wallets:
-            ph_indexes[wallet_id] = await self.puzzle_store.get_unused_count(wallet_id)
+            ph_indexes[wallet_id] = await self.puzzle_store.get_used_count(wallet_id)
 
         async with func(self, *args, **kwargs) as action_scope:
             yield action_scope
@@ -160,7 +160,7 @@ def new_action_scope_wrapper(func: Any) -> Any:
         # Finally, check that the number of puzzle hashes did or did not increase by the specified amount
         if action_scope.config.tx_config.reuse_puzhash:
             for wallet_id, ph_index in zip(self.wallets, ph_indexes):
-                if not ph_indexes[wallet_id] == (await self.puzzle_store.get_unused_count(wallet_id)):
+                if not ph_indexes[wallet_id] == (await self.puzzle_store.get_used_count(wallet_id)):
                     raise NewPuzzleHashError(
                         f"wallet ID {wallet_id} generated new puzzle hashes while reuse_puzhash was False"
                     )

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -54,6 +54,13 @@ class InternalError(DBWrapperError):
     pass
 
 
+class PurposefulAbort(DBWrapperError):
+    obj: object
+
+    def __init__(self, obj: object) -> None:
+        self.obj = obj
+
+
 def generate_in_memory_db_uri() -> str:
     # We need to use shared cache as our DB wrapper uses different types of connections
     return f"file:db_{secrets.token_hex(16)}?mode=memory&cache=shared"

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -470,7 +470,8 @@ class WalletNode:
         async with self.wallet_state_manager.puzzle_store.lock:
             index = await self.wallet_state_manager.puzzle_store.get_last_derivation_path()
             if index is None or index < self.wallet_state_manager.initial_num_public_keys - 1:
-                await self.wallet_state_manager.create_more_puzzle_hashes(from_zero=True)
+                result = await self.wallet_state_manager.create_more_puzzle_hashes(from_zero=True)
+                await result.commit(self.wallet_state_manager)
 
         if self.wallet_peers is None:
             self.initialize_wallet_peers()
@@ -828,7 +829,8 @@ class WalletNode:
         min_height_for_subscriptions = fork_height if use_delta_sync else 0
         already_checked_ph: set[bytes32] = set()
         while not self._shut_down:
-            await self.wallet_state_manager.create_more_puzzle_hashes()
+            result = await self.wallet_state_manager.create_more_puzzle_hashes()
+            await result.commit(self.wallet_state_manager)
             all_puzzle_hashes = await self.get_puzzle_hashes_to_subscribe()
             not_checked_puzzle_hashes = set(all_puzzle_hashes) - already_checked_ph
             if not_checked_puzzle_hashes == set():

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -380,7 +380,7 @@ class WalletPuzzleStore:
             pass
         self.last_derivation_index = None
 
-    async def get_unused_count(self, wallet_id: uint32) -> int:
+    async def get_used_count(self, wallet_id: uint32) -> int:
         """
         Returns a count of unused derivation indexes
         """

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -10,7 +10,7 @@ import traceback
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, cast
 
 import aiosqlite
 from chia_rs import AugSchemeMPL, ConsensusConstants, G1Element, G2Element, PrivateKey
@@ -40,7 +40,7 @@ from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.condition_tools import conditions_dict_for_solution, pkm_pairs_for_conditions_dict
 from chia.util.db_synchronous import db_synchronous_on
-from chia.util.db_wrapper import DBWrapper2
+from chia.util.db_wrapper import DBWrapper2, PurposefulAbort
 from chia.util.errors import Err
 from chia.util.hash import std_hash
 from chia.util.lru_cache import LRUCache
@@ -134,6 +134,7 @@ from chia.wallet.wallet_retry_store import WalletRetryStore
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 from chia.wallet.wallet_transaction_store import WalletTransactionStore
 from chia.wallet.wallet_user_store import WalletUserStore
+from chia.wallet.wsm_apis import CreateMorePuzzleHashesResult, GetUnusedDerivationRecordResult
 
 TWalletType = TypeVar("TWalletType", bound=WalletProtocol[Any])
 
@@ -374,124 +375,151 @@ class WalletStateManager:
         mark_existing_as_used: bool = True,
         up_to_index: Optional[uint32] = None,
         num_additional_phs: Optional[int] = None,
-    ) -> None:
+        previous_result: Optional[CreateMorePuzzleHashesResult] = None,
+        _commit_previous_result: bool = True,
+    ) -> CreateMorePuzzleHashesResult:
         """
         For all wallets in the user store, generates the first few puzzle hashes so
         that we can restore the wallet from only the private keys.
         """
-        targets = list(self.wallets.keys())
-        self.log.debug("Target wallets to generate puzzle hashes for: %s", repr(targets))
-        unused: Optional[uint32] = (
-            uint32(up_to_index + 1) if up_to_index is not None else await self.puzzle_store.get_unused_derivation_path()
-        )
-        if unused is None:
-            # This handles the case where the database has entries but they have all been used
-            unused = await self.puzzle_store.get_last_derivation_path()
-            self.log.debug("Tried finding unused: %s", unused)
-            if unused is None:
-                # This handles the case where the database is empty
-                unused = uint32(0)
+        try:
+            async with self.db_wrapper.writer():
+                if previous_result is not None:
+                    if previous_result.mark_existing_as_used is not mark_existing_as_used:
+                        raise ValueError(
+                            "Called `create_more_puzzle_hashes` with a previous result and different configuration"
+                        )
+                    if _commit_previous_result:
+                        await previous_result.commit(self)
+                targets = list(self.wallets.keys())
+                self.log.debug("Target wallets to generate puzzle hashes for: %s", repr(targets))
+                unused: Optional[uint32] = (
+                    up_to_index if up_to_index is not None else await self.puzzle_store.get_unused_derivation_path()
+                )
+                if unused is None:
+                    # This handles the case where the database has entries but they have all been used
+                    unused = await self.puzzle_store.get_last_derivation_path()
+                    self.log.debug("Tried finding unused: %s", unused)
+                    if unused is None:
+                        # This handles the case where the database is empty
+                        unused = uint32(0)
+                    else:
+                        # The first unused will be the one after the last used one we got above
+                        unused = uint32(unused + 1)
 
-        self.log.debug(f"Requested to generate puzzle hashes to at least index {unused}")
-        start_t = time.time()
-        to_generate = num_additional_phs if num_additional_phs is not None else self.initial_num_public_keys
+                self.log.debug(f"Requested to generate puzzle hashes to at least index {unused}")
+                start_t = time.time()
+                to_generate = num_additional_phs if num_additional_phs is not None else self.initial_num_public_keys
 
-        # iterate all wallets that need derived keys and establish the start
-        # index for all of them
-        start_index_by_wallet: dict[uint32, int] = {}
-        last_index = unused + to_generate
-        for wallet_id in targets:
-            target_wallet = self.wallets[wallet_id]
-            if not target_wallet.require_derivation_paths():
-                self.log.debug("Skipping wallet %s as no derivation paths required", wallet_id)
-                continue
-            if from_zero:
-                start_index_by_wallet[wallet_id] = 0
-                continue
-            last: Optional[uint32] = await self.puzzle_store.get_last_derivation_path_for_wallet(wallet_id)
-            if last is not None:
-                if last + 1 >= last_index:
-                    self.log.debug(f"Nothing to create for for wallet_id: {wallet_id}, index: {last_index}")
-                    continue
-                start_index_by_wallet[wallet_id] = last + 1
-            else:
-                start_index_by_wallet[wallet_id] = 0
+                # iterate all wallets that need derived keys and establish the start
+                # index for all of them
+                start_index_by_wallet: dict[uint32, int] = {}
+                last_index = unused + to_generate
+                for wallet_id in targets:
+                    target_wallet = self.wallets[wallet_id]
+                    if not target_wallet.require_derivation_paths():
+                        self.log.debug("Skipping wallet %s as no derivation paths required", wallet_id)
+                        continue
+                    if from_zero:
+                        start_index_by_wallet[wallet_id] = 0
+                        continue
+                    last: Optional[uint32] = await self.puzzle_store.get_last_derivation_path_for_wallet(wallet_id)
+                    if last is not None:
+                        if last >= last_index:
+                            self.log.debug(f"Nothing to create for for wallet_id: {wallet_id}, index: {last_index}")
+                            continue
+                        start_index_by_wallet[wallet_id] = last
+                    else:
+                        start_index_by_wallet[wallet_id] = 0
 
-        if len(start_index_by_wallet) == 0:
-            return
-
-        lowest_start_index = min(start_index_by_wallet.values())
-
-        # now derive the keysfrom lowest_start_index to last_index
-        # these maps derivation index to public key
-        hardened_keys: dict[int, G1Element] = {}
-        unhardened_keys: dict[int, G1Element] = {}
-
-        if self.private_key is not None:
-            # Hardened
-            intermediate_sk = master_sk_to_wallet_sk_intermediate(self.private_key)
-            for index in range(lowest_start_index, last_index):
-                hardened_keys[index] = _derive_path(intermediate_sk, [index]).get_g1()
-
-        # Unhardened
-        intermediate_pk_un = master_pk_to_wallet_pk_unhardened_intermediate(self.root_pubkey)
-        for index in range(lowest_start_index, last_index):
-            unhardened_keys[index] = _derive_pk_unhardened(intermediate_pk_un, [index])
-
-        for wallet_id, start_index in start_index_by_wallet.items():
-            target_wallet = self.wallets[wallet_id]
-            assert target_wallet.type() != WalletType.POOLING_WALLET
-            assert start_index < last_index
-
-            derivation_paths: list[DerivationRecord] = []
-            creating_msg = f"Creating puzzle hashes from {start_index} to {last_index - 1} for wallet_id: {wallet_id}"
-            self.log.info(f"Start: {creating_msg}")
-            for index in range(start_index, last_index):
-                pubkey: Optional[G1Element] = hardened_keys.get(index)
-                if pubkey is not None:
-                    # Hardened
-                    puzzlehash: bytes32 = target_wallet.puzzle_hash_for_pk(pubkey)
-                    self.log.debug(f"Puzzle at index {index} wallet ID {wallet_id} puzzle hash {puzzlehash.hex()}")
-                    derivation_paths.append(
-                        DerivationRecord(
-                            uint32(index),
-                            puzzlehash,
-                            pubkey,
-                            target_wallet.type(),
-                            uint32(target_wallet.id()),
-                            True,
+                if len(start_index_by_wallet) == 0:
+                    raise PurposefulAbort(
+                        CreateMorePuzzleHashesResult(
+                            derivation_paths=[] if previous_result is None else previous_result.derivation_paths,
+                            mark_existing_as_used=mark_existing_as_used,
+                            unused=unused,
+                            new_unhardened_keys=False,
+                            last_index=last_index,
                         )
                     )
+
+                lowest_start_index = min(start_index_by_wallet.values())
+
+                # now derive the keysfrom lowest_start_index to last_index
+                # these maps derivation index to public key
+                hardened_keys: dict[int, G1Element] = {}
+                unhardened_keys: dict[int, G1Element] = {}
+
+                if self.private_key is not None:
+                    # Hardened
+                    intermediate_sk = master_sk_to_wallet_sk_intermediate(self.private_key)
+                    for index in range(lowest_start_index, last_index + 1):
+                        hardened_keys[index] = _derive_path(intermediate_sk, [index]).get_g1()
+
                 # Unhardened
-                pubkey = unhardened_keys.get(index)
-                assert pubkey is not None
-                puzzlehash_unhardened: bytes32 = target_wallet.puzzle_hash_for_pk(pubkey)
-                self.log.debug(
-                    f"Puzzle at index {index} wallet ID {wallet_id} puzzle hash {puzzlehash_unhardened.hex()}"
+                intermediate_pk_un = master_pk_to_wallet_pk_unhardened_intermediate(self.root_pubkey)
+                for index in range(lowest_start_index, last_index + 1):
+                    unhardened_keys[index] = _derive_pk_unhardened(intermediate_pk_un, [index])
+
+                derivation_paths: list[DerivationRecord] = (
+                    [] if previous_result is None else previous_result.derivation_paths
                 )
-                derivation_paths.append(
-                    DerivationRecord(
-                        uint32(index),
-                        puzzlehash_unhardened,
-                        pubkey,
-                        target_wallet.type(),
-                        uint32(target_wallet.id()),
-                        False,
+                for wallet_id, start_index in start_index_by_wallet.items():
+                    target_wallet = self.wallets[wallet_id]
+                    assert target_wallet.type() != WalletType.POOLING_WALLET
+                    assert start_index < last_index
+
+                    creating_msg = (
+                        f"Creating puzzle hashes from {start_index} to {last_index} for wallet_id: {wallet_id}"
+                    )
+                    self.log.info(f"Start: {creating_msg}")
+                    for index in range(start_index, last_index + 1):
+                        pubkey: Optional[G1Element] = hardened_keys.get(index)
+                        if pubkey is not None:
+                            # Hardened
+                            puzzlehash: bytes32 = target_wallet.puzzle_hash_for_pk(pubkey)
+                            self.log.debug(
+                                f"Puzzle at index {index} wallet ID {wallet_id} puzzle hash {puzzlehash.hex()}"
+                            )
+                            derivation_paths.append(
+                                DerivationRecord(
+                                    uint32(index),
+                                    puzzlehash,
+                                    pubkey,
+                                    target_wallet.type(),
+                                    uint32(target_wallet.id()),
+                                    True,
+                                )
+                            )
+                        # Unhardened
+                        pubkey = unhardened_keys.get(index)
+                        assert pubkey is not None
+                        puzzlehash_unhardened: bytes32 = target_wallet.puzzle_hash_for_pk(pubkey)
+                        self.log.debug(
+                            f"Puzzle at index {index} wallet ID {wallet_id} puzzle hash {puzzlehash_unhardened.hex()}"
+                        )
+                        derivation_paths.append(
+                            DerivationRecord(
+                                uint32(index),
+                                puzzlehash_unhardened,
+                                pubkey,
+                                target_wallet.type(),
+                                uint32(target_wallet.id()),
+                                False,
+                            )
+                        )
+                    self.log.info(f"Done: {creating_msg} Time: {time.time() - start_t} seconds")
+                raise PurposefulAbort(
+                    CreateMorePuzzleHashesResult(
+                        derivation_paths=derivation_paths,
+                        mark_existing_as_used=mark_existing_as_used,
+                        unused=unused,
+                        new_unhardened_keys=(len(hardened_keys) > 0),
+                        last_index=last_index,
                     )
                 )
-            self.log.info(f"Done: {creating_msg} Time: {time.time() - start_t} seconds")
-            if len(derivation_paths) > 0:
-                await self.puzzle_store.add_derivation_paths(derivation_paths)
-                if wallet_id == self.main_wallet.id():
-                    await self.wallet_node.new_peak_queue.subscribe_to_puzzle_hashes(
-                        [record.puzzle_hash for record in derivation_paths]
-                    )
-        if len(unhardened_keys) > 0:
-            self.state_changed("new_derivation_index", data_object={"index": last_index - 1})
-        # By default, we'll mark previously generated unused puzzle hashes as used if we have new paths
-        if mark_existing_as_used and unused > 0 and len(unhardened_keys) > 0:
-            self.log.info(f"Updating last used derivation index: {unused - 1}")
-            await self.puzzle_store.set_used_up_to(uint32(unused - 1))
+        except PurposefulAbort as e:
+            return cast(CreateMorePuzzleHashesResult, e.obj)
 
     async def update_wallet_puzzle_hashes(self, wallet_id: uint32) -> None:
         derivation_paths: list[DerivationRecord] = []
@@ -522,35 +550,64 @@ class WalletStateManager:
                 )
             await self.puzzle_store.add_derivation_paths(derivation_paths)
 
-    async def get_unused_derivation_record(self, wallet_id: uint32, *, hardened: bool = False) -> DerivationRecord:
+    async def _get_unused_derivation_record(
+        self,
+        wallet_id: uint32,
+        *,
+        hardened: bool = False,
+        previous_result: Optional[GetUnusedDerivationRecordResult] = None,
+    ) -> GetUnusedDerivationRecordResult:
         """
         Creates a puzzle hash for the given wallet, and then makes more puzzle hashes
         for every wallet to ensure we always have more in the database. Never reusue the
         same public key more than once (for privacy).
         """
-        async with self.puzzle_store.lock:
-            # If we have no unused public keys, we will create new ones
-            unused: Optional[uint32] = await self.puzzle_store.get_unused_derivation_path()
-            if unused is None:
-                self.log.debug("No unused paths, generate more ")
-                await self.create_more_puzzle_hashes()
-                # Now we must have unused public keys
-                unused = await self.puzzle_store.get_unused_derivation_path()
-                assert unused is not None
+        try:
+            async with self.db_wrapper.writer():
+                if previous_result is not None:
+                    await previous_result.commit(self)
+                    create_more_puzzle_hashes_result: Optional[CreateMorePuzzleHashesResult] = (
+                        previous_result.create_more_puzzle_hashes_result
+                    )
+                else:
+                    create_more_puzzle_hashes_result = None
+                # If we have no unused public keys, we will create new ones
+                unused: Optional[uint32] = await self.puzzle_store.get_unused_derivation_path()
+                if unused is None:
+                    self.log.debug("No unused paths, generate more ")
+                    create_more_puzzle_hashes_result = await self.create_more_puzzle_hashes(
+                        previous_result=create_more_puzzle_hashes_result, _commit_previous_result=False
+                    )
+                    await create_more_puzzle_hashes_result.commit(self)
+                    # Now we must have unused public keys
+                    unused = await self.puzzle_store.get_unused_derivation_path()
+                    assert unused is not None
 
-            self.log.debug("Fetching derivation record for: %s %s %s", unused, wallet_id, hardened)
-            record: Optional[DerivationRecord] = await self.puzzle_store.get_derivation_record(
-                unused, wallet_id, hardened
-            )
-            if record is None:
-                raise ValueError(f"Missing derivation '{unused}' for wallet id '{wallet_id}' (hardened={hardened})")
+                self.log.debug("Fetching derivation record for: %s %s %s", unused, wallet_id, hardened)
+                record: Optional[DerivationRecord] = await self.puzzle_store.get_derivation_record(
+                    unused, wallet_id, hardened
+                )
+                if record is None:
+                    raise ValueError(f"Missing derivation '{unused}' for wallet id '{wallet_id}' (hardened={hardened})")
 
-            # Set this key to used so we never use it again
-            await self.puzzle_store.set_used_up_to(record.index)
+                # Set this key to used so we never use it again
+                await self.puzzle_store.set_used_up_to(record.index)
 
-            # Create more puzzle hashes / keys
-            await self.create_more_puzzle_hashes()
-            return record
+                # Create more puzzle hashes / keys
+                create_more_puzzle_hashes_result = await self.create_more_puzzle_hashes(
+                    previous_result=create_more_puzzle_hashes_result,
+                    up_to_index=record.index,
+                    _commit_previous_result=False,
+                )
+                await create_more_puzzle_hashes_result.commit(self)
+                raise PurposefulAbort(GetUnusedDerivationRecordResult(record, create_more_puzzle_hashes_result))
+        except PurposefulAbort as e:
+            return cast(GetUnusedDerivationRecordResult, e.obj)
+
+    async def get_unused_derivation_record(self, wallet_id: uint32, *, hardened: bool = False) -> DerivationRecord:
+        result = await self._get_unused_derivation_record(wallet_id, hardened=hardened)
+        await result.commit(self)
+        return result.record
 
     async def get_current_derivation_record_for_wallet(self, wallet_id: uint32) -> Optional[DerivationRecord]:
         async with self.puzzle_store.lock:
@@ -2107,7 +2164,8 @@ class WalletStateManager:
 
         await self.wallets[wallet_id].coin_added(coin, height, peer, coin_data)
 
-        await self.create_more_puzzle_hashes()
+        result = await self.create_more_puzzle_hashes()
+        await result.commit(self)
 
     async def add_pending_transactions(
         self,
@@ -2357,7 +2415,8 @@ class WalletStateManager:
 
     async def add_new_wallet(self, wallet: WalletProtocol[Any]) -> None:
         self.wallets[wallet.id()] = wallet
-        await self.create_more_puzzle_hashes()
+        result = await self.create_more_puzzle_hashes()
+        await result.commit(self)
         self.state_changed("wallet_created")
 
     async def get_spendable_coins_for_wallet(

--- a/chia/wallet/wsm_apis.py
+++ b/chia/wallet/wsm_apis.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from chia_rs.sized_ints import uint32
+
+from chia.wallet.derivation_record import DerivationRecord
+
+if TYPE_CHECKING:
+    # avoiding a circular import
+    from chia.wallet.wallet_state_manager import WalletStateManager
+
+
+@dataclasses.dataclass
+class CreateMorePuzzleHashesResult:
+    derivation_paths: list[DerivationRecord]
+    mark_existing_as_used: bool
+    unused: int
+    new_unhardened_keys: bool
+    last_index: int
+
+    async def commit(self, wallet_state_manager: WalletStateManager) -> None:
+        if len(self.derivation_paths) > 0:
+            await wallet_state_manager.puzzle_store.add_derivation_paths(self.derivation_paths)
+            await wallet_state_manager.wallet_node.new_peak_queue.subscribe_to_puzzle_hashes(
+                [
+                    record.puzzle_hash
+                    for record in self.derivation_paths
+                    if record.wallet_id == wallet_state_manager.main_wallet.id()
+                ]
+            )
+        if self.new_unhardened_keys:
+            wallet_state_manager.state_changed("new_derivation_index", data_object={"index": self.last_index - 1})
+        # By default, we'll mark previously generated unused puzzle hashes as used if we have new paths
+        if self.mark_existing_as_used and self.unused > 0 and self.new_unhardened_keys:
+            wallet_state_manager.log.info(f"Updating last used derivation index: {self.unused - 1}")
+            await wallet_state_manager.puzzle_store.set_used_up_to(uint32(self.unused - 1))
+
+
+@dataclasses.dataclass
+class GetUnusedDerivationRecordResult:
+    record: DerivationRecord
+    create_more_puzzle_hashes_result: CreateMorePuzzleHashesResult
+
+    async def commit(self, wallet_state_manager: WalletStateManager) -> None:
+        await self.create_more_puzzle_hashes_result.commit(wallet_state_manager)
+        await wallet_state_manager.puzzle_store.set_used_up_to(self.record.index)


### PR DESCRIPTION
(hide whitespace)

This PR is in response to discovering that the wallet state manager methods `create_more_puzzle_hashes` and `get_unused_derivation_record` are only tested implicitly.  This adds a comprehensive test for them and makes changes accordingly.  I _believe_ this will result in some desirable changes for end users who find themselves with more puzzle hashes than "used" + "derivation window".  A lot of the changes I made seemed like they would be helpful in addressing gaps.

In addition, a change is made to separate the generation and commitment of the puzzle hashes in preparation for moving them into action scopes which require delayed commitment of side effects.