### PR TITLE
CHIA-2743 Synchronous block generator creation

### DIFF
--- a/benchmarks/mempool-long-lived.py
+++ b/benchmarks/mempool-long-lived.py
@@ -17,7 +17,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.coin_record import CoinRecord
 from chia.types.condition_opcodes import ConditionOpcode
-from chia.types.eligible_coin_spends import UnspentLineageInfo
+from chia.types.mempool_item import UnspentLineageInfo
 
 # this is one week worth of blocks
 NUM_ITERS = 32256

--- a/benchmarks/mempool.py
+++ b/benchmarks/mempool.py
@@ -19,8 +19,8 @@ from chia.full_node.mempool_manager import MempoolManager
 from chia.simulator.wallet_tools import WalletTool
 from chia.types.blockchain_format.coin import Coin
 from chia.types.coin_record import CoinRecord
-from chia.types.eligible_coin_spends import UnspentLineageInfo
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
+from chia.types.mempool_item import UnspentLineageInfo
 from chia.util.batches import to_batches
 from chia.util.task_referencer import create_referenced_task
 
@@ -243,9 +243,7 @@ async def run_mempool_benchmark() -> None:
         with enable_profiler(True, f"create-{suffix}"):
             start = monotonic()
             for _ in range(10):
-                await mempool.create_block_generator(
-                    last_tb_header_hash=rec.header_hash,
-                )
+                mempool.create_block_generator(last_tb_header_hash=rec.header_hash)
             stop = monotonic()
         print(f"  time: {stop - start:0.4f}s")
         print(f"  per call: {(stop - start) / 10 * 1000:0.2f}ms")
@@ -254,7 +252,7 @@ async def run_mempool_benchmark() -> None:
         with enable_profiler(True, f"create2-{suffix}"):
             start = monotonic()
             for _ in range(10):
-                await mempool.create_block_generator2(last_tb_header_hash=rec.header_hash)
+                mempool.create_block_generator2(last_tb_header_hash=rec.header_hash)
             stop = monotonic()
         print(f"  time: {stop - start:0.4f}s")
         print(f"  per call: {(stop - start) / 10 * 1000:0.2f}ms")

--- a/chia/_tests/blockchain/test_blockchain_transactions.py
+++ b/chia/_tests/blockchain/test_blockchain_transactions.py
@@ -66,7 +66,7 @@ class TestBlockchainTransactions:
         assert sb == spend_bundle
 
         last_block = blocks[-1]
-        result = await full_node_1.mempool_manager.create_bundle_from_mempool(last_block.header_hash)
+        result = full_node_1.mempool_manager.create_bundle_from_mempool(last_block.header_hash)
         assert result is not None
         next_spendbundle, _ = result
 

--- a/chia/_tests/core/full_node/stores/test_coin_store.py
+++ b/chia/_tests/core/full_node/stores/test_coin_store.py
@@ -26,8 +26,8 @@ from chia.simulator.block_tools import BlockTools, test_constants
 from chia.simulator.wallet_tools import WalletTool
 from chia.types.blockchain_format.coin import Coin
 from chia.types.coin_record import CoinRecord
-from chia.types.eligible_coin_spends import UnspentLineageInfo
 from chia.types.generator_types import BlockGenerator
+from chia.types.mempool_item import UnspentLineageInfo
 from chia.util.generator_tools import tx_removals_and_additions
 from chia.util.hash import std_hash
 

--- a/chia/_tests/core/full_node/test_performance.py
+++ b/chia/_tests/core/full_node/test_performance.py
@@ -122,7 +122,7 @@ class TestPerformance:
         curr: BlockRecord = peak
         while not curr.is_transaction_block:
             curr = full_node_1.full_node.blockchain.block_record(curr.prev_hash)
-        mempool_bundle = await full_node_1.full_node.mempool_manager.create_bundle_from_mempool(curr.header_hash)
+        mempool_bundle = full_node_1.full_node.mempool_manager.create_bundle_from_mempool(curr.header_hash)
         if mempool_bundle is None:
             spend_bundle = None
         else:

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -7,7 +7,6 @@ from typing import Callable, Optional
 
 import pytest
 from chia_rs import (
-    ELIGIBLE_FOR_FF,
     ENABLE_KECCAK_OPS_OUTSIDE_GUARD,
     AugSchemeMPL,
     CoinSpend,
@@ -68,11 +67,11 @@ from chia.types.clvm_cost import CLVMCost
 from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
-from chia.types.eligible_coin_spends import UnspentLineageInfo, run_for_cost
+from chia.types.eligible_coin_spends import run_for_cost
 from chia.types.fee_rate import FeeRate
 from chia.types.generator_types import BlockGenerator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.types.mempool_item import MempoolItem
+from chia.types.mempool_item import MempoolItem, UnspentLineageInfo
 from chia.types.spend_bundle import estimate_fees
 from chia.util.errors import Err
 from chia.util.hash import std_hash
@@ -2932,45 +2931,8 @@ def test_items_by_feerate(items: list[MempoolItem], expected: list[Coin]) -> Non
         last_fpc = mi.fee_per_cost
 
 
-# make sure that after failing to pick 3 fast-forward spends, we skip
-# FF spends. create_block_generator2() does not stop trying FF spends after 3
-# failures, it keeps going. The new function (create_block_generator2()) does
-# not have a limit on FF and dedup spends so it tries all 5. make_test_coins()
-# only returns 5 coins
-@pytest.mark.anyio
-@pytest.mark.parametrize("old, expected", [(True, 3), (False, 5)])
-async def test_skip_error_items(old: bool, expected: int) -> None:
-    fee_estimator = create_bitcoin_fee_estimator(uint64(11000000000))
-    mempool_info = MempoolInfo(
-        CLVMCost(uint64(11000000000 * 3)),
-        FeeRate(uint64(1000000)),
-        CLVMCost(uint64(11000000000)),
-    )
-    mempool = Mempool(mempool_info, fee_estimator)
-
-    # all 5 items support fast forward
-    for i in range(5):
-        item = mk_item(coins[i : i + 1], flags=[ELIGIBLE_FOR_FF], fee=0, cost=50)
-        add_info = mempool.add_to_pool(item)
-        assert add_info.error is None
-
-    called = 0
-
-    async def local_get_unspent_lineage_info(ph: bytes32) -> Optional[UnspentLineageInfo]:
-        nonlocal called
-        called += 1
-        raise RuntimeError("failed to find fast forward coin")
-
-    create_block = mempool.create_block_generator if old else mempool.create_block_generator2
-    generator = await create_block(local_get_unspent_lineage_info, DEFAULT_CONSTANTS, uint32(10), 10.0)
-    assert generator is None
-
-    assert called == expected
-
-
-@pytest.mark.anyio
 @pytest.mark.parametrize("old", [True, False])
-async def test_timeout(old: bool) -> None:
+def test_timeout(old: bool) -> None:
     fee_estimator = create_bitcoin_fee_estimator(uint64(11000000000))
     mempool_info = MempoolInfo(
         CLVMCost(uint64(11000000000 * 3)),
@@ -2984,13 +2946,10 @@ async def test_timeout(old: bool) -> None:
         add_info = mempool.add_to_pool(item)
         assert add_info.error is None
 
-    async def local_get_unspent_lineage_info(ph: bytes32) -> Optional[UnspentLineageInfo]:
-        assert False  # pragma: no cover
-
     create_block = mempool.create_block_generator if old else mempool.create_block_generator2
 
     # the timeout is set to 0, we should *always* fail with a timeout
-    generator = await create_block(local_get_unspent_lineage_info, DEFAULT_CONSTANTS, uint32(10), 0.0)
+    generator = create_block(DEFAULT_CONSTANTS, uint32(10), 0.0)
     assert generator is None
 
 
@@ -3175,11 +3134,7 @@ def make_test_spendbundle(coin: Coin, *, fee: int = 0, with_higher_cost: bool = 
     return sb
 
 
-@pytest.mark.anyio
-async def test_aggregating_on_a_solution_then_a_more_cost_saving_one_appears() -> None:
-    async def get_unspent_lineage_info_for_puzzle_hash(_: bytes32) -> Optional[UnspentLineageInfo]:
-        assert False  # pragma: no cover
-
+def test_aggregating_on_a_solution_then_a_more_cost_saving_one_appears() -> None:
     def agg_and_add_sb_returning_cost_info(mempool: Mempool, spend_bundles: list[SpendBundle]) -> uint64:
         sb = SpendBundle.aggregate(spend_bundles)
         mi = mempool_item_from_spendbundle(sb)
@@ -3210,9 +3165,7 @@ async def test_aggregating_on_a_solution_then_a_more_cost_saving_one_appears() -
     sb_low_rate = make_test_spendbundle(coins[2], fee=highest_fee // 5)
     saved_cost_on_solution_A = agg_and_add_sb_returning_cost_info(mempool, [sb_A, sb_low_rate])
     invariant_check_mempool(mempool)
-    result = await mempool.create_bundle_from_mempool_items(
-        get_unspent_lineage_info_for_puzzle_hash, test_constants, uint32(0)
-    )
+    result = mempool.create_bundle_from_mempool_items(test_constants, uint32(0))
     assert result is not None
     agg, _ = result
     # Make sure both items would be processed
@@ -3231,9 +3184,7 @@ async def test_aggregating_on_a_solution_then_a_more_cost_saving_one_appears() -
     # If we process everything now, the 3 x ~3 FPC items get skipped because
     # sb_A1 gets picked before them (~10 FPC), so from then on only sb_A2 (~2 FPC)
     # would get picked
-    result = await mempool.create_bundle_from_mempool_items(
-        get_unspent_lineage_info_for_puzzle_hash, test_constants, uint32(0)
-    )
+    result = mempool.create_bundle_from_mempool_items(test_constants, uint32(0))
     assert result is not None
     agg, _ = result
     # The 3 items got skipped here
@@ -3250,12 +3201,8 @@ def test_get_puzzle_and_solution_for_coin_failure() -> None:
         get_puzzle_and_solution_for_coin(BlockGenerator(SerializedProgram.to(None), []), TEST_COIN, 0, test_constants)
 
 
-@pytest.mark.anyio
 @pytest.mark.parametrize("old", [True, False])
-async def test_create_block_generator(old: bool) -> None:
-    async def get_unspent_lineage_info_for_puzzle_hash(_: bytes32) -> Optional[UnspentLineageInfo]:
-        assert False  # pragma: no cover
-
+def test_create_block_generator(old: bool) -> None:
     mempool_info = MempoolInfo(
         CLVMCost(uint64(11000000000 * 3)),
         FeeRate(uint64(1000000)),
@@ -3278,7 +3225,7 @@ async def test_create_block_generator(old: bool) -> None:
         invariant_check_mempool(mempool)
 
     create_block = mempool.create_block_generator if old else mempool.create_block_generator2
-    generator = await create_block(get_unspent_lineage_info_for_puzzle_hash, test_constants, uint32(0), 10.0)
+    generator = create_block(test_constants, uint32(0), 10.0)
     assert generator is not None
 
     assert set(generator.additions) == expected_additions

--- a/chia/_tests/core/mempool/test_singleton_fast_forward.py
+++ b/chia/_tests/core/mempool/test_singleton_fast_forward.py
@@ -30,27 +30,21 @@ from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.eligible_coin_spends import (
     SingletonFastForward,
-    UnspentLineageInfo,
     perform_the_fast_forward,
 )
 from chia.types.internal_mempool_item import InternalMempoolItem
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.types.mempool_item import BundleCoinSpend
+from chia.types.mempool_item import BundleCoinSpend, UnspentLineageInfo
 from chia.util.errors import Err
 from chia.wallet.puzzles import p2_conditions, p2_delegated_puzzle_or_hidden_puzzle
 from chia.wallet.puzzles import singleton_top_layer_v1_1 as singleton_top_layer
 
 
-@pytest.mark.anyio
-async def test_process_fast_forward_spends_nothing_to_do() -> None:
+def test_process_fast_forward_spends_nothing_to_do() -> None:
     """
     This tests the case when we don't have an eligible coin, so there is
     nothing to fast forward and the item remains unchanged
     """
-
-    async def get_unspent_lineage_info_for_puzzle_hash(_: bytes32) -> Optional[UnspentLineageInfo]:
-        assert False  # pragma: no cover
-
     sk = AugSchemeMPL.key_gen(b"b" * 32)
     g1 = sk.get_g1()
     sig = AugSchemeMPL.sign(sk, b"foobar", g1)
@@ -62,49 +56,36 @@ async def test_process_fast_forward_spends_nothing_to_do() -> None:
     internal_mempool_item = InternalMempoolItem(sb, item.conds, item.height_added_to_mempool, item.bundle_coin_spends)
     original_version = dataclasses.replace(internal_mempool_item)
     singleton_ff = SingletonFastForward()
-    bundle_coin_spends = await singleton_ff.process_fast_forward_spends(
-        mempool_item=internal_mempool_item,
-        get_unspent_lineage_info_for_puzzle_hash=get_unspent_lineage_info_for_puzzle_hash,
-        height=TEST_HEIGHT,
-        constants=DEFAULT_CONSTANTS,
+    bundle_coin_spends = singleton_ff.process_fast_forward_spends(
+        mempool_item=internal_mempool_item, height=TEST_HEIGHT, constants=DEFAULT_CONSTANTS
     )
     assert singleton_ff == SingletonFastForward()
     assert bundle_coin_spends == original_version.bundle_coin_spends
 
 
-@pytest.mark.anyio
-async def test_process_fast_forward_spends_unknown_ff() -> None:
+def test_process_fast_forward_spends_unknown_ff() -> None:
     """
     This tests the case when we process for the first time but we are unable
-    to lookup the latest version from the DB
+    to lookup the latest version from the item's latest singleton lineage
     """
-
-    async def get_unspent_lineage_info_for_puzzle_hash(puzzle_hash: bytes32) -> Optional[UnspentLineageInfo]:
-        if puzzle_hash == IDENTITY_PUZZLE_HASH:
-            return None
-        assert False  # pragma: no cover
-
     test_coin = Coin(TEST_COIN_ID, IDENTITY_PUZZLE_HASH, uint64(1))
     conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1]]
     sb = spend_bundle_from_conditions(conditions, test_coin)
     item = mempool_item_from_spendbundle(sb)
     # The coin is eligible for fast forward
     assert item.bundle_coin_spends[test_coin.name()].eligible_for_fast_forward is True
+    item.bundle_coin_spends[test_coin.name()].latest_singleton_lineage = None
     internal_mempool_item = InternalMempoolItem(sb, item.conds, item.height_added_to_mempool, item.bundle_coin_spends)
     singleton_ff = SingletonFastForward()
     # We have no fast forward records yet, so we'll process this coin for the
-    # first time here, but the DB lookup will return None
+    # first time here, but the item's latest singleton lineage returns None
     with pytest.raises(ValueError, match="Cannot proceed with singleton spend fast forward."):
-        await singleton_ff.process_fast_forward_spends(
-            mempool_item=internal_mempool_item,
-            get_unspent_lineage_info_for_puzzle_hash=get_unspent_lineage_info_for_puzzle_hash,
-            height=TEST_HEIGHT,
-            constants=DEFAULT_CONSTANTS,
+        singleton_ff.process_fast_forward_spends(
+            mempool_item=internal_mempool_item, height=TEST_HEIGHT, constants=DEFAULT_CONSTANTS
         )
 
 
-@pytest.mark.anyio
-async def test_process_fast_forward_spends_latest_unspent() -> None:
+def test_process_fast_forward_spends_latest_unspent() -> None:
     """
     This tests the case when we are the latest singleton version already, so
     we don't need to fast forward, we just need to set the next version from
@@ -116,11 +97,6 @@ async def test_process_fast_forward_spends_latest_unspent() -> None:
         coin_id=test_coin.name(), parent_id=test_coin.parent_coin_info, parent_parent_id=TEST_COIN_ID
     )
 
-    async def get_unspent_lineage_info_for_puzzle_hash(puzzle_hash: bytes32) -> Optional[UnspentLineageInfo]:
-        if puzzle_hash == IDENTITY_PUZZLE_HASH:
-            return test_unspent_lineage_info
-        assert False  # pragma: no cover
-
     # At this point, spends are considered *potentially* eligible for singleton
     # fast forward mainly when their amount is odd and they don't have conditions
     # that disqualify them
@@ -128,14 +104,12 @@ async def test_process_fast_forward_spends_latest_unspent() -> None:
     sb = spend_bundle_from_conditions(conditions, test_coin)
     item = mempool_item_from_spendbundle(sb)
     assert item.bundle_coin_spends[test_coin.name()].eligible_for_fast_forward is True
+    item.bundle_coin_spends[test_coin.name()].latest_singleton_lineage = test_unspent_lineage_info
     internal_mempool_item = InternalMempoolItem(sb, item.conds, item.height_added_to_mempool, item.bundle_coin_spends)
     original_version = dataclasses.replace(internal_mempool_item)
     singleton_ff = SingletonFastForward()
-    bundle_coin_spends = await singleton_ff.process_fast_forward_spends(
-        mempool_item=internal_mempool_item,
-        get_unspent_lineage_info_for_puzzle_hash=get_unspent_lineage_info_for_puzzle_hash,
-        height=TEST_HEIGHT,
-        constants=DEFAULT_CONSTANTS,
+    bundle_coin_spends = singleton_ff.process_fast_forward_spends(
+        mempool_item=internal_mempool_item, height=TEST_HEIGHT, constants=DEFAULT_CONSTANTS
     )
     child_coin = item.bundle_coin_spends[test_coin.name()].additions[0]
     expected_fast_forward_spends = {
@@ -628,9 +602,7 @@ async def test_mempool_items_immutability_on_ff() -> None:
         original_item = copy.copy(sim_client.service.mempool_manager.get_mempool_item(sb_name))
         original_filter = sim_client.service.mempool_manager.get_filter()
         # Let's trigger the fast forward by creating a mempool bundle
-        result = await sim.mempool_manager.create_bundle_from_mempool(
-            sim_client.service.block_records[-1].header_hash,
-        )
+        result = sim.mempool_manager.create_bundle_from_mempool(sim_client.service.block_records[-1].header_hash)
         assert result is not None
         bundle, _ = result
         # Make sure the mempool bundle we created contains the result of our

--- a/chia/_tests/util/misc.py
+++ b/chia/_tests/util/misc.py
@@ -492,7 +492,10 @@ def invariant_check_mempool(mempool: Mempool) -> None:
             assert item.bundle_coin_spends[coin_id].coin_spend.coin.name() == coin_id
             continue
 
-        assert any(i.latest_singleton_coin == coin_id for i in item.bundle_coin_spends.values())
+        assert any(
+            i.latest_singleton_lineage is not None and i.latest_singleton_lineage.coin_id == coin_id
+            for i in item.bundle_coin_spends.values()
+        )
 
 
 async def wallet_height_at_least(wallet_node: WalletNode, h: uint32) -> bool:

--- a/chia/_tests/util/spend_sim.py
+++ b/chia/_tests/util/spend_sim.py
@@ -271,7 +271,7 @@ class SpendSim:
         if (len(self.block_records) > 0) and (self.mempool_manager.mempool.size() > 0):
             peak = self.mempool_manager.peak
             if peak is not None:
-                result = await self.mempool_manager.create_bundle_from_mempool(last_tb_header_hash=peak.header_hash)
+                result = self.mempool_manager.create_bundle_from_mempool(last_tb_header_hash=peak.header_hash)
                 if result is not None:
                     bundle, additions = result
                     generator_bundle = bundle

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -15,7 +15,7 @@ from chia_rs.sized_ints import uint32, uint64
 
 from chia.types.blockchain_format.coin import Coin
 from chia.types.coin_record import CoinRecord
-from chia.types.eligible_coin_spends import UnspentLineageInfo
+from chia.types.mempool_item import UnspentLineageInfo
 from chia.util.batches import to_batches
 from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER, DBWrapper2
 

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -868,7 +868,7 @@ class FullNodeAPI:
                         else:
                             create_block = self.full_node.mempool_manager.create_block_generator2
 
-                        new_block_gen = await create_block(curr_l_tb.header_hash)
+                        new_block_gen = create_block(curr_l_tb.header_hash)
 
                         if (
                             new_block_gen is not None and peak.height < self.full_node.constants.HARD_FORK_HEIGHT

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from collections.abc import Awaitable, Iterator
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from time import monotonic
-from typing import Callable, Optional
+from typing import Optional
 
 from chia_rs import (
     DONT_VALIDATE_SIGNATURE,
@@ -35,7 +35,6 @@ from chia.types.eligible_coin_spends import (
     IdenticalSpendDedup,
     SingletonFastForward,
     SkipDedup,
-    UnspentLineageInfo,
 )
 from chia.types.generator_types import NewBlockGenerator
 from chia.types.internal_mempool_item import InternalMempoolItem
@@ -475,8 +474,8 @@ class Mempool:
             for coin_id, bcs in item.bundle_coin_spends.items():
                 # any FF spend should be indexed by its latest singleton coin
                 # ID, this way we'll find it when the singleton is spent
-                if bcs.latest_singleton_coin is not None:
-                    all_coin_spends.append((bcs.latest_singleton_coin, item_name))
+                if bcs.latest_singleton_lineage is not None:
+                    all_coin_spends.append((bcs.latest_singleton_lineage.coin_id, item_name))
                 else:
                     all_coin_spends.append((coin_id, item_name))
             conn.executemany("INSERT OR IGNORE INTO spends VALUES(?, ?)", all_coin_spends)
@@ -503,9 +502,8 @@ class Mempool:
 
         return self._total_cost + cost > self.mempool_info.max_size_in_cost
 
-    async def create_block_generator(
+    def create_block_generator(
         self,
-        get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[Optional[UnspentLineageInfo]]],
         constants: ConsensusConstants,
         height: uint32,
         timeout: float,
@@ -515,12 +513,7 @@ class Mempool:
         re-run its puzzle.
         """
 
-        mempool_bundle = await self.create_bundle_from_mempool_items(
-            get_unspent_lineage_info_for_puzzle_hash,
-            constants,
-            height,
-            timeout,
-        )
+        mempool_bundle = self.create_bundle_from_mempool_items(constants, height, timeout)
         if mempool_bundle is None:
             return None
 
@@ -567,12 +560,8 @@ class Mempool:
             uint64(conds.cost),
         )
 
-    async def create_bundle_from_mempool_items(
-        self,
-        get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[Optional[UnspentLineageInfo]]],
-        constants: ConsensusConstants,
-        height: uint32,
-        timeout: float = 1.0,
+    def create_bundle_from_mempool_items(
+        self, constants: ConsensusConstants, height: uint32, timeout: float = 1.0
     ) -> Optional[tuple[SpendBundle, list[Coin]]]:
         cost_sum = 0  # Checks that total cost does not exceed block maximum
         fee_sum = 0  # Checks that total fees don't exceed 64 bits
@@ -625,11 +614,8 @@ class Mempool:
                         unique_additions.extend(spend_data.additions)
                     cost_saving = 0
                 else:
-                    bundle_coin_spends = await singleton_ff.process_fast_forward_spends(
-                        mempool_item=item,
-                        get_unspent_lineage_info_for_puzzle_hash=get_unspent_lineage_info_for_puzzle_hash,
-                        height=height,
-                        constants=constants,
+                    bundle_coin_spends = singleton_ff.process_fast_forward_spends(
+                        mempool_item=item, height=height, constants=constants
                     )
                     unique_coin_spends, cost_saving, unique_additions = dedup_coin_spends.get_deduplication_info(
                         bundle_coin_spends=bundle_coin_spends, max_cost=cost
@@ -691,12 +677,8 @@ class Mempool:
         )
         return agg, additions
 
-    async def create_block_generator2(
-        self,
-        get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[Optional[UnspentLineageInfo]]],
-        constants: ConsensusConstants,
-        height: uint32,
-        timeout: float,
+    def create_block_generator2(
+        self, constants: ConsensusConstants, height: uint32, timeout: float
     ) -> Optional[NewBlockGenerator]:
         fee_sum = 0  # Checks that total fees don't exceed 64 bits
         additions: list[Coin] = []
@@ -731,11 +713,8 @@ class Mempool:
             try:
                 assert item.conds is not None
                 cost = item.conds.condition_cost + item.conds.execution_cost
-                bundle_coin_spends = await singleton_ff.process_fast_forward_spends(
-                    mempool_item=item,
-                    get_unspent_lineage_info_for_puzzle_hash=get_unspent_lineage_info_for_puzzle_hash,
-                    height=height,
-                    constants=constants,
+                bundle_coin_spends = singleton_ff.process_fast_forward_spends(
+                    mempool_item=item, height=height, constants=constants
                 )
                 unique_coin_spends, cost_saving, unique_additions = dedup_coin_spends.get_deduplication_info(
                     bundle_coin_spends=bundle_coin_spends, max_cost=cost

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -869,7 +869,7 @@ class FullNodeRpcApi:
             start_time = time.monotonic()
 
             try:
-                maybe_gen = await self.service.mempool_manager.create_block_generator2(curr_l_tb.header_hash)
+                maybe_gen = self.service.mempool_manager.create_block_generator2(curr_l_tb.header_hash)
                 if maybe_gen is None:
                     self.service.log.error(f"failed to create block generator, peak: {peak}")
                 else:

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -203,7 +203,7 @@ class FullNodeSimulator(FullNodeAPI):
                     await asyncio.sleep(1)
                 else:
                     current_time = False
-            mempool_bundle = await self.full_node.mempool_manager.create_bundle_from_mempool(curr.header_hash)
+            mempool_bundle = self.full_node.mempool_manager.create_bundle_from_mempool(curr.header_hash)
             if mempool_bundle is None:
                 spend_bundle = None
             else:
@@ -256,7 +256,7 @@ class FullNodeSimulator(FullNodeAPI):
                     await asyncio.sleep(1)
                 else:
                     current_time = False
-            mempool_bundle = await self.full_node.mempool_manager.create_bundle_from_mempool(curr.header_hash)
+            mempool_bundle = self.full_node.mempool_manager.create_bundle_from_mempool(curr.header_hash)
             if mempool_bundle is None:
                 spend_bundle = None
             else:

--- a/chia/types/mempool_item.py
+++ b/chia/types/mempool_item.py
@@ -11,6 +11,13 @@ from chia.types.blockchain_format.coin import Coin
 from chia.util.streamable import recurse_jsonify
 
 
+@dataclass(frozen=True)
+class UnspentLineageInfo:
+    coin_id: bytes32
+    parent_id: bytes32
+    parent_parent_id: bytes32
+
+
 @dataclass
 class BundleCoinSpend:
     coin_spend: CoinSpend
@@ -21,10 +28,10 @@ class BundleCoinSpend:
     cost: Optional[uint64] = None
 
     # if this spend is eligible for fast forward, this may be set to the
-    # current unspent coin belonging to this singleton, that we would rebase
-    # this spen on top of if we were to make a block now
-    # When finding MempoolItems by coin ID, we use this Coin ID if it's set
-    latest_singleton_coin: Optional[bytes32] = None
+    # current unspent lineage belonging to this singleton, that we would rebase
+    # this spend on top of if we were to make a block now
+    # When finding MempoolItems by coin ID, we use Coin ID from it if it's set
+    latest_singleton_lineage: Optional[UnspentLineageInfo] = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION

### Purpose:

As we now track the most recent unspent for fast forward singleton spends in mempool items, we can create block generators in the mempool without performing the latest unspent DB lookup we currently do, resulting in synchronous block generator creation.

### Current Behavior:

Block generator creation is asynchronous due to the singleton fast forward latest unspent DB lookup step.

### New Behavior:

Block generator creation is synchronous by leveraging mempool items latest unspent data.