### PR TITLE
[CHIA-2636] Remove direct secret key access from pool wallet

### DIFF
--- a/chia/_tests/pools/test_pool_cmdline.py
+++ b/chia/_tests/pools/test_pool_cmdline.py
@@ -808,7 +808,7 @@ async def test_plotnft_cli_inspect(
 
     assert (
         json_output["pool_wallet_info"]["current"]["owner_pubkey"]
-        == "0xb286bbf7a10fa058d2a2a758921377ef00bb7f8143e1bd40dd195ae918dbef42cfc481140f01b9eae13b430a0c8fe304"
+        == "0x880afd6f9e123005655376e389015877e60060b768592809d2c746325d256edeb0017e1b406cba0832aa983e5c4bbf54"
     )
     assert json_output["pool_wallet_info"]["current"]["state"] == PoolSingletonState.FARMING_TO_POOL.value
 
@@ -833,7 +833,7 @@ async def test_plotnft_cli_inspect(
 
     assert (
         json_output["pool_wallet_info"]["current"]["owner_pubkey"]
-        == "0x893474c97d04a0283483ba1af9e070768dff9e9a83d9ae2cf00a34be96ca29aec387dfb7474f2548d777000e5463f602"
+        == "0xb286bbf7a10fa058d2a2a758921377ef00bb7f8143e1bd40dd195ae918dbef42cfc481140f01b9eae13b430a0c8fe304"
     )
 
     assert json_output["pool_wallet_info"]["current"]["state"] == PoolSingletonState.SELF_POOLING.value

--- a/chia/_tests/pools/test_pool_rpc.py
+++ b/chia/_tests/pools/test_pool_rpc.py
@@ -476,11 +476,8 @@ class TestPoolWalletRpc:
                 pool_list = full_config["pool"]["pool_list"]
                 assert len(pool_list) == i + 3
                 if i == 0:
-                    # Ensures that the CAT creation does not cause pool wallet IDs to increment
-                    max_id = 0
                     for some_wallet in wallet_node.wallet_state_manager.wallets.values():
                         if some_wallet.type() == WalletType.POOLING_WALLET:
-                            max_id = max(max_id, some_wallet.id())
                             status: PoolWalletInfo = (await client.pw_status(some_wallet.id()))[0]
                             auth_sk = find_authentication_sk(
                                 [some_wallet.wallet_state_manager.get_master_private_key()], status.current.owner_pubkey
@@ -491,7 +488,6 @@ class TestPoolWalletRpc:
                             )
                             assert owner_sk is not None
                             assert owner_sk[0] != auth_sk
-                    assert max_id < 5
 
     @pytest.mark.anyio
     async def test_absorb_self(

--- a/chia/_tests/pools/test_pool_rpc.py
+++ b/chia/_tests/pools/test_pool_rpc.py
@@ -301,7 +301,7 @@ class TestPoolWalletRpc:
         assert status.target is None
         assert status.current.owner_pubkey == G1Element.from_bytes(
             bytes.fromhex(
-                "b286bbf7a10fa058d2a2a758921377ef00bb7f8143e1bd40dd195ae918dbef42cfc481140f01b9eae13b430a0c8fe304"
+                "880afd6f9e123005655376e389015877e60060b768592809d2c746325d256edeb0017e1b406cba0832aa983e5c4bbf54"
             )
         )
         assert status.current.pool_url == ""
@@ -314,7 +314,7 @@ class TestPoolWalletRpc:
         pool_config = pool_list[0]
         assert (
             pool_config["owner_public_key"]
-            == "0xb286bbf7a10fa058d2a2a758921377ef00bb7f8143e1bd40dd195ae918dbef42cfc481140f01b9eae13b430a0c8fe304"
+            == "0x880afd6f9e123005655376e389015877e60060b768592809d2c746325d256edeb0017e1b406cba0832aa983e5c4bbf54"
         )
         # It can be one of multiple launcher IDs, due to selecting a different coin
         launcher_id = None
@@ -354,7 +354,7 @@ class TestPoolWalletRpc:
         assert status.target is None
         assert status.current.owner_pubkey == G1Element.from_bytes(
             bytes.fromhex(
-                "b286bbf7a10fa058d2a2a758921377ef00bb7f8143e1bd40dd195ae918dbef42cfc481140f01b9eae13b430a0c8fe304"
+                "880afd6f9e123005655376e389015877e60060b768592809d2c746325d256edeb0017e1b406cba0832aa983e5c4bbf54"
             )
         )
         assert status.current.pool_url == "http://pool.example.com"
@@ -367,7 +367,7 @@ class TestPoolWalletRpc:
         pool_config = pool_list[0]
         assert (
             pool_config["owner_public_key"]
-            == "0xb286bbf7a10fa058d2a2a758921377ef00bb7f8143e1bd40dd195ae918dbef42cfc481140f01b9eae13b430a0c8fe304"
+            == "0x880afd6f9e123005655376e389015877e60060b768592809d2c746325d256edeb0017e1b406cba0832aa983e5c4bbf54"
         )
         # It can be one of multiple launcher IDs, due to selecting a different coin
         launcher_id = None
@@ -477,10 +477,11 @@ class TestPoolWalletRpc:
                 assert len(pool_list) == i + 3
                 if i == 0:
                     # Ensures that the CAT creation does not cause pool wallet IDs to increment
+                    max_id = 0
                     for some_wallet in wallet_node.wallet_state_manager.wallets.values():
                         if some_wallet.type() == WalletType.POOLING_WALLET:
+                            max_id = max(max_id, some_wallet.id())
                             status: PoolWalletInfo = (await client.pw_status(some_wallet.id()))[0]
-                            assert (await some_wallet.get_pool_wallet_index()) < 5
                             auth_sk = find_authentication_sk(
                                 [some_wallet.wallet_state_manager.get_master_private_key()], status.current.owner_pubkey
                             )
@@ -490,6 +491,7 @@ class TestPoolWalletRpc:
                             )
                             assert owner_sk is not None
                             assert owner_sk[0] != auth_sk
+                    assert max_id < 5
 
     @pytest.mark.anyio
     async def test_absorb_self(

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -5,7 +5,7 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
-from chia_rs import G1Element, G2Element, PrivateKey
+from chia_rs import G1Element, G2Element
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64, uint128
 from typing_extensions import Unpack, final
@@ -80,7 +80,6 @@ class PoolWallet:
     next_transaction_fee: uint64 = uint64(0)
     next_tx_config: TXConfig = DEFAULT_TX_CONFIG
     target_state: Optional[PoolState] = None
-    _owner_sk_and_index: Optional[tuple[PrivateKey, uint32]] = None
 
     """
     From the user's perspective, this is not a wallet at all, but a way to control

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -43,7 +43,6 @@ from chia.types.blockchain_format.program import Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.wallet.conditions import AssertCoinAnnouncement, Condition, ConditionValidTimes
-from chia.wallet.derive_keys import find_owner_sk
 from chia.wallet.puzzles.singleton_top_layer import SINGLETON_LAUNCHER
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
@@ -444,18 +443,6 @@ class PoolWallet:
         )
 
         return p2_singleton_puzzle_hash, launcher_coin_id
-
-    async def _get_owner_key_cache(self) -> tuple[PrivateKey, uint32]:
-        if self._owner_sk_and_index is None:
-            self._owner_sk_and_index = find_owner_sk(
-                [self.wallet_state_manager.get_master_private_key()],
-                (await self.get_current_state()).current.owner_pubkey,
-            )
-        assert self._owner_sk_and_index is not None
-        return self._owner_sk_and_index
-
-    async def get_pool_wallet_index(self) -> uint32:
-        return (await self._get_owner_key_cache())[1]
 
     async def generate_fee_transaction(
         self,

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -1126,6 +1126,7 @@ class WalletRpcApi:
                         raise ValueError(f"Too many pool wallets ({max_pwi}), cannot create any more on this key.")
 
                     owner_pk: G1Element = self.service.wallet_state_manager.main_wallet.hardened_pubkey_for_path(
+                        # copied from chia.wallet.derive_keys. Could maybe be an exported constant in the future.
                         [12381, 8444, 5, max_pwi]
                     )
 

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -109,7 +109,6 @@ from chia.wallet.derive_keys import (
     MAX_POOL_WALLETS,
     master_sk_to_farmer_sk,
     master_sk_to_pool_sk,
-    master_sk_to_singleton_owner_sk,
     match_address_to_sk,
 )
 from chia.wallet.did_wallet import did_wallet_puzzles
@@ -1121,17 +1120,14 @@ class WalletRpcApi:
                     max_pwi = 1
                     for _, wallet in self.service.wallet_state_manager.wallets.items():
                         if wallet.type() == WalletType.POOLING_WALLET:
-                            assert isinstance(wallet, PoolWallet)
-                            pool_wallet_index = await wallet.get_pool_wallet_index()
-                            max_pwi = max(max_pwi, pool_wallet_index)
+                            max_pwi += 1
 
                     if max_pwi + 1 >= (MAX_POOL_WALLETS - 1):
                         raise ValueError(f"Too many pool wallets ({max_pwi}), cannot create any more on this key.")
 
-                    owner_sk: PrivateKey = master_sk_to_singleton_owner_sk(
-                        self.service.wallet_state_manager.get_master_private_key(), uint32(max_pwi + 1)
+                    owner_pk: G1Element = self.service.wallet_state_manager.main_wallet.hardened_pubkey_for_path(
+                        [12381, 8444, 5, max_pwi]
                     )
-                    owner_pk: G1Element = owner_sk.get_g1()
 
                     initial_target_state = initial_pool_state_from_dict(
                         request["initial_target_state"], owner_pk, owner_puzzle_hash

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -522,6 +522,9 @@ class Wallet:
                 return True
         return False
 
+    def hardened_pubkey_for_path(self, path: list[int]) -> G1Element:
+        return _derive_path(self.wallet_state_manager.get_master_private_key(), path).get_g1()
+
     async def sum_hint_for_pubkey(self, pk: bytes) -> Optional[SumHint]:
         pk_parsed: G1Element = G1Element.from_bytes(pk)
         dr: Optional[DerivationRecord] = await self.wallet_state_manager.puzzle_store.record_for_puzzle_hash(


### PR DESCRIPTION
This deletes a little bit of code in service of having all of the private key access in the wallet being grouped together so it's prepared for migration eventually to the daemon.