### PR TITLE
[CHIA-2615] Add ContextManager to FullNodePeers

### DIFF
--- a/chia/_tests/core/server/test_node_discovery.py
+++ b/chia/_tests/core/server/test_node_discovery.py
@@ -20,16 +20,17 @@ async def test_enable_private_networks(
 
     # Missing `enable_private_networks` config entry in introducer_peer should default to False for back compat
     discovery0 = FullNodeDiscovery(
-        chia_server,
-        0,
-        SIMULATOR_ROOT_PATH / Path(chia_server.config["peers_file_path"]),
-        {"host": "introducer.chia.net", "port": 8444},
-        [],
-        0,
-        chia_server.config["selected_network"],
-        None,
-        Logger("node_discovery_tests"),
+        server=chia_server,
+        target_outbound_count=0,
+        peers_file_path=SIMULATOR_ROOT_PATH / Path(chia_server.config["peers_file_path"]),
+        introducer_info={"host": "introducer.chia.net", "port": 8444},
+        dns_servers=[],
+        peer_connect_interval=0,
+        selected_network=chia_server.config["selected_network"],
+        default_port=None,
+        log=Logger("node_discovery_tests"),
     )
+
     assert discovery0 is not None
     assert discovery0.enable_private_networks is False
     await discovery0.initialize_address_manager()
@@ -38,15 +39,15 @@ async def test_enable_private_networks(
 
     # Test with enable_private_networks set to False in Config
     discovery1 = FullNodeDiscovery(
-        chia_server,
-        0,
-        SIMULATOR_ROOT_PATH / Path(chia_server.config["peers_file_path"]),
-        {"host": "introducer.chia.net", "port": 8444, "enable_private_networks": False},
-        [],
-        0,
-        chia_server.config["selected_network"],
-        None,
-        Logger("node_discovery_tests"),
+        server=chia_server,
+        target_outbound_count=0,
+        peers_file_path=SIMULATOR_ROOT_PATH / Path(chia_server.config["peers_file_path"]),
+        introducer_info={"host": "introducer.chia.net", "port": 8444, "enable_private_networks": False},
+        dns_servers=[],
+        peer_connect_interval=0,
+        selected_network=chia_server.config["selected_network"],
+        default_port=None,
+        log=Logger("node_discovery_tests"),
     )
     assert discovery1 is not None
     assert discovery1.enable_private_networks is False
@@ -56,15 +57,15 @@ async def test_enable_private_networks(
 
     # Test with enable_private_networks set to True in Config
     discovery2 = FullNodeDiscovery(
-        chia_server,
-        0,
-        SIMULATOR_ROOT_PATH / Path(chia_server.config["peers_file_path"]),
-        {"host": "introducer.chia.net", "port": 8444, "enable_private_networks": True},
-        [],
-        0,
-        chia_server.config["selected_network"],
-        None,
-        Logger("node_discovery_tests"),
+        server=chia_server,
+        target_outbound_count=0,
+        peers_file_path=SIMULATOR_ROOT_PATH / Path(chia_server.config["peers_file_path"]),
+        introducer_info={"host": "introducer.chia.net", "port": 8444, "enable_private_networks": True},
+        dns_servers=[],
+        peer_connect_interval=0,
+        selected_network=chia_server.config["selected_network"],
+        default_port=None,
+        log=Logger("node_discovery_tests"),
     )
     assert discovery2 is not None
     assert discovery2.enable_private_networks is True

--- a/chia/_tests/core/server/test_node_discovery.py
+++ b/chia/_tests/core/server/test_node_discovery.py
@@ -30,12 +30,25 @@ async def test_enable_private_networks(
         default_port=None,
         log=Logger("node_discovery_tests"),
     )
-
     assert discovery0 is not None
     assert discovery0.enable_private_networks is False
     await discovery0.initialize_address_manager()
     assert discovery0.address_manager is not None
     assert discovery0.address_manager.allow_private_subnets is False
+
+    # Missing `default_port` but known selected_network should automatically pick a port
+    discovery0 = FullNodeDiscovery(
+        server=chia_server,
+        target_outbound_count=0,
+        peers_file_path=SIMULATOR_ROOT_PATH / Path(chia_server.config["peers_file_path"]),
+        introducer_info={"host": "introducer.chia.net", "port": 8444},
+        dns_servers=[],
+        peer_connect_interval=0,
+        selected_network="testnet7",
+        default_port=None,
+        log=Logger("node_discovery_tests"),
+    )
+    assert discovery0.default_port == 58444
 
     # Test with enable_private_networks set to False in Config
     discovery1 = FullNodeDiscovery(

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -345,8 +345,6 @@ class FullNode:
                 self.wallet_sync_task = create_referenced_task(self._wallets_sync_task_handler())
 
             self.initialized = True
-
-            # TODO: this is the place the code needs juicing up
             if self.full_node_peers is not None:
                 async with self.full_node_peers.manage():
                     try:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -546,15 +546,15 @@ class FullNode:
             dns_servers.append("dns-introducer.chia.net")
         try:
             self.full_node_peers = FullNodePeers(
-                self.server,
-                self.config["target_outbound_peer_count"],
-                self.root_path / Path(self.config.get("peers_file_path", "db/peers.dat")),
-                self.config["introducer_peer"],
-                dns_servers,
-                self.config["peer_connect_interval"],
-                self.config["selected_network"],
-                default_port,
-                self.log,
+                server=self.server,
+                target_outbound_count=self.config["target_outbound_peer_count"],
+                peers_file_path=self.root_path / Path(self.config.get("peers_file_path", "db/peers.dat")),
+                introducer_info=self.config["introducer_peer"],
+                dns_servers=dns_servers,
+                peer_connect_interval=self.config["peer_connect_interval"],
+                selected_network=self.config["selected_network"],
+                default_port=default_port,
+                log=self.log,
             )
         except Exception as e:
             error_stack = traceback.format_exc()

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -345,56 +345,55 @@ class FullNode:
                 self.wallet_sync_task = create_referenced_task(self._wallets_sync_task_handler())
 
             self.initialized = True
+
+            # TODO: this is the place the code needs juicing up
             if self.full_node_peers is not None:
-                create_referenced_task(self.full_node_peers.start(), known_unreferenced=True)
-            try:
-                yield
-            finally:
-                self._shut_down = True
-                if self._init_weight_proof is not None:
-                    self._init_weight_proof.cancel()
+                async with self.full_node_peers.manage():
+                    try:
+                        yield
+                    finally:
+                        self._shut_down = True
+                        if self._init_weight_proof is not None:
+                            self._init_weight_proof.cancel()
 
-                # blockchain is created in _start and in certain cases it may not exist here during _close
-                if self._blockchain is not None:
-                    self.blockchain.shut_down()
-                # same for mempool_manager
-                if self._mempool_manager is not None:
-                    self.mempool_manager.shut_down()
-
-                if self.full_node_peers is not None:
-                    create_referenced_task(self.full_node_peers.close(), known_unreferenced=True)
-                if self.uncompact_task is not None:
-                    self.uncompact_task.cancel()
-                if self._transaction_queue_task is not None:
-                    self._transaction_queue_task.cancel()
-                cancel_task_safe(task=self.wallet_sync_task, log=self.log)
-                for one_tx_task in self._tx_task_list:
-                    if not one_tx_task.done():
-                        cancel_task_safe(task=one_tx_task, log=self.log)
-                for one_sync_task in self._sync_task_list:
-                    if not one_sync_task.done():
-                        cancel_task_safe(task=one_sync_task, log=self.log)
-                for segment_task in self._segment_task_list:
-                    cancel_task_safe(segment_task, self.log)
-                for task_id, task in list(self.full_node_store.tx_fetch_tasks.items()):
-                    cancel_task_safe(task, self.log)
-                if self._init_weight_proof is not None:
-                    await asyncio.wait([self._init_weight_proof])
-                for one_tx_task in self._tx_task_list:
-                    if one_tx_task.done():
-                        self.log.info(f"TX task {one_tx_task.get_name()} done")
-                    else:
-                        with contextlib.suppress(asyncio.CancelledError):
-                            self.log.info(f"Awaiting TX task {one_tx_task.get_name()}")
-                            await one_tx_task
-                for one_sync_task in self._sync_task_list:
-                    if one_sync_task.done():
-                        self.log.info(f"Long sync task {one_sync_task.get_name()} done")
-                    else:
-                        with contextlib.suppress(asyncio.CancelledError):
-                            self.log.info(f"Awaiting long sync task {one_sync_task.get_name()}")
-                            await one_sync_task
-                await asyncio.gather(*self._segment_task_list, return_exceptions=True)
+                        # blockchain is created in _start and in certain cases it may not exist here during _close
+                        if self._blockchain is not None:
+                            self.blockchain.shut_down()
+                        # same for mempool_manager
+                        if self._mempool_manager is not None:
+                            self.mempool_manager.shut_down()
+                        if self.uncompact_task is not None:
+                            self.uncompact_task.cancel()
+                        if self._transaction_queue_task is not None:
+                            self._transaction_queue_task.cancel()
+                        cancel_task_safe(task=self.wallet_sync_task, log=self.log)
+                        for one_tx_task in self._tx_task_list:
+                            if not one_tx_task.done():
+                                cancel_task_safe(task=one_tx_task, log=self.log)
+                        for one_sync_task in self._sync_task_list:
+                            if not one_sync_task.done():
+                                cancel_task_safe(task=one_sync_task, log=self.log)
+                        for segment_task in self._segment_task_list:
+                            cancel_task_safe(segment_task, self.log)
+                        for task_id, task in list(self.full_node_store.tx_fetch_tasks.items()):
+                            cancel_task_safe(task, self.log)
+                        if self._init_weight_proof is not None:
+                            await asyncio.wait([self._init_weight_proof])
+                        for one_tx_task in self._tx_task_list:
+                            if one_tx_task.done():
+                                self.log.info(f"TX task {one_tx_task.get_name()} done")
+                            else:
+                                with contextlib.suppress(asyncio.CancelledError):
+                                    self.log.info(f"Awaiting TX task {one_tx_task.get_name()}")
+                                    await one_tx_task
+                        for one_sync_task in self._sync_task_list:
+                            if one_sync_task.done():
+                                self.log.info(f"Long sync task {one_sync_task.get_name()} done")
+                            else:
+                                with contextlib.suppress(asyncio.CancelledError):
+                                    self.log.info(f"Awaiting long sync task {one_sync_task.get_name()}")
+                                    await one_sync_task
+                        await asyncio.gather(*self._segment_task_list, return_exceptions=True)
 
     @property
     def block_store(self) -> BlockStore:
@@ -913,6 +912,7 @@ class FullNode:
 
         self._state_changed("add_connection")
         self._state_changed("sync_mode")
+        # TODO: this can probably be improved
         if self.full_node_peers is not None:
             create_referenced_task(self.full_node_peers.on_connect(connection))
 

--- a/chia/server/address_manager.py
+++ b/chia/server/address_manager.py
@@ -172,7 +172,7 @@ def create_new_matrix() -> list[list[int]]:
 @dataclass
 class AddressManager:
     id_count: int = 0
-    key: int = randbits(256)
+    key: int = field(default_factory=functools.partial(randbits, 256))
     random_pos: list[int] = field(default_factory=list)
     tried_matrix: list[list[int]] = field(default_factory=create_tried_matrix)
     new_matrix: list[list[int]] = field(default_factory=create_new_matrix)

--- a/chia/server/address_manager.py
+++ b/chia/server/address_manager.py
@@ -160,11 +160,11 @@ class ExtendedPeerInfo:
         return chance
 
 
-def create_tried_matrix():
+def create_tried_matrix() -> list[list[int]]:
     return [[-1 for x in range(BUCKET_SIZE)] for y in range(TRIED_BUCKET_COUNT)]
 
 
-def create_new_matrix():
+def create_new_matrix() -> list[list[int]]:
     return [[-1 for x in range(BUCKET_SIZE)] for y in range(NEW_BUCKET_COUNT)]
 
 

--- a/chia/server/address_manager.py
+++ b/chia/server/address_manager.py
@@ -4,6 +4,7 @@ import logging
 import math
 import time
 from asyncio import Lock
+from dataclasses import dataclass, field
 from random import choice, randrange
 from secrets import randbits
 from typing import Optional
@@ -159,26 +160,32 @@ class ExtendedPeerInfo:
         return chance
 
 
-# This is a Python port from 'CAddrMan' class from Bitcoin core code.
-class AddressManager:
-    id_count: int
-    key: int
-    random_pos: list[int]
-    tried_matrix: list[list[int]]
-    new_matrix: list[list[int]]
-    tried_count: int
-    new_count: int
-    map_addr: dict[str, int]
-    map_info: dict[int, ExtendedPeerInfo]
-    last_good: int
-    tried_collisions: list[int]
-    used_new_matrix_positions: set[tuple[int, int]]
-    used_tried_matrix_positions: set[tuple[int, int]]
-    allow_private_subnets: bool
+def create_tried_matrix():
+    return [[-1 for x in range(BUCKET_SIZE)] for y in range(TRIED_BUCKET_COUNT)]
 
-    def __init__(self) -> None:
-        self.clear()
-        self.lock: Lock = Lock()
+
+def create_new_matrix():
+    return [[-1 for x in range(BUCKET_SIZE)] for y in range(NEW_BUCKET_COUNT)]
+
+
+# This is a Python port from 'CAddrMan' class from Bitcoin core code.
+@dataclass
+class AddressManager:
+    id_count: int = 0
+    key: int = randbits(256)
+    random_pos: list[int] = field(default_factory=list)
+    tried_matrix: list[list[int]] = field(default_factory=create_tried_matrix)
+    new_matrix: list[list[int]] = field(default_factory=create_new_matrix)
+    tried_count: int = 0
+    new_count: int = 0
+    map_addr: dict[str, int] = field(default_factory=dict)
+    map_info: dict[int, ExtendedPeerInfo] = field(default_factory=dict)
+    last_good: int = 1
+    tried_collisions: list[int] = field(default_factory=list)
+    used_new_matrix_positions: set[tuple[int, int]] = field(default_factory=set)
+    used_tried_matrix_positions: set[tuple[int, int]] = field(default_factory=set)
+    allow_private_subnets: bool = False
+    lock: Lock = field(default_factory=Lock)
 
     def clear(self) -> None:
         self.id_count = 0

--- a/chia/server/address_manager.py
+++ b/chia/server/address_manager.py
@@ -191,8 +191,8 @@ class AddressManager:
         self.id_count = 0
         self.key = randbits(256)
         self.random_pos = []
-        self.tried_matrix = [[-1 for x in range(BUCKET_SIZE)] for y in range(TRIED_BUCKET_COUNT)]
-        self.new_matrix = [[-1 for x in range(BUCKET_SIZE)] for y in range(NEW_BUCKET_COUNT)]
+        self.tried_matrix = create_tried_matrix()
+        self.new_matrix = create_new_matrix()
         self.tried_count = 0
         self.new_count = 0
         self.map_addr = {}

--- a/chia/server/address_manager.py
+++ b/chia/server/address_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 import math
 import time

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -488,7 +488,7 @@ class FullNodeDiscovery:
 class FullNodePeers(FullNodeDiscovery):
     self_advertise_task: Optional[asyncio.Task[None]] = field(default=None, init=False)
     address_relay_task: Optional[asyncio.Task[None]] = field(default=None, init=False)
-    relay_queue: asyncio.Queue = field(default_factory=asyncio.Queue, init=False)
+    relay_queue: asyncio.Queue[tuple[TimestampedPeerInfo, int]] = field(default_factory=asyncio.Queue, init=False)
     neighbour_known_peers: dict[PeerInfo, set[str]] = field(default_factory=dict, init=False)
     key: int = field(default_factory=lambda: random.getrandbits(256), init=False)
 

--- a/chia/server/node_discovery.py
+++ b/chia/server/node_discovery.py
@@ -176,7 +176,8 @@ class FullNodeDiscovery:
             await peer.send_message(msg)
 
         await self.server.start_client(
-            PeerInfo(await resolve(self.introducer_info_obj.host, prefer_ipv6=False), self.introducer_info_obj.port), on_connect
+            PeerInfo(await resolve(self.introducer_info_obj.host, prefer_ipv6=False), self.introducer_info_obj.port),
+            on_connect,
         )
 
     async def _query_dns(self, dns_address: str) -> None:
@@ -648,7 +649,6 @@ class FullNodePeers(FullNodeDiscovery):
 
 @dataclass
 class WalletPeers(FullNodeDiscovery):
-
     def __post_init__(self) -> None:
         super().__post_init__()
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -708,15 +708,16 @@ class WalletNode:
         testing = self.config.get("testing", False)
         if self.wallet_peers is None and connect_to_unknown_peers and not testing:
             self.wallet_peers = WalletPeers(
-                self.server,
-                self.config["target_peer_count"],
-                self.root_path / Path(self.config.get("wallet_peers_file_path", "wallet/db/wallet_peers.dat")),
-                self.config["introducer_peer"],
-                self.config.get("dns_servers", ["dns-introducer.chia.net"]),
-                self.config["peer_connect_interval"],
-                network_name,
-                default_port,
-                self.log,
+                server=self.server,
+                target_outbound_count=self.config["target_peer_count"],
+                peers_file_path=self.root_path
+                / Path(self.config.get("wallet_peers_file_path", "wallet/db/wallet_peers.dat")),
+                introducer_info=self.config["introducer_peer"],
+                dns_servers=self.config.get("dns_servers", ["dns-introducer.chia.net"]),
+                peer_connect_interval=self.config["peer_connect_interval"],
+                selected_network=network_name,
+                default_port=default_port,
+                log=self.log,
             )
             create_referenced_task(self.wallet_peers.start())
 


### PR DESCRIPTION
### Purpose:
This PR changes the FullNodePeers, FullNodeDiscovery, and WalletPeers classes to be `@dataclass`es.
It also changed FullNodePeers to use a context manager instead of `start()` and `stop()` functions.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
