### PR TITLE
stop testing soft fork 6. it has already activated

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -196,12 +196,11 @@ def get_keychain():
 class ConsensusMode(ComparableEnum):
     PLAIN = 0
     HARD_FORK_2_0 = 1
-    SOFT_FORK_6 = 2
 
 
 @pytest.fixture(
     scope="session",
-    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.SOFT_FORK_6],
+    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0],
 )
 def consensus_mode(request):
     return request.param
@@ -216,10 +215,6 @@ def blockchain_constants(consensus_mode: ConsensusMode) -> ConsensusConstants:
             PLOT_FILTER_128_HEIGHT=uint32(10),
             PLOT_FILTER_64_HEIGHT=uint32(15),
             PLOT_FILTER_32_HEIGHT=uint32(20),
-        )
-    if consensus_mode >= ConsensusMode.SOFT_FORK_6:
-        ret = ret.replace(
-            SOFT_FORK6_HEIGHT=uint32(2),
         )
     return ret
 

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -147,6 +147,7 @@ test_constants = DEFAULT_CONSTANTS.replace(
     # Allows creating blockchains with timestamps up to 10 days in the future, for testing
     MAX_FUTURE_TIME2=uint32(3600 * 24 * 10),
     MEMPOOL_BLOCK_BUFFER=uint8(6),
+    SOFT_FORK6_HEIGHT=uint32(2),
 )
 
 


### PR DESCRIPTION
enable it for all tests

### Purpose:

The soft fork 6 constant is still taken into account. This just stops testing the case where it's not activated, to save time.
In a future PR we'll remove it from `chia_rs` and then the use of it.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
