### PR TITLE
bump clvm to version 0.9.12

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -936,22 +936,22 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "clvm"
-version = "0.9.11"
+version = "0.9.12"
 description = "[Contract Language | Chialisp] Virtual Machine"
 optional = false
 python-versions = "<4,>=3.8.1"
 files = [
-    {file = "clvm-0.9.11-py3-none-any.whl", hash = "sha256:d39df22eb32b2e9b7d39545787a8a68e18e944d551790d5da05211c8812c7111"},
-    {file = "clvm-0.9.11.tar.gz", hash = "sha256:60a644eea1c8d52a61654d4b063337b46983477d4243265e10287639e4625206"},
+    {file = "clvm-0.9.12-py3-none-any.whl", hash = "sha256:fb7aec7349ca902eee52651a31a31e8f3806ff2b10ad13d5b6e39c8ae348fee4"},
+    {file = "clvm-0.9.12.tar.gz", hash = "sha256:c14c8c63ee70be05df1df5b211ff5f170033e9de9eaaffa7edc3a4fa8c03a4be"},
 ]
 
 [package.dependencies]
-chia-rs = ">=0.2.13"
-importlib-metadata = ">=7.1,<8.0"
+chia_rs = ">=0.2.13"
+importlib_metadata = ">=7.1,<8.0"
 typing-extensions = ">=4.0,<5.0"
 
 [package.extras]
-dev = ["clvm-tools (>=0.4.4)", "mypy", "pytest", "setuptools", "types-setuptools"]
+dev = ["clvm_tools (>=0.4.4)", "mypy", "pytest", "setuptools", "types-setuptools"]
 
 [[package]]
 name = "clvm-rs"
@@ -3337,4 +3337,4 @@ upnp = ["miniupnpc"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9, <4"
-content-hash = "f122ad7c51f8ed6947a2c47fd320ad7a8de4b0cf197229e4b635a59f77b57901"
+content-hash = "54e86b1cfad6c1c46aa105a0ef9837e0ee7f67dd7f15e453c0b96feeabd46393"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ chia-puzzles-py = ">=0.20.1"
 chia_rs = ">=0.21.1"
 chiavdf = ">=1.1.10"  # timelord and vdf verification
 click = ">=8.1.7"  # For the CLI
-clvm = ">=0.9.11"
+clvm = ">=0.9.12"
 clvm_tools = ">=0.4.9"  # Currying Program.to other conveniences
 clvm_tools_rs = ">=0.1.45"  # Rust implementation of clvm_tools' compiler
 colorama = ">=0.4.6"  # Colorizes terminal output


### PR DESCRIPTION
### Purpose:

bump `clvm` to latest version. changelog is [here](https://github.com/Chia-Network/clvm/releases/tag/0.9.12).
