### PR TITLE
use monotonic clock when timing functions in harvester

### DIFF
--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -88,7 +88,7 @@ class HarvesterAPI:
             f"sp_hash: {new_challenge.sp_hash}, signage_point_index: {new_challenge.signage_point_index}"
         )
 
-        start = time.time()
+        start = time.monotonic()
         assert len(new_challenge.challenge_hash) == 32
 
         loop = asyncio.get_running_loop()
@@ -254,11 +254,11 @@ class HarvesterAPI:
             self.harvester.log.debug(f"new_signage_point_harvester {passed} plots passed the plot filter")
 
         # Concurrently executes all lookups on disk, to take advantage of multiple disk parallelism
-        time_taken = time.time() - start
+        time_taken = time.monotonic() - start
         total_proofs_found = 0
         for filename_sublist_awaitable in asyncio.as_completed(awaitables):
             filename, sublist = await filename_sublist_awaitable
-            time_taken = time.time() - start
+            time_taken = time.monotonic() - start
             if time_taken > 8:
                 self.harvester.log.warning(
                     f"Looking up qualities on {filename} took: {time_taken}. This should be below 8 seconds"


### PR DESCRIPTION
### Purpose:
Fix issues like this:
```
2025-04-20T09:42:07.723 2.5.3 harvester harvester_server        : ERROR    Exception: Value -1450200 does not fit into uint64, PeerInfo(_ip=IPv4Address('127.0.0.1'), _port=8447). Traceback (most recent call last):
  File "chia\server\ws_connection.py", line 443, in wrapped_coroutine
  File "chia\harvester\harvester_api.py", line 284, in new_signage_point_harvester
  File "chia_rs\struct_stream.py", line 82, in __init__
ValueError: Value -1450200 does not fit into uint64
```

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
