### PR TITLE
CHIA-2646 Fix create_block_generator2 to perform identical spend deduplication using the mempool item's potentially fast forwarded coin spends data

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -699,14 +699,14 @@ class Mempool:
             try:
                 assert item.conds is not None
                 cost = item.conds.condition_cost + item.conds.execution_cost
-                await eligible_coin_spends.process_fast_forward_spends(
+                bundle_coin_spends = await eligible_coin_spends.process_fast_forward_spends(
                     mempool_item=item,
                     get_unspent_lineage_info_for_puzzle_hash=get_unspent_lineage_info_for_puzzle_hash,
                     height=height,
                     constants=constants,
                 )
                 unique_coin_spends, cost_saving, unique_additions = eligible_coin_spends.get_deduplication_info(
-                    bundle_coin_spends=item.bundle_coin_spends, max_cost=cost
+                    bundle_coin_spends=bundle_coin_spends, max_cost=cost
                 )
                 new_fee_sum = fee_sum + fee
                 if new_fee_sum > DEFAULT_CONSTANTS.MAX_COIN_AMOUNT:


### PR DESCRIPTION
### Purpose:

When we introduced `create_block_generator2` in PR #19270 it unintentionally used the mempool item's vanilla coin spends data, instead of the fast forwarded one. This corrects that.

### Current Behavior:

`create_block_generator2`, unlike `create_block_generator`, uses the mempool item's coin spends data without any consideration for potentially fast forwarded spends.

### New Behavior:

`create_block_generator2` uses the mempool item's potentially fast forwarded coin spends data just like `create_block_generator` does.