### PR TITLE
add timeout when waiting for chiapos to return

### DIFF
--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -63,6 +63,7 @@ class Harvester:
     event_loop: asyncio.events.AbstractEventLoop
     _server: Optional[ChiaServer]
     _mode: HarvestingMode
+    possible_stuck_lookups: bool
 
     @property
     def server(self) -> ChiaServer:
@@ -76,6 +77,7 @@ class Harvester:
     def __init__(self, root_path: Path, config: dict[str, Any], constants: ConsensusConstants):
         self.log = log
         self.root_path = root_path
+        self.possible_stuck_lookups = False
         # TODO, remove checks below later after some versions / time
         refresh_parameter: PlotsRefreshParameter = PlotsRefreshParameter()
         if "plot_loading_frequency_seconds" in config:

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -56,6 +56,7 @@ class Harvester:
     root_path: Path
     _shut_down: bool
     executor: ThreadPoolExecutor
+    harvester_threads: int
     state_changed_callback: Optional[StateChangedProtocol] = None
     constants: ConsensusConstants
     _refresh_lock: asyncio.Lock
@@ -94,8 +95,9 @@ class Harvester:
             root_path, refresh_parameter=refresh_parameter, refresh_callback=self._plot_refresh_callback
         )
         self._shut_down = False
+        self.harvester_threads = config.get("num_threads", 30)
         self.executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=config["num_threads"], thread_name_prefix="harvester-"
+            max_workers=self.harvester_threads, thread_name_prefix="harvester-"
         )
         self._server = None
         self.constants = constants


### PR DESCRIPTION
This is likely only a small benefit, but it will log an error sooner and cause a FarmingInfo message to be sent to the farmer when the timeout fires, which is possibly helpful in diagnostics. It also upgrades from a warning to an error in cases where it takes such a long time for the call to return.

I believe the python thread that is "occupied" doing the actual disk lookups via chiapos will continue to be occupied after this timeout, so I don't think this frees the thread to be used by another lookup. That is the thread is still blocked waiting for a chiapos response.

This just allows us to log the error sooner and return a message to the farmer rather than waiting for however long it takes the actual `blocking_lookup` call to return.

My reading of the overall code is that once all the available threads (default 30) get blocked, your harvester won't be able to process any SPs and they will pile up here as they get scheduled by `run_in_executor` - possibly there should be some limit set as to how many SPs can get piled up here before we stop doing that. This would need to add in some tracking of the tasks outstanding and if too many, stop scheduling them.