### PR TITLE
validate block generator created by the debug RPC

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -869,7 +869,9 @@ class FullNodeAPI:
 
                         new_block_gen = await create_block(curr_l_tb.header_hash)
 
-                        if new_block_gen is not None and peak.height < self.full_node.constants.HARD_FORK_HEIGHT:
+                        if (
+                            new_block_gen is not None and peak.height < self.full_node.constants.HARD_FORK_HEIGHT
+                        ):  # pragma: no cover
                             self.log.error("Cannot farm blocks pre-hard fork")
 
                     except Exception as e:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -869,6 +869,9 @@ class FullNodeAPI:
 
                         new_block_gen = await create_block(curr_l_tb.header_hash)
 
+                        if new_block_gen is not None and peak.height < self.full_node.constants.HARD_FORK_HEIGHT:
+                            self.log.error("Cannot farm blocks pre-hard fork")
+
                     except Exception as e:
                         self.log.error(f"Traceback: {traceback.format_exc()}")
                         self.full_node.log.error(f"Error making spend bundle {e} peak: {peak}")

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -615,7 +615,7 @@ class Mempool:
                     if any(
                         sd.eligible_for_dedup or sd.eligible_for_fast_forward for sd in item.bundle_coin_spends.values()
                     ):
-                        log.info("Skipping transaction with dedup or FF spends {item.name}")
+                        log.info(f"Skipping transaction with dedup or FF spends {item.spend_bundle.name()}")
                         continue
 
                     unique_coin_spends = []

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -880,7 +880,7 @@ class FullNodeRpcApi:
                     run_block_generator2,
                     bytes(gen.program),
                     gen.generator_refs,
-                    min(self.service.constants.MAX_BLOCK_COST_CLVM, gen.cost),
+                    self.service.constants.MAX_BLOCK_COST_CLVM,
                     MEMPOOL_MODE,
                     gen.signature,
                     None,
@@ -891,7 +891,11 @@ class FullNodeRpcApi:
                 else:
                     assert conds is not None
                     if conds.cost != gen.cost:
-                        self.service.log.error(f"invalid cost of generated block: {conds.cost} expected {gen.cost}")
+                        self.service.log.error(
+                            f"invalid cost of generated block: {conds.cost} expected {gen.cost}"
+                            f" exe-cost: {conds.execution_cost}"
+                            f" cond-cost: {conds.condition_cost}"
+                        )
                     # TODO: maybe validate additions and removals too
 
         return {

--- a/chia/rpc/full_node_rpc_api.py
+++ b/chia/rpc/full_node_rpc_api.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
-from chia_rs import FullBlock, SpendBundleConditions
+from chia_rs import MEMPOOL_MODE, FullBlock, SpendBundleConditions, run_block_generator2
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64, uint128
 
@@ -871,6 +872,27 @@ class FullNodeRpcApi:
             except Exception:
                 self.service.log.exception(f"Error creating block generator, peak: {peak}")
             self.service.log.info(f"Simulated block constructed in {time.monotonic() - start_time:0.2f} seconds")
+
+            if maybe_gen is not None:
+                # this also validates the signature
+                err, conds = await asyncio.get_running_loop().run_in_executor(
+                    self.service.blockchain.pool,
+                    run_block_generator2,
+                    bytes(gen.program),
+                    gen.generator_refs,
+                    min(self.service.constants.MAX_BLOCK_COST_CLVM, gen.cost),
+                    MEMPOOL_MODE,
+                    gen.signature,
+                    None,
+                    self.service.constants,
+                )
+                if err is not None:
+                    self.service.log.error(f"failed to validate block: {err}")
+                else:
+                    assert conds is not None
+                    if conds.cost != gen.cost:
+                        self.service.log.error(f"invalid cost of generated block: {conds.cost} expected {gen.cost}")
+                    # TODO: maybe validate additions and removals too
 
         return {
             "generator": gen.program,


### PR DESCRIPTION
### Purpose:

When running the (debug) RPC to create a block generator from the current mempool, also run the block generator to ensure it passes validation and has the cost that was computed.

### Current Behavior:

`chia dev mempool create_block` does not validate the resulting block generator.

### New Behavior:

`chia dev mempool create_block` validates some aspects of the resulting block generator.

### Testing Notes:

Tested this manually on a mainnet node