### PR TITLE
Use smctl util to sync windows signing certificate

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -143,7 +143,7 @@ jobs:
           smksp_registrar.exe list
           smctl.exe keypair ls
           C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
-          smksp_cert_sync.exe
+          smctl.exe windows certsync --keypair-alias=${{ secrets.SM_CERTKEY_ALIAS }}
 
       - name: Get latest madmax plotter
         env:


### PR DESCRIPTION
### Purpose:

The `smksp_cert_sync` utility appears to not be pulling our signing certificate out of digicert's locker anymore. Speaking with digicert support, they suggested using smctl to sync it to the runner instead, which appears to work, but requires knowing the alias for the cert in advance.

### Current Behavior:

Windows builds fail to sign.

### New Behavior:

Windows builds are signed.

### Testing Notes:

See the Windows installer builder workflow
