### PR TITLE
[CHIA-1162] Port `test_nft_bulk_mint.py` to `WalletTestFramework`

### DIFF
--- a/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -13,6 +13,7 @@ from chia._tests.util.setup_nodes import SimulatorsAndWalletsServices
 from chia._tests.util.time_out_assert import time_out_assert, time_out_assert_not_none
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
+from chia.rpc.wallet_request_types import PushTransactions
 from chia.rpc.wallet_rpc_api import WalletRpcApi
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.simulator.full_node_simulator import FullNodeSimulator
@@ -21,8 +22,10 @@ from chia.types.blockchain_format.program import Program
 from chia.types.peer_info import PeerInfo
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.wallet.did_wallet.did_wallet import DIDWallet
+from chia.wallet.nft_wallet.nft_info import NFTInfo
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.nft_wallet.uncurry_nft import UncurriedNFT
+from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.tx_config import DEFAULT_COIN_SELECTION_CONFIG, DEFAULT_TX_CONFIG
 
@@ -202,198 +205,217 @@ async def test_nft_mint_from_did(wallet_environments: WalletTestFramework) -> No
         assert nft.minter_did == did_id
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes
+@pytest.mark.parametrize("wallet_environments", [{"num_environments": 2, "blocks_needed": [1, 1]}], indirect=True)
 @pytest.mark.anyio
-async def test_nft_mint_from_did_rpc(
-    two_wallet_nodes_services: SimulatorsAndWalletsServices,
-    trusted: Any,
-    self_hostname: str,
-    seeded_random: random.Random,
-) -> None:
-    [full_node_service], wallet_services, bt = two_wallet_nodes_services
-    full_node_api: FullNodeSimulator = full_node_service._api
-    full_node_server = full_node_api.server
-    wallet_node_maker = wallet_services[0]._node
-    wallet_node_taker = wallet_services[1]._node
-    server_0 = wallet_node_maker.server
-    server_1 = wallet_node_taker.server
-    wallet_maker = wallet_node_maker.wallet_state_manager.main_wallet
-    wallet_taker = wallet_node_taker.wallet_state_manager.main_wallet
+async def test_nft_mint_from_did_rpc(wallet_environments: WalletTestFramework) -> None:
+    env_0 = wallet_environments.environments[0]
+    env_1 = wallet_environments.environments[1]
+    wallet_0 = env_0.xch_wallet
+    env_0.wallet_aliases = {
+        "xch": 1,
+        "did": 2,
+        "nft": 3,
+    }
+    env_1.wallet_aliases = {
+        "xch": 1,
+        "nft": 2,
+    }
 
-    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
-    async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        ph_taker = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
-    ph_token = bytes32.random(seeded_random)
+    async with env_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
+        await action_scope.get_puzzle_hash(env_0.wallet_state_manager)
+    async with env_1.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
+        ph_1 = await action_scope.get_puzzle_hash(env_1.wallet_state_manager)
 
-    if trusted:
-        wallet_node_maker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_taker.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_maker.config["trusted_peers"] = {}
-        wallet_node_taker.config["trusted_peers"] = {}
-
-    await server_0.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
-    await server_1.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
-
-    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_maker))
-    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_taker))
-    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
-
-    funds = calculate_pool_reward(uint32(1)) + calculate_base_farmer_reward(uint32(1))
-
-    await time_out_assert(30, wallet_maker.get_unconfirmed_balance, funds)
-    await time_out_assert(30, wallet_maker.get_confirmed_balance, funds)
-    await time_out_assert(30, wallet_taker.get_unconfirmed_balance, funds)
-    await time_out_assert(30, wallet_taker.get_confirmed_balance, funds)
-
-    api_maker = WalletRpcApi(wallet_node_maker)
-    api_taker = WalletRpcApi(wallet_node_taker)
-    config = bt.config
-
-    assert wallet_services[0].rpc_server is not None
-    assert full_node_service.rpc_server is not None
-
-    async with contextlib.AsyncExitStack() as exit_stack:
-        client = await exit_stack.enter_async_context(
-            WalletRpcClient.create_as_context(
-                self_hostname,
-                wallet_services[0].rpc_server.listen_port,
-                wallet_services[0].root_path,
-                wallet_services[0].config,
-            )
-        )
-        client_node = await exit_stack.enter_async_context(
-            FullNodeRpcClient.create_as_context(
-                self_hostname,
-                full_node_service.rpc_server.listen_port,
-                full_node_service.root_path,
-                full_node_service.config,
-            )
+    async with env_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
+        did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
+            env_0.wallet_state_manager, wallet_0, uint64(1), action_scope
         )
 
-        async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-            did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
-                wallet_node_maker.wallet_state_manager, wallet_maker, uint64(1), action_scope
-            )
-        await full_node_api.process_transaction_records(action_scope.side_effects.transactions)
-
-        await time_out_assert(30, wallet_maker.get_pending_change_balance, 0)
-        await time_out_assert(30, wallet_maker.get_unconfirmed_balance, funds - 1)
-        await time_out_assert(30, wallet_maker.get_confirmed_balance, funds - 1)
-
-        hex_did_id = did_wallet_maker.get_my_DID()
-        hmr_did_id = encode_puzzle_hash(bytes32.from_hexstr(hex_did_id), AddressType.DID.hrp(config))
-
-        await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_maker, timeout=20)
-
-        nft_wallet_maker = await api_maker.create_new_wallet(
-            dict(wallet_type="nft_wallet", name="NFT WALLET 1", did_id=hmr_did_id)
-        )
-        assert isinstance(nft_wallet_maker, dict)
-        assert nft_wallet_maker.get("success")
-
-        nft_wallet_taker = await api_taker.create_new_wallet(dict(wallet_type="nft_wallet", name="NFT WALLET 2"))
-
-        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
-
-        n = 10
-        metadata_list = [
-            {
-                "hash": bytes32.random(seeded_random).hex(),
-                "uris": [f"https://data.com/{i}"],
-                "meta_hash": bytes32.random(seeded_random).hex(),
-                "meta_uris": [f"https://meatadata.com/{i}"],
-                "license_hash": bytes32.random(seeded_random).hex(),
-                "license_uris": [f"https://license.com/{i}"],
-                "edition_number": i + 1,
-                "edition_total": n,
-            }
-            for i in range(n)
+    await wallet_environments.process_pending_states(
+        [
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "xch": {
+                        "set_remainder": True,
+                    },
+                    "did": {
+                        "init": True,
+                        "set_remainder": True,
+                    },
+                },
+                post_block_balance_updates={
+                    "xch": {
+                        "set_remainder": True,
+                    },
+                    "did": {
+                        "set_remainder": True,
+                    },
+                },
+            ),
+            WalletStateTransition(),
         ]
-        target_list = [encode_puzzle_hash((ph_taker), "xch") for x in range(n)]
-        royalty_address = encode_puzzle_hash(bytes32.random(seeded_random), "xch")
-        royalty_percentage = 300
-        fee = 100
-        required_amount = n + (fee * n)
-        xch_coins = await client.select_coins(
-            amount=required_amount, coin_selection_config=DEFAULT_COIN_SELECTION_CONFIG, wallet_id=wallet_maker.id()
+    )
+
+    hex_did_id = did_wallet_maker.get_my_DID()
+    hmr_did_id = encode_puzzle_hash(bytes32.from_hexstr(hex_did_id), AddressType.DID.hrp(env_0.node.config))
+
+    nft_wallet_maker = await env_0.rpc_client.create_new_nft_wallet(name="NFT WALLET 1", did_id=hmr_did_id)
+
+    await env_1.rpc_client.create_new_nft_wallet(name="NFT WALLET 2", did_id=None)
+
+    await env_0.change_balances({"nft": {"init": True}})
+    await env_1.change_balances({"nft": {"init": True}})
+
+    n = 10
+    chunk = 5
+    metadata_list = [
+        {
+            "hash": bytes([i] * 32).hex(),
+            "uris": [f"https://data.com/{i}"],
+            "meta_hash": bytes([i] * 32).hex(),
+            "meta_uris": [f"https://meatadata.com/{i}"],
+            "license_hash": bytes([i] * 32).hex(),
+            "license_uris": [f"https://license.com/{i}"],
+            "edition_number": i + 1,
+            "edition_total": n,
+        }
+        for i in range(n)
+    ]
+    target_list = [encode_puzzle_hash(ph_1, "xch") for x in range(n)]
+    royalty_address = encode_puzzle_hash(bytes32.zeros, "xch")
+    royalty_percentage = 300
+    fee = 100
+    num_chunks = int(n / chunk) + (1 if n % chunk > 0 else 0)
+    required_amount = n + (fee * num_chunks)
+    xch_coins = await env_0.rpc_client.select_coins(
+        amount=required_amount,
+        coin_selection_config=wallet_environments.tx_config.coin_selection_config,
+        wallet_id=wallet_0.id(),
+    )
+    funding_coin = xch_coins[0]
+    assert funding_coin.amount >= required_amount
+    funding_coin_dict = xch_coins[0].to_json_dict()
+    next_coin = funding_coin
+    did_coin = (
+        await env_0.rpc_client.select_coins(
+            amount=1,
+            coin_selection_config=wallet_environments.tx_config.coin_selection_config,
+            wallet_id=env_0.wallet_aliases["did"],
         )
-        funding_coin = xch_coins[0]
-        assert funding_coin.amount >= required_amount
-        funding_coin_dict = xch_coins[0].to_json_dict()
-        chunk = 5
-        next_coin = funding_coin
-        did_coin = (
-            await client.select_coins(amount=1, coin_selection_config=DEFAULT_COIN_SELECTION_CONFIG, wallet_id=2)
-        )[0]
-        did_lineage_parent = None
-        spends = []
-        nft_ids = set()
-        for i in range(0, n, chunk):
-            await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node_maker, timeout=20)
-            resp = await client.nft_mint_bulk(
-                wallet_id=nft_wallet_maker["wallet_id"],
-                metadata_list=metadata_list[i : i + chunk],
-                target_list=target_list[i : i + chunk],
-                royalty_percentage=royalty_percentage,
-                royalty_address=royalty_address,
-                mint_number_start=i + 1,
-                mint_total=n,
-                xch_coins=[next_coin.to_json_dict()],
-                xch_change_target=funding_coin_dict["puzzle_hash"],
-                did_coin=did_coin.to_json_dict(),
-                did_lineage_parent=did_lineage_parent,
-                mint_from_did=True,
-                fee=fee,
-                tx_config=DEFAULT_TX_CONFIG,
-            )
-            sb = resp.spend_bundle
-            did_lineage_parent = next(cn for cn in sb.removals() if cn.name() == did_coin.name()).parent_coin_info.hex()
-            did_coin = next(
-                cn for cn in sb.additions() if (cn.parent_coin_info == did_coin.name()) and (cn.amount == 1)
-            )
-            spends.append(sb)
-            xch_adds = [c for c in sb.additions() if c.puzzle_hash == funding_coin.puzzle_hash]
-            assert len(xch_adds) == 1
-            next_coin = xch_adds[0]
-            for nft_id in resp.nft_id_list:
-                nft_ids.add(decode_puzzle_hash(nft_id))
-        for sb in spends:
-            push_resp = await client_node.push_tx(sb)
-            assert push_resp["success"]
-            await full_node_api.process_spend_bundles([sb])
+    )[0]
+    did_lineage_parent = None
+    txs: list[TransactionRecord] = []
+    nft_ids = set()
+    for i in range(0, n, chunk):
+        resp = await env_0.rpc_client.nft_mint_bulk(
+            wallet_id=nft_wallet_maker["wallet_id"],
+            metadata_list=metadata_list[i : i + chunk],
+            target_list=target_list[i : i + chunk],
+            royalty_percentage=royalty_percentage,
+            royalty_address=royalty_address,
+            mint_number_start=i + 1,
+            mint_total=n,
+            xch_coins=[next_coin.to_json_dict()],
+            xch_change_target=funding_coin_dict["puzzle_hash"],
+            did_coin=did_coin.to_json_dict(),
+            did_lineage_parent=did_lineage_parent,
+            mint_from_did=True,
+            fee=fee,
+            tx_config=wallet_environments.tx_config,
+        )
+        # did_lineage_parent = next(cn for cn in sb.removals() if cn.name() == did_coin.name()).parent_coin_info.hex()
+        did_coin = next(
+            cn
+            for tx in resp.transactions
+            if tx.spend_bundle is not None
+            for cn in tx.spend_bundle.additions()
+            if (cn.parent_coin_info == did_coin.name()) and (cn.amount == 1)
+        )
+        txs.extend(resp.transactions)
+        xch_adds = [
+            c
+            for tx in resp.transactions
+            if tx.spend_bundle is not None
+            for c in tx.spend_bundle.additions()
+            if c.puzzle_hash == funding_coin.puzzle_hash
+        ]
+        assert len(xch_adds) == 1
+        next_coin = xch_adds[0]
+        for nft_id in resp.nft_id_list:
+            nft_ids.add(decode_puzzle_hash(nft_id))
 
-        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
+    await env_0.rpc_client.push_transactions(PushTransactions(transactions=txs), wallet_environments.tx_config)
 
-        async def get_taker_nfts() -> int:
-            return int((await api_taker.nft_count_nfts({"wallet_id": nft_wallet_taker["wallet_id"]}))["count"])
+    await wallet_environments.process_pending_states(
+        [
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "xch": {
+                        "unconfirmed_wallet_balance": -(fee * num_chunks) - n,
+                        "<=#spendable_balance": -(fee * num_chunks) - n,
+                        "<=#max_send_amount": -(fee * num_chunks) - n,
+                        ">=#pending_change": 1,
+                        "pending_coin_removal_count": num_chunks,
+                    },
+                    "did": {
+                        "spendable_balance": -1,
+                        "max_send_amount": -1,
+                        # 2 here feels a bit weird but I'm not sure it's necessarily incorrect
+                        "pending_change": 2,
+                        "pending_coin_removal_count": 2,
+                    },
+                    "nft": {
+                        "pending_coin_removal_count": n,
+                    },
+                },
+                post_block_balance_updates={
+                    "xch": {
+                        "confirmed_wallet_balance": -(fee * num_chunks) - n,
+                        ">=#spendable_balance": 1,
+                        ">=#max_send_amount": 1,
+                        "<=#pending_change": -1,
+                        "pending_coin_removal_count": -num_chunks,
+                    },
+                    "did": {
+                        "spendable_balance": 1,
+                        "max_send_amount": 1,
+                        "pending_change": -2,
+                        "pending_coin_removal_count": -2,
+                    },
+                    "nft": {
+                        "pending_coin_removal_count": -n,
+                    },
+                },
+            ),
+            WalletStateTransition(
+                pre_block_balance_updates={},
+                post_block_balance_updates={
+                    "nft": {
+                        "unspent_coin_count": n,
+                    }
+                },
+            ),
+        ]
+    )
 
-        # We are using a long time out here because it can take a long time for the NFTs to show up
-        # Even with only 10 NFTs it regularly takes longer than 30-40s for them to be found
-        await time_out_assert(60, get_taker_nfts, n)
-
-        # check NFT edition numbers
-        nfts = (await api_taker.nft_get_nfts({"wallet_id": nft_wallet_taker["wallet_id"]}))["nft_list"]
-        for nft in nfts:
-            edition_num = nft.edition_number
-            meta_dict = metadata_list[edition_num - 1]
-            assert meta_dict["hash"] == nft.data_hash.hex()
-            assert meta_dict["uris"] == nft.data_uris
-            assert meta_dict["meta_hash"] == nft.metadata_hash.hex()
-            assert meta_dict["meta_uris"] == nft.metadata_uris
-            assert meta_dict["license_hash"] == nft.license_hash.hex()
-            assert meta_dict["license_uris"] == nft.license_uris
-            assert meta_dict["edition_number"] == nft.edition_number
-            assert meta_dict["edition_total"] == nft.edition_total
-            assert nft.launcher_id in nft_ids
+    # check NFT edition numbers
+    nfts = [
+        NFTInfo.from_json_dict(nft)
+        for nft in (await env_1.rpc_client.list_nfts(env_1.wallet_aliases["nft"]))["nft_list"]
+    ]
+    for nft in nfts:
+        edition_num = nft.edition_number
+        meta_dict = metadata_list[edition_num - 1]
+        assert meta_dict["hash"] == nft.data_hash.hex()
+        assert meta_dict["uris"] == nft.data_uris
+        assert meta_dict["meta_hash"] == nft.metadata_hash.hex()
+        assert meta_dict["meta_uris"] == nft.metadata_uris
+        assert meta_dict["license_hash"] == nft.license_hash.hex()
+        assert meta_dict["license_uris"] == nft.license_uris
+        assert meta_dict["edition_number"] == nft.edition_number
+        assert meta_dict["edition_total"] == nft.edition_total
+        assert nft.launcher_id in nft_ids
 
 
 @pytest.mark.parametrize(

--- a/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -10,7 +10,7 @@ from chia_rs.sized_ints import uint16, uint32, uint64
 
 from chia._tests.environments.wallet import WalletStateTransition, WalletTestFramework
 from chia._tests.util.setup_nodes import SimulatorsAndWalletsServices
-from chia._tests.util.time_out_assert import time_out_assert, time_out_assert_not_none
+from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
 from chia.rpc.wallet_request_types import PushTransactions
@@ -417,68 +417,70 @@ async def test_nft_mint_from_did_rpc(wallet_environments: WalletTestFramework, z
         assert nft.launcher_id in nft_ids
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes
+@pytest.mark.parametrize("wallet_environments", [{"num_environments": 2, "blocks_needed": [1, 1]}], indirect=True)
 @pytest.mark.anyio
-async def test_nft_mint_from_did_multiple_xch(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, seeded_random: random.Random
-) -> None:
-    full_nodes, wallets, _ = two_wallet_nodes
-    full_node_api: FullNodeSimulator = full_nodes[0]
-    full_node_server = full_node_api.server
-    wallet_node_0, server_0 = wallets[0]
-    wallet_node_1, server_1 = wallets[1]
-    wallet_maker = wallet_node_0.wallet_state_manager.main_wallet
-    wallet_taker = wallet_node_1.wallet_state_manager.main_wallet
-    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
-    async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        ph_taker = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
-    ph_token = bytes32.random(seeded_random)
+async def test_nft_mint_from_did_multiple_xch(wallet_environments: WalletTestFramework) -> None:
+    env_0 = wallet_environments.environments[0]
+    env_1 = wallet_environments.environments[1]
+    wallet_0 = env_0.xch_wallet
+    wallet_1 = env_1.xch_wallet
+    env_0.wallet_aliases = {
+        "xch": 1,
+        "did": 2,
+        "nft": 3,
+    }
+    env_1.wallet_aliases = {
+        "xch": 1,
+        "nft": 2,
+    }
 
-    if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
-
-    await server_0.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
-    await server_1.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
-
-    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_maker))
-    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
-
-    funds = calculate_pool_reward(uint32(1)) + calculate_base_farmer_reward(uint32(1))
-
-    await time_out_assert(30, wallet_maker.get_unconfirmed_balance, funds)
-    await time_out_assert(30, wallet_maker.get_confirmed_balance, funds)
-
-    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with env_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
+        ph_0 = await action_scope.get_puzzle_hash(env_0.wallet_state_manager)
         did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node_0.wallet_state_manager, wallet_maker, uint64(1), action_scope
+            env_0.wallet_state_manager, wallet_0, uint64(1), action_scope
         )
-    await full_node_api.process_transaction_records(action_scope.side_effects.transactions)
-    await time_out_assert(30, wallet_maker.get_pending_change_balance, 0)
+    async with env_1.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
+        ph_1 = await action_scope.get_puzzle_hash(env_1.wallet_state_manager)
+
+    await wallet_environments.process_pending_states(
+        [
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "xch": {
+                        "set_remainder": True,
+                    },
+                    "did": {
+                        "init": True,
+                        "set_remainder": True,
+                    },
+                },
+                post_block_balance_updates={
+                    "xch": {
+                        "set_remainder": True,
+                    },
+                    "did": {
+                        "set_remainder": True,
+                    },
+                },
+            ),
+            WalletStateTransition(),
+        ]
+    )
 
     hex_did_id = did_wallet.get_my_DID()
     did_id = bytes32.fromhex(hex_did_id)
 
     await time_out_assert(5, did_wallet.get_confirmed_balance, 1)
 
-    nft_wallet_maker = await NFTWallet.create_new_nft_wallet(
-        wallet_node_0.wallet_state_manager, wallet_maker, name="NFT WALLET 1", did_id=did_id
+    nft_wallet_0 = await NFTWallet.create_new_nft_wallet(
+        env_0.wallet_state_manager, wallet_0, name="NFT WALLET 1", did_id=did_id
     )
 
-    nft_wallet_taker = await NFTWallet.create_new_nft_wallet(
-        wallet_node_1.wallet_state_manager, wallet_taker, name="NFT WALLET 2"
-    )
+    await NFTWallet.create_new_nft_wallet(wallet_1.wallet_state_manager, wallet_1, name="NFT WALLET 2")
+
+    await env_0.change_balances({"nft": {"init": True}})
+    await env_1.change_balances({"nft": {"init": True}})
 
     # construct sample metadata
     metadata = Program.to(
@@ -488,7 +490,7 @@ async def test_nft_mint_from_did_multiple_xch(
         ]
     )
     royalty_pc = uint16(300)
-    royalty_addr = ph_maker
+    royalty_addr = ph_0
 
     mint_total = 1
     fee = uint64(100)
@@ -497,18 +499,18 @@ async def test_nft_mint_from_did_multiple_xch(
     ]
 
     # Grab two coins for testing that we can create a bulk minting with more than 1 xch coin
-    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=False) as action_scope:
-        xch_coins_1 = await wallet_maker.select_coins(amount=10000, action_scope=action_scope)
-        xch_coins_2 = await wallet_maker.select_coins(
-            amount=10000,
+    async with env_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=False) as action_scope:
+        xch_coins_1 = await wallet_0.select_coins(amount=uint64(10000), action_scope=action_scope)
+        xch_coins_2 = await wallet_0.select_coins(
+            amount=uint64(10000),
             action_scope=action_scope,
         )
     xch_coins = xch_coins_1.union(xch_coins_2)
 
-    target_list = [ph_taker for x in range(mint_total)]
+    target_list = [ph_1 for x in range(mint_total)]
 
-    async with nft_wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        await nft_wallet_maker.mint_from_did(
+    async with env_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
+        await nft_wallet_0.mint_from_did(
             metadata_list,
             action_scope,
             target_list=target_list,
@@ -517,18 +519,58 @@ async def test_nft_mint_from_did_multiple_xch(
             xch_coins=xch_coins,
             fee=fee,
         )
-    sb = action_scope.side_effects.transactions[0].spend_bundle
-    assert sb is not None
 
-    await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, sb.name())
-    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
-
-    await time_out_assert(30, nft_count, mint_total, nft_wallet_taker)
-    await time_out_assert(30, nft_count, 0, nft_wallet_maker)
-
-    # confirm that the spend uses the right amount of xch
-    expected_xch_bal = funds - fee - mint_total - 1
-    await time_out_assert(30, wallet_maker.get_confirmed_balance, expected_xch_bal)
+    await wallet_environments.process_pending_states(
+        [
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "xch": {
+                        "unconfirmed_wallet_balance": -fee - mint_total,
+                        "<=#spendable_balance": -fee - mint_total,
+                        "<=#max_send_amount": -fee - mint_total,
+                        ">=#pending_change": 1,
+                        "pending_coin_removal_count": 2,
+                    },
+                    "did": {
+                        "spendable_balance": -1,
+                        "max_send_amount": -1,
+                        "pending_change": 1,
+                        "pending_coin_removal_count": 1,
+                    },
+                    "nft": {
+                        "pending_coin_removal_count": mint_total,
+                    },
+                },
+                post_block_balance_updates={
+                    "xch": {
+                        "confirmed_wallet_balance": -fee - mint_total,
+                        ">=#spendable_balance": 1,
+                        ">=#max_send_amount": 1,
+                        "<=#pending_change": -1,
+                        "pending_coin_removal_count": -2,
+                        "unspent_coin_count": -1,  # The two coins get combined for change
+                    },
+                    "did": {
+                        "spendable_balance": 1,
+                        "max_send_amount": 1,
+                        "pending_change": -1,
+                        "pending_coin_removal_count": -1,
+                    },
+                    "nft": {
+                        "pending_coin_removal_count": -mint_total,
+                    },
+                },
+            ),
+            WalletStateTransition(
+                pre_block_balance_updates={},
+                post_block_balance_updates={
+                    "nft": {
+                        "unspent_coin_count": mint_total,
+                    }
+                },
+            ),
+        ]
+    )
 
 
 @pytest.mark.parametrize(

--- a/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
 
-import random
-from typing import Any, cast
+from typing import cast
 
 import pytest
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint16, uint32, uint64
+from chia_rs.sized_ints import uint16, uint64
 
 from chia._tests.environments.wallet import WalletStateTransition, WalletTestFramework
 from chia._tests.util.time_out_assert import time_out_assert
-from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.rpc.wallet_request_types import PushTransactions
-from chia.simulator.full_node_simulator import FullNodeSimulator
-from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.blockchain_format.program import Program
-from chia.types.peer_info import PeerInfo
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.nft_wallet.nft_info import NFTInfo
@@ -22,7 +17,6 @@ from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.nft_wallet.uncurry_nft import UncurriedNFT
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.address_type import AddressType
-from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 
 
 async def nft_count(wallet: NFTWallet) -> int:
@@ -893,68 +887,69 @@ async def test_nft_mint_from_xch_rpc(wallet_environments: WalletTestFramework) -
         assert meta_dict["edition_total"] == nft.edition_total
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes
+@pytest.mark.parametrize("wallet_environments", [{"num_environments": 2, "blocks_needed": [1, 1]}], indirect=True)
 @pytest.mark.anyio
-async def test_nft_mint_from_xch_multiple_xch(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, seeded_random: random.Random
-) -> None:
-    full_nodes, wallets, _ = two_wallet_nodes
-    full_node_api: FullNodeSimulator = full_nodes[0]
-    full_node_server = full_node_api.server
-    wallet_node_0, server_0 = wallets[0]
-    wallet_node_1, server_1 = wallets[1]
-    wallet_maker = wallet_node_0.wallet_state_manager.main_wallet
-    wallet_taker = wallet_node_1.wallet_state_manager.main_wallet
-    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        ph_maker = await action_scope.get_puzzle_hash(wallet_maker.wallet_state_manager)
-    async with wallet_taker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        ph_taker = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
-    ph_token = bytes32.random(seeded_random)
+async def test_nft_mint_from_xch_multiple_xch(wallet_environments: WalletTestFramework) -> None:
+    env_0 = wallet_environments.environments[0]
+    env_1 = wallet_environments.environments[1]
+    wallet_0 = env_0.xch_wallet
+    wallet_1 = env_1.xch_wallet
+    env_0.wallet_aliases = {
+        "xch": 1,
+        "did": 2,
+        "nft": 3,
+    }
+    env_1.wallet_aliases = {
+        "xch": 1,
+        "nft": 2,
+    }
+    async with env_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
+        ph_0 = await action_scope.get_puzzle_hash(wallet_0.wallet_state_manager)
+    async with env_1.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
+        ph_1 = await action_scope.get_puzzle_hash(wallet_1.wallet_state_manager)
 
-    if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
-
-    await server_0.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
-    await server_1.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
-
-    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_maker))
-    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
-
-    funds = calculate_pool_reward(uint32(1)) + calculate_base_farmer_reward(uint32(1))
-
-    await time_out_assert(30, wallet_maker.get_unconfirmed_balance, funds)
-    await time_out_assert(30, wallet_maker.get_confirmed_balance, funds)
-
-    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with env_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node_0.wallet_state_manager, wallet_maker, uint64(1), action_scope
+            env_0.wallet_state_manager, wallet_0, uint64(1), action_scope
         )
-    await full_node_api.process_transaction_records(action_scope.side_effects.transactions)
-    await time_out_assert(30, wallet_maker.get_pending_change_balance, 0)
+
+    await wallet_environments.process_pending_states(
+        [
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "xch": {
+                        "set_remainder": True,
+                    },
+                    "did": {
+                        "init": True,
+                        "set_remainder": True,
+                    },
+                },
+                post_block_balance_updates={
+                    "xch": {
+                        "set_remainder": True,
+                    },
+                    "did": {
+                        "set_remainder": True,
+                    },
+                },
+            ),
+            WalletStateTransition(),
+        ]
+    )
 
     hex_did_id = did_wallet.get_my_DID()
     did_id = bytes32.fromhex(hex_did_id)
 
-    await time_out_assert(5, did_wallet.get_confirmed_balance, 1)
-
-    nft_wallet_maker = await NFTWallet.create_new_nft_wallet(
-        wallet_node_0.wallet_state_manager, wallet_maker, name="NFT WALLET 1", did_id=did_id
+    nft_wallet_0 = await NFTWallet.create_new_nft_wallet(
+        env_0.wallet_state_manager, wallet_0, name="NFT WALLET 1", did_id=did_id
     )
 
-    nft_wallet_taker = await NFTWallet.create_new_nft_wallet(
-        wallet_node_1.wallet_state_manager, wallet_taker, name="NFT WALLET 2"
-    )
+    await NFTWallet.create_new_nft_wallet(env_1.wallet_state_manager, wallet_1, name="NFT WALLET 2")
+
+    await env_0.change_balances({"nft": {"init": True}})
+    await env_1.change_balances({"nft": {"init": True}})
 
     # construct sample metadata
     metadata = Program.to(
@@ -964,7 +959,7 @@ async def test_nft_mint_from_xch_multiple_xch(
         ]
     )
     royalty_pc = uint16(300)
-    royalty_addr = ph_maker
+    royalty_addr = ph_0
 
     mint_total = 1
     fee = uint64(100)
@@ -973,18 +968,22 @@ async def test_nft_mint_from_xch_multiple_xch(
     ]
 
     # Grab two coins for testing that we can create a bulk minting with more than 1 xch coin
-    async with wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=False) as action_scope:
-        xch_coins_1 = await wallet_maker.select_coins(amount=10000, action_scope=action_scope)
-        xch_coins_2 = await wallet_maker.select_coins(
-            amount=10000,
+    async with wallet_0.wallet_state_manager.new_action_scope(
+        wallet_environments.tx_config, push=False
+    ) as action_scope:
+        xch_coins_1 = await wallet_0.select_coins(amount=uint64(10000), action_scope=action_scope)
+        xch_coins_2 = await wallet_0.select_coins(
+            amount=uint64(10000),
             action_scope=action_scope,
         )
     xch_coins = xch_coins_1.union(xch_coins_2)
 
-    target_list = [ph_taker for x in range(mint_total)]
+    target_list = [ph_1 for x in range(mint_total)]
 
-    async with nft_wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        await nft_wallet_maker.mint_from_xch(
+    async with nft_wallet_0.wallet_state_manager.new_action_scope(
+        wallet_environments.tx_config, push=True
+    ) as action_scope:
+        await nft_wallet_0.mint_from_xch(
             metadata_list,
             action_scope,
             target_list=target_list,
@@ -994,11 +993,42 @@ async def test_nft_mint_from_xch_multiple_xch(
             fee=fee,
         )
 
-    await full_node_api.process_transaction_records(action_scope.side_effects.transactions)
-
-    await time_out_assert(30, nft_count, mint_total, nft_wallet_taker)
-    await time_out_assert(30, nft_count, 0, nft_wallet_maker)
-
-    # confirm that the spend uses the right amount of xch
-    expected_xch_bal = funds - fee - mint_total - 1
-    await time_out_assert(30, wallet_maker.get_confirmed_balance, expected_xch_bal)
+    await wallet_environments.process_pending_states(
+        [
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "xch": {
+                        "unconfirmed_wallet_balance": -fee - mint_total,
+                        "<=#spendable_balance": -fee - mint_total,
+                        "<=#max_send_amount": -fee - mint_total,
+                        ">=#pending_change": 1,
+                        "pending_coin_removal_count": 2,
+                    },
+                    "nft": {
+                        "pending_coin_removal_count": mint_total,
+                    },
+                },
+                post_block_balance_updates={
+                    "xch": {
+                        "confirmed_wallet_balance": -fee - mint_total,
+                        ">=#spendable_balance": 1,
+                        ">=#max_send_amount": 1,
+                        "<=#pending_change": -1,
+                        "pending_coin_removal_count": -2,
+                        "unspent_coin_count": -1,  # The two coins get combined for change
+                    },
+                    "nft": {
+                        "pending_coin_removal_count": -mint_total,
+                    },
+                },
+            ),
+            WalletStateTransition(
+                pre_block_balance_updates={},
+                post_block_balance_updates={
+                    "nft": {
+                        "unspent_coin_count": mint_total,
+                    }
+                },
+            ),
+        ]
+    )

--- a/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -573,76 +573,76 @@ async def test_nft_mint_from_did_multiple_xch(wallet_environments: WalletTestFra
     )
 
 
-@pytest.mark.parametrize(
-    "trusted",
-    [True, False],
-)
+@pytest.mark.limit_consensus_modes
+@pytest.mark.parametrize("wallet_environments", [{"num_environments": 2, "blocks_needed": [1, 1]}], indirect=True)
 @pytest.mark.anyio
-async def test_nft_mint_from_xch(
-    self_hostname: str, two_wallet_nodes: Any, trusted: Any, seeded_random: random.Random
-) -> None:
-    full_nodes, wallets, _ = two_wallet_nodes
-    full_node_api: FullNodeSimulator = full_nodes[0]
-    full_node_server = full_node_api.server
-    wallet_node_0, server_0 = wallets[0]
-    wallet_node_1, server_1 = wallets[1]
-    wallet_0 = wallet_node_0.wallet_state_manager.main_wallet
-    wallet_1 = wallet_node_1.wallet_state_manager.main_wallet
-    async with wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        ph_maker = await action_scope.get_puzzle_hash(wallet_0.wallet_state_manager)
-    ph_token = bytes32.random(seeded_random)
+async def test_nft_mint_from_xch(wallet_environments: WalletTestFramework) -> None:
+    env_0 = wallet_environments.environments[0]
+    env_1 = wallet_environments.environments[1]
+    wallet_0 = env_0.xch_wallet
+    wallet_1 = env_1.xch_wallet
+    env_0.wallet_aliases = {
+        "xch": 1,
+        "did": 2,
+        "nft": 3,
+    }
+    env_1.wallet_aliases = {
+        "xch": 1,
+        "nft": 2,
+    }
 
-    if trusted:
-        wallet_node_0.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-        wallet_node_1.config["trusted_peers"] = {
-            full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-        }
-    else:
-        wallet_node_0.config["trusted_peers"] = {}
-        wallet_node_1.config["trusted_peers"] = {}
-
-    await server_0.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
-    await server_1.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
-
-    # for _ in range(1, num_blocks):
-    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_maker))
-    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph_token))
-    funds = calculate_pool_reward(uint32(1)) + calculate_base_farmer_reward(uint32(1))
-
-    await time_out_assert(30, wallet_0.get_unconfirmed_balance, funds)
-    await time_out_assert(30, wallet_0.get_confirmed_balance, funds)
-
-    async with wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with wallet_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
+        ph_0 = await action_scope.get_puzzle_hash(env_0.wallet_state_manager)
         did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node_0.wallet_state_manager, wallet_0, uint64(1), action_scope
+            env_0.wallet_state_manager, wallet_0, uint64(1), action_scope
         )
-    await full_node_api.process_transaction_records(action_scope.side_effects.transactions)
-    await time_out_assert(30, wallet_0.get_pending_change_balance, 0)
+
+    await wallet_environments.process_pending_states(
+        [
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "xch": {
+                        "set_remainder": True,
+                    },
+                    "did": {
+                        "init": True,
+                        "set_remainder": True,
+                    },
+                },
+                post_block_balance_updates={
+                    "xch": {
+                        "set_remainder": True,
+                    },
+                    "did": {
+                        "set_remainder": True,
+                    },
+                },
+            ),
+            WalletStateTransition(),
+        ]
+    )
 
     hex_did_id = did_wallet.get_my_DID()
     did_id = bytes32.fromhex(hex_did_id)
 
-    await time_out_assert(5, did_wallet.get_confirmed_balance, 1)
-
     nft_wallet_maker = await NFTWallet.create_new_nft_wallet(
-        wallet_node_0.wallet_state_manager, wallet_0, name="NFT WALLET 1", did_id=did_id
+        env_0.wallet_state_manager, wallet_0, name="NFT WALLET 1", did_id=did_id
     )
 
-    nft_wallet_taker = await NFTWallet.create_new_nft_wallet(
-        wallet_node_1.wallet_state_manager, wallet_1, name="NFT WALLET 2"
-    )
+    nft_wallet_taker = await NFTWallet.create_new_nft_wallet(env_1.wallet_state_manager, wallet_1, name="NFT WALLET 2")
+
+    await env_0.change_balances({"nft": {"init": True}})
+    await env_1.change_balances({"nft": {"init": True}})
 
     royalty_pc = uint16(300)
-    royalty_addr = ph_maker
+    royalty_addr = ph_0
 
     mint_total = 1
     fee = uint64(100)
     metadata_list = [
         {
             "program": Program.to(
-                [("u", ["https://www.chia.net/img/branding/chia-logo.svg"]), ("h", bytes32.random(seeded_random).hex())]
+                [("u", ["https://www.chia.net/img/branding/chia-logo.svg"]), ("h", bytes([x] * 32).hex())]
             ),
             "royalty_pc": royalty_pc,
             "royalty_ph": royalty_addr,
@@ -650,10 +650,12 @@ async def test_nft_mint_from_xch(
         for x in range(mint_total)
     ]
 
-    async with wallet_1.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with wallet_1.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         target_list = [await action_scope.get_puzzle_hash(wallet_1.wallet_state_manager) for x in range(mint_total)]
 
-    async with nft_wallet_maker.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with nft_wallet_maker.wallet_state_manager.new_action_scope(
+        wallet_environments.tx_config, push=True
+    ) as action_scope:
         await nft_wallet_maker.mint_from_xch(
             metadata_list,
             action_scope,
@@ -663,13 +665,44 @@ async def test_nft_mint_from_xch(
             fee=fee,
         )
 
-    await full_node_api.process_transaction_records(action_scope.side_effects.transactions)
-
-    await time_out_assert(30, nft_count, mint_total, nft_wallet_taker)
-    await time_out_assert(30, nft_count, 0, nft_wallet_maker)
-
-    expected_xch_bal = funds - fee - mint_total - 1
-    await time_out_assert(30, wallet_0.get_confirmed_balance, expected_xch_bal)
+    await wallet_environments.process_pending_states(
+        [
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "xch": {
+                        "unconfirmed_wallet_balance": -fee - mint_total,
+                        "<=#spendable_balance": -fee - mint_total,
+                        "<=#max_send_amount": -fee - mint_total,
+                        ">=#pending_change": 1,
+                        "pending_coin_removal_count": 1,
+                    },
+                    "nft": {
+                        "pending_coin_removal_count": mint_total,
+                    },
+                },
+                post_block_balance_updates={
+                    "xch": {
+                        "confirmed_wallet_balance": -fee - mint_total,
+                        ">=#spendable_balance": 1,
+                        ">=#max_send_amount": 1,
+                        "<=#pending_change": -1,
+                        "pending_coin_removal_count": -1,
+                    },
+                    "nft": {
+                        "pending_coin_removal_count": -mint_total,
+                    },
+                },
+            ),
+            WalletStateTransition(
+                pre_block_balance_updates={},
+                post_block_balance_updates={
+                    "nft": {
+                        "unspent_coin_count": mint_total,
+                    }
+                },
+            ),
+        ]
+    )
 
     nfts = await nft_wallet_taker.get_current_nfts()
     matched_data = dict(zip(target_list, metadata_list))
@@ -683,7 +716,8 @@ async def test_nft_mint_from_xch(
         inner_ph = inner_args.at("rrrf").get_tree_hash()
         meta = unft.metadata.at("rfr").as_atom()
         # check that the target puzzle hashes of transferred nfts matches the metadata entry
-        assert matched_data[inner_ph]["program"].at("rfr").as_atom() == meta
+        prog: Program = cast(Program, matched_data[inner_ph]["program"])
+        assert prog.at("rfr").as_atom() == meta
         assert not nft.minter_did
 
 

--- a/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -572,8 +572,7 @@ async def test_nft_mint_from_xch(wallet_environments: WalletTestFramework) -> No
     wallet_1 = env_1.xch_wallet
     env_0.wallet_aliases = {
         "xch": 1,
-        "did": 2,
-        "nft": 3,
+        "nft": 2,
     }
     env_1.wallet_aliases = {
         "xch": 1,
@@ -582,41 +581,8 @@ async def test_nft_mint_from_xch(wallet_environments: WalletTestFramework) -> No
 
     async with wallet_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         ph_0 = await action_scope.get_puzzle_hash(env_0.wallet_state_manager)
-        did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-            env_0.wallet_state_manager, wallet_0, uint64(1), action_scope
-        )
 
-    await wallet_environments.process_pending_states(
-        [
-            WalletStateTransition(
-                pre_block_balance_updates={
-                    "xch": {
-                        "set_remainder": True,
-                    },
-                    "did": {
-                        "init": True,
-                        "set_remainder": True,
-                    },
-                },
-                post_block_balance_updates={
-                    "xch": {
-                        "set_remainder": True,
-                    },
-                    "did": {
-                        "set_remainder": True,
-                    },
-                },
-            ),
-            WalletStateTransition(),
-        ]
-    )
-
-    hex_did_id = did_wallet.get_my_DID()
-    did_id = bytes32.fromhex(hex_did_id)
-
-    nft_wallet_maker = await NFTWallet.create_new_nft_wallet(
-        env_0.wallet_state_manager, wallet_0, name="NFT WALLET 1", did_id=did_id
-    )
+    nft_wallet_maker = await NFTWallet.create_new_nft_wallet(env_0.wallet_state_manager, wallet_0, name="NFT WALLET 1")
 
     nft_wallet_taker = await NFTWallet.create_new_nft_wallet(env_1.wallet_state_manager, wallet_1, name="NFT WALLET 2")
 
@@ -719,8 +685,7 @@ async def test_nft_mint_from_xch_rpc(wallet_environments: WalletTestFramework) -
     wallet_0 = env_0.xch_wallet
     env_0.wallet_aliases = {
         "xch": 1,
-        "did": 2,
-        "nft": 3,
+        "nft": 2,
     }
     env_1.wallet_aliases = {
         "xch": 1,
@@ -730,40 +695,7 @@ async def test_nft_mint_from_xch_rpc(wallet_environments: WalletTestFramework) -
     async with env_1.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         ph_1 = await action_scope.get_puzzle_hash(env_1.wallet_state_manager)
 
-    async with env_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
-        did_wallet_maker: DIDWallet = await DIDWallet.create_new_did_wallet(
-            env_0.wallet_state_manager, wallet_0, uint64(1), action_scope
-        )
-
-    await wallet_environments.process_pending_states(
-        [
-            WalletStateTransition(
-                pre_block_balance_updates={
-                    "xch": {
-                        "set_remainder": True,
-                    },
-                    "did": {
-                        "init": True,
-                        "set_remainder": True,
-                    },
-                },
-                post_block_balance_updates={
-                    "xch": {
-                        "set_remainder": True,
-                    },
-                    "did": {
-                        "set_remainder": True,
-                    },
-                },
-            ),
-            WalletStateTransition(),
-        ]
-    )
-
-    hex_did_id = did_wallet_maker.get_my_DID()
-    hmr_did_id = encode_puzzle_hash(bytes32.from_hexstr(hex_did_id), AddressType.DID.hrp(env_0.node.config))
-
-    nft_wallet_maker = await env_0.rpc_client.create_new_nft_wallet(name="NFT WALLET 1", did_id=hmr_did_id)
+    nft_wallet_maker = await env_0.rpc_client.create_new_nft_wallet(name="NFT WALLET 1", did_id=None)
 
     await env_1.rpc_client.create_new_nft_wallet(name="NFT WALLET 2", did_id=None)
 
@@ -897,8 +829,7 @@ async def test_nft_mint_from_xch_multiple_xch(wallet_environments: WalletTestFra
     wallet_1 = env_1.xch_wallet
     env_0.wallet_aliases = {
         "xch": 1,
-        "did": 2,
-        "nft": 3,
+        "nft": 2,
     }
     env_1.wallet_aliases = {
         "xch": 1,
@@ -909,42 +840,7 @@ async def test_nft_mint_from_xch_multiple_xch(wallet_environments: WalletTestFra
     async with env_1.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         ph_1 = await action_scope.get_puzzle_hash(wallet_1.wallet_state_manager)
 
-    async with env_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
-        did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-            env_0.wallet_state_manager, wallet_0, uint64(1), action_scope
-        )
-
-    await wallet_environments.process_pending_states(
-        [
-            WalletStateTransition(
-                pre_block_balance_updates={
-                    "xch": {
-                        "set_remainder": True,
-                    },
-                    "did": {
-                        "init": True,
-                        "set_remainder": True,
-                    },
-                },
-                post_block_balance_updates={
-                    "xch": {
-                        "set_remainder": True,
-                    },
-                    "did": {
-                        "set_remainder": True,
-                    },
-                },
-            ),
-            WalletStateTransition(),
-        ]
-    )
-
-    hex_did_id = did_wallet.get_my_DID()
-    did_id = bytes32.fromhex(hex_did_id)
-
-    nft_wallet_0 = await NFTWallet.create_new_nft_wallet(
-        env_0.wallet_state_manager, wallet_0, name="NFT WALLET 1", did_id=did_id
-    )
+    nft_wallet_0 = await NFTWallet.create_new_nft_wallet(env_0.wallet_state_manager, wallet_0, name="NFT WALLET 1")
 
     await NFTWallet.create_new_nft_wallet(env_1.wallet_state_manager, wallet_1, name="NFT WALLET 2")
 

--- a/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -223,8 +223,6 @@ async def test_nft_mint_from_did_rpc(wallet_environments: WalletTestFramework, z
         "nft": 2,
     }
 
-    async with env_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
-        await action_scope.get_puzzle_hash(env_0.wallet_state_manager)
     async with env_1.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         ph_1 = await action_scope.get_puzzle_hash(env_1.wallet_state_manager)
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -3618,6 +3618,7 @@ class WalletRpcApi:
         async with action_scope.use() as interface:
             sb = WalletSpendBundle.aggregate(
                 [tx.spend_bundle for tx in interface.side_effects.transactions if tx.spend_bundle is not None]
+                + [sb for sb in interface.side_effects.extra_spends]
             )
         nft_id_list = []
         for cs in sb.coin_spends:

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -869,7 +869,7 @@ class WalletRpcApi:
                     await self.service.wallet_state_manager.main_wallet.create_tandem_xch_tx(
                         request.fee,
                         inner_action_scope,
-                        (
+                        extra_conditions=(
                             *extra_conditions,
                             CreateCoinAnnouncement(
                                 create_coin_announcement.msg, announcement_origin

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -1353,6 +1353,7 @@ class NFTWallet:
             coins=xch_coins,
             extra_conditions=xch_extra_conditions,
             reserve_fee=fee,
+            preferred_change_puzzle_hash=xch_change_ph,
         )
 
         # Create the DID spend using the announcements collected when making the intermediate launcher coins
@@ -1600,6 +1601,7 @@ class NFTWallet:
             # We should have a better API to generate_signed_transaction that takes the whole CreateCoin in the API.
             memos=[p.memos if p.memos is not None else [] for p in primaries],
             extra_conditions=extra_conditions,
+            preferred_change_puzzle_hash=xch_change_ph,
         )
 
         async with action_scope.use() as interface:

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -1151,7 +1151,7 @@ class NFTWallet:
         new_p2_puzhash: Optional[bytes32] = None,
         did_coin: Optional[Coin] = None,
         did_lineage_parent: Optional[bytes32] = None,
-        fee: Optional[uint64] = uint64(0),
+        fee: uint64 = uint64(0),
         extra_conditions: tuple[Condition, ...] = tuple(),
     ) -> None:
         """
@@ -1205,6 +1205,7 @@ class NFTWallet:
         # Ensure we have a did coin and its next inner puzzle hash
         if did_coin is None:
             did_coin = await did_wallet.get_coin()
+        assert did_coin is not None
         innerpuz: Program = did_wallet.did_info.current_inner
         if new_innerpuzhash is None:
             new_innerpuzhash = innerpuz.get_tree_hash()
@@ -1215,13 +1216,6 @@ class NFTWallet:
         assert new_p2_puzhash is not None
         # make the primaries for the DID spend
         primaries = [CreateCoin(new_innerpuzhash, uint64(did_coin.amount), [bytes(new_p2_puzhash)])]
-
-        # Ensure we have an xch coin of high enough amount
-        assert isinstance(fee, uint64)
-        total_amount = len(metadata_list) + fee
-        if xch_coins is None:
-            xch_coins = await self.standard_wallet.select_coins(uint64(total_amount), action_scope)
-        assert len(xch_coins) > 0
 
         # set the chunk size for the spend bundle we're going to create
         chunk_size = len(metadata_list)
@@ -1343,45 +1337,27 @@ class NFTWallet:
 
         # We've now created all the intermediate, launcher, eve and transfer spends.
         # Create the xch spend to fund the minting.
-        spend_value = sum(coin.amount for coin in xch_coins)
-        change: uint64 = uint64(spend_value - total_amount)
-        if xch_change_ph is None:
-            xch_change_ph = await action_scope.get_puzzle_hash(self.wallet_state_manager)
-        xch_payment = CreateCoin(xch_change_ph, change, [xch_change_ph])
-
-        xch_coins_iter = iter(xch_coins)
-        xch_coin = next(xch_coins_iter)
-
+        total_amount = len(metadata_list) + fee
+        if xch_coins is None:
+            xch_coins = await self.standard_wallet.select_coins(uint64(total_amount), action_scope)
+        assert len(xch_coins) > 0
         message_list: list[bytes32] = [c.name() for c in xch_coins]
-        message_list.append(Coin(xch_coin.name(), xch_payment.puzzle_hash, xch_payment.amount).name())
         message: bytes32 = std_hash(b"".join(message_list))
 
         xch_extra_conditions: tuple[Condition, ...] = (
             AssertCoinAnnouncement(asserted_id=did_coin.name(), asserted_msg=message),
         )
-        if len(xch_coins) > 1:
-            xch_extra_conditions += (CreateCoinAnnouncement(message),)
 
-        solution: Program = self.standard_wallet.make_solution(
-            primaries=[xch_payment],
-            fee=fee,
-            conditions=xch_extra_conditions,
+        await self.standard_wallet.create_tandem_xch_tx(
+            uint64(total_amount),
+            action_scope,
+            coins=xch_coins,
+            extra_conditions=xch_extra_conditions,
+            reserve_fee=fee,
         )
-        primary_announcement_hash = AssertCoinAnnouncement(asserted_id=xch_coin.name(), asserted_msg=message).msg_calc
-        # connect this coin assertion to the DID announcement
-        did_coin_announcement = CreateCoinAnnouncement(message)
-        puzzle = await self.standard_wallet.puzzle_for_puzzle_hash(xch_coin.puzzle_hash)
-        xch_spends = [make_spend(xch_coin, puzzle, solution)]
-
-        for xch_coin in xch_coins_iter:
-            puzzle = await self.standard_wallet.puzzle_for_puzzle_hash(xch_coin.puzzle_hash)
-            solution = self.standard_wallet.make_solution(
-                primaries=[], conditions=(AssertCoinAnnouncement(primary_announcement_hash),)
-            )
-            xch_spends.append(make_spend(xch_coin, puzzle, solution))
-        xch_spend = WalletSpendBundle(xch_spends, G2Element())
 
         # Create the DID spend using the announcements collected when making the intermediate launcher coins
+        did_coin_announcement = CreateCoinAnnouncement(message)
         did_p2_solution = self.standard_wallet.make_solution(
             primaries=primaries,
             conditions=(
@@ -1421,22 +1397,30 @@ class NFTWallet:
         did_spend = make_spend(did_coin, did_full_puzzle, did_full_sol)
 
         # Collect up all the coin spends and sign them
-        list_of_coinspends = [did_spend, *intermediate_coin_spends, *launcher_spends, *xch_spend.coin_spends]
+        list_of_coinspends = [did_spend, *intermediate_coin_spends, *launcher_spends]
         unsigned_spend_bundle = WalletSpendBundle(list_of_coinspends, G2Element())
 
-        # Aggregate everything into a single spend bundle
         async with action_scope.use() as interface:
-            # This should not be looked to for best practice. I think many of the spends generated above could call
-            # wallet methods that generate transactions and prevent most of the need for this. Refactoring this function
-            # is out of scope so for now we're using this hack.
-            if interface.side_effects.transactions[0].spend_bundle is None:
-                new_spend = unsigned_spend_bundle
-            else:
-                new_spend = WalletSpendBundle.aggregate(
-                    [interface.side_effects.transactions[0].spend_bundle, unsigned_spend_bundle]
+            interface.side_effects.transactions.append(
+                TransactionRecord(
+                    confirmed_at_height=uint32(0),
+                    created_at_time=uint64(int(time.time())),
+                    to_puzzle_hash=innerpuz.get_tree_hash(),
+                    amount=uint64(1),
+                    fee_amount=fee,
+                    confirmed=False,
+                    sent=uint32(0),
+                    spend_bundle=unsigned_spend_bundle,
+                    additions=list(unsigned_spend_bundle.additions()),
+                    removals=list(unsigned_spend_bundle.removals()),
+                    wallet_id=did_wallet.id(),
+                    sent_to=[],
+                    trade_id=None,
+                    type=uint32(TransactionType.OUTGOING_TX.value),
+                    name=unsigned_spend_bundle.name(),
+                    memos=list(compute_memos(unsigned_spend_bundle).items()),
+                    valid_times=parse_timelock_info(extra_conditions),
                 )
-            interface.side_effects.transactions[0] = dataclasses.replace(
-                interface.side_effects.transactions[0], spend_bundle=new_spend, name=new_spend.name()
             )
 
     async def mint_from_xch(

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -241,6 +241,7 @@ class Wallet:
         puzzle_decorator_override: Optional[list[dict[str, Any]]] = None,
         extra_conditions: tuple[Condition, ...] = tuple(),
         reserve_fee: Optional[uint64] = None,
+        preferred_change_puzzle_hash: Optional[bytes32] = None,
     ) -> list[CoinSpend]:
         """
         Generates a unsigned transaction in form of List(Puzzle, Solutions)
@@ -307,9 +308,17 @@ class Wallet:
                 ]
 
                 if change > 0:
-                    change_puzzle_hash = await action_scope.get_puzzle_hash(self.wallet_state_manager)
+                    change_puzzle_hash = (
+                        preferred_change_puzzle_hash
+                        if preferred_change_puzzle_hash is not None
+                        else await action_scope.get_puzzle_hash(self.wallet_state_manager)
+                    )
                     for primary in primaries:
                         if change_puzzle_hash == primary.puzzle_hash and change == primary.amount:
+                            if preferred_change_puzzle_hash is not None:
+                                raise ValueError(
+                                    "A `preferred_change_puzzle_hash` was specified that would make a duplicate output"
+                                )
                             # We cannot create two coins has same id, create a new puzhash for the change:
                             change_puzzle_hash = await action_scope.get_puzzle_hash(
                                 self.wallet_state_manager, override_reuse_puzhash_with=False
@@ -385,6 +394,7 @@ class Wallet:
         negative_change_allowed: bool = kwargs.get("negative_change_allowed", False)
         puzzle_decorator_override: Optional[list[dict[str, Any]]] = kwargs.get("puzzle_decorator_override", None)
         reserve_fee: Optional[uint64] = kwargs.get("reserve_fee", None)
+        preferred_change_puzzle_hash: Optional[bytes32] = kwargs.get("preferred_change_puzzle_hash", None)
         """
         Use this to generate transaction.
         Note: this must be called under a wallet state manager lock
@@ -405,6 +415,7 @@ class Wallet:
             puzzle_decorator_override=puzzle_decorator_override,
             extra_conditions=extra_conditions,
             reserve_fee=reserve_fee,
+            preferred_change_puzzle_hash=preferred_change_puzzle_hash,
         )
         assert len(transaction) > 0
         spend_bundle = WalletSpendBundle(transaction, G2Element())
@@ -450,6 +461,7 @@ class Wallet:
         coins: Optional[set[Coin]] = None,
         extra_conditions: tuple[Condition, ...] = tuple(),
         reserve_fee: Optional[uint64] = None,
+        preferred_change_puzzle_hash: Optional[bytes32] = None,
     ) -> None:
         if coins is None:
             coins = await self.select_coins(fee, action_scope)
@@ -461,6 +473,7 @@ class Wallet:
             coins=coins,
             extra_conditions=extra_conditions,
             reserve_fee=reserve_fee,
+            preferred_change_puzzle_hash=preferred_change_puzzle_hash,
         )
 
     async def get_coins_to_offer(

--- a/chia/wallet/wallet_protocol.py
+++ b/chia/wallet/wallet_protocol.py
@@ -103,3 +103,4 @@ class GSTOptionalArgs(TypedDict):
     negative_change_allowed: NotRequired[bool]
     puzzle_decorator_override: NotRequired[Optional[list[dict[str, Any]]]]
     reserve_fee: NotRequired[Optional[uint64]]
+    preferred_change_puzzle_hash: NotRequired[Optional[bytes32]]

--- a/chia/wallet/wallet_protocol.py
+++ b/chia/wallet/wallet_protocol.py
@@ -102,3 +102,4 @@ class GSTOptionalArgs(TypedDict):
     origin_id: NotRequired[Optional[bytes32]]
     negative_change_allowed: NotRequired[bool]
     puzzle_decorator_override: NotRequired[Optional[list[dict[str, Any]]]]
+    reserve_fee: NotRequired[Optional[uint64]]


### PR DESCRIPTION
This PR migrates the tests for bulk minting to the paradigmatic `WalletTestFramework`.  Unlike most PRs lately, there is a decent chunk of wallet changes accompanying this migration.

The bulk minting endpoints have been a little special cased in that there is a tool that is expected to call them higher up in the stack than exists in this codebase.  As a result, a lot of the UX around them hasn't been paid much attention because it's different than normal transactions, and they also duplicate a lot of code because of a lack of support in the supporting wallets for certain features that are unique to the endpoints.

The `WalletTestFramework` forces us to address the UX of the situation (to some extent, I think there's still work to be done) and the features that were missing (primarily in the XCH wallet) have been added.