### PR TITLE
log an error if we fail to compute the block cost

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -544,7 +544,7 @@ class Mempool:
 
         flags = get_flags_for_height_and_constants(height, constants) | MEMPOOL_MODE | DONT_VALIDATE_SIGNATURE
 
-        _, conds = run_block_generator2(
+        err, conds = run_block_generator2(
             block_program,
             [],
             constants.MAX_BLOCK_COST_CLVM,
@@ -553,6 +553,15 @@ class Mempool:
             None,
             constants,
         )
+
+        # this should not happen. This is essentially an assertion failure
+        if err is not None:  # pragma: no cover
+            log.error(
+                f"Failed to compute block cost during farming: {err} "
+                f"height: {height} "
+                f"generator: {bytes(block_program).hex()}"
+            )
+            return None
 
         assert conds is not None
         assert conds.cost > 0


### PR DESCRIPTION
instead of failing an assertion

### Purpose:

This is not expected to happen, but if it does, it's good to have an error message indicating what's going on.

### Current Behavior:

We throw an `AssertionFailure` exception if we fail to compute the block cost during farming.

### New Behavior:

We print an error message with relevant information and return `None` in case we fail to compute the block cost during farming. `None` means we farm a block without transactions.