### PR TITLE
Allow DIDs from other wallets with NIL recovery lists

### DIFF
--- a/chia/_tests/cmds/wallet/test_did.py
+++ b/chia/_tests/cmds/wallet/test_did.py
@@ -26,19 +26,6 @@ from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 test_condition_valid_times: ConditionValidTimes = ConditionValidTimes(min_time=uint64(100), max_time=uint64(150))
 
 
-# @pytest.mark.parametrize(
-#     argnames=["program", "result"],
-#     argvalues=[
-#         (Program.to(NIL_TREEHASH), NIL_TREEHASH),
-#         (NIL, alternate_wallet_nil_recovery_list_bytes),
-#         (Program.to(bytes32([1] * 32)), bytes32([1] * 32)),
-#     ],
-# )
-# def test_did_recovery_as_bytes(program: Program, result: bytes32) -> None:
-#     # test that the alternate wallet nil recovery list bytes are used
-#     assert did_recovery_as_bytes(program) == result
-
-
 @pytest.mark.parametrize(
     argnames=["program", "result"],
     argvalues=[
@@ -53,8 +40,6 @@ def test_did_recovery_is_nil(program: Program, result: bool) -> None:
 
 
 # DID Commands
-
-
 def test_did_create(capsys: object, get_test_cli_clients: tuple[TestRpcClients, Path]) -> None:
     test_rpc_clients, root_dir = get_test_cli_clients
 

--- a/chia/_tests/cmds/wallet/test_did.py
+++ b/chia/_tests/cmds/wallet/test_did.py
@@ -16,9 +16,7 @@ from chia.types.signing_mode import SigningMode
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.config import load_config
 from chia.wallet.conditions import Condition, ConditionValidTimes, CreateCoinAnnouncement, CreatePuzzleAnnouncement
-from chia.wallet.did_wallet.did_info import (
-    did_recovery_is_nil,
-)
+from chia.wallet.did_wallet.did_info import did_recovery_is_nil
 from chia.wallet.util.curry_and_treehash import NIL_TREEHASH
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, TXConfig
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle

--- a/chia/_tests/cmds/wallet/test_did.py
+++ b/chia/_tests/cmds/wallet/test_did.py
@@ -17,8 +17,6 @@ from chia.util.bech32m import encode_puzzle_hash
 from chia.util.config import load_config
 from chia.wallet.conditions import Condition, ConditionValidTimes, CreateCoinAnnouncement, CreatePuzzleAnnouncement
 from chia.wallet.did_wallet.did_info import (
-    alternate_wallet_nil_recovery_list_bytes,
-    did_recovery_as_bytes,
     did_recovery_is_nil,
 )
 from chia.wallet.util.curry_and_treehash import NIL_TREEHASH
@@ -28,17 +26,17 @@ from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 test_condition_valid_times: ConditionValidTimes = ConditionValidTimes(min_time=uint64(100), max_time=uint64(150))
 
 
-@pytest.mark.parametrize(
-    argnames=["program", "result"],
-    argvalues=[
-        (Program.to(NIL_TREEHASH), NIL_TREEHASH),
-        (NIL, alternate_wallet_nil_recovery_list_bytes),
-        (Program.to(bytes32([1] * 32)), bytes32([1] * 32)),
-    ],
-)
-def test_did_recovery_as_bytes(program: Program, result: bytes32) -> None:
-    # test that the alternate wallet nil recovery list bytes are used
-    assert did_recovery_as_bytes(program) == result
+# @pytest.mark.parametrize(
+#     argnames=["program", "result"],
+#     argvalues=[
+#         (Program.to(NIL_TREEHASH), NIL_TREEHASH),
+#         (NIL, alternate_wallet_nil_recovery_list_bytes),
+#         (Program.to(bytes32([1] * 32)), bytes32([1] * 32)),
+#     ],
+# )
+# def test_did_recovery_as_bytes(program: Program, result: bytes32) -> None:
+#     # test that the alternate wallet nil recovery list bytes are used
+#     assert did_recovery_as_bytes(program) == result
 
 
 @pytest.mark.parametrize(
@@ -46,7 +44,6 @@ def test_did_recovery_as_bytes(program: Program, result: bytes32) -> None:
     argvalues=[
         (Program.to(NIL_TREEHASH), True),
         (NIL, True),
-        (Program.to(alternate_wallet_nil_recovery_list_bytes), True),
         (Program.to(bytes32([1] * 32)), False),
     ],
 )

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import pytest
 from chia_rs import AugSchemeMPL, G1Element, G2Element
@@ -37,6 +37,8 @@ from chia.wallet.singleton import (
 from chia.wallet.util.address_type import AddressType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.wallet import Wallet
+from chia.wallet.wallet_action_scope import WalletActionScope
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
@@ -49,15 +51,59 @@ def get_parent_num(did_wallet: DIDWallet):
     return len(did_wallet.did_info.parent_info)
 
 
+async def make_did_wallet(
+    wallet_state_manager: Any,
+    wallet: Wallet,
+    amount: uint64,
+    action_scope: WalletActionScope,
+    recovery_list: list[bytes32] = [],
+    metadata: dict[str, str] = {},
+    fee: uint64 = uint64(0),
+    use_alternate_recovery: bool = False,
+) -> DIDWallet:
+    def alt_create_innerpuz(
+        p2_puzzle_or_hash: Union[Program, bytes32],
+        recovery_list: list[bytes32],
+        num_of_backup_ids_needed: uint64,
+        launcher_id: bytes32,
+        metadata: Program = Program.to([]),
+        recovery_list_hash: Optional[Program] = None,
+    ) -> Program:
+        # override the default of NIL_TREEHASH with NIL to match other wallet implementations
+        nil_recovery = Program.to(None)
+        singleton_struct = Program.to((SINGLETON_TOP_LAYER_MOD_HASH, (launcher_id, SINGLETON_LAUNCHER_PUZZLE_HASH)))
+        return DID_INNERPUZ_MOD.curry(p2_puzzle_or_hash, nil_recovery, 0, singleton_struct, metadata)
+
+    if use_alternate_recovery:
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr("chia.wallet.did_wallet.did_wallet_puzzles.create_innerpuz", alt_create_innerpuz)
+            did_wallet = await DIDWallet.create_new_did_wallet(
+                wallet_state_manager, wallet, uint64(101), action_scope, metadata=metadata, fee=fee
+            )
+    else:
+        did_wallet = await DIDWallet.create_new_did_wallet(
+            wallet_state_manager, wallet, amount, action_scope, backups_ids=recovery_list, metadata=metadata, fee=fee
+        )
+
+    return did_wallet
+
+
 #  TODO: See Issue CHIA-1544
 #  This test should be ported to WalletTestFramework once we can replace keys in the wallet node
 @pytest.mark.parametrize(
     "trusted",
     [True, False],
 )
+@pytest.mark.parametrize(
+    "use_alternate_recovery",
+    [True, False],
+)
 @pytest.mark.anyio
 async def test_creation_from_coin_spend(
-    self_hostname: str, two_nodes_two_wallets_with_same_keys: OldSimulatorsAndWallets, trusted: bool
+    self_hostname: str,
+    two_nodes_two_wallets_with_same_keys: OldSimulatorsAndWallets,
+    trusted: bool,
+    use_alternate_recovery: bool,
 ) -> None:
     """
     Verify that DIDWallet.create_new_did_wallet_from_coin_spend() is called after Singleton creation on
@@ -100,8 +146,12 @@ async def test_creation_from_coin_spend(
 
     # Wallet1 sets up DIDWallet1 without any backup set
     async with wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        did_wallet_0: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node_0.wallet_state_manager, wallet_0, uint64(101), action_scope
+        did_wallet_0: DIDWallet = await make_did_wallet(
+            wallet_node_0.wallet_state_manager,
+            wallet_0,
+            uint64(101),
+            action_scope,
+            use_alternate_recovery=use_alternate_recovery,
         )
 
     with pytest.raises(RuntimeError):
@@ -137,9 +187,15 @@ async def test_creation_from_coin_spend(
     ],
     indirect=True,
 )
+@pytest.mark.parametrize(
+    "use_alternate_recovery",
+    [True, False],
+)
 @pytest.mark.anyio
 @pytest.mark.limit_consensus_modes(reason="irrelevant")
-async def test_creation_from_backup_file(wallet_environments: WalletTestFramework) -> None:
+async def test_creation_from_backup_file(
+    wallet_environments: WalletTestFramework, use_alternate_recovery: bool
+) -> None:
     env_0 = wallet_environments.environments[0]
     env_1 = wallet_environments.environments[1]
     env_2 = wallet_environments.environments[2]
@@ -159,8 +215,12 @@ async def test_creation_from_backup_file(wallet_environments: WalletTestFramewor
 
     # Wallet1 sets up DIDWallet1 without any backup set
     async with env_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
-        did_wallet_0: DIDWallet = await DIDWallet.create_new_did_wallet(
-            env_0.wallet_state_manager, env_0.xch_wallet, uint64(101), action_scope
+        did_wallet_0: DIDWallet = await make_did_wallet(
+            env_0.wallet_state_manager,
+            env_0.xch_wallet,
+            uint64(101),
+            action_scope,
+            use_alternate_recovery=use_alternate_recovery,
         )
 
     await wallet_environments.process_pending_states(
@@ -429,8 +489,14 @@ async def test_creation_from_backup_file(wallet_environments: WalletTestFramewor
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="irrelevant")
 @pytest.mark.parametrize("wallet_environments", [{"num_environments": 2, "blocks_needed": [1, 1]}], indirect=True)
+@pytest.mark.parametrize(
+    "use_alternate_recovery",
+    [True, False],
+)
 @pytest.mark.anyio
-async def test_did_recovery_with_multiple_backup_dids(wallet_environments: WalletTestFramework):
+async def test_did_recovery_with_multiple_backup_dids(
+    wallet_environments: WalletTestFramework, use_alternate_recovery: bool
+) -> None:
     env_0 = wallet_environments.environments[0]
     env_1 = wallet_environments.environments[1]
     wallet_node_0 = env_0.node
@@ -448,8 +514,12 @@ async def test_did_recovery_with_multiple_backup_dids(wallet_environments: Walle
     }
 
     async with wallet_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
-        did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node_0.wallet_state_manager, wallet_0, uint64(101), action_scope
+        did_wallet: DIDWallet = await make_did_wallet(
+            wallet_node_0.wallet_state_manager,
+            wallet_0,
+            uint64(101),
+            action_scope,
+            use_alternate_recovery=use_alternate_recovery,
         )
     assert did_wallet.get_name() == "Profile 1"
     recovery_list = [bytes32.from_hexstr(did_wallet.get_my_DID())]
@@ -714,8 +784,12 @@ async def test_did_recovery_with_multiple_backup_dids(wallet_environments: Walle
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="irrelevant")
 @pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
+@pytest.mark.parametrize(
+    "use_alternate_recovery",
+    [True, False],
+)
 @pytest.mark.anyio
-async def test_did_recovery_with_empty_set(wallet_environments: WalletTestFramework):
+async def test_did_recovery_with_empty_set(wallet_environments: WalletTestFramework, use_alternate_recovery: bool):
     env_0 = wallet_environments.environments[0]
     wallet_node_0 = env_0.node
     wallet_0 = env_0.xch_wallet
@@ -729,8 +803,12 @@ async def test_did_recovery_with_empty_set(wallet_environments: WalletTestFramew
         ph = await action_scope.get_puzzle_hash(wallet_0.wallet_state_manager)
 
     async with wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node_0.wallet_state_manager, wallet_0, uint64(101), action_scope
+        did_wallet: DIDWallet = await make_did_wallet(
+            wallet_node_0.wallet_state_manager,
+            wallet_0,
+            uint64(101),
+            action_scope,
+            use_alternate_recovery=use_alternate_recovery,
         )
 
     await wallet_environments.process_pending_states(
@@ -782,8 +860,12 @@ async def test_did_recovery_with_empty_set(wallet_environments: WalletTestFramew
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="irrelevant")
 @pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
+@pytest.mark.parametrize(
+    "use_alternate_recovery",
+    [True, False],
+)
 @pytest.mark.anyio
-async def test_did_find_lost_did(wallet_environments: WalletTestFramework):
+async def test_did_find_lost_did(wallet_environments: WalletTestFramework, use_alternate_recovery: bool):
     env_0 = wallet_environments.environments[0]
     wallet_node_0 = env_0.node
     wallet_0 = env_0.xch_wallet
@@ -795,8 +877,12 @@ async def test_did_find_lost_did(wallet_environments: WalletTestFramework):
     }
 
     async with wallet_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
-        did_wallet = await DIDWallet.create_new_did_wallet(
-            wallet_node_0.wallet_state_manager, wallet_0, uint64(101), action_scope
+        did_wallet_0 = await make_did_wallet(
+            wallet_node_0.wallet_state_manager,
+            wallet_0,
+            uint64(101),
+            action_scope,
+            use_alternate_recovery=use_alternate_recovery,
         )
 
     await wallet_environments.process_pending_states(
@@ -831,14 +917,14 @@ async def test_did_find_lost_did(wallet_environments: WalletTestFramework):
     )
 
     # Delete the coin and wallet
-    coin = await did_wallet.get_coin()
+    coin = await did_wallet_0.get_coin()
     await wallet_node_0.wallet_state_manager.coin_store.delete_coin_record(coin.name())
-    await wallet_node_0.wallet_state_manager.delete_wallet(did_wallet.wallet_info.id)
-    wallet_node_0.wallet_state_manager.wallets.pop(did_wallet.wallet_info.id)
+    await wallet_node_0.wallet_state_manager.delete_wallet(did_wallet_0.wallet_info.id)
+    wallet_node_0.wallet_state_manager.wallets.pop(did_wallet_0.wallet_info.id)
     assert len(wallet_node_0.wallet_state_manager.wallets) == 1
     # Find lost DID
-    assert did_wallet.did_info.origin_coin is not None  # mypy
-    resp = await api_0.did_find_lost_did({"coin_id": did_wallet.did_info.origin_coin.name().hex()})
+    assert did_wallet_0.did_info.origin_coin is not None  # mypy
+    resp = await api_0.did_find_lost_did({"coin_id": did_wallet_0.did_info.origin_coin.name().hex()})
     assert resp["success"]
     did_wallets = list(
         filter(
@@ -847,6 +933,7 @@ async def test_did_find_lost_did(wallet_environments: WalletTestFramework):
         )
     )
     did_wallet = wallet_node_0.wallet_state_manager.wallets[did_wallets[0].id]
+    assert isinstance(did_wallet, DIDWallet)
     env_0.wallet_aliases["did_found"] = did_wallets[0].id
     await env_0.change_balances(
         {
@@ -914,8 +1001,12 @@ async def test_did_find_lost_did(wallet_environments: WalletTestFramework):
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="irrelevant")
 @pytest.mark.parametrize("wallet_environments", [{"num_environments": 2, "blocks_needed": [1, 1]}], indirect=True)
+@pytest.mark.parametrize(
+    "use_alternate_recovery",
+    [True, False],
+)
 @pytest.mark.anyio
-async def test_did_attest_after_recovery(wallet_environments: WalletTestFramework):
+async def test_did_attest_after_recovery(wallet_environments: WalletTestFramework, use_alternate_recovery: bool):
     env_0 = wallet_environments.environments[0]
     env_1 = wallet_environments.environments[1]
     wallet_node_0 = env_0.node
@@ -933,8 +1024,12 @@ async def test_did_attest_after_recovery(wallet_environments: WalletTestFramewor
     }
 
     async with wallet_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
-        did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node_0.wallet_state_manager, wallet_0, uint64(101), action_scope
+        did_wallet: DIDWallet = await make_did_wallet(
+            wallet_node_0.wallet_state_manager,
+            wallet_0,
+            uint64(101),
+            action_scope,
+            use_alternate_recovery=use_alternate_recovery,
         )
     await wallet_environments.process_pending_states(
         [
@@ -1521,8 +1616,12 @@ async def test_did_auto_transfer_limit(
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="irrelevant")
 @pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
+@pytest.mark.parametrize(
+    "use_alternate_recovery",
+    [True, False],
+)
 @pytest.mark.anyio
-async def test_update_recovery_list(wallet_environments: WalletTestFramework):
+async def test_update_recovery_list(wallet_environments: WalletTestFramework, use_alternate_recovery: bool):
     env = wallet_environments.environments[0]
     wallet_node = env.node
     wallet = env.xch_wallet
@@ -1534,8 +1633,12 @@ async def test_update_recovery_list(wallet_environments: WalletTestFramework):
 
     async with wallet.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
-        did_wallet_1: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node.wallet_state_manager, wallet, uint64(101), action_scope, []
+        did_wallet_1: DIDWallet = await make_did_wallet(
+            wallet_node.wallet_state_manager,
+            wallet,
+            uint64(101),
+            action_scope,
+            use_alternate_recovery=use_alternate_recovery,
         )
 
     await wallet_environments.process_pending_states(
@@ -1596,8 +1699,12 @@ async def test_update_recovery_list(wallet_environments: WalletTestFramework):
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="irrelevant")
 @pytest.mark.parametrize("wallet_environments", [{"num_environments": 2, "blocks_needed": [1, 1]}], indirect=True)
+@pytest.mark.parametrize(
+    "use_alternate_recovery",
+    [True, False],
+)
 @pytest.mark.anyio
-async def test_get_info(wallet_environments: WalletTestFramework):
+async def test_get_info(wallet_environments: WalletTestFramework, use_alternate_recovery: bool):
     env_0 = wallet_environments.environments[0]
     env_1 = wallet_environments.environments[1]
     wallet_node_0 = env_0.node
@@ -1620,7 +1727,7 @@ async def test_get_info(wallet_environments: WalletTestFramework):
         ph_1 = await action_scope.get_puzzle_hash(wallet_1.wallet_state_manager)
 
     async with wallet_0.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
-        did_wallet_1: DIDWallet = await DIDWallet.create_new_did_wallet(
+        did_wallet_1: DIDWallet = await make_did_wallet(
             wallet_node_0.wallet_state_manager,
             wallet_0,
             did_amount,
@@ -1628,6 +1735,7 @@ async def test_get_info(wallet_environments: WalletTestFramework):
             [],
             metadata={"twitter": "twitter"},
             fee=fee,
+            use_alternate_recovery=use_alternate_recovery,
         )
 
     await wallet_environments.process_pending_states(
@@ -1672,7 +1780,10 @@ async def test_get_info(wallet_environments: WalletTestFramework):
     assert response["metadata"]["twitter"] == "twitter"
     assert response["latest_coin"] == (await did_wallet_1.get_coin()).name().hex()
     assert response["num_verification"] == 0
-    assert response["recovery_list_hash"] == Program(Program.to([])).get_tree_hash().hex()
+    if use_alternate_recovery:
+        assert response["recovery_list_hash"] == ""
+    else:
+        assert response["recovery_list_hash"] == Program(Program.to([])).get_tree_hash().hex()
     assert decode_puzzle_hash(response["p2_address"]).hex() == response["hints"][0]
 
     # Test non-singleton coin
@@ -1740,8 +1851,12 @@ async def test_get_info(wallet_environments: WalletTestFramework):
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="irrelevant")
 @pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
+@pytest.mark.parametrize(
+    "use_alternate_recovery",
+    [True, False],
+)
 @pytest.mark.anyio
-async def test_message_spend(wallet_environments: WalletTestFramework):
+async def test_message_spend(wallet_environments: WalletTestFramework, use_alternate_recovery: bool):
     env = wallet_environments.environments[0]
     wallet_node = env.node
     wallet = env.xch_wallet
@@ -1755,8 +1870,14 @@ async def test_message_spend(wallet_environments: WalletTestFramework):
     fee = uint64(1000)
 
     async with wallet.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
-        did_wallet_1: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node.wallet_state_manager, wallet, uint64(101), action_scope, [], fee=fee
+        did_wallet_1: DIDWallet = await make_did_wallet(
+            wallet_node.wallet_state_manager,
+            wallet,
+            uint64(101),
+            action_scope,
+            [],
+            fee=fee,
+            use_alternate_recovery=use_alternate_recovery,
         )
     await wallet_environments.process_pending_states(
         [
@@ -1804,8 +1925,12 @@ async def test_message_spend(wallet_environments: WalletTestFramework):
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="irrelevant")
 @pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
+@pytest.mark.parametrize(
+    "use_alternate_recovery",
+    [True, False],
+)
 @pytest.mark.anyio
-async def test_update_metadata(wallet_environments: WalletTestFramework):
+async def test_update_metadata(wallet_environments: WalletTestFramework, use_alternate_recovery: bool):
     env = wallet_environments.environments[0]
     wallet_node = env.node
     wallet = env.xch_wallet
@@ -1819,8 +1944,14 @@ async def test_update_metadata(wallet_environments: WalletTestFramework):
     did_amount = uint64(101)
 
     async with wallet.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
-        did_wallet_1: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node.wallet_state_manager, wallet, did_amount, action_scope, [], fee=fee
+        did_wallet_1: DIDWallet = await make_did_wallet(
+            wallet_node.wallet_state_manager,
+            wallet,
+            did_amount,
+            action_scope,
+            [],
+            fee=fee,
+            use_alternate_recovery=use_alternate_recovery,
         )
 
     await wallet_environments.process_pending_states(
@@ -2222,16 +2353,24 @@ async def test_did_resync(
     ],
     indirect=True,
 )
+@pytest.mark.parametrize(
+    "use_alternate_recovery",
+    [True, False],
+)
 @pytest.mark.anyio
-async def test_did_coin_records(wallet_environments: WalletTestFramework, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_did_coin_records(wallet_environments: WalletTestFramework, use_alternate_recovery: bool) -> None:
     # Setup
     wallet_node = wallet_environments.environments[0].node
     wallet = wallet_environments.environments[0].xch_wallet
 
     # Generate DID wallet
     async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
-            wallet_node.wallet_state_manager, wallet, uint64(1), action_scope
+        did_wallet: DIDWallet = await make_did_wallet(
+            wallet_node.wallet_state_manager,
+            wallet,
+            uint64(1),
+            action_scope,
+            use_alternate_recovery=use_alternate_recovery,
         )
 
     await wallet_environments.process_pending_states(
@@ -2274,116 +2413,3 @@ async def test_did_coin_records(wallet_environments: WalletTestFramework, monkey
         )
 
     assert len(await wallet.wallet_state_manager.get_spendable_coins_for_wallet(did_wallet.id())) == 1
-
-
-@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="irrelevant")
-@pytest.mark.anyio
-async def test_alternate_did_recovery(
-    self_hostname: str, simulator_and_wallet: OldSimulatorsAndWallets, monkeypatch: pytest.MonkeyPatch
-):
-    [full_node_api], [(wallet_node, wallet_server)], _ = simulator_and_wallet
-    api = WalletRpcApi(wallet_node)
-
-    wallet = wallet_node.wallet_state_manager.main_wallet
-    wallet_node.config["trusted_peers"] = {
-        full_node_api.full_node.server.node_id.hex(): full_node_api.full_node.server.node_id.hex()
-    }
-
-    await wallet_server.start_client(PeerInfo(self_hostname, full_node_api.server.get_port()), None)
-    await full_node_api.farm_blocks_to_wallet(1, wallet)
-
-    def alt_create_innerpuz(
-        p2_puzzle_or_hash: Union[Program, bytes32],
-        recovery_list: list[bytes32],
-        num_of_backup_ids_needed: uint64,
-        launcher_id: bytes32,
-        metadata: Program = Program.to([]),
-        recovery_list_hash: Optional[Program] = None,
-    ) -> Program:
-        # override the default of NIL_TREEHASH with NIL to match other wallet implementations
-        nil_recovery = Program.to(None)
-        singleton_struct = Program.to((SINGLETON_TOP_LAYER_MOD_HASH, (launcher_id, SINGLETON_LAUNCHER_PUZZLE_HASH)))
-        return DID_INNERPUZ_MOD.curry(p2_puzzle_or_hash, nil_recovery, 0, singleton_struct, metadata)
-
-    with monkeypatch.context() as m:
-        m.setattr("chia.wallet.did_wallet.did_wallet_puzzles.create_innerpuz", alt_create_innerpuz)
-        async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-            ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)
-            did_wallet = await DIDWallet.create_new_did_wallet(
-                wallet_node.wallet_state_manager, wallet, uint64(101), action_scope
-            )
-
-    with pytest.raises(RuntimeError, match="DID is not currently spendable"):
-        assert await did_wallet.get_coin() == set()
-    assert await did_wallet.get_info_for_recovery() is None
-    await full_node_api.process_transaction_records(records=action_scope.side_effects.transactions)
-    await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node])
-
-    await time_out_assert(15, did_wallet.get_confirmed_balance, 101)
-    await time_out_assert(15, did_wallet.get_unconfirmed_balance, 101)
-    await time_out_assert(15, did_wallet.get_pending_change_balance, 0)
-
-    response = await api.did_get_info({"coin_id": did_wallet.did_info.origin_coin.name().hex()})
-    # make sure the recovery list hash is empty as expected for this alternate implementation
-    assert response["recovery_list_hash"] == ""
-    await did_wallet.get_coin()
-
-    #
-    # Check that we can make an metadata update spend for this DID
-    #
-    parent_num = get_parent_num(did_wallet)
-    metadata = {}
-    metadata["Twitter"] = "http://www.twitter.com"
-    await did_wallet.update_metadata(metadata)
-    async with did_wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        await did_wallet.create_update_spend(action_scope, uint64(1000))
-
-    await full_node_api.process_transaction_records(records=action_scope.side_effects.transactions)
-    await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node])
-
-    assert get_parent_num(did_wallet) == parent_num + 2
-    assert did_wallet.did_info.metadata.find("Twitter") > 0
-    await did_wallet.get_coin()
-
-    #
-    # Check that we can make an recovery update spend for this DID
-    #
-    await did_wallet.update_recovery_list([ph], uint64(1))
-    async with did_wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
-        await did_wallet.create_update_spend(action_scope)
-
-    await full_node_api.process_transaction_records(records=action_scope.side_effects.transactions)
-    await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node])
-
-    response = await api.did_get_info({"coin_id": did_wallet.did_info.origin_coin.name().hex()})
-    # make sure the recovery list hash is empty as expected for this alternate implementation
-    assert response["recovery_list_hash"] == Program.to([ph]).get_tree_hash().hex()
-    coin = await did_wallet.get_coin()
-
-    #
-    # Test that we can delete and find the DID again
-    #
-    # Delete the coin and wallet
-    await wallet_node.wallet_state_manager.coin_store.delete_coin_record(coin.name())
-    await wallet_node.wallet_state_manager.delete_wallet(did_wallet.wallet_info.id)
-    wallet_node.wallet_state_manager.wallets.pop(did_wallet.wallet_info.id)
-    assert len(wallet_node.wallet_state_manager.wallets) == 1
-
-    # Find lost DID
-    assert did_wallet.did_info.origin_coin is not None  # mypy
-    resp = await api.did_find_lost_did({"coin_id": did_wallet.did_info.origin_coin.name().hex()})
-    assert resp["success"]
-    did_wallets = list(
-        filter(
-            lambda w: (w.type == WalletType.DECENTRALIZED_ID),
-            await wallet_node.wallet_state_manager.get_all_wallet_info_entries(),
-        )
-    )
-    assert len(wallet_node.wallet_state_manager.wallets) == 2
-    found_did_wallet = wallet_node.wallet_state_manager.wallets[did_wallets[0].id]
-    # assert did_wallet.did_info.origin_coin == found_did_wallet.did_info.origin_coin
-
-    await full_node_api.wait_for_wallets_synced(wallet_nodes=[wallet_node])
-    await time_out_assert(15, found_did_wallet.get_confirmed_balance, 101)
-    await time_out_assert(15, found_did_wallet.get_unconfirmed_balance, 101)
-    await time_out_assert(15, found_did_wallet.get_pending_change_balance, 0)

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -2600,7 +2600,7 @@ class WalletRpcApi:
         p2_puzzle, recovery_list_hash, num_verification, singleton_struct, metadata = curried_args
         did_data: DIDCoinData = DIDCoinData(
             p2_puzzle,
-            recovery_list_hash.as_atom(),
+            bytes32(recovery_list_hash.as_atom()) if recovery_list_hash != Program.to(None) else None,
             uint16(num_verification.as_int()),
             singleton_struct,
             metadata,

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -112,7 +112,7 @@ from chia.wallet.derive_keys import (
     match_address_to_sk,
 )
 from chia.wallet.did_wallet import did_wallet_puzzles
-from chia.wallet.did_wallet.did_info import DIDCoinData, DIDInfo, did_recovery_as_bytes, did_recovery_is_nil
+from chia.wallet.did_wallet.did_info import DIDCoinData, DIDInfo, did_recovery_is_nil
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.did_wallet.did_wallet_puzzles import (
     DID_INNERPUZ_MOD,
@@ -2600,7 +2600,7 @@ class WalletRpcApi:
         p2_puzzle, recovery_list_hash, num_verification, singleton_struct, metadata = curried_args
         did_data: DIDCoinData = DIDCoinData(
             p2_puzzle,
-            did_recovery_as_bytes(recovery_list_hash),
+            recovery_list_hash.as_atom(),
             uint16(num_verification.as_int()),
             singleton_struct,
             metadata,

--- a/chia/rpc/wallet_rpc_api.py
+++ b/chia/rpc/wallet_rpc_api.py
@@ -112,7 +112,7 @@ from chia.wallet.derive_keys import (
     match_address_to_sk,
 )
 from chia.wallet.did_wallet import did_wallet_puzzles
-from chia.wallet.did_wallet.did_info import DIDCoinData, DIDInfo
+from chia.wallet.did_wallet.did_info import DIDCoinData, DIDInfo, did_recovery_as_bytes, did_recovery_is_nil
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.did_wallet.did_wallet_puzzles import (
     DID_INNERPUZ_MOD,
@@ -2600,7 +2600,7 @@ class WalletRpcApi:
         p2_puzzle, recovery_list_hash, num_verification, singleton_struct, metadata = curried_args
         did_data: DIDCoinData = DIDCoinData(
             p2_puzzle,
-            bytes32(recovery_list_hash.as_atom()),
+            did_recovery_as_bytes(recovery_list_hash),
             uint16(num_verification.as_int()),
             singleton_struct,
             metadata,
@@ -2729,7 +2729,7 @@ class WalletRpcApi:
                     inner_solution: Program = full_solution.rest().rest().first()
                     recovery_list: list[bytes32] = []
                     backup_required: int = num_verification.as_int()
-                    if recovery_list_hash != NIL_TREEHASH:
+                    if not did_recovery_is_nil(recovery_list_hash):
                         try:
                             for did in inner_solution.rest().rest().rest().rest().rest().as_python():
                                 recovery_list.append(did[0])

--- a/chia/wallet/did_wallet/did_info.py
+++ b/chia/wallet/did_wallet/did_info.py
@@ -18,21 +18,21 @@ from chia.wallet.util.curry_and_treehash import NIL_TREEHASH
 # For DB reasons, the reference wallet needs somethign to store in the DB
 # This was randomly generated and doesn't correspond to any real recovery list
 # and cannot be used to recover anything
-alternate_wallet_nil_recovery_list_bytes = bytes32.fromhex(
-    "1e56bb33a795ec7d8039708d2783491c22e55b94c9cec43911807064353ddbb8"
-)
+# alternate_wallet_nil_recovery_list_bytes = bytes32.fromhex(
+#    "1e56bb33a795ec7d8039708d2783491c22e55b94c9cec43911807064353ddbb8"
+# )
 
 
-def did_recovery_as_bytes(recovery_program: Program) -> bytes32:
-    try:
-        return bytes32(recovery_program.as_atom())
-    except ValueError:
-        return alternate_wallet_nil_recovery_list_bytes
+# def did_recovery_as_bytes(recovery_program: Program) -> bytes:
+#    try:
+#        return recovery_program.as_atom()
+#    except ValueError:
+#        return bytes(Program.to(None))
 
 
 def did_recovery_is_nil(recovery_program: Program) -> bool:
     # cannot use set as not hashable
-    if recovery_program in (NIL, NIL_TREEHASH, alternate_wallet_nil_recovery_list_bytes):  # noqa: PLR6201
+    if recovery_program in (NIL, NIL_TREEHASH):  # noqa: PLR6201
         return True
     else:
         return False
@@ -57,7 +57,7 @@ class DIDInfo(Streamable):
 @dataclass(frozen=True)
 class DIDCoinData(Streamable):
     p2_puzzle: Program
-    recovery_list_hash: bytes32
+    recovery_list_hash: bytes
     num_verification: uint16
     singleton_struct: Program
     metadata: Program

--- a/chia/wallet/did_wallet/did_info.py
+++ b/chia/wallet/did_wallet/did_info.py
@@ -16,6 +16,8 @@ from chia.wallet.util.curry_and_treehash import NIL_TREEHASH
 # hardcode values to use for supporting DIDs from third party wallet
 # that use an actually empty recovery list instead of the hash of an empty list
 # For DB reasons, the reference wallet needs somethign to store in the DB
+# This was randomly generated and doesn't correspond to any real recovery list
+# and cannot be used to recover anything
 alternate_wallet_nil_recovery_list_bytes = bytes32.fromhex(
     "1e56bb33a795ec7d8039708d2783491c22e55b94c9cec43911807064353ddbb8"
 )
@@ -29,7 +31,8 @@ def did_recovery_as_bytes(recovery_program: Program) -> bytes32:
 
 
 def did_recovery_is_nil(recovery_program: Program) -> bool:
-    if recovery_program in {NIL_TREEHASH, alternate_wallet_nil_recovery_list_bytes}:
+    # cannot use set as not hashable
+    if recovery_program in (NIL_TREEHASH, alternate_wallet_nil_recovery_list_bytes):  # noqa: PLR6201
         return True
     else:
         return False

--- a/chia/wallet/did_wallet/did_info.py
+++ b/chia/wallet/did_wallet/did_info.py
@@ -11,6 +11,28 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.util.streamable import Streamable, streamable
 from chia.wallet.lineage_proof import LineageProof
+from chia.wallet.util.curry_and_treehash import NIL_TREEHASH
+
+# hardcode values to use for supporting DIDs from third party wallet
+# that use an actually empty recovery list instead of the hash of an empty list
+# For DB reasons, the reference wallet needs somethign to store in the DB
+alternate_wallet_nil_recovery_list_bytes = bytes32.fromhex(
+    "1e56bb33a795ec7d8039708d2783491c22e55b94c9cec43911807064353ddbb8"
+)
+
+
+def did_recovery_as_bytes(recovery_program: Program) -> bytes32:
+    try:
+        return bytes32(recovery_program.as_atom())
+    except ValueError:
+        return alternate_wallet_nil_recovery_list_bytes
+
+
+def did_recovery_is_nil(recovery_program: Program) -> bool:
+    if recovery_program in {NIL_TREEHASH, alternate_wallet_nil_recovery_list_bytes}:
+        return True
+    else:
+        return False
 
 
 @streamable

--- a/chia/wallet/did_wallet/did_info.py
+++ b/chia/wallet/did_wallet/did_info.py
@@ -13,22 +13,6 @@ from chia.util.streamable import Streamable, streamable
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.util.curry_and_treehash import NIL_TREEHASH
 
-# hardcode values to use for supporting DIDs from third party wallet
-# that use an actually empty recovery list instead of the hash of an empty list
-# For DB reasons, the reference wallet needs somethign to store in the DB
-# This was randomly generated and doesn't correspond to any real recovery list
-# and cannot be used to recover anything
-# alternate_wallet_nil_recovery_list_bytes = bytes32.fromhex(
-#    "1e56bb33a795ec7d8039708d2783491c22e55b94c9cec43911807064353ddbb8"
-# )
-
-
-# def did_recovery_as_bytes(recovery_program: Program) -> bytes:
-#    try:
-#        return recovery_program.as_atom()
-#    except ValueError:
-#        return bytes(Program.to(None))
-
 
 def did_recovery_is_nil(recovery_program: Program) -> bool:
     # cannot use set as not hashable

--- a/chia/wallet/did_wallet/did_info.py
+++ b/chia/wallet/did_wallet/did_info.py
@@ -8,7 +8,7 @@ from chia_rs.sized_ints import uint16, uint64
 
 from chia.protocols.wallet_protocol import CoinState
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import NIL, Program
 from chia.util.streamable import Streamable, streamable
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.util.curry_and_treehash import NIL_TREEHASH
@@ -32,7 +32,7 @@ def did_recovery_as_bytes(recovery_program: Program) -> bytes32:
 
 def did_recovery_is_nil(recovery_program: Program) -> bool:
     # cannot use set as not hashable
-    if recovery_program in (NIL_TREEHASH, alternate_wallet_nil_recovery_list_bytes):  # noqa: PLR6201
+    if recovery_program in (NIL, NIL_TREEHASH, alternate_wallet_nil_recovery_list_bytes):  # noqa: PLR6201
         return True
     else:
         return False

--- a/chia/wallet/did_wallet/did_info.py
+++ b/chia/wallet/did_wallet/did_info.py
@@ -41,7 +41,7 @@ class DIDInfo(Streamable):
 @dataclass(frozen=True)
 class DIDCoinData(Streamable):
     p2_puzzle: Program
-    recovery_list_hash: bytes
+    recovery_list_hash: Optional[bytes32]
     num_verification: uint16
     singleton_struct: Program
     metadata: Program

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -28,7 +28,7 @@ from chia.wallet.conditions import (
 )
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.did_wallet import did_wallet_puzzles
-from chia.wallet.did_wallet.did_info import DIDCoinData, DIDInfo, did_recovery_as_bytes, did_recovery_is_nil
+from chia.wallet.did_wallet.did_info import DIDCoinData, DIDInfo, did_recovery_is_nil
 from chia.wallet.did_wallet.did_wallet_puzzles import match_did_puzzle, uncurry_innerpuz
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
@@ -387,7 +387,7 @@ class DIDWallet:
             p2_puzzle, recovery_list_hash, num_verification, singleton_struct, metadata = did_curried_args
             did_data = DIDCoinData(
                 p2_puzzle=p2_puzzle,
-                recovery_list_hash=did_recovery_as_bytes(recovery_list_hash),
+                recovery_list_hash=recovery_list_hash.as_atom(),
                 num_verification=uint16(num_verification.as_int()),
                 singleton_struct=singleton_struct,
                 metadata=metadata,

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -28,7 +28,7 @@ from chia.wallet.conditions import (
 )
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.did_wallet import did_wallet_puzzles
-from chia.wallet.did_wallet.did_info import DIDCoinData, DIDInfo
+from chia.wallet.did_wallet.did_info import DIDCoinData, DIDInfo, did_recovery_as_bytes, did_recovery_is_nil
 from chia.wallet.did_wallet.did_wallet_puzzles import match_did_puzzle, uncurry_innerpuz
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
@@ -229,7 +229,7 @@ class DIDWallet:
         inner_solution: Program = full_solution.rest().rest().first()
         recovery_list: list[bytes32] = []
         backup_required: int = num_verification.as_int()
-        if recovery_list_hash != NIL_TREEHASH:
+        if not did_recovery_is_nil(recovery_list_hash):
             try:
                 for did in inner_solution.rest().rest().rest().rest().rest().as_python():
                     recovery_list.append(bytes32(did[0]))
@@ -387,7 +387,7 @@ class DIDWallet:
             p2_puzzle, recovery_list_hash, num_verification, singleton_struct, metadata = did_curried_args
             did_data = DIDCoinData(
                 p2_puzzle=p2_puzzle,
-                recovery_list_hash=bytes32(recovery_list_hash.as_atom()),
+                recovery_list_hash=did_recovery_as_bytes(recovery_list_hash),
                 num_verification=uint16(num_verification.as_int()),
                 singleton_struct=singleton_struct,
                 metadata=metadata,

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -387,7 +387,9 @@ class DIDWallet:
             p2_puzzle, recovery_list_hash, num_verification, singleton_struct, metadata = did_curried_args
             did_data = DIDCoinData(
                 p2_puzzle=p2_puzzle,
-                recovery_list_hash=recovery_list_hash.as_atom(),
+                recovery_list_hash=bytes32(recovery_list_hash.as_atom())
+                if recovery_list_hash != Program.to(None)
+                else None,
                 num_verification=uint16(num_verification.as_int()),
                 singleton_struct=singleton_struct,
                 metadata=metadata,

--- a/chia/wallet/did_wallet/did_wallet_puzzles.py
+++ b/chia/wallet/did_wallet/did_wallet_puzzles.py
@@ -89,7 +89,7 @@ def get_inner_puzhash_by_p2(
     # in that case the list is ignored and the hash is used
     # this matches the behaviour of create_innerpuz
     if recovery_list_hash is not None:
-        backup_ids_hash = bytes(recovery_list_hash.as_atom())
+        backup_ids_hash = recovery_list_hash.as_atom()
     elif recovery_list is not None:
         backup_ids_hash = shatree_atom_list(recovery_list)
 

--- a/chia/wallet/did_wallet/did_wallet_puzzles.py
+++ b/chia/wallet/did_wallet/did_wallet_puzzles.py
@@ -70,7 +70,7 @@ def get_inner_puzhash_by_p2(
     launcher_id: bytes32,
     metadata: Program = Program.to([]),
     recovery_list: Optional[list[bytes32]] = None,
-    recovery_list_hash: Optional[bytes32] = None,
+    recovery_list_hash: Optional[Program] = None,
 ) -> bytes32:
     """
     Calculate DID inner puzzle hash based on a P2 puzzle hash
@@ -84,14 +84,14 @@ def get_inner_puzhash_by_p2(
 
     if recovery_list is None and recovery_list_hash is None:
         raise ValueError("Cannot construct DID inner puzzle without information about recovery list")
-    if recovery_list is not None and recovery_list_hash is not None:
-        raise ValueError("Must only specify recovery information a single way to construct DID inner puzzle")
 
-    if recovery_list is not None:
+    # Allow both recovery_list and recovery_list_hash to be provided but
+    # in that case the list is ignored and the hash is used
+    # this matches the behaviour of create_innerpuz
+    if recovery_list_hash is not None:
+        backup_ids_hash = bytes(recovery_list_hash.as_atom())
+    elif recovery_list is not None:
         backup_ids_hash = shatree_atom_list(recovery_list)
-    else:
-        assert recovery_list_hash is not None
-        backup_ids_hash = recovery_list_hash
 
     # singleton_struct = (MOD_HASH . (LAUNCHER_ID . LAUNCHER_PUZZLE_HASH))
     singleton_struct = shatree_pair(

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -69,7 +69,7 @@ from chia.wallet.derive_keys import (
     master_sk_to_wallet_sk_intermediate,
     master_sk_to_wallet_sk_unhardened,
 )
-from chia.wallet.did_wallet.did_info import DIDCoinData
+from chia.wallet.did_wallet.did_info import DIDCoinData, did_recovery_as_bytes
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.did_wallet.did_wallet_puzzles import DID_INNERPUZ_MOD, match_did_puzzle
 from chia.wallet.key_val_store import KeyValStore
@@ -867,7 +867,7 @@ class WalletStateManager:
             p2_puzzle, recovery_list_hash, num_verification, singleton_struct, metadata = did_curried_args
             did_data: DIDCoinData = DIDCoinData(
                 p2_puzzle,
-                bytes32(recovery_list_hash.as_atom()),
+                did_recovery_as_bytes(recovery_list_hash),
                 uint16(num_verification.as_int()),
                 singleton_struct,
                 metadata,

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -69,7 +69,7 @@ from chia.wallet.derive_keys import (
     master_sk_to_wallet_sk_intermediate,
     master_sk_to_wallet_sk_unhardened,
 )
-from chia.wallet.did_wallet.did_info import DIDCoinData, did_recovery_as_bytes
+from chia.wallet.did_wallet.did_info import DIDCoinData
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.did_wallet.did_wallet_puzzles import DID_INNERPUZ_MOD, match_did_puzzle
 from chia.wallet.key_val_store import KeyValStore
@@ -867,7 +867,7 @@ class WalletStateManager:
             p2_puzzle, recovery_list_hash, num_verification, singleton_struct, metadata = did_curried_args
             did_data: DIDCoinData = DIDCoinData(
                 p2_puzzle,
-                did_recovery_as_bytes(recovery_list_hash),
+                recovery_list_hash.as_atom(),
                 uint16(num_verification.as_int()),
                 singleton_struct,
                 metadata,

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -33,7 +33,7 @@ from chia.server.outbound_message import NodeType
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin
-from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import NIL, Program
 from chia.types.coin_record import CoinRecord
 from chia.types.coin_spend import CoinSpend, compute_additions
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
@@ -1258,10 +1258,22 @@ class WalletStateManager:
                 parent_data.singleton_struct,
                 parent_data.metadata,
             )
+            alt_did_puzzle_empty_recovery = DID_INNERPUZ_MOD.curry(
+                our_inner_puzzle,
+                NIL,
+                uint64(0),
+                parent_data.singleton_struct,
+                parent_data.metadata,
+            )
+
             full_puzzle_empty_recovery = create_singleton_puzzle(did_puzzle_empty_recovery, launch_id)
+            alt_full_puzzle_empty_recovery = create_singleton_puzzle(alt_did_puzzle_empty_recovery, launch_id)
             if full_puzzle.get_tree_hash() != coin_state.coin.puzzle_hash:
                 if full_puzzle_empty_recovery.get_tree_hash() == coin_state.coin.puzzle_hash:
                     did_puzzle = did_puzzle_empty_recovery
+                    self.log.info("DID recovery list was reset by the previous owner.")
+                elif alt_full_puzzle_empty_recovery.get_tree_hash() == coin_state.coin.puzzle_hash:
+                    did_puzzle = alt_did_puzzle_empty_recovery
                     self.log.info("DID recovery list was reset by the previous owner.")
                 else:
                     self.log.error("DID puzzle hash doesn't match, please check curried parameters.")

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -867,7 +867,7 @@ class WalletStateManager:
             p2_puzzle, recovery_list_hash, num_verification, singleton_struct, metadata = did_curried_args
             did_data: DIDCoinData = DIDCoinData(
                 p2_puzzle,
-                recovery_list_hash.as_atom(),
+                bytes32(recovery_list_hash.as_atom()) if recovery_list_hash != Program.to(None) else None,
                 uint16(num_verification.as_int()),
                 singleton_struct,
                 metadata,


### PR DESCRIPTION
Attempt to fix https://github.com/Chia-Network/chia-blockchain/issues/18947

This PR changes the `DIDCoinData` class member `recovery_list_hash` from `bytes32` to `Optional[bytes32]`. This makes it clear that None/NIL is allowed, but otherwise it should be a proper 32-byte hash. This class is marked as `Streamable`, however, I don't believe it is serialized and stored anywhere that requires backwards deserialization. This change should not introduce any backward-compatible issues.

With this change, the recovery_list_hash can be either the `NIL` program (as defined by `NIL = Program.to(None)` or the `NIL_TREEHASH`. This does require a little bit of work in a ternary so if using the NIL Program, we use None in DIDCoinData, otherwise, we expect 32 bytes of data.

This allows the DIDs from other wallets to be found and work correctly.

In order to spend this DID, the changes were a little more substantial - we need to make sure we don't curry in NIL_TREEHASH instead whenever we are creating inner puzzles for these DIDs - this was a little hacky to make sure that we always use the original curried in parameter unless we are adding recovery ids to the list.

If you add a recovery list and then remove it - you probably end up with NIL_TREEHASH , but that seems ok. Need to test that.

Added parameterized testing to most tests to include creating these types of DID