### PR TITLE
CHIA-2580 Significantly speedup mempool manager tests by not forcing them to request unneeded fixtures

### DIFF
--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -2509,12 +2509,12 @@ async def test_advancing_ff(use_optimization: bool) -> None:
     assert spend.latest_singleton_coin == spend_c.coin.name()
 
 
-@pytest.fixture(name="test_wallet", autouse=True)
+@pytest.fixture(name="test_wallet")
 def test_wallet_fixture() -> WalletTool:
     return WalletTool(DEFAULT_CONSTANTS)
 
 
-@pytest.fixture(name="transactions_1000", autouse=True)
+@pytest.fixture(name="transactions_1000")
 def transactions_1000_fixture(test_wallet: WalletTool, seeded_random: random.Random) -> list[SpendBundle]:
     op = ConditionOpcode
     bundles: list[SpendBundle] = []


### PR DESCRIPTION
### Purpose:

We introduced `test_wallet` and `transactions_1000` fixtures in PR #19390 for `test_create_block_generator` but we're forcing every other test to request them.

### Current Behavior:

Mempool manager test runs are significantly slower than before, plus they became flaky on `macos-intel` as they time out from time to time.

Example test run before the issue, taking 14m 54s: https://github.com/Chia-Network/chia-blockchain/actions/runs/13951544229/job/39052162400

Example test runs with this issue, taking the full 50 minutes and then timing out:

https://github.com/Chia-Network/chia-blockchain/actions/runs/13954198286/job/39061147992
https://github.com/Chia-Network/chia-blockchain/actions/runs/13971273486/job/39113539044
https://github.com/Chia-Network/chia-blockchain/actions/runs/13975812052/job/39129238029

### New Behavior:

Mempool manager tests run significantly faster.