### PR TITLE
fix tl node peak sync

### DIFF
--- a/chia/timelord/timelord_api.py
+++ b/chia/timelord/timelord_api.py
@@ -75,6 +75,19 @@ class TimelordAPI:
             if self.timelord.last_state.peak.reward_chain_block.get_hash() == new_peak.reward_chain_block.get_hash():
                 log.info("Skipping peak, already have.")
             else:
+                if (
+                    self.timelord.last_state.peak.reward_chain_block.total_iters
+                    >= new_peak.reward_chain_block.total_iters
+                ):
+                    log.info("Not skipping peak, has equal weight but lower")
+                    log.info(
+                        f"New peak: height: {new_peak.reward_chain_block.height} weight: "
+                        f"{new_peak.reward_chain_block.weight} "
+                    )
+                    self.timelord.new_peak = new_peak
+                    self.timelord.state_changed("new_peak", {"height": new_peak.reward_chain_block.height})
+                    return
+
                 log.info("Skipping peak, block has equal or lower weight then our peak.")
                 log.debug(
                     f"new peak height {new_peak.reward_chain_block.height} weight {new_peak.reward_chain_block.weight}"

--- a/chia/timelord/timelord_api.py
+++ b/chia/timelord/timelord_api.py
@@ -59,10 +59,9 @@ class TimelordAPI:
                 and self.timelord.last_state.peak.reward_chain_block.total_iters
                 >= new_peak.reward_chain_block.total_iters
             ):
-                log.info("Not skipping peak, has equal weight but lower iterations")
                 log.info(
-                    f"New peak: height: {new_peak.reward_chain_block.height} weight: "
-                    f"{new_peak.reward_chain_block.weight} "
+                    "Not skipping peak, has equal weight but lower iterations,"
+                    "current peak:{self.timelord.last_state.total_iters} new peak  {new_peak.reward_chain_block.total_iters}"
                 )
                 self.timelord.new_peak = new_peak
                 self.timelord.state_changed("new_peak", {"height": new_peak.reward_chain_block.height})
@@ -79,9 +78,9 @@ class TimelordAPI:
                     self.timelord.state_changed("skipping_peak", {"height": new_peak.reward_chain_block.height})
                     return
 
-                log.info("Not skipping peak, don't have. Maybe we are not the fastest timelord")
                 log.info(
-                    f"New peak: height: {new_peak.reward_chain_block.height} weight: "
+                    "Not skipping peak, don't have. Maybe we are not the fastest timelord "
+                    f"height: {new_peak.reward_chain_block.height} weight:"
                     f"{new_peak.reward_chain_block.weight} "
                 )
                 self.timelord.new_peak = new_peak

--- a/chia/timelord/timelord_api.py
+++ b/chia/timelord/timelord_api.py
@@ -57,11 +57,12 @@ class TimelordAPI:
             if (
                 self.timelord.last_state.get_weight() == new_peak.reward_chain_block.weight
                 and self.timelord.last_state.peak.reward_chain_block.total_iters
-                >= new_peak.reward_chain_block.total_iters
+                > new_peak.reward_chain_block.total_iters
             ):
                 log.info(
                     "Not skipping peak, has equal weight but lower iterations,"
-                    "current peak:{self.timelord.last_state.total_iters} new peak  {new_peak.reward_chain_block.total_iters}"
+                    f"current peak:{self.timelord.last_state.total_iters} new peak "
+                    f"{new_peak.reward_chain_block.total_iters}"
                 )
                 self.timelord.new_peak = new_peak
                 self.timelord.state_changed("new_peak", {"height": new_peak.reward_chain_block.height})
@@ -91,7 +92,8 @@ class TimelordAPI:
                 log.info("Skipping peak, already have.")
             else:
                 log.info(
-                    f"Skipping peak height {new_peak.reward_chain_block.height} weight {new_peak.reward_chain_block.weight}"
+                    f"Skipping peak height {new_peak.reward_chain_block.height} "
+                    f"weight {new_peak.reward_chain_block.weight}"
                 )
 
             self.timelord.state_changed("skipping_peak", {"height": new_peak.reward_chain_block.height})

--- a/chia/timelord/timelord_api.py
+++ b/chia/timelord/timelord_api.py
@@ -52,12 +52,13 @@ class TimelordAPI:
                 self.timelord.new_peak = new_peak
                 self.timelord.state_changed("new_peak", {"height": new_peak.reward_chain_block.height})
                 return
+
+            # new peak has equal weight but lower iterations
             if (
                 self.timelord.last_state.get_weight() == new_peak.reward_chain_block.weight
                 and self.timelord.last_state.peak.reward_chain_block.total_iters
                 >= new_peak.reward_chain_block.total_iters
             ):
-                # new peak has equal weight but lower iterations
                 log.info("Not skipping peak, has equal weight but lower iterations")
                 log.info(
                     f"New peak: height: {new_peak.reward_chain_block.height} weight: "
@@ -66,6 +67,8 @@ class TimelordAPI:
                 self.timelord.new_peak = new_peak
                 self.timelord.state_changed("new_peak", {"height": new_peak.reward_chain_block.height})
                 return
+
+            # new peak is heavier
             if self.timelord.last_state.get_weight() < new_peak.reward_chain_block.weight:
                 # if there is an unfinished block with less iterations, skip so we dont orphan it
                 if (
@@ -88,10 +91,10 @@ class TimelordAPI:
             if self.timelord.last_state.peak.reward_chain_block.get_hash() == new_peak.reward_chain_block.get_hash():
                 log.info("Skipping peak, already have.")
             else:
-                log.info("Skipping peak, block has equal or lower weight then our peak.")
-            log.debug(
-                f"new peak height {new_peak.reward_chain_block.height} weight {new_peak.reward_chain_block.weight}"
-            )
+                log.info(
+                    f"Skipping peak height {new_peak.reward_chain_block.height} weight {new_peak.reward_chain_block.weight}"
+                )
+
             self.timelord.state_changed("skipping_peak", {"height": new_peak.reward_chain_block.height})
 
     def check_orphaned_unfinished_block(self, new_peak: NewPeakTimelord):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,8 @@
 [pytest]
 ; logging options
-log_cli = True
+log_cli = False
 addopts = --verbose --tb=short -n auto -p no:monitor
-log_level = INFO
+log_level = WARNING
 console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
 markers =

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,8 @@
 [pytest]
 ; logging options
-log_cli = False
+log_cli = True
 addopts = --verbose --tb=short -n auto -p no:monitor
-log_level = WARNING
+log_level = INFO
 console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s
 markers =


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

fix peak change conditions to match the full node

### Current Behavior:

in the case of a new peak with equal weight the full node will prefer the peak with lower iterations, the timelord will keep whichever peak he got first 

### New Behavior:

make the timelord switch peaks in the case where the weight of the new peak is equal but the iterations are lower

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
