### PR TITLE
log if computing cost fails during block creation

### DIFF
--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -54,7 +54,7 @@ def compute_block_cost(generator: BlockGenerator, constants: ConsensusConstants,
     else:
         run_block = run_block_generator
 
-    _, conds = run_block(
+    err, conds = run_block(
         bytes(generator.program),
         generator.generator_refs,
         constants.MAX_BLOCK_COST_CLVM,
@@ -63,6 +63,8 @@ def compute_block_cost(generator: BlockGenerator, constants: ConsensusConstants,
         None,
         constants,
     )
+    if conds is None:  # pragma: no cover
+        log.error(f"unexpected error while computing block cost: {err} height: {height} generator: {generator.program}")
     return uint64(0 if conds is None else conds.cost)
 
 


### PR DESCRIPTION
### Purpose:

There has been one user report of failing to farm a transaction block because `cost` was set to 0 in the block header. It's unclear why this happened, but it might have been caused by failing to compute cost. This patch introduces an error log, with error code, if it fails.

This PR is against the 2.5.4 release branch, in case we decide we want another bugfix release from this branch.

### Current Behavior:

If block cost computation fails, we set cost block header field to 0.

### New Behavior:

If block cost computation fails, we set cost block header field to 0 and log an error.