### PR TITLE
dont skip same peak if in unfinished cache

### DIFF
--- a/chia/_tests/timelord/test_new_peak.py
+++ b/chia/_tests/timelord/test_new_peak.py
@@ -255,72 +255,6 @@ class TestNewPeak:
                 assert peak_after_unf_infusion.header_hash == block_1.header_hash
 
     @pytest.mark.anyio
-    async def test_timelord_new_peak_is_in_unfinished_cache(
-        self,
-        one_node: tuple[list[FullNodeService], list[FullNodeSimulator], BlockTools],
-        timelord: tuple[TimelordAPI, ChiaServer],
-        default_1000_blocks: list[FullBlock],
-    ) -> None:
-        _, _, bt = one_node
-        async with create_blockchain(bt.constants, 2) as (b1, _):
-            timelord_api, _ = timelord
-            for block in default_1000_blocks:
-                await _validate_and_add_block(b1, block)
-
-            peak = timelord_peak_from_block(b1, default_1000_blocks[-1])
-            assert peak is not None
-            assert timelord_api.timelord.new_peak is None
-            await timelord_api.new_peak_timelord(peak)
-            assert timelord_api.timelord.new_peak is not None
-            await time_out_assert(60, tl_new_peak_is_none, True, timelord_api)
-            assert timelord_api.timelord.last_state.peak is not None
-            assert (
-                timelord_api.timelord.last_state.peak.reward_chain_block.get_hash()
-                == peak.reward_chain_block.get_hash()
-            )
-
-            # make two new blocks on tip, block_2 has higher total iterations
-            block_1 = bt.get_consecutive_blocks(1, default_1000_blocks)[-1]
-
-            await _validate_and_add_block(b1, block_1)
-
-            block_record_1 = b1.block_record(block_1.header_hash)
-            sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
-                bt.constants,
-                len(block_1.finished_sub_slots) > 0,
-                b1.block_record(block_1.prev_header_hash),
-                b1,
-            )
-
-            timelord_unf_block = timelord_protocol.NewUnfinishedBlockTimelord(
-                block_1.reward_chain_block.get_unfinished(),
-                difficulty,
-                sub_slot_iters,
-                block_1.foliage,
-                next_sub_epoch_summary(bt.constants, b1, block_record_1.required_iters, block_1, True),
-                await get_rc_prev(b1, block_1),
-            )
-            await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
-            assert timelord_api.timelord.unfinished_blocks[-1].get_hash() == timelord_unf_block.get_hash()
-            assert (
-                timelord_api.timelord.unfinished_blocks[-1].reward_chain_block.get_hash()
-                == timelord_unf_block.reward_chain_block.get_hash()
-            )
-            new_peak = timelord_peak_from_block(b1, block_1)
-
-            assert timelord_unf_block.reward_chain_block.total_iters == new_peak.reward_chain_block.total_iters
-            await timelord_api.new_peak_timelord(new_peak)
-            await time_out_assert(60, tl_new_peak_is_none, True, timelord_api)
-
-            # check that peak was not skipped
-            assert (
-                timelord_api.timelord.last_state.peak.reward_chain_block.get_hash()
-                == new_peak.reward_chain_block.get_hash()
-            )
-            # check unfinished block_1 is not in cache
-            assert len(timelord_api.timelord.unfinished_blocks) == 0
-
-    @pytest.mark.anyio
     async def test_timelord_new_peak_unfinished_orphaned_overflow(
         self, bt: BlockTools, timelord: tuple[TimelordAPI, ChiaServer], default_1000_blocks: list[FullBlock]
     ) -> None:
@@ -519,6 +453,72 @@ class TestNewPeak:
                 assert peak == block_1
                 peak_tl = timelord_api.timelord.new_peak
                 assert peak_tl.reward_chain_block.get_hash() == peak.reward_chain_block.get_hash()
+
+    @pytest.mark.anyio
+    async def test_timelord_new_peak_is_in_unfinished_cache(
+        self,
+        one_node: tuple[list[FullNodeService], list[FullNodeSimulator], BlockTools],
+        timelord: tuple[TimelordAPI, ChiaServer],
+        default_1000_blocks: list[FullBlock],
+    ) -> None:
+        _, _, bt = one_node
+        async with create_blockchain(bt.constants, 2) as (b1, _):
+            timelord_api, _ = timelord
+            for block in default_1000_blocks:
+                await _validate_and_add_block(b1, block)
+
+            peak = timelord_peak_from_block(b1, default_1000_blocks[-1])
+            assert peak is not None
+            assert timelord_api.timelord.new_peak is None
+            await timelord_api.new_peak_timelord(peak)
+            assert timelord_api.timelord.new_peak is not None
+            await time_out_assert(60, tl_new_peak_is_none, True, timelord_api)
+            assert timelord_api.timelord.last_state.peak is not None
+            assert (
+                timelord_api.timelord.last_state.peak.reward_chain_block.get_hash()
+                == peak.reward_chain_block.get_hash()
+            )
+
+            # make two new blocks on tip, block_2 has higher total iterations
+            block_1 = bt.get_consecutive_blocks(1, default_1000_blocks)[-1]
+
+            await _validate_and_add_block(b1, block_1)
+
+            block_record_1 = b1.block_record(block_1.header_hash)
+            sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
+                bt.constants,
+                len(block_1.finished_sub_slots) > 0,
+                b1.block_record(block_1.prev_header_hash),
+                b1,
+            )
+
+            timelord_unf_block = timelord_protocol.NewUnfinishedBlockTimelord(
+                block_1.reward_chain_block.get_unfinished(),
+                difficulty,
+                sub_slot_iters,
+                block_1.foliage,
+                next_sub_epoch_summary(bt.constants, b1, block_record_1.required_iters, block_1, True),
+                await get_rc_prev(b1, block_1),
+            )
+            await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
+            assert timelord_api.timelord.unfinished_blocks[-1].get_hash() == timelord_unf_block.get_hash()
+            assert (
+                timelord_api.timelord.unfinished_blocks[-1].reward_chain_block.get_hash()
+                == timelord_unf_block.reward_chain_block.get_hash()
+            )
+            new_peak = timelord_peak_from_block(b1, block_1)
+
+            assert timelord_unf_block.reward_chain_block.total_iters == new_peak.reward_chain_block.total_iters
+            await timelord_api.new_peak_timelord(new_peak)
+            await time_out_assert(60, tl_new_peak_is_none, True, timelord_api)
+
+            # check that peak was not skipped
+            assert (
+                timelord_api.timelord.last_state.peak.reward_chain_block.get_hash()
+                == new_peak.reward_chain_block.get_hash()
+            )
+            # check unfinished block_1 is not in cache
+            assert len(timelord_api.timelord.unfinished_blocks) == 0
 
 
 async def get_rc_prev(blockchain: Blockchain, block: FullBlock) -> bytes32:

--- a/chia/_tests/timelord/test_new_peak.py
+++ b/chia/_tests/timelord/test_new_peak.py
@@ -279,7 +279,12 @@ class TestNewPeak:
                 # make two new blocks on tip
                 block_1 = bt.get_consecutive_blocks(1, default_1000_blocks, time_per_block=9, force_overflow=True)[-1]
                 block_2 = bt.get_consecutive_blocks(
-                    1, default_1000_blocks, seed=b"data", time_per_block=50, skip_slots=1, min_signage_point=block_1.reward_chain_block.signage_point_index
+                    1,
+                    default_1000_blocks,
+                    seed=b"data",
+                    time_per_block=50,
+                    skip_slots=1,
+                    min_signage_point=block_1.reward_chain_block.signage_point_index,
                 )[-1]
                 # make sure block_2 has higher iterations
                 assert block_2.total_iters >= block_1.total_iters
@@ -305,7 +310,7 @@ class TestNewPeak:
                 )
                 await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
 
-                assert timelord_api.timelord.overflow_blocks[-1].get_hash() == timelord_unf_block.get_hash()                
+                assert timelord_api.timelord.overflow_blocks[-1].get_hash() == timelord_unf_block.get_hash()
                 new_peak = timelord_peak_from_block(b2, block_2)
                 assert timelord_unf_block.reward_chain_block.total_iters <= new_peak.reward_chain_block.total_iters
                 assert block_1.reward_chain_block.get_hash() != new_peak.reward_chain_block.get_hash()

--- a/chia/_tests/timelord/test_new_peak.py
+++ b/chia/_tests/timelord/test_new_peak.py
@@ -255,6 +255,72 @@ class TestNewPeak:
                 assert peak_after_unf_infusion.header_hash == block_1.header_hash
 
     @pytest.mark.anyio
+    async def test_timelord_new_peak_is_in_unfinished_cache(
+        self,
+        one_node: tuple[list[FullNodeService], list[FullNodeSimulator], BlockTools],
+        timelord: tuple[TimelordAPI, ChiaServer],
+        default_1000_blocks: list[FullBlock],
+    ) -> None:
+        _, _, bt = one_node
+        async with create_blockchain(bt.constants, 2) as (b1, _):
+            timelord_api, _ = timelord
+            for block in default_1000_blocks:
+                await _validate_and_add_block(b1, block)
+
+            peak = timelord_peak_from_block(b1, default_1000_blocks[-1])
+            assert peak is not None
+            assert timelord_api.timelord.new_peak is None
+            await timelord_api.new_peak_timelord(peak)
+            assert timelord_api.timelord.new_peak is not None
+            await time_out_assert(60, tl_new_peak_is_none, True, timelord_api)
+            assert timelord_api.timelord.last_state.peak is not None
+            assert (
+                timelord_api.timelord.last_state.peak.reward_chain_block.get_hash()
+                == peak.reward_chain_block.get_hash()
+            )
+
+            # make two new blocks on tip, block_2 has higher total iterations
+            block_1 = bt.get_consecutive_blocks(1, default_1000_blocks)[-1]
+
+            await _validate_and_add_block(b1, block_1)
+
+            block_record_1 = b1.block_record(block_1.header_hash)
+            sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
+                bt.constants,
+                len(block_1.finished_sub_slots) > 0,
+                b1.block_record(block_1.prev_header_hash),
+                b1,
+            )
+
+            timelord_unf_block = timelord_protocol.NewUnfinishedBlockTimelord(
+                block_1.reward_chain_block.get_unfinished(),
+                difficulty,
+                sub_slot_iters,
+                block_1.foliage,
+                next_sub_epoch_summary(bt.constants, b1, block_record_1.required_iters, block_1, True),
+                await get_rc_prev(b1, block_1),
+            )
+            await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
+            assert timelord_api.timelord.unfinished_blocks[-1].get_hash() == timelord_unf_block.get_hash()
+            assert (
+                timelord_api.timelord.unfinished_blocks[-1].reward_chain_block.get_hash()
+                == timelord_unf_block.reward_chain_block.get_hash()
+            )
+            new_peak = timelord_peak_from_block(b1, block_1)
+
+            assert timelord_unf_block.reward_chain_block.total_iters == new_peak.reward_chain_block.total_iters
+            await timelord_api.new_peak_timelord(new_peak)
+            await time_out_assert(60, tl_new_peak_is_none, True, timelord_api)
+
+            # check that peak was not skipped
+            assert (
+                timelord_api.timelord.last_state.peak.reward_chain_block.get_hash()
+                == new_peak.reward_chain_block.get_hash()
+            )
+            # check unfinished block_1 is not in cache
+            assert len(timelord_api.timelord.unfinished_blocks) == 0
+
+    @pytest.mark.anyio
     async def test_timelord_new_peak_unfinished_orphaned_overflow(
         self, bt: BlockTools, timelord: tuple[TimelordAPI, ChiaServer], default_1000_blocks: list[FullBlock]
     ) -> None:

--- a/chia/_tests/timelord/test_new_peak.py
+++ b/chia/_tests/timelord/test_new_peak.py
@@ -279,7 +279,7 @@ class TestNewPeak:
                 # make two new blocks on tip
                 block_1 = bt.get_consecutive_blocks(1, default_1000_blocks, time_per_block=9, force_overflow=True)[-1]
                 block_2 = bt.get_consecutive_blocks(
-                    1, default_1000_blocks, seed=b"data", time_per_block=50, skip_slots=1
+                    1, default_1000_blocks, seed=b"data", time_per_block=50, skip_slots=1, min_signage_point=block_1.reward_chain_block.signage_point_index
                 )[-1]
                 # make sure block_2 has higher iterations
                 assert block_2.total_iters >= block_1.total_iters
@@ -305,9 +305,10 @@ class TestNewPeak:
                 )
                 await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
 
-                assert timelord_api.timelord.overflow_blocks[-1].get_hash() == timelord_unf_block.get_hash()
+                assert timelord_api.timelord.overflow_blocks[-1].get_hash() == timelord_unf_block.get_hash()                
                 new_peak = timelord_peak_from_block(b2, block_2)
                 assert timelord_unf_block.reward_chain_block.total_iters <= new_peak.reward_chain_block.total_iters
+                assert block_1.reward_chain_block.get_hash() != new_peak.reward_chain_block.get_hash()
                 await timelord_api.new_peak_timelord(new_peak)
 
                 await time_out_assert(60, tl_new_peak_is_none, True, timelord_api)

--- a/chia/timelord/timelord_api.py
+++ b/chia/timelord/timelord_api.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, ClassVar, Optional, cast
 from chia_rs.sized_ints import uint64
 
 from chia.protocols import timelord_protocol
+from chia.protocols.timelord_protocol import NewPeakTimelord
 from chia.rpc.rpc_server import StateChangedProtocol
 from chia.server.api_protocol import ApiMetadata
 from chia.timelord.iters_from_block import iters_from_block
@@ -37,7 +38,7 @@ class TimelordAPI:
         self.timelord.state_changed_callback = callback
 
     @metadata.request()
-    async def new_peak_timelord(self, new_peak: timelord_protocol.NewPeakTimelord) -> None:
+    async def new_peak_timelord(self, new_peak: NewPeakTimelord) -> None:
         if self.timelord.last_state is None:
             return None
         async with self.timelord.lock:
@@ -99,7 +100,7 @@ class TimelordAPI:
 
             self.timelord.state_changed("skipping_peak", {"height": new_peak.reward_chain_block.height})
 
-    def check_orphaned_unfinished_block(self, new_peak: timelord_protocol.NewPeakTimelord):
+    def check_orphaned_unfinished_block(self, new_peak: NewPeakTimelord):
         new_peak_unf_rh = new_peak.reward_chain_block.get_unfinished().get_hash()
         for unf_block in self.timelord.unfinished_blocks:
             if unf_block.reward_chain_block.total_iters <= new_peak.reward_chain_block.total_iters:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
dont skip a peak from the full node if it is in the unfinished cache
<!-- Does this PR introduce a breaking change? -->

### Current Behavior:
we skip it only to infuse an already infused peak
### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
