### PR TITLE
Fix `chia.util` <= `chia.server` dependency

### DIFF
--- a/chia/_tests/util/test_config.py
+++ b/chia/_tests/util/test_config.py
@@ -7,8 +7,8 @@ from chia_rs.sized_ints import uint16
 
 from chia._tests.util.misc import DataCase, Marks, datacases
 from chia.server.outbound_message import NodeType
+from chia.server.resolve_peer_info import get_unresolved_peer_infos, set_peer_info
 from chia.types.peer_info import UnresolvedPeerInfo
-from chia.util.config import get_unresolved_peer_infos, set_peer_info
 
 
 @dataclass

--- a/chia/cmds/configure.py
+++ b/chia/cmds/configure.py
@@ -8,12 +8,12 @@ import yaml
 
 from chia.cmds.cmd_classes import ChiaCliContext
 from chia.server.outbound_message import NodeType
+from chia.server.resolve_peer_info import set_peer_info
 from chia.util.config import (
     initial_config_file,
     load_defaults_for_missing_services,
     lock_and_load_config,
     save_config,
-    set_peer_info,
     str2bool,
 )
 

--- a/chia/cmds/sim_funcs.py
+++ b/chia/cmds/sim_funcs.py
@@ -16,10 +16,11 @@ from chia.cmds.cmds_util import get_any_service_client
 from chia.cmds.start_funcs import async_start
 from chia.consensus.coinbase import create_puzzlehash_for_pk
 from chia.server.outbound_message import NodeType
+from chia.server.resolve_peer_info import set_peer_info
 from chia.simulator.simulator_full_node_rpc_client import SimulatorFullNodeRpcClient
 from chia.types.coin_record import CoinRecord
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
-from chia.util.config import load_config, save_config, set_peer_info
+from chia.util.config import load_config, save_config
 from chia.util.errors import KeychainFingerprintExists
 from chia.util.keychain import Keychain, bytes_to_mnemonic
 from chia.wallet.derive_keys import (

--- a/chia/server/resolve_peer_info.py
+++ b/chia/server/resolve_peer_info.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from chia.server.outbound_message import NodeType
+from chia.types.peer_info import UnresolvedPeerInfo
+
+log = logging.getLogger(__name__)
+
+PEER_INFO_MAPPING: dict[NodeType, str] = {
+    NodeType.FULL_NODE: "full_node_peer",
+    NodeType.FARMER: "farmer_peer",
+}
+
+
+def get_unresolved_peer_infos(service_config: dict[str, Any], peer_type: NodeType) -> set[UnresolvedPeerInfo]:
+    peer_info_key = PEER_INFO_MAPPING[peer_type]
+    peer_infos: list[dict[str, Any]] = service_config.get(f"{peer_info_key}s", [])
+    peer_info: Optional[dict[str, Any]] = service_config.get(peer_info_key)
+    if peer_info is not None:
+        peer_infos.append(peer_info)
+
+    return {UnresolvedPeerInfo(host=peer["host"], port=peer["port"]) for peer in peer_infos}
+
+
+def set_peer_info(
+    service_config: dict[str, Any],
+    peer_type: NodeType,
+    peer_host: Optional[str] = None,
+    peer_port: Optional[int] = None,
+) -> None:
+    peer_info_key = PEER_INFO_MAPPING[peer_type]
+    if peer_info_key in service_config:
+        if peer_host is not None:
+            service_config[peer_info_key]["host"] = peer_host
+        if peer_port is not None:
+            service_config[peer_info_key]["port"] = peer_port
+    elif f"{peer_info_key}s" in service_config and len(service_config[f"{peer_info_key}s"]) > 0:
+        if peer_host is not None:
+            service_config[f"{peer_info_key}s"][0]["host"] = peer_host
+        if peer_port is not None:
+            service_config[f"{peer_info_key}s"][0]["port"] = peer_port

--- a/chia/server/start_farmer.py
+++ b/chia/server/start_farmer.py
@@ -15,10 +15,11 @@ from chia.farmer.farmer_api import FarmerAPI
 from chia.rpc.farmer_rpc_api import FarmerRpcApi
 from chia.server.aliases import FarmerService
 from chia.server.outbound_message import NodeType
+from chia.server.resolve_peer_info import get_unresolved_peer_infos
 from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_service import RpcInfo, Service, async_run
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import get_unresolved_peer_infos, load_config, load_config_cli
+from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import resolve_root_path
 from chia.util.keychain import Keychain
 from chia.util.task_timing import maybe_manage_task_instrumentation

--- a/chia/server/start_full_node.py
+++ b/chia/server/start_full_node.py
@@ -17,10 +17,11 @@ from chia.full_node.full_node_api import FullNodeAPI
 from chia.rpc.full_node_rpc_api import FullNodeRpcApi
 from chia.server.aliases import FullNodeService
 from chia.server.outbound_message import NodeType
+from chia.server.resolve_peer_info import get_unresolved_peer_infos
 from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_service import RpcInfo, Service, async_run
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import get_unresolved_peer_infos, load_config, load_config_cli
+from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import resolve_root_path
 from chia.util.task_timing import maybe_manage_task_instrumentation
 

--- a/chia/server/start_harvester.py
+++ b/chia/server/start_harvester.py
@@ -15,11 +15,12 @@ from chia.harvester.harvester_api import HarvesterAPI
 from chia.rpc.harvester_rpc_api import HarvesterRpcApi
 from chia.server.aliases import HarvesterService
 from chia.server.outbound_message import NodeType
+from chia.server.resolve_peer_info import get_unresolved_peer_infos
 from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_service import RpcInfo, Service, async_run
 from chia.types.peer_info import UnresolvedPeerInfo
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import get_unresolved_peer_infos, load_config, load_config_cli
+from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import resolve_root_path
 from chia.util.task_timing import maybe_manage_task_instrumentation
 

--- a/chia/server/start_timelord.py
+++ b/chia/server/start_timelord.py
@@ -13,12 +13,13 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.rpc.timelord_rpc_api import TimelordRpcApi
 from chia.server.aliases import TimelordService
 from chia.server.outbound_message import NodeType
+from chia.server.resolve_peer_info import get_unresolved_peer_infos
 from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_service import RpcInfo, Service, async_run
 from chia.timelord.timelord import Timelord
 from chia.timelord.timelord_api import TimelordAPI
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import get_unresolved_peer_infos, load_config, load_config_cli
+from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import resolve_root_path
 from chia.util.task_timing import maybe_manage_task_instrumentation
 

--- a/chia/server/start_wallet.py
+++ b/chia/server/start_wallet.py
@@ -14,10 +14,11 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.rpc.wallet_rpc_api import WalletRpcApi
 from chia.server.aliases import WalletService
 from chia.server.outbound_message import NodeType
+from chia.server.resolve_peer_info import get_unresolved_peer_infos
 from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_service import RpcInfo, Service, async_run
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import get_unresolved_peer_infos, load_config, load_config_cli
+from chia.util.config import load_config, load_config_cli
 from chia.util.default_root import resolve_root_path
 from chia.util.keychain import Keychain
 from chia.util.task_timing import maybe_manage_task_instrumentation

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -31,6 +31,7 @@ from chia.server.aliases import (
     WalletService,
 )
 from chia.server.outbound_message import NodeType
+from chia.server.resolve_peer_info import set_peer_info
 from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_farmer import create_farmer_service
 from chia.server.start_full_node import create_full_node_service
@@ -46,7 +47,7 @@ from chia.ssl.create_ssl import create_all_ssl
 from chia.timelord.timelord_launcher import VDFClientProcessMgr, find_vdf_client, spawn_process
 from chia.types.peer_info import UnresolvedPeerInfo
 from chia.util.bech32m import encode_puzzle_hash
-from chia.util.config import config_path_for_filename, load_config, lock_and_load_config, save_config, set_peer_info
+from chia.util.config import config_path_for_filename, load_config, lock_and_load_config, save_config
 from chia.util.db_wrapper import generate_in_memory_db_uri
 from chia.util.keychain import bytes_to_mnemonic
 from chia.util.lock import Lockfile

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -18,8 +18,6 @@ import importlib_resources
 import yaml
 from typing_extensions import Literal
 
-from chia.server.outbound_message import NodeType
-from chia.types.peer_info import UnresolvedPeerInfo
 from chia.util.lock import Lockfile
 
 log = logging.getLogger(__name__)
@@ -330,38 +328,3 @@ def load_defaults_for_missing_services(config: dict[str, Any], config_name: str)
                     defaulted[service]["selected_network"] = "".join(to_be_referenced)
 
     return defaulted
-
-
-PEER_INFO_MAPPING: dict[NodeType, str] = {
-    NodeType.FULL_NODE: "full_node_peer",
-    NodeType.FARMER: "farmer_peer",
-}
-
-
-def get_unresolved_peer_infos(service_config: dict[str, Any], peer_type: NodeType) -> set[UnresolvedPeerInfo]:
-    peer_info_key = PEER_INFO_MAPPING[peer_type]
-    peer_infos: list[dict[str, Any]] = service_config.get(f"{peer_info_key}s", [])
-    peer_info: Optional[dict[str, Any]] = service_config.get(peer_info_key)
-    if peer_info is not None:
-        peer_infos.append(peer_info)
-
-    return {UnresolvedPeerInfo(host=peer["host"], port=peer["port"]) for peer in peer_infos}
-
-
-def set_peer_info(
-    service_config: dict[str, Any],
-    peer_type: NodeType,
-    peer_host: Optional[str] = None,
-    peer_port: Optional[int] = None,
-) -> None:
-    peer_info_key = PEER_INFO_MAPPING[peer_type]
-    if peer_info_key in service_config:
-        if peer_host is not None:
-            service_config[peer_info_key]["host"] = peer_host
-        if peer_port is not None:
-            service_config[peer_info_key]["port"] = peer_port
-    elif f"{peer_info_key}s" in service_config and len(service_config[f"{peer_info_key}s"]) > 0:
-        if peer_host is not None:
-            service_config[f"{peer_info_key}s"][0]["host"] = peer_host
-        if peer_port is not None:
-            service_config[f"{peer_info_key}s"][0]["port"] = peer_port


### PR DESCRIPTION
`chia.util.config` to `chia.server.resolve_peer_info.py` so that `chia.util` no longer depends upon `chia.server`.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

The `chia.util` module depends on `chia.server` and it should not. This change resolves this problem.

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
