### PR TITLE
NewBlockGenerator as an extension of BlockGenerator

### DIFF
--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -2957,9 +2957,8 @@ async def test_skip_error_items() -> None:
         called += 1
         raise RuntimeError("failed to find fast forward coin")
 
-    result = await mempool.create_block_generator(local_get_unspent_lineage_info, DEFAULT_CONSTANTS, uint32(10))
-    assert result is not None
-    generator, _, _, _ = result
+    generator = await mempool.create_block_generator(local_get_unspent_lineage_info, DEFAULT_CONSTANTS, uint32(10))
+    assert generator is not None
 
     assert called == 3
     assert generator.program == SerializedProgram.from_bytes(bytes.fromhex("ff01ff8080"))
@@ -3247,21 +3246,21 @@ async def test_create_block_generator() -> None:
         mempool.add_to_pool(mi)
         invariant_check_mempool(mempool)
 
-    block = await mempool.create_block_generator(get_unspent_lineage_info_for_puzzle_hash, test_constants, uint32(0))
-    assert block is not None
-    generator, signature, additions, _ = block
+    generator = await mempool.create_block_generator(
+        get_unspent_lineage_info_for_puzzle_hash, test_constants, uint32(0)
+    )
+    assert generator is not None
 
-    assert set(additions) == expected_additions
-
-    assert len(additions) == len(expected_additions)
-    assert signature == expected_signature
+    assert set(generator.additions) == expected_additions
+    assert len(generator.additions) == len(expected_additions)
+    assert generator.signature == expected_signature
 
     err, conds = run_block_generator2(
         bytes(generator.program),
         generator.generator_refs,
         test_constants.MAX_BLOCK_COST_CLVM,
         0,
-        signature,
+        generator.signature,
         None,
         test_constants,
     )
@@ -3278,7 +3277,7 @@ async def test_create_block_generator() -> None:
             assert Coin(spend.coin_id, add2[0], uint64(add2[1])) in expected_additions
             num_additions += 1
 
-    assert num_additions == len(additions)
+    assert num_additions == len(generator.additions)
     invariant_check_mempool(mempool)
 
 

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -20,7 +20,7 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.clvm_cost import CLVMCost
 from chia.types.coin_spend import CoinSpend
 from chia.types.eligible_coin_spends import EligibleCoinSpends, SkipDedup, UnspentLineageInfo
-from chia.types.generator_types import BlockGenerator
+from chia.types.generator_types import NewBlockGenerator
 from chia.types.internal_mempool_item import InternalMempoolItem
 from chia.types.mempool_item import MempoolItem
 from chia.types.spend_bundle import SpendBundle
@@ -492,7 +492,7 @@ class Mempool:
         get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[Optional[UnspentLineageInfo]]],
         constants: ConsensusConstants,
         height: uint32,
-    ) -> Optional[tuple[BlockGenerator, G2Element, list[Coin], list[Coin]]]:
+    ) -> Optional[NewBlockGenerator]:
         """
         height is needed in case we fast-forward a transaction and we need to
         re-run its puzzle.
@@ -520,8 +520,10 @@ class Mempool:
             logging.INFO if duration < 1 else logging.WARNING,
             f"serializing block generator took {duration:0.2f} seconds",
         )
-        return (
-            BlockGenerator(SerializedProgram.from_bytes(block_program), []),
+        return NewBlockGenerator(
+            SerializedProgram.from_bytes(block_program),
+            [],
+            [],
             spend_bundle.aggregated_signature,
             additions,
             removals,

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -13,7 +13,6 @@ from chia_rs import (
     ELIGIBLE_FOR_FF,
     BLSCache,
     ConsensusConstants,
-    G2Element,
     supports_fast_forward,
     validate_clvm_and_signature,
 )
@@ -34,7 +33,7 @@ from chia.types.clvm_cost import CLVMCost
 from chia.types.coin_record import CoinRecord
 from chia.types.eligible_coin_spends import EligibilityAndAdditions, UnspentLineageInfo
 from chia.types.fee_rate import FeeRate
-from chia.types.generator_types import BlockGenerator
+from chia.types.generator_types import NewBlockGenerator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.mempool_item import BundleCoinSpend, MempoolItem
 from chia.types.spend_bundle import SpendBundle
@@ -244,7 +243,7 @@ class MempoolManager:
     async def create_block_generator(
         self,
         last_tb_header_hash: bytes32,
-    ) -> Optional[tuple[BlockGenerator, G2Element, list[Coin], list[Coin]]]:
+    ) -> Optional[NewBlockGenerator]:
         """
         Returns a block generator program, the aggregate signature and all additions and removals, for a new block
         """

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -97,7 +97,7 @@ from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.full_block import FullBlock
-from chia.types.generator_types import BlockGenerator
+from chia.types.generator_types import BlockGenerator, NewBlockGenerator
 from chia.types.spend_bundle import SpendBundle
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.bech32m import encode_puzzle_hash
@@ -596,6 +596,8 @@ class BlockTools:
         skip_overflow: bool = False,
         min_signage_point: int = -1,
     ) -> list[FullBlock]:
+        # make a copy to not have different invocations affect each other
+        block_refs = block_refs[:]
         assert num_blocks > 0
         if block_list_input is not None:
             block_list = block_list_input.copy()
@@ -611,6 +613,9 @@ class BlockTools:
                     tx_block_heights.append(b.height)
 
         constants = self.constants
+
+        # this indicates whether the passed in transaction_data has been
+        # included in a transaction block yet
         transaction_data_included = False
         if time_per_block is None:
             time_per_block = float(constants.SUB_SLOT_TIME_TARGET) / float(constants.SLOT_BLOCKS_TARGET)
@@ -767,20 +772,9 @@ class BlockTools:
                                     continue
 
                         assert latest_block.header_hash in blocks
-                        additions = None
-                        removals = None
                         if transaction_data_included:
                             transaction_data = None
                             block_refs = []
-                        if transaction_data is not None:
-                            additions = compute_additions_unchecked(transaction_data)
-                            removals = transaction_data.removals()
-                        elif include_transactions:
-                            assert wallet is not None
-                            assert rng is not None
-                            transaction_data, additions = make_spend_bundle(available_coins, wallet, rng)
-                            removals = transaction_data.removals()
-                            transaction_data_included = False
 
                         assert last_timestamp is not None
                         if proof_of_space.pool_contract_puzzle_hash is not None:
@@ -795,32 +789,48 @@ class BlockTools:
                             else:
                                 pool_target = PoolTarget(self.pool_ph, uint32(0))
 
-                        block_generator: Optional[BlockGenerator]
+                        if dummy_block_references and len(tx_block_heights) > 4:
+                            block_refs.extend(
+                                [
+                                    tx_block_heights[1],
+                                    tx_block_heights[len(tx_block_heights) // 2],
+                                    tx_block_heights[-2],
+                                ]
+                            )
+
+                        new_gen: Optional[NewBlockGenerator]
                         if transaction_data is not None:
+                            # this means the caller passed in transaction_data
+                            # to be included in the block.
+                            additions = compute_additions_unchecked(transaction_data)
+                            removals = transaction_data.removals()
                             if start_height >= constants.HARD_FORK_HEIGHT:
-                                block_generator = simple_solution_generator_backrefs(transaction_data)
-                                block_refs = []
+                                program = simple_solution_generator_backrefs(transaction_data).program
                             else:
-                                block_generator = simple_solution_generator(transaction_data)
-
-                            aggregate_signature = transaction_data.aggregated_signature
+                                program = simple_solution_generator(transaction_data).program
+                            block_refs = []
+                            new_gen = NewBlockGenerator(
+                                program, [], block_refs, transaction_data.aggregated_signature, additions, removals
+                            )
+                        elif include_transactions:
+                            # if the caller did not pass in specific
+                            # transactions, this parameter means we just want
+                            # some transactions
+                            assert wallet is not None
+                            assert rng is not None
+                            transaction_data, additions = make_spend_bundle(available_coins, wallet, rng)
+                            removals = transaction_data.removals()
+                            program = simple_solution_generator(transaction_data).program
+                            new_gen = NewBlockGenerator(
+                                program, [], block_refs, transaction_data.aggregated_signature, additions, removals
+                            )
+                            transaction_data_included = False
+                        elif dummy_block_references:
+                            program = SerializedProgram.from_bytes(solution_generator([]))
+                            new_gen = NewBlockGenerator(program, [], block_refs, G2Element(), [], [])
                         else:
-                            block_generator = None
-                            aggregate_signature = G2Element()
+                            new_gen = None
 
-                        if dummy_block_references:
-                            if block_generator is None:
-                                program = SerializedProgram.from_bytes(solution_generator([]))
-                                block_generator = BlockGenerator(program, [])
-
-                            if len(tx_block_heights) > 4:
-                                block_refs.extend(
-                                    [
-                                        tx_block_heights[1],
-                                        tx_block_heights[len(tx_block_heights) // 2],
-                                        tx_block_heights[-2],
-                                    ]
-                                )
                         (
                             full_block,
                             block_record,
@@ -838,10 +848,7 @@ class BlockTools:
                             last_timestamp,
                             start_height,
                             time_per_block,
-                            block_generator,
-                            aggregate_signature,
-                            additions,
-                            removals,
+                            new_gen,
                             height_to_hash,
                             difficulty,
                             required_iters,
@@ -854,7 +861,6 @@ class BlockTools:
                             seed,
                             normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
                             current_time=current_time,
-                            block_refs=block_refs,
                         )
                         if block_record.is_transaction_block:
                             transaction_data_included = True
@@ -1033,19 +1039,8 @@ class BlockTools:
             latest_block_eos = latest_block
             overflow_cc_challenge = finished_sub_slots_at_ip[-1].challenge_chain.get_hash()
             overflow_rc_challenge = finished_sub_slots_at_ip[-1].reward_chain.get_hash()
-            additions = None
-            removals = None
             if transaction_data_included:
                 transaction_data = None
-            if transaction_data is not None:
-                additions = compute_additions_unchecked(transaction_data)
-                removals = transaction_data.removals()
-            elif include_transactions:
-                assert wallet is not None
-                assert rng is not None
-                transaction_data, additions = make_spend_bundle(available_coins, wallet, rng)
-                removals = transaction_data.removals()
-                transaction_data_included = False
             sub_slots_finished += 1
             self.log.info(
                 f"Sub slot finished. blocks included: {blocks_added_this_sub_slot} blocks_per_slot: "
@@ -1113,30 +1108,47 @@ class BlockTools:
                                 pool_target = PoolTarget(pool_reward_puzzle_hash, uint32(0))
                             else:
                                 pool_target = PoolTarget(self.pool_ph, uint32(0))
+
+                        if dummy_block_references and len(tx_block_heights) > 4:
+                            block_refs.extend(
+                                [
+                                    tx_block_heights[1],
+                                    tx_block_heights[len(tx_block_heights) // 2],
+                                    tx_block_heights[-2],
+                                ]
+                            )
+
                         if transaction_data is not None:
+                            # this means the caller passed in transaction_data
+                            # to be included in the block.
+                            additions = compute_additions_unchecked(transaction_data)
+                            removals = transaction_data.removals()
                             if start_height >= constants.HARD_FORK_HEIGHT:
-                                block_generator = simple_solution_generator_backrefs(transaction_data)
-                                block_refs = []
+                                program = simple_solution_generator_backrefs(transaction_data).program
                             else:
-                                block_generator = simple_solution_generator(transaction_data)
-                            aggregate_signature = transaction_data.aggregated_signature
+                                program = simple_solution_generator(transaction_data).program
+                            block_refs = []
+                            new_gen = NewBlockGenerator(
+                                program, [], block_refs, transaction_data.aggregated_signature, additions, removals
+                            )
+                        elif include_transactions:
+                            # if the caller did not pass in specific
+                            # transactions, this parameter means we just want
+                            # some transactions
+                            assert wallet is not None
+                            assert rng is not None
+                            transaction_data, additions = make_spend_bundle(available_coins, wallet, rng)
+                            removals = transaction_data.removals()
+                            program = simple_solution_generator(transaction_data).program
+                            new_gen = NewBlockGenerator(
+                                program, [], block_refs, transaction_data.aggregated_signature, additions, removals
+                            )
+                            transaction_data_included = False
+                        elif dummy_block_references:
+                            program = SerializedProgram.from_bytes(solution_generator([]))
+                            new_gen = NewBlockGenerator(program, [], block_refs, G2Element(), [], [])
                         else:
-                            block_generator = None
-                            aggregate_signature = G2Element()
-
-                        if dummy_block_references:
-                            if block_generator is None:
-                                program = SerializedProgram.from_bytes(solution_generator([]))
-                                block_generator = BlockGenerator(program, [])
-
-                            if len(tx_block_heights) > 4:
-                                block_refs.extend(
-                                    [
-                                        tx_block_heights[1],
-                                        tx_block_heights[len(tx_block_heights) // 2],
-                                        tx_block_heights[-2],
-                                    ]
-                                )
+                            new_gen = None
 
                         (
                             full_block,
@@ -1155,10 +1167,7 @@ class BlockTools:
                             last_timestamp,
                             start_height,
                             time_per_block,
-                            block_generator,
-                            aggregate_signature,
-                            additions,
-                            removals,
+                            new_gen,
                             height_to_hash,
                             difficulty,
                             required_iters,
@@ -1173,7 +1182,6 @@ class BlockTools:
                             overflow_rc_challenge=overflow_rc_challenge,
                             normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
                             current_time=current_time,
-                            block_refs=block_refs,
                         )
 
                         if block_record.is_transaction_block:
@@ -1788,10 +1796,7 @@ def get_full_block_and_block_record(
     last_timestamp: float,
     start_height: uint32,
     time_per_block: float,
-    block_generator: Optional[BlockGenerator],
-    aggregate_signature: G2Element,
-    additions: Optional[list[Coin]],
-    removals: Optional[list[Coin]],
+    new_gen: Optional[NewBlockGenerator],
     height_to_hash: dict[uint32, bytes32],
     difficulty: uint64,
     required_iters: uint64,
@@ -1803,7 +1808,6 @@ def get_full_block_and_block_record(
     prev_block: BlockRecord,
     seed: bytes = b"",
     *,
-    block_refs: list[uint32] = [],
     overflow_cc_challenge: Optional[bytes32] = None,
     overflow_rc_challenge: Optional[bytes32] = None,
     normalized_to_identity_cc_ip: bool = False,
@@ -1838,10 +1842,7 @@ def get_full_block_and_block_record(
         uint64(timestamp),
         BlockCache(blocks),
         seed,
-        block_generator,
-        aggregate_signature,
-        additions,
-        removals,
+        new_gen,
         prev_block,
         finished_sub_slots,
         compute_cost=compute_cost_test,

--- a/chia/types/generator_types.py
+++ b/chia/types/generator_types.py
@@ -2,12 +2,38 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from chia_rs import Coin, G2Element
+from chia_rs.sized_ints import uint32
+
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.util.streamable import Streamable, streamable
 
 
+# This holds what we need to pre validate a block generator
 @streamable
 @dataclass(frozen=True)
 class BlockGenerator(Streamable):
     program: SerializedProgram = field(default_factory=SerializedProgram.default)
+    # to run the block generator, we need the actual bytes of the previous
+    # generators it may reference. These are parameters passed in to the block
+    # generator
     generator_refs: list[bytes] = field(default_factory=list)
+
+
+# When we create a new block, this object holds the block generator and
+# additional information we need to create the UnfinishedBlock from it.
+# When creating a block, we still need to be able to run it, to compute its cost
+# and validate it. Therefore, this is a superset of the BlockGenerator class.
+@dataclass(frozen=True)
+class NewBlockGenerator(BlockGenerator):
+    # when creating a block, we include the block heights of the generators we
+    # reference. Tese are block heights and generator_refs contain the
+    # corresponding bytes of the generator programs
+    block_refs: list[uint32] = field(default_factory=list)
+    # the aggregate signature of all AGG_SIG_* conditions returned by the block
+    # generator.
+    signature: G2Element = G2Element()
+    # all CREATE_COIN outputs created by the block generator
+    additions: list[Coin] = field(default_factory=list)
+    # all coins being spent by the block generator
+    removals: list[Coin] = field(default_factory=list)


### PR DESCRIPTION
### Purpose:

Simplify the return value from `create_block_generator()` to return a single object (`NewBlockGenerator`) rather than a 4-tuple. This combines the generator itself, signature, additions and removals.

Also add a unit test that creates a blocks and validates the signature, additions and removals along with executing the block generator.

### Current Behavior:

Test coverage of `create_block_generator()` is not very thorough.

`create_block_generator()` returns a 4-tuple.

### New Behavior:

Test coverage of `create_block_generator()` is improved.

`create_block_generator()` returns a type, `NewBlockGenerator` with named members, `block_refs`, `signature`, `additions` and `removals`, slightly simplifying the block creation code.