### PR TITLE
CHIA-2570 Adapt to requiring the same amount across singleton fast forward versions

### DIFF
--- a/chia/_tests/core/full_node/stores/test_coin_store.py
+++ b/chia/_tests/core/full_node/stores/test_coin_store.py
@@ -802,7 +802,7 @@ class UnspentLineageInfoCase:
             ),
         ],
         parent_with_diff_amount=True,
-        expected_success=True,
+        expected_success=False,
     ),
     UnspentLineageInfoCase(
         id="Unspent with parent that has same puzzlehash and amount but is also unspent",
@@ -884,13 +884,11 @@ async def test_get_unspent_lineage_info_for_puzzle_hash(case: UnspentLineageInfo
         if case.expected_success:
             assert result == UnspentLineageInfo(
                 coin_id=bytes32(TEST_COIN_ID),
-                coin_amount=TEST_AMOUNT,
                 parent_id=(
                     bytes32(TEST_PARENT_ID_DIFFERENT_AMOUNT)
                     if case.parent_with_diff_amount
                     else bytes32(TEST_PARENT_ID)
                 ),
-                parent_amount=TEST_PARENT_DIFFERENT_AMOUNT if case.parent_with_diff_amount else TEST_AMOUNT,
                 parent_parent_id=bytes32(TEST_PARENT_PARENT_ID),
             )
         else:

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -3356,11 +3356,7 @@ async def test_lineage_cache(seeded_random: random.Random) -> None:
     called = 0
 
     info1 = UnspentLineageInfo(
-        bytes32.random(seeded_random),
-        uint64.from_bytes(seeded_random.randbytes(8)),
-        bytes32.random(seeded_random),
-        uint64.from_bytes(seeded_random.randbytes(8)),
-        bytes32.random(seeded_random),
+        bytes32.random(seeded_random), bytes32.random(seeded_random), bytes32.random(seeded_random)
     )
 
     async def callback1(ph: bytes32) -> Optional[UnspentLineageInfo]:

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -2202,9 +2202,7 @@ class TestCoins:
             self.coin_records[c.name()] = CoinRecord(c, uint32(0), uint32(0), False, TEST_TIMESTAMP)
         self.lineage_info = {}
         for ph, c in lineage.items():
-            self.lineage_info[ph] = UnspentLineageInfo(
-                c.name(), c.amount, c.parent_coin_info, uint64(1337), bytes32([42] * 32)
-            )
+            self.lineage_info[ph] = UnspentLineageInfo(c.name(), c.parent_coin_info, bytes32([42] * 32))
 
     def spend_coin(self, coin_id: bytes32, height: uint32 = uint32(10)) -> None:
         self.coin_records[coin_id] = dataclasses.replace(self.coin_records[coin_id], spent_block_index=height)
@@ -2215,9 +2213,7 @@ class TestCoins:
         else:
             assert coin.puzzle_hash == puzzle_hash
             prev = self.lineage_info[puzzle_hash]
-            self.lineage_info[puzzle_hash] = UnspentLineageInfo(
-                coin.name(), coin.amount, coin.parent_coin_info, prev.coin_amount, prev.coin_id
-            )
+            self.lineage_info[puzzle_hash] = UnspentLineageInfo(coin.name(), coin.parent_coin_info, prev.coin_id)
 
     async def get_coin_records(self, coin_ids: Collection[bytes32]) -> list[CoinRecord]:
         ret = []


### PR DESCRIPTION
### Purpose:

We no longer allow the singleton fast forward to change its amount across versions, but we still have logic related to that.

### Current Behavior:

We have remaining logic related to when we allowed the amount to change.

### New Behavior:

We no longer have any logic that assumes the amount can change.