### PR TITLE
[CHIA-2541] validate more of cached test chains

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
         python-version: ["3.10"]
     env:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
-      BLOCKS_AND_PLOTS_VERSION: 0.41.0
+      BLOCKS_AND_PLOTS_VERSION: 0.43.0
 
     steps:
       - name: Clean workspace

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -126,7 +126,7 @@ jobs:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
       CHIA_SIMULATOR_ROOT: ${{ github.workspace }}/.chia/simulator
       JOB_FILE_NAME: tests_${{ matrix.os.file_name }}_python-${{ matrix.python.file_name }}_${{ matrix.configuration.module_import_path }}${{ matrix.configuration.file_name_index }}
-      BLOCKS_AND_PLOTS_VERSION: 0.41.0
+      BLOCKS_AND_PLOTS_VERSION: 0.43.0
 
     steps:
       - name: Configure git

--- a/chia/_tests/blockchain/test_build_chains.py
+++ b/chia/_tests/blockchain/test_build_chains.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-import pytest
+from typing import Optional
 
+import pytest
+from chia_rs.sized_ints import uint64
+
+from chia.simulator.block_tools import BlockTools
 from chia.types.full_block import FullBlock
 
 # These test targets are used to trigger a build of the test chains.
@@ -57,3 +61,164 @@ def test_trigger_default_2000_compact(default_2000_blocks_compact: list[FullBloc
 @pytest.mark.build_test_chains
 def test_trigger_default_10000_compact(default_10000_blocks_compact: list[FullBlock]) -> None:
     pass
+
+
+def validate_chain(
+    bt: BlockTools,
+    blocks: list[FullBlock],
+    *,
+    seed: bytes = b"",
+    empty_sub_slots: int = 0,
+    normalized_to_identity_cc_eos: bool = False,
+    normalized_to_identity_icc_eos: bool = False,
+    normalized_to_identity_cc_sp: bool = False,
+    normalized_to_identity_cc_ip: bool = False,
+    block_list_input: Optional[list[FullBlock]] = None,
+    time_per_block: Optional[float] = None,
+    dummy_block_references: bool = False,
+    include_transactions: bool = False,
+) -> None:
+    # make sure that the blocks we found on-disk are consistent with
+    # the ones we would have generated
+    input_length = len(block_list_input) if block_list_input else 0
+
+    # 80 blocks is a balance between capturing all features of the
+    # chains (such as block references) versus the cost of
+    # generating and comparing blocks.
+    request_length = min(80, len(blocks) - input_length)
+
+    expected_blocks: list[FullBlock] = bt.get_consecutive_blocks(
+        request_length,
+        block_list_input=block_list_input,
+        time_per_block=time_per_block,
+        seed=seed,
+        skip_slots=empty_sub_slots,
+        normalized_to_identity_cc_eos=normalized_to_identity_cc_eos,
+        normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
+        normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
+        normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
+        dummy_block_references=dummy_block_references,
+        include_transactions=include_transactions,
+        genesis_timestamp=uint64(1234567890),
+    )
+    assert len(expected_blocks) - request_length == input_length
+    # if this assert fails, and changing the test chains was
+    # intentional, please also update the test chain cache.
+    # run: pytest -m build_test_chains
+    for i in range(input_length, len(expected_blocks)):
+        print(f"i: {i}")
+        if blocks[i] != expected_blocks[i]:  # pragma: no cover
+            print(
+                f"Block {i} in the block cache on disk differs "
+                "from what BlockTools generated. Please make sure "
+                "your test blocks are up-to-date"
+            )
+            print(f"disk:\n{blocks[i]}")
+            print(f"block-tools:\n{expected_blocks[i]}")
+        assert blocks[i] == expected_blocks[i]
+
+
+def test_validate_default_400(bt: BlockTools, default_400_blocks: list[FullBlock]) -> None:
+    validate_chain(bt, default_400_blocks, seed=b"400")
+
+
+def test_validate_default_1000(bt: BlockTools, default_1000_blocks: list[FullBlock]) -> None:
+    validate_chain(bt, default_1000_blocks, seed=b"1000")
+
+
+def test_validate_pre_genesis_empty_1000(bt: BlockTools, pre_genesis_empty_slots_1000_blocks: list[FullBlock]) -> None:
+    validate_chain(bt, pre_genesis_empty_slots_1000_blocks, seed=b"empty_slots", empty_sub_slots=1)
+
+
+def test_validate_default_1500(bt: BlockTools, default_1500_blocks: list[FullBlock]) -> None:
+    validate_chain(bt, default_1500_blocks, seed=b"1500")
+
+
+def test_validate_default_10000(
+    bt: BlockTools,
+    default_10000_blocks: list[FullBlock],
+) -> None:
+    validate_chain(
+        bt,
+        default_10000_blocks,
+        seed=b"10000",
+        dummy_block_references=True,
+    )
+
+
+def test_validate_default_2000_compact(bt: BlockTools, default_2000_blocks_compact: list[FullBlock]) -> None:
+    validate_chain(
+        bt,
+        default_2000_blocks_compact,
+        normalized_to_identity_cc_eos=True,
+        normalized_to_identity_icc_eos=True,
+        normalized_to_identity_cc_ip=True,
+        normalized_to_identity_cc_sp=True,
+        seed=b"2000_compact",
+    )
+
+
+def test_validate_default_10000_compact(bt: BlockTools, default_10000_blocks_compact: list[FullBlock]) -> None:
+    validate_chain(
+        bt,
+        default_10000_blocks_compact,
+        normalized_to_identity_cc_eos=True,
+        normalized_to_identity_icc_eos=True,
+        normalized_to_identity_cc_ip=True,
+        normalized_to_identity_cc_sp=True,
+        seed=b"1000_compact",
+    )
+
+
+def test_validate_long_reorg_blocks(
+    bt: BlockTools, test_long_reorg_blocks: list[FullBlock], default_10000_blocks: list[FullBlock]
+) -> None:
+    validate_chain(
+        bt,
+        test_long_reorg_blocks,
+        block_list_input=default_10000_blocks[:500],
+        seed=b"reorg_blocks",
+        time_per_block=8,
+        dummy_block_references=True,
+        include_transactions=True,
+    )
+
+
+def test_validate_long_reorg_blocks_light(
+    bt: BlockTools, test_long_reorg_blocks_light: list[FullBlock], default_10000_blocks: list[FullBlock]
+) -> None:
+    validate_chain(
+        bt,
+        test_long_reorg_blocks_light,
+        block_list_input=default_10000_blocks[:500],
+        seed=b"reorg_blocks2",
+        dummy_block_references=True,
+        include_transactions=True,
+    )
+
+
+def test_validate_long_reorg_1500_blocks(
+    bt: BlockTools, test_long_reorg_1500_blocks: list[FullBlock], default_10000_blocks: list[FullBlock]
+) -> None:
+    validate_chain(
+        bt,
+        test_long_reorg_1500_blocks,
+        block_list_input=default_10000_blocks[:1500],
+        seed=b"reorg_blocks",
+        time_per_block=8,
+        dummy_block_references=True,
+        include_transactions=True,
+    )
+
+
+def test_validate_long_reorg_1500_blocks_light(
+    bt: BlockTools, test_long_reorg_1500_blocks_light: list[FullBlock], default_10000_blocks: list[FullBlock]
+) -> None:
+    validate_chain(
+        bt,
+        test_long_reorg_1500_blocks_light,
+        block_list_input=default_10000_blocks[:1500],
+        seed=b"reorg_blocks2",
+        dummy_block_references=True,
+        include_transactions=True,
+    )

--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -468,6 +468,11 @@ def default_10000_blocks_compact(bt, consensus_mode):
     )
 
 
+# If you add another test chain, don't forget to also add a "build_test_chains"
+# generator to chia/_tests/blockchain/test_build_chains.py as well as a test in
+# the same file.
+
+
 @pytest.fixture(scope="function")
 def tmp_dir():
     with tempfile.TemporaryDirectory() as folder:

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2538,6 +2538,7 @@ async def validate_coin_set(coin_store: CoinStore, blocks: list[FullBlock]) -> N
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("light_blocks", [True, False])
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="save time")
 async def test_long_reorg(
     light_blocks: bool,
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -2549,14 +2550,15 @@ async def test_long_reorg(
     node, _server, _bt = one_node_one_block
 
     fork_point = 1499
-    blocks = default_10000_blocks[:3000]
 
     if light_blocks:
         # if the blocks have lighter weight, we need more height to compensate,
         # to force a reorg
-        reorg_blocks = test_long_reorg_1500_blocks_light[:3050]
+        reorg_blocks = test_long_reorg_1500_blocks_light[:1950]
+        blocks = default_10000_blocks[:1900]
     else:
-        reorg_blocks = test_long_reorg_1500_blocks[:2700]
+        reorg_blocks = test_long_reorg_1500_blocks[:2300]
+        blocks = default_10000_blocks[:3000]
 
     await add_blocks_in_batches(blocks, node.full_node)
     peak = node.full_node.blockchain.get_peak()
@@ -2623,7 +2625,10 @@ async def test_long_reorg_nodes(
     fork_point: int,
     three_nodes: list[FullNodeAPI],
     default_10000_blocks: list[FullBlock],
-    test_long_reorg_blocks: list[FullBlock],
+    # this is commented out because it's currently only used by a skipped test.
+    # If we ever want to un-skip the test, we need this fixture again. Loading
+    # these blocks from disk takes non-trivial time
+    # test_long_reorg_blocks: list[FullBlock],
     test_long_reorg_blocks_light: list[FullBlock],
     test_long_reorg_1500_blocks: list[FullBlock],
     test_long_reorg_1500_blocks_light: list[FullBlock],
@@ -2636,26 +2641,28 @@ async def test_long_reorg_nodes(
     assert full_node_2.full_node._coin_store is not None
     assert full_node_3.full_node._coin_store is not None
 
-    if fork_point == 1500:
-        blocks = default_10000_blocks[: 3600 - chain_length]
-    else:
-        blocks = default_10000_blocks[: 1600 - chain_length]
-
     if light_blocks:
         if fork_point == 1500:
-            reorg_blocks = test_long_reorg_1500_blocks_light[: 3600 - chain_length]
-            reorg_height = 4000
+            blocks = default_10000_blocks[: 3105 - chain_length]
+            reorg_blocks = test_long_reorg_1500_blocks_light[: 3105 - chain_length]
+            reorg_height = 3300
         else:
+            blocks = default_10000_blocks[: 1600 - chain_length]
             reorg_blocks = test_long_reorg_blocks_light[: 1600 - chain_length]
-            reorg_height = 4000
+            reorg_height = 2000
     else:
         if fork_point == 1500:
-            reorg_blocks = test_long_reorg_1500_blocks[: 3100 - chain_length]
-            reorg_height = 10000
-        else:
-            reorg_blocks = test_long_reorg_blocks[: 1200 - chain_length]
-            reorg_height = 4000
+            blocks = default_10000_blocks[: 1900 - chain_length]
+            reorg_blocks = test_long_reorg_1500_blocks[: 1900 - chain_length]
+            reorg_height = 2300
+        else:  # pragma: no cover
             pytest.skip("We rely on the light-blocks test for a 0 forkpoint")
+            blocks = default_10000_blocks[: 1100 - chain_length]
+            # reorg_blocks = test_long_reorg_blocks[: 1100 - chain_length]
+            reorg_height = 1600
+
+    # this is a pre-requisite for a reorg to happen
+    assert default_10000_blocks[reorg_height].weight > reorg_blocks[-1].weight
 
     await add_blocks_in_batches(blocks, full_node_1.full_node)
 

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2504,9 +2504,9 @@ async def validate_coin_set(coin_store: CoinStore, blocks: list[FullBlock]) -> N
             assert records == {}
             continue
 
-        if len(block.transactions_generator_ref_list) > 0:  # pragma: no cover
-            # TODO: Support block references
-            assert False
+        # TODO: Support block references
+        # if len(block.transactions_generator_ref_list) > 0:
+        #    assert False
 
         flags = get_flags_for_height_and_constants(block.height, test_constants)
         additions, removals = additions_and_removals(bytes(block.transactions_generator), [], flags, test_constants)

--- a/chia/_tests/util/blockchain.py
+++ b/chia/_tests/util/blockchain.py
@@ -75,39 +75,6 @@ def persistent_blocks(
             if len(blocks) == num_of_blocks + len(block_list_input):
                 print(f"\n loaded {file_path} with {len(blocks)} blocks")
 
-                # make sure that the blocks we found on-disk are consistent with
-                # the ones we would have generated
-                # 40 blocks is a balance between capturing all features of the
-                # chains (such as block references) versus the cost of
-                # generating and comparing blocks.
-                expected_blocks: list[FullBlock] = bt.get_consecutive_blocks(
-                    40,
-                    block_list_input=block_list_input,
-                    time_per_block=time_per_block,
-                    seed=seed,
-                    skip_slots=empty_sub_slots,
-                    normalized_to_identity_cc_eos=normalized_to_identity_cc_eos,
-                    normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
-                    normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
-                    normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
-                    dummy_block_references=dummy_block_references,
-                    include_transactions=include_transactions,
-                    genesis_timestamp=uint64(1234567890),
-                )
-                # if this assert fails, and changing the test chains was
-                # intentional, please also update the test chain cache.
-                # run: pytest -m build_test_chains
-                for i in range(len(expected_blocks)):
-                    if blocks[i] != expected_blocks[i]:  # pragma: no cover
-                        print(
-                            f"Block {i} in the block cache on disk differs "
-                            "from what BlockTools generated. Please make sure "
-                            "your test blocks are up-to-date"
-                        )
-                        print(f"disk:\n{blocks[i]}")
-                        print(f"block-tools:\n{expected_blocks[i]}")
-                    assert blocks[i] == expected_blocks[i]
-
                 return blocks
         except EOFError:
             print("\n error reading db file")

--- a/chia/_tests/util/blockchain.py
+++ b/chia/_tests/util/blockchain.py
@@ -78,7 +78,7 @@ def persistent_blocks(
                 # make sure that the blocks we found on-disk are consistent with
                 # the ones we would have generated
                 expected_blocks: list[FullBlock] = bt.get_consecutive_blocks(
-                    5,
+                    40,
                     block_list_input=block_list_input,
                     time_per_block=time_per_block,
                     seed=seed,
@@ -94,7 +94,7 @@ def persistent_blocks(
                 # if this assert fails, and changing the test chains was
                 # intentional, please also update the test chain cache.
                 # run: pytest -m build_test_chains
-                for i in range(5):
+                for i in range(40):
                     if blocks[i] != expected_blocks[i]:  # pragma: no cover
                         print(
                             f"Block {i} in the block cache on disk differs "

--- a/chia/_tests/util/blockchain.py
+++ b/chia/_tests/util/blockchain.py
@@ -77,6 +77,9 @@ def persistent_blocks(
 
                 # make sure that the blocks we found on-disk are consistent with
                 # the ones we would have generated
+                # 40 blocks is a balance between capturing all features of the
+                # chains (such as block references) versus the cost of
+                # generating and comparing blocks.
                 expected_blocks: list[FullBlock] = bt.get_consecutive_blocks(
                     40,
                     block_list_input=block_list_input,
@@ -94,7 +97,7 @@ def persistent_blocks(
                 # if this assert fails, and changing the test chains was
                 # intentional, please also update the test chain cache.
                 # run: pytest -m build_test_chains
-                for i in range(40):
+                for i in range(len(expected_blocks)):
                     if blocks[i] != expected_blocks[i]:  # pragma: no cover
                         print(
                             f"Block {i} in the block cache on disk differs "

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -132,6 +132,8 @@ def create_foliage(
         assert prev_block is not None
         prev_block_hash = prev_block.header_hash
 
+    generator_block_heights_list: list[uint32] = []
+
     foliage_transaction_block_hash: Optional[bytes32]
 
     if is_transaction_block:
@@ -192,6 +194,7 @@ def create_foliage(
             byte_array_tx.append(bytearray(coin.puzzle_hash))
 
         if new_block_gen is not None:
+            generator_block_heights_list = new_block_gen.block_refs
             for coin in new_block_gen.additions:
                 tx_additions.append(coin)
                 byte_array_tx.append(bytearray(coin.puzzle_hash))
@@ -227,6 +230,10 @@ def create_foliage(
             generator_hash = std_hash(new_block_gen.program)
 
         generator_refs_hash = bytes32([1] * 32)
+        if generator_block_heights_list not in (None, []):
+            generator_ref_list_bytes = b"".join([i.stream_to_bytes() for i in generator_block_heights_list])
+            generator_refs_hash = std_hash(generator_ref_list_bytes)
+
         filter_hash: bytes32 = std_hash(encoded)
 
         transactions_info: Optional[TransactionsInfo] = TransactionsInfo(

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -828,13 +828,13 @@ class BlockTools:
                                 pool_target = PoolTarget(self.pool_ph, uint32(0))
 
                         if dummy_block_references and len(tx_block_heights) > 4:
-                            block_refs.extend(
-                                [
-                                    tx_block_heights[1],
-                                    tx_block_heights[len(tx_block_heights) // 2],
-                                    tx_block_heights[-2],
-                                ]
-                            )
+                            dummy_refs = [
+                                tx_block_heights[1],
+                                tx_block_heights[len(tx_block_heights) // 2],
+                                tx_block_heights[-2],
+                            ]
+                        else:
+                            dummy_refs = []
 
                         new_gen: Optional[NewBlockGenerator]
                         if transaction_data is not None:
@@ -870,7 +870,7 @@ class BlockTools:
                             new_gen = NewBlockGenerator(
                                 program,
                                 [],
-                                block_refs,
+                                block_refs + dummy_refs,
                                 transaction_data.aggregated_signature,
                                 additions,
                                 removals,
@@ -880,7 +880,7 @@ class BlockTools:
                         elif dummy_block_references:
                             program = SerializedProgram.from_bytes(solution_generator([]))
                             cost = compute_block_cost(program, constants, uint32(curr.height + 1))
-                            new_gen = NewBlockGenerator(program, [], block_refs, G2Element(), [], [], cost)
+                            new_gen = NewBlockGenerator(program, [], block_refs + dummy_refs, G2Element(), [], [], cost)
                         else:
                             new_gen = None
 
@@ -1163,13 +1163,13 @@ class BlockTools:
                                 pool_target = PoolTarget(self.pool_ph, uint32(0))
 
                         if dummy_block_references and len(tx_block_heights) > 4:
-                            block_refs.extend(
-                                [
-                                    tx_block_heights[1],
-                                    tx_block_heights[len(tx_block_heights) // 2],
-                                    tx_block_heights[-2],
-                                ]
-                            )
+                            dummy_refs = [
+                                tx_block_heights[1],
+                                tx_block_heights[len(tx_block_heights) // 2],
+                                tx_block_heights[-2],
+                            ]
+                        else:
+                            dummy_refs = []
 
                         if transaction_data is not None:
                             # this means the caller passed in transaction_data
@@ -1204,7 +1204,7 @@ class BlockTools:
                             new_gen = NewBlockGenerator(
                                 program,
                                 [],
-                                block_refs,
+                                block_refs + dummy_refs,
                                 transaction_data.aggregated_signature,
                                 additions,
                                 removals,
@@ -1214,7 +1214,7 @@ class BlockTools:
                         elif dummy_block_references:
                             program = SerializedProgram.from_bytes(solution_generator([]))
                             cost = compute_block_cost(program, constants, uint32(curr.height + 1))
-                            new_gen = NewBlockGenerator(program, [], block_refs, G2Element(), [], [], cost)
+                            new_gen = NewBlockGenerator(program, [], block_refs + dummy_refs, G2Element(), [], [], cost)
                         else:
                             new_gen = None
 


### PR DESCRIPTION
check 80 blocks instead of 5 when loading test chains from disk.

This caught an issue where the dummy references stopped working when the last test chains were generated. This fixes that issue And will require the test chains to be updated. Hopefully "locked in" this time.

The validation of the cached chains are also moved from every time they're loaded from disk (which slows down all tests) to their own tests. The new validation of cached chains were added to `chia/_tests/blockchain/test_build_chains.py` and improved to:

1. check the first 80 blocks, instead of just 5
2. correctly check the diverging blocks, when another test chain is used as the first few blocks
3. validate that generators spend coins that exists with a simple coin set model

### Purpose:

Improve fidelity and performance of the validation of cached test chains.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
