### PR TITLE
CHIA-2645 Remove no longer needed TestNodeLoad class

### DIFF
--- a/chia/_tests/core/full_node/test_node_load.py
+++ b/chia/_tests/core/full_node/test_node_load.py
@@ -8,27 +8,26 @@ from chia._tests.util.time_out_assert import time_out_assert
 from chia.types.peer_info import PeerInfo
 
 
-class TestNodeLoad:
-    @pytest.mark.anyio
-    async def test_blocks_load(self, two_nodes, self_hostname, benchmark_runner: BenchmarkRunner):
-        num_blocks = 50
-        full_node_1, full_node_2, server_1, server_2, bt = two_nodes
-        blocks = bt.get_consecutive_blocks(num_blocks)
-        await full_node_1.full_node.add_block(blocks[0])
-        await time_out_assert(10, node_height_at_least, True, full_node_1, 0)
-        await server_2.start_client(
-            PeerInfo(self_hostname, server_1.get_port()), on_connect=full_node_2.full_node.on_connect
-        )
+@pytest.mark.anyio
+async def test_blocks_load(two_nodes, self_hostname, benchmark_runner: BenchmarkRunner):
+    num_blocks = 50
+    full_node_1, full_node_2, server_1, server_2, bt = two_nodes
+    blocks = bt.get_consecutive_blocks(num_blocks)
+    await full_node_1.full_node.add_block(blocks[0])
+    await time_out_assert(10, node_height_at_least, True, full_node_1, 0)
+    await server_2.start_client(
+        PeerInfo(self_hostname, server_1.get_port()), on_connect=full_node_2.full_node.on_connect
+    )
 
-        async def num_connections():
-            return len(server_2.get_connections())
+    async def num_connections():
+        return len(server_2.get_connections())
 
-        await time_out_assert(10, num_connections, 1)
-        await time_out_assert(10, node_height_at_least, True, full_node_2, 0)
+    await time_out_assert(10, num_connections, 1)
+    await time_out_assert(10, node_height_at_least, True, full_node_2, 0)
 
-        with benchmark_runner.assert_runtime(seconds=100) as runtime_results_future:
-            for i in range(1, num_blocks):
-                await full_node_1.full_node.add_block(blocks[i])
-                await full_node_2.full_node.add_block(blocks[i])
-        runtime_results = runtime_results_future.result(timeout=0)
-        print(f"Time taken to process {num_blocks} is {runtime_results.duration}")
+    with benchmark_runner.assert_runtime(seconds=100) as runtime_results_future:
+        for i in range(1, num_blocks):
+            await full_node_1.full_node.add_block(blocks[i])
+            await full_node_2.full_node.add_block(blocks[i])
+    runtime_results = runtime_results_future.result(timeout=0)
+    print(f"Time taken to process {num_blocks} is {runtime_results.duration}")


### PR DESCRIPTION
### Purpose:

As we're using pytest instead of unittest, this class isn't needed anymore.

### Current Behavior:

Tests are grouped into a `TestNodeLoad` class.

### New Behavior:

Tests are no longer grouped into a `TestNodeLoad` class.