### PR TITLE
bump clvm to version 0.9.12

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3522,4 +3522,4 @@ upnp = ["miniupnpc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9, <4"
-content-hash = "2d8cad1cff51663123dec0890d07b2bb785a6719bfbc2a9c9800838712513274"
+content-hash = "20a8e85b3354d63c73352721a75225f583eb535a323e6602fff85593c3d3b315"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ chia-puzzles-py = ">=0.20.1"
 chia_rs = ">=0.21.2"
 chiavdf = ">=1.1.10"  # timelord and vdf verification
 click = ">=8.1.7"  # For the CLI
-clvm = ">=0.9.11"
+clvm = ">=0.9.12"
 clvm_tools = ">=0.4.9"  # Currying Program.to other conveniences
 clvm_tools_rs = ">=0.1.45"  # Rust implementation of clvm_tools' compiler
 colorama = ">=0.4.6"  # Colorizes terminal output


### PR DESCRIPTION
### Purpose:

bump `clvm` to latest version. changelog is [here](https://github.com/Chia-Network/clvm/releases/tag/0.9.12).
