### PR TITLE
Refactor `BlockTools`

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
         python-version: ["3.10"]
     env:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
-      BLOCKS_AND_PLOTS_VERSION: 0.43.0
+      BLOCKS_AND_PLOTS_VERSION: 0.44.0
 
     steps:
       - name: Clean workspace

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -126,7 +126,7 @@ jobs:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
       CHIA_SIMULATOR_ROOT: ${{ github.workspace }}/.chia/simulator
       JOB_FILE_NAME: tests_${{ matrix.os.file_name }}_python-${{ matrix.python.file_name }}_${{ matrix.configuration.module_import_path }}${{ matrix.configuration.file_name_index }}
-      BLOCKS_AND_PLOTS_VERSION: 0.43.0
+      BLOCKS_AND_PLOTS_VERSION: 0.44.0
 
     steps:
       - name: Configure git

--- a/chia/_tests/blockchain/test_build_chains.py
+++ b/chia/_tests/blockchain/test_build_chains.py
@@ -81,7 +81,7 @@ def validate_coins(constants: ConsensusConstants, blocks: list[FullBlock]) -> No
             for rem in removals:
                 try:
                     unspent_coins.remove(rem)
-                except KeyError:
+                except KeyError:  # pragma: no cover
                     print(f"at height: {block.height} removal: {rem} does not exist")
                     print("coinset: ", unspent_coins)
                     raise

--- a/chia/_tests/blockchain/test_build_chains.py
+++ b/chia/_tests/blockchain/test_build_chains.py
@@ -79,7 +79,12 @@ def validate_coins(constants: ConsensusConstants, blocks: list[FullBlock]) -> No
             )
 
             for rem in removals:
-                unspent_coins.remove(rem)
+                try:
+                    unspent_coins.remove(rem)
+                except KeyError as e:
+                    print(f"at height: {block.height} removal: {rem} does not exist")
+                    print("coinset: ", unspent_coins)
+                    raise
 
             for add, _ in additions:
                 unspent_coins.add(add)

--- a/chia/_tests/blockchain/test_build_chains.py
+++ b/chia/_tests/blockchain/test_build_chains.py
@@ -81,7 +81,7 @@ def validate_coins(constants: ConsensusConstants, blocks: list[FullBlock]) -> No
             for rem in removals:
                 try:
                     unspent_coins.remove(rem)
-                except KeyError as e:
+                except KeyError:
                     print(f"at height: {block.height} removal: {rem} does not exist")
                     print("coinset: ", unspent_coins)
                     raise

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2683,7 +2683,7 @@ async def test_long_reorg_nodes(
         p2 = full_node_1.full_node.blockchain.get_peak()
         return p1 == p2
 
-    await time_out_assert(200, check_nodes_in_sync)
+    await time_out_assert(300, check_nodes_in_sync)
     peak = full_node_2.full_node.blockchain.get_peak()
     assert peak is not None
     print(f"peak: {str(peak.header_hash)[:6]}")

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2683,7 +2683,7 @@ async def test_long_reorg_nodes(
         p2 = full_node_1.full_node.blockchain.get_peak()
         return p1 == p2
 
-    await time_out_assert(100, check_nodes_in_sync)
+    await time_out_assert(200, check_nodes_in_sync)
     peak = full_node_2.full_node.blockchain.get_peak()
     assert peak is not None
     print(f"peak: {str(peak.header_hash)[:6]}")

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -791,7 +791,6 @@ class BlockTools:
             curr = blocks[curr.prev_hash]
         assert curr.timestamp is not None
         last_timestamp = float(curr.timestamp)
-        start_height = curr.height
 
         curr = latest_block
         blocks_added_this_sub_slot = 1
@@ -922,7 +921,6 @@ class BlockTools:
                             farmer_reward_puzzle_hash,
                             pool_target,
                             last_timestamp,
-                            start_height,
                             time_per_block,
                             new_gen,
                             height_to_hash,
@@ -1215,7 +1213,6 @@ class BlockTools:
                             farmer_reward_puzzle_hash,
                             pool_target,
                             last_timestamp,
-                            start_height,
                             time_per_block,
                             new_gen,
                             height_to_hash,
@@ -1846,7 +1843,6 @@ def get_full_block_and_block_record(
     farmer_reward_puzzle_hash: bytes32,
     pool_target: PoolTarget,
     last_timestamp: float,
-    start_height: uint32,
     time_per_block: float,
     new_gen: Optional[NewBlockGenerator],
     height_to_hash: dict[uint32, bytes32],

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -35,7 +35,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
 
 from chia.consensus.block_creation import create_unfinished_block, unfinished_block_to_full_block
-from chia.consensus.block_record import BlockRecord
+from chia.consensus.block_record import BlockRecord, BlockRecordProtocol
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.coinbase import create_puzzlehash_for_pk
 from chia.consensus.condition_costs import ConditionCost
@@ -337,6 +337,82 @@ class BlockTools:
             refresh_callback=test_callback,
             match_str=str(self.plot_dir.relative_to(DEFAULT_ROOT_PATH.parent)) if not automated_testing else None,
         )
+
+    def setup_new_gen(
+        self,
+        tx_block_heights: list[uint32],
+        curr: BlockRecordProtocol,
+        wallet: Optional[WalletTool],
+        rng: Optional[random.Random],
+        available_coins: list[Coin],
+        *,
+        dummy_block_references: bool,
+        include_transactions: bool,
+        transaction_data: Optional[SpendBundle],
+        block_refs: list[uint32],
+    ) -> Optional[NewBlockGenerator]:
+        # we don't know if the new block will be a transaction
+        # block or not, so even though we prepare a block
+        # generator, we can't update our state (like,
+        # available_coins) until it's confirmed the block
+        # generator made it into the block.
+        dummy_refs: list[uint32]
+        if dummy_block_references and len(tx_block_heights) > 4:
+            dummy_refs = [
+                tx_block_heights[1],
+                tx_block_heights[len(tx_block_heights) // 2],
+                tx_block_heights[-2],
+            ]
+        else:
+            dummy_refs = []
+
+        if transaction_data is not None:
+            # this means the caller passed in transaction_data
+            # to be included in the block.
+            additions = compute_additions_unchecked(transaction_data)
+            removals = transaction_data.removals()
+            if curr.height >= self.constants.HARD_FORK_HEIGHT:
+                program = simple_solution_generator_backrefs(transaction_data).program
+            else:
+                program = simple_solution_generator(transaction_data).program
+            block_refs = []
+            cost = compute_block_cost(program, self.constants, uint32(curr.height + 1))
+            return NewBlockGenerator(
+                program,
+                [],
+                block_refs,
+                transaction_data.aggregated_signature,
+                additions,
+                removals,
+                cost,
+            )
+
+        if include_transactions:
+            # if the caller did not pass in specific
+            # transactions, this parameter means we just want
+            # some transactions
+            assert wallet is not None
+            assert rng is not None
+            bundle, additions = make_spend_bundle(available_coins, wallet, rng)
+            removals = bundle.removals()
+            program = simple_solution_generator(bundle).program
+            cost = compute_block_cost(program, self.constants, uint32(curr.height + 1))
+            return NewBlockGenerator(
+                program,
+                [],
+                block_refs + dummy_refs,
+                bundle.aggregated_signature,
+                additions,
+                removals,
+                cost,
+            )
+
+        if dummy_block_references:
+            program = SerializedProgram.from_bytes(solution_generator([]))
+            cost = compute_block_cost(program, self.constants, uint32(curr.height + 1))
+            return NewBlockGenerator(program, [], block_refs + dummy_refs, G2Element(), [], [], cost)
+
+        return None
 
     async def setup_keys(self, fingerprint: Optional[int] = None, reward_ph: Optional[bytes32] = None) -> None:
         keychain_proxy: Optional[KeychainProxy]
@@ -819,66 +895,17 @@ class BlockTools:
                             else:
                                 pool_target = PoolTarget(self.pool_ph, uint32(0))
 
-                        # we don't know if the new block will be a transaction
-                        # block or not, so even though we prepare a block
-                        # generator, we can't update our state (like,
-                        # available_coins) until it's confirmed the block
-                        # generator made it into the block.
-                        if dummy_block_references and len(tx_block_heights) > 4:
-                            dummy_refs = [
-                                tx_block_heights[1],
-                                tx_block_heights[len(tx_block_heights) // 2],
-                                tx_block_heights[-2],
-                            ]
-                        else:
-                            dummy_refs = []
-
-                        new_gen: Optional[NewBlockGenerator]
-                        if transaction_data is not None:
-                            # this means the caller passed in transaction_data
-                            # to be included in the block.
-                            additions = compute_additions_unchecked(transaction_data)
-                            removals = transaction_data.removals()
-                            if curr.height >= constants.HARD_FORK_HEIGHT:
-                                program = simple_solution_generator_backrefs(transaction_data).program
-                            else:
-                                program = simple_solution_generator(transaction_data).program
-                            block_refs = []
-                            cost = compute_block_cost(program, constants, uint32(curr.height + 1))
-                            new_gen = NewBlockGenerator(
-                                program,
-                                [],
-                                block_refs,
-                                transaction_data.aggregated_signature,
-                                additions,
-                                removals,
-                                cost,
-                            )
-                        elif include_transactions:
-                            # if the caller did not pass in specific
-                            # transactions, this parameter means we just want
-                            # some transactions
-                            assert wallet is not None
-                            assert rng is not None
-                            bundle, additions = make_spend_bundle(available_coins, wallet, rng)
-                            removals = bundle.removals()
-                            program = simple_solution_generator(bundle).program
-                            cost = compute_block_cost(program, constants, uint32(curr.height + 1))
-                            new_gen = NewBlockGenerator(
-                                program,
-                                [],
-                                block_refs + dummy_refs,
-                                bundle.aggregated_signature,
-                                additions,
-                                removals,
-                                cost,
-                            )
-                        elif dummy_block_references:
-                            program = SerializedProgram.from_bytes(solution_generator([]))
-                            cost = compute_block_cost(program, constants, uint32(curr.height + 1))
-                            new_gen = NewBlockGenerator(program, [], block_refs + dummy_refs, G2Element(), [], [], cost)
-                        else:
-                            new_gen = None
+                        new_gen = self.setup_new_gen(
+                            tx_block_heights,
+                            curr,
+                            wallet,
+                            rng,
+                            available_coins,
+                            dummy_block_references=dummy_block_references,
+                            transaction_data=transaction_data,
+                            include_transactions=include_transactions,
+                            block_refs=block_refs,
+                        )
 
                         (
                             full_block,
@@ -910,6 +937,8 @@ class BlockTools:
                             seed,
                             normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
                             current_time=current_time,
+                            overflow_cc_challenge=None,
+                            overflow_rc_challenge=None,
                         )
                         if block_record.is_transaction_block:
                             transaction_data = None
@@ -920,8 +949,8 @@ class BlockTools:
                             continue
                         # print(f"{full_block.height:4}: difficulty {difficulty} "
                         #     f"time: {new_timestamp - last_timestamp:0.2f} "
-                        #     f"additions: {len(additions) if block_record.is_transaction_block else 0:2} "
-                        #     f"removals: {len(removals) if block_record.is_transaction_block else 0:2} "
+                        #     f"additions: {len(new_gen.additions) if block_record.is_transaction_block else 0:2} "
+                        #     f"removals: {len(new_gen.removals) if block_record.is_transaction_block else 0:2} "
                         #     f"refs: {len(full_block.transactions_generator_ref_list):3} "
                         #     f"tx: {block_record.is_transaction_block}")
                         last_timestamp = new_timestamp
@@ -934,23 +963,23 @@ class BlockTools:
                             if full_block.is_transaction_block():
                                 available_coins.extend(pending_rewards)
                                 pending_rewards = []
-                                for rem in removals:
-                                    available_coins.remove(rem)
-                                available_coins.extend(additions)
+                                if new_gen is not None:
+                                    for rem in new_gen.removals:
+                                        available_coins.remove(rem)
+                                    available_coins.extend(new_gen.additions)
 
                         if full_block.transactions_generator is not None:
                             tx_block_heights.append(full_block.height)
 
                         blocks_added_this_sub_slot += 1
-
                         blocks[full_block.header_hash] = block_record
-                        self.log.info(
-                            f"Created block {block_record.height} ove=False, iters {block_record.total_iters}"
-                        )
+                        self.log.info(f"Created block {block_record.height} ov=False, iters {block_record.total_iters}")
+                        num_blocks -= 1
+
                         height_to_hash[uint32(full_block.height)] = full_block.header_hash
                         latest_block = blocks[full_block.header_hash]
                         finished_sub_slots_at_ip = []
-                        num_blocks -= 1
+
                         if num_blocks <= 0 and not keep_going_until_tx_block:
                             self._block_cache_header = block_list[-1].header_hash
                             self._block_cache_height_to_hash = height_to_hash
@@ -1159,65 +1188,17 @@ class BlockTools:
                             else:
                                 pool_target = PoolTarget(self.pool_ph, uint32(0))
 
-                        # we don't know if the new block will be a transaction
-                        # block or not, so even though we prepare a block
-                        # generator, we can't update our state (like,
-                        # available_coins) until it's confirmed the block
-                        # generator made it into the block.
-                        if dummy_block_references and len(tx_block_heights) > 4:
-                            dummy_refs = [
-                                tx_block_heights[1],
-                                tx_block_heights[len(tx_block_heights) // 2],
-                                tx_block_heights[-2],
-                            ]
-                        else:
-                            dummy_refs = []
-
-                        if transaction_data is not None:
-                            # this means the caller passed in transaction_data
-                            # to be included in the block.
-                            additions = compute_additions_unchecked(transaction_data)
-                            removals = transaction_data.removals()
-                            if curr.height + 1 >= constants.HARD_FORK_HEIGHT:
-                                program = simple_solution_generator_backrefs(transaction_data).program
-                            else:
-                                program = simple_solution_generator(transaction_data).program
-                            block_refs = []
-                            cost = compute_block_cost(program, constants, uint32(curr.height + 1))
-                            new_gen = NewBlockGenerator(
-                                program,
-                                [],
-                                block_refs,
-                                transaction_data.aggregated_signature,
-                                additions,
-                                removals,
-                                cost,
-                            )
-                        elif include_transactions:
-                            # if the caller did not pass in specific
-                            # transactions, this parameter means we just want
-                            # some transactions
-                            assert wallet is not None
-                            assert rng is not None
-                            bundle, additions = make_spend_bundle(available_coins, wallet, rng)
-                            removals = bundle.removals()
-                            program = simple_solution_generator(bundle).program
-                            cost = compute_block_cost(program, constants, uint32(curr.height + 1))
-                            new_gen = NewBlockGenerator(
-                                program,
-                                [],
-                                block_refs + dummy_refs,
-                                bundle.aggregated_signature,
-                                additions,
-                                removals,
-                                cost,
-                            )
-                        elif dummy_block_references:
-                            program = SerializedProgram.from_bytes(solution_generator([]))
-                            cost = compute_block_cost(program, constants, uint32(curr.height + 1))
-                            new_gen = NewBlockGenerator(program, [], block_refs + dummy_refs, G2Element(), [], [], cost)
-                        else:
-                            new_gen = None
+                        new_gen = self.setup_new_gen(
+                            tx_block_heights,
+                            curr,
+                            wallet,
+                            rng,
+                            available_coins,
+                            dummy_block_references=dummy_block_references,
+                            transaction_data=transaction_data,
+                            include_transactions=include_transactions,
+                            block_refs=block_refs,
+                        )
 
                         (
                             full_block,
@@ -1247,10 +1228,10 @@ class BlockTools:
                             signage_point,
                             latest_block,
                             seed,
-                            overflow_cc_challenge=overflow_cc_challenge,
-                            overflow_rc_challenge=overflow_rc_challenge,
                             normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
                             current_time=current_time,
+                            overflow_cc_challenge=overflow_cc_challenge,
+                            overflow_rc_challenge=overflow_rc_challenge,
                         )
 
                         if block_record.is_transaction_block:
@@ -1262,12 +1243,11 @@ class BlockTools:
                             continue
                         # print(f"{full_block.height:4}: difficulty {difficulty} "
                         #     f"time: {new_timestamp - last_timestamp:0.2f} "
-                        #     f"additions: {len(additions) if block_record.is_transaction_block else 0:2} "
-                        #     f"removals: {len(removals) if block_record.is_transaction_block else 0:2} "
+                        #     f"additions: {len(new_gen.additions) if block_record.is_transaction_block else 0:2} "
+                        #     f"removals: {len(new_gen.removals) if block_record.is_transaction_block else 0:2} "
                         #     f"refs: {len(full_block.transactions_generator_ref_list):3} "
                         #     f"tx: {block_record.is_transaction_block}")
                         last_timestamp = new_timestamp
-
                         block_list.append(full_block)
 
                         if include_transactions:
@@ -1277,18 +1257,19 @@ class BlockTools:
                             if full_block.is_transaction_block():
                                 available_coins.extend(pending_rewards)
                                 pending_rewards = []
-                                for rem in removals:
-                                    available_coins.remove(rem)
-                                available_coins.extend(additions)
+                                if new_gen is not None:
+                                    for rem in new_gen.removals:
+                                        available_coins.remove(rem)
+                                    available_coins.extend(new_gen.additions)
 
                         if full_block.transactions_generator is not None:
                             tx_block_heights.append(full_block.height)
 
                         blocks_added_this_sub_slot += 1
+                        blocks[full_block.header_hash] = block_record
                         self.log.info(f"Created block {block_record.height} ov=True, iters {block_record.total_iters}")
                         num_blocks -= 1
 
-                        blocks[full_block.header_hash] = block_record
                         height_to_hash[uint32(full_block.height)] = full_block.header_hash
                         latest_block = blocks[full_block.header_hash]
                         finished_sub_slots_at_ip = []


### PR DESCRIPTION
### Purpose:

Simplify `BlockTools` to make it easier and more robust to additions and changes.

This PR is best reviewed one commit at a time.

One realization (that's mentioned in a new comment in this PR) is that we don't know whether a block will end up a transaction block or not up-front. We always prepare the transactions and pass into `get_full_block_and_block_record()`, only afterwards do we know whether the transactions were included or not.

The `include_transactions` feature (which includes some number of transactions in each TX block) maintains a list of `available_coins` that it spends some of, and add the coins created by those spends. These spends used to rely on another feature `transaction_data` (which can also be passed in by the caller), in order to "wait" until we get a transaction block to make the next set of transactions.

This patch removes this coupling and instead explicitly updates `available_coins` every time we get a transaction block. This makes the transactions not be created identically to the current chains and causes validation failures. That's why this needs an updated `test-cache` version of the blockchains. (available [here](https://github.com/Chia-Network/test-cache/pull/20))

### Current Behavior:

* there is a lot of code that's duplicated in `get_consecutive_blocks()`.
* there are unintuitive (and difficult to follow) dependencies between loop iterations when generating multiple blocks
   * `include_transactions` feature generate dummy transactions by setting `transaction_data`
   * `transaction_data_included` is set to true when `transaction_data` is included into a block that turned out to be a transaction block. We then set `transaction_data` to `None` to not include it again.
   * the `start_height` parameter was unused
* when generating transactions, we track `available_coins` and we remove the coins immediately when we create the bundle. This means we must keep the bundle around until the generated blocks turns out to be a transaction block (hence the dependency on `transaction_data`.

### New Behavior:

* there is slightly less code duplicated (some code was factored out into `setup_new_gen()`)
* there code to generate blocks is more insulated and has fewer unexpected dependencies. For example
   * the `transaction_data` feature is now independent from `include_transactions` feature.
   * `transaction_data_included` was removed. `transaction_data` is set to `None` directly
   * the `start_height` parameter was removed
* when generating transactions, we track `available_coins` and we remove coins we spent if the block turned into a transaction block

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
