### PR TITLE
[CHIA-2540] Compute block cost

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -181,6 +181,7 @@ jobs:
           path: |
             ${{ github.workspace }}/.chia/blocks
             ${{ github.workspace }}/.chia/test-plots
+            ${{ github.workspace }}/.chia/test-bundles
           key: ${{ env.BLOCKS_AND_PLOTS_VERSION }}
 
       - name: Checkout test blocks and plots

--- a/chia/_tests/core/consensus/test_block_creation.py
+++ b/chia/_tests/core/consensus/test_block_creation.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 import pytest
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint32, uint64
+from chia_rs.sized_ints import uint64
 
-from chia._tests.core.make_block_generator import make_block_generator
-from chia.consensus.block_creation import compute_block_cost, compute_block_fee
-from chia.consensus.condition_costs import ConditionCost
-from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.consensus.block_creation import compute_block_fee
 from chia.types.blockchain_format.coin import Coin
 
 
@@ -26,29 +23,3 @@ def test_compute_block_fee(add_amount: list[int], rem_amount: list[int]) -> None
             compute_block_fee(additions, removals)
     else:
         assert compute_block_fee(additions, removals) == expected
-
-
-def test_compute_block_cost(softfork_height: uint32) -> None:
-    num_coins = 10
-    generator = make_block_generator(num_coins)
-    cost = int(compute_block_cost(generator, DEFAULT_CONSTANTS, softfork_height))
-
-    coin_cost = ConditionCost.CREATE_COIN.value * num_coins
-    agg_sig_cost = ConditionCost.AGG_SIG.value * num_coins
-
-    cost -= coin_cost
-    cost -= agg_sig_cost
-    cost -= len(bytes(generator.program)) * DEFAULT_CONSTANTS.COST_PER_BYTE
-
-    print(f"{cost=}")
-
-    # the cost is a non-trivial combination of the CLVM cost of running the puzzles
-    # and before the hard-fork, combined with the cost of running the generator ROM
-    # Consensus requires these costs to be unchanged over time, so this test
-    # ensures compatibility
-    if softfork_height >= DEFAULT_CONSTANTS.HARD_FORK_HEIGHT:
-        expected = 180980
-    else:
-        expected = 3936699
-
-    assert cost == expected

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -67,6 +67,7 @@ from chia.types.mempool_item import BundleCoinSpend, MempoolItem
 from chia.types.peer_info import PeerInfo
 from chia.types.spend_bundle import SpendBundle
 from chia.types.spend_bundle_conditions import SpendBundleConditions, SpendConditions
+from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.errors import Err, ValidationError
 from chia.wallet.conditions import AssertCoinAnnouncement
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
@@ -95,6 +96,26 @@ TEST_COIN3 = Coin(IDENTITY_PUZZLE_HASH, IDENTITY_PUZZLE_HASH, TEST_COIN_AMOUNT3)
 TEST_COIN_ID3 = TEST_COIN3.name()
 TEST_COIN_RECORD3 = CoinRecord(TEST_COIN3, uint32(0), uint32(0), False, TEST_TIMESTAMP)
 TEST_HEIGHT = uint32(5)
+
+
+@pytest.fixture(name="test_bundles")
+def test_bundles_fixture() -> list[SpendBundle]:
+    ret: list[SpendBundle] = []
+
+    bundle_path_dir = DEFAULT_ROOT_PATH.parent.joinpath("test-bundles")
+    for p in bundle_path_dir.iterdir():
+        if not p.is_file():
+            continue
+        if len(p.name) != 64 + 7:
+            continue
+
+        sb = SpendBundle.from_bytes(p.read_bytes())
+        ret.append(sb)
+
+    print(f"loaded {len(ret)} spend bundles from disk")
+
+    ret.sort(key=lambda x: x.name())
+    return ret
 
 
 @dataclasses.dataclass(frozen=True)
@@ -2274,7 +2295,7 @@ async def setup_mempool(coins: TestCoins) -> MempoolManager:
         coins.get_unspent_lineage_info,
         DEFAULT_CONSTANTS,
     )
-    test_block_record = create_test_block_record(height=uint32(10), timestamp=uint64(12345678))
+    test_block_record = create_test_block_record(height=uint32(5000000), timestamp=uint64(12345678))
     await mempool_manager.new_peak(test_block_record, None)
     return mempool_manager
 
@@ -2690,6 +2711,7 @@ async def test_create_block_generator(
     else:
         assert len(conds.spends) == len(expected_removals)
     assert conds.cost < DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM
+    assert new_block_gen.cost == conds.cost
 
     num_additions = 0
     for spend in conds.spends:
@@ -2699,3 +2721,68 @@ async def test_create_block_generator(
             num_additions += 1
 
     assert num_additions == len(new_block_gen.additions)
+
+
+# if we try to fill the mempool with more than 550, all spends won't
+# necessarily fit in the block, which the test assumes
+@pytest.mark.anyio
+@pytest.mark.parametrize("seed", [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+@pytest.mark.parametrize("old", [True, False])
+async def test_create_block_generator_real_bundles(seed: int, old: bool, test_bundles: list[SpendBundle]) -> None:
+    all_coins = [s.coin for b in test_bundles for s in b.coin_spends]
+    coins = TestCoins(all_coins, {})
+
+    rng = random.Random(seed)
+
+    mempool_manager = await setup_mempool(coins)
+
+    included_bundles = rng.sample(test_bundles, len(test_bundles) // 5)
+    for sb in included_bundles:
+        pre_validation = await mempool_manager.pre_validate_spendbundle(sb)
+        bundle_add_info = await mempool_manager.add_spend_bundle(
+            sb, pre_validation, sb.name(), first_added_height=uint32(1)
+        )
+
+        # in the test bundles, we have some duplicate spends
+        # just ignore them for now
+        if bundle_add_info.status == MempoolInclusionStatus.FAILED:
+            assert bundle_add_info.error == Err.DOUBLE_SPEND
+            continue
+        assert bundle_add_info.status == MempoolInclusionStatus.SUCCESS
+        item = mempool_manager.get_mempool_item(sb.name())
+        assert item is not None
+
+    invariant_check_mempool(mempool_manager.mempool)
+
+    assert mempool_manager.peak is not None
+    create_block = mempool_manager.create_block_generator if old else mempool_manager.create_block_generator2
+    new_block_gen = await create_block(mempool_manager.peak.header_hash, 10.0)
+    assert new_block_gen is not None
+
+    # now, make sure the generator we got is valid
+
+    err, conds = run_block_generator2(
+        bytes(new_block_gen.program),
+        new_block_gen.generator_refs,
+        DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
+        MEMPOOL_MODE,
+        new_block_gen.signature,
+        None,
+        DEFAULT_CONSTANTS,
+    )
+
+    assert err is None
+    assert conds is not None
+
+    assert conds.cost == new_block_gen.cost
+
+    removals: set[Coin] = set()
+    additions: set[Coin] = set()
+
+    for spend in conds.spends:
+        removals.add(Coin(spend.parent_id, spend.puzzle_hash, uint64(spend.coin_amount)))
+        for add in spend.create_coin:
+            additions.add(Coin(spend.coin_id, add[0], uint64(add[1])))
+
+    assert removals == set(new_block_gen.removals)
+    assert additions == set(new_block_gen.additions)

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -104,9 +104,11 @@ def test_bundles_fixture() -> list[SpendBundle]:
 
     bundle_path_dir = DEFAULT_ROOT_PATH.parent.joinpath("test-bundles")
     for p in bundle_path_dir.iterdir():
-        if not p.is_file():
+        if not p.is_file():  # pragma: no cover
             continue
-        if len(p.name) != 64 + 7:
+        if p.suffix != ".bundle":  # pragma: no cover
+            continue
+        if len(p.name) != 64 + 7:  # pragma: no cover
             continue
 
         sb = SpendBundle.from_bytes(p.read_bytes())

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -7,8 +7,6 @@ from typing import Callable, Optional
 
 import chia_rs
 from chia_rs import (
-    DONT_VALIDATE_SIGNATURE,
-    MEMPOOL_MODE,
     ConsensusConstants,
     Foliage,
     FoliageBlockData,
@@ -20,9 +18,6 @@ from chia_rs import (
     RewardChainBlockUnfinished,
     TransactionsInfo,
     compute_merkle_set_root,
-    get_flags_for_height_and_constants,
-    run_block_generator,
-    run_block_generator2,
 )
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64, uint128
@@ -38,32 +33,12 @@ from chia.types.blockchain_format.proof_of_space import ProofOfSpace
 from chia.types.blockchain_format.vdf import VDFInfo, VDFProof
 from chia.types.end_of_slot_bundle import EndOfSubSlotBundle
 from chia.types.full_block import FullBlock
-from chia.types.generator_types import BlockGenerator, NewBlockGenerator
+from chia.types.generator_types import NewBlockGenerator
 from chia.types.unfinished_block import UnfinishedBlock
 from chia.util.hash import std_hash
 from chia.util.prev_transaction_block import get_prev_transaction_block
 
 log = logging.getLogger(__name__)
-
-
-def compute_block_cost(generator: BlockGenerator, constants: ConsensusConstants, height: uint32) -> uint64:
-    flags = get_flags_for_height_and_constants(height, constants) | MEMPOOL_MODE | DONT_VALIDATE_SIGNATURE
-
-    if height >= constants.HARD_FORK_HEIGHT:
-        run_block = run_block_generator2
-    else:
-        run_block = run_block_generator
-
-    _, conds = run_block(
-        bytes(generator.program),
-        generator.generator_refs,
-        constants.MAX_BLOCK_COST_CLVM,
-        flags,
-        G2Element(),
-        None,
-        constants,
-    )
-    return uint64(0 if conds is None else conds.cost)
 
 
 def compute_block_fee(additions: Sequence[Coin], removals: Sequence[Coin]) -> uint64:
@@ -89,7 +64,6 @@ def create_foliage(
     get_plot_signature: Callable[[bytes32, G1Element], G2Element],
     get_pool_signature: Callable[[PoolTarget, Optional[G1Element]], Optional[G2Element]],
     seed: bytes,
-    compute_cost: Callable[[BlockGenerator, ConsensusConstants, uint32], uint64],
     compute_fees: Callable[[Sequence[Coin], Sequence[Coin]], uint64],
 ) -> tuple[Foliage, Optional[FoliageTransactionBlock], Optional[TransactionsInfo]]:
     """
@@ -166,7 +140,7 @@ def create_foliage(
 
         # Calculate the cost of transactions
         if new_block_gen is not None:
-            cost = compute_cost(new_block_gen, constants, height)
+            cost = new_block_gen.cost
             spend_bundle_fees = compute_fees(new_block_gen.additions, new_block_gen.removals)
         else:
             spend_bundle_fees = uint64(0)
@@ -323,7 +297,6 @@ def create_unfinished_block(
     new_block_gen: Optional[NewBlockGenerator] = None,
     prev_block: Optional[BlockRecord] = None,
     finished_sub_slots_input: Optional[list[EndOfSubSlotBundle]] = None,
-    compute_cost: Callable[[BlockGenerator, ConsensusConstants, uint32], uint64] = compute_block_cost,
     compute_fees: Callable[[Sequence[Coin], Sequence[Coin]], uint64] = compute_block_fee,
 ) -> UnfinishedBlock:
     """
@@ -418,7 +391,6 @@ def create_unfinished_block(
         get_plot_signature,
         get_pool_signature,
         seed,
-        compute_cost,
         compute_fees,
     )
     return UnfinishedBlock(

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -805,6 +805,7 @@ class Mempool:
             f"create_block_generator2() took {duration:0.4f} seconds. "
             f"block cost: {cost} spends: {added_spends} additions: {len(additions)}",
         )
+        assert block_cost == cost
 
         return NewBlockGenerator(
             SerializedProgram.from_bytes(block_program),

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -9,7 +9,18 @@ from enum import Enum
 from time import monotonic
 from typing import Callable, Optional
 
-from chia_rs import AugSchemeMPL, BlockBuilder, Coin, ConsensusConstants, G2Element, solution_generator_backrefs
+from chia_rs import (
+    DONT_VALIDATE_SIGNATURE,
+    MEMPOOL_MODE,
+    AugSchemeMPL,
+    BlockBuilder,
+    Coin,
+    ConsensusConstants,
+    G2Element,
+    get_flags_for_height_and_constants,
+    run_block_generator2,
+    solution_generator_backrefs,
+)
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
@@ -525,6 +536,22 @@ class Mempool:
             f"serializing block generator took {duration:0.2f} seconds "
             f"spends: {len(removals)} additions: {len(additions)}",
         )
+
+        flags = get_flags_for_height_and_constants(height, constants) | MEMPOOL_MODE | DONT_VALIDATE_SIGNATURE
+
+        _, conds = run_block_generator2(
+            block_program,
+            [],
+            constants.MAX_BLOCK_COST_CLVM,
+            flags,
+            spend_bundle.aggregated_signature,
+            None,
+            constants,
+        )
+
+        assert conds is not None
+        assert conds.cost > 0
+
         return NewBlockGenerator(
             SerializedProgram.from_bytes(block_program),
             [],
@@ -532,6 +559,7 @@ class Mempool:
             spend_bundle.aggregated_signature,
             additions,
             removals,
+            uint64(conds.cost),
         )
 
     async def create_bundle_from_mempool_items(
@@ -785,4 +813,5 @@ class Mempool:
             signature,
             additions,
             removals,
+            uint64(block_cost),
         )

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -852,6 +852,7 @@ class FullNodeRpcApi:
                     "additions": gen.additions,
                     "removals": gen.removals,
                     "sig": gen.signature,
+                    "cost": gen.cost,
                 }
 
             # Finds the last transaction block before this one
@@ -878,6 +879,7 @@ class FullNodeRpcApi:
             "additions": gen.additions,
             "removals": gen.removals,
             "sig": gen.signature,
+            "cost": gen.cost,
         }
 
     def _get_spendbundle_type_cost(self, name: str) -> uint64:

--- a/chia/types/generator_types.py
+++ b/chia/types/generator_types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from chia_rs import Coin, G2Element
-from chia_rs.sized_ints import uint32
+from chia_rs.sized_ints import uint32, uint64
 
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.util.streamable import Streamable, streamable
@@ -37,3 +37,5 @@ class NewBlockGenerator(BlockGenerator):
     additions: list[Coin] = field(default_factory=list)
     # all coins being spent by the block generator
     removals: list[Coin] = field(default_factory=list)
+    # the total cost of the block generator, CLVM + bytes + conditions
+    cost: uint64 = field(default=uint64(0))


### PR DESCRIPTION
### Purpose:

Save time when farming a block by not running the block generator an extra time just to compute its cost, information we already have. We pass the (known) cost from `create_block_generator2()` via `NewBlockGenerator`.

### Current Behavior:

`create_foliage()` runs the block generator in order to compute the cost of the block. i.e. the CLVM execution cost + cost of conditions + cost of bytes. The block cost is a field in `TransactionsInfo` and is validated by block validation.

### New Behavior:

Since the new mempool block creation (`create_block_geneator2()`) tracks the cost accurately (in order to fill it all the way), we can just pass on that information into `create_foliage()` and not run the block generator.

The original function (`create_block_generator()`) still needs to compute the block cost by running it.

### Testing Notes:

There's a new test that loads the `test-bundles` from the `test-cache` and picks random combinations of them, generating blocks and validating that they're valid, including the cost being correct. The new directory of `test-bundles` require a small update to the workflow file, to update the cache if it's not there