### PR TITLE
add different foliage coverage to TL new peak

### DIFF
--- a/chia/_tests/timelord/test_new_peak.py
+++ b/chia/_tests/timelord/test_new_peak.py
@@ -5,7 +5,7 @@ from typing import Optional
 import pytest
 from chia_rs import BlockRecord, FullBlock, SubEpochSummary, UnfinishedBlock
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint128
+from chia_rs.sized_ints import uint64, uint128
 
 from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from chia._tests.util.blockchain import create_blockchain
@@ -18,6 +18,7 @@ from chia.server.aliases import FullNodeService
 from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator
+from chia.simulator.wallet_tools import WalletTool
 from chia.timelord.timelord_api import TimelordAPI
 
 
@@ -115,14 +116,11 @@ class TestNewPeak:
             await _validate_and_add_block(b1, block_2)
 
             block_record = b1.block_record(block_2.header_hash)
-            sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
-                bt.constants, len(block_1.finished_sub_slots) > 0, b1.block_record(block_1.prev_header_hash), b1
-            )
 
             timelord_unf_block = timelord_protocol.NewUnfinishedBlockTimelord(
                 block_1.reward_chain_block.get_unfinished(),
-                difficulty,
-                sub_slot_iters,
+                uint64(block_record.weight - default_1000_blocks[-1].weight),
+                block_record.sub_slot_iters,
                 block_1.foliage,
                 next_sub_epoch_summary(bt.constants, b1, block_record.required_iters, block_1, True),
                 await get_rc_prev(b1, block_1),
@@ -185,17 +183,11 @@ class TestNewPeak:
                 await _validate_and_add_block(b2, block_2)
 
                 block_record_1 = b1.block_record(block_1.header_hash)
-                sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
-                    bt.constants,
-                    len(block_1.finished_sub_slots) > 0,
-                    b1.block_record(block_1.prev_header_hash),
-                    b1,
-                )
 
                 timelord_unf_block = timelord_protocol.NewUnfinishedBlockTimelord(
                     block_1.reward_chain_block.get_unfinished(),
-                    difficulty,
-                    sub_slot_iters,
+                    uint64(block_record_1.weight - default_1000_blocks[-1].weight),
+                    block_record_1.sub_slot_iters,
                     block_1.foliage,
                     next_sub_epoch_summary(bt.constants, b1, block_record_1.required_iters, block_1, True),
                     await get_rc_prev(b1, block_1),
@@ -367,17 +359,10 @@ class TestNewPeak:
                 assert fn_peak is not None and fn_peak.header_hash == block_2.header_hash
 
                 block_record = b2.block_record(block_2.header_hash)
-                sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
-                    bt.constants,
-                    len(block_2.finished_sub_slots) > 0,
-                    b1.block_record(block_2.prev_header_hash),
-                    b1,
-                )
-
                 timelord_unf_block = timelord_protocol.NewUnfinishedBlockTimelord(
                     block_2.reward_chain_block.get_unfinished(),
-                    difficulty,
-                    sub_slot_iters,
+                    uint64(block_record.weight - default_1000_blocks[-1].weight),
+                    block_record.sub_slot_iters,
                     block_2.foliage,
                     next_sub_epoch_summary(bt.constants, b1, block_record.required_iters, block_2, True),
                     await get_rc_prev(b2, block_2),
@@ -461,59 +446,97 @@ class TestNewPeak:
                 assert peak_tl.reward_chain_block.get_hash() == peak.reward_chain_block.get_hash()
 
     @pytest.mark.anyio
+    @pytest.mark.parametrize("different_foliage", [False, True])
     async def test_timelord_new_peak_is_in_unfinished_cache(
         self,
         one_node: tuple[list[FullNodeService], list[FullNodeSimulator], BlockTools],
         timelord: tuple[TimelordAPI, ChiaServer],
         default_1000_blocks: list[FullBlock],
+        different_foliage: bool,
     ) -> None:
         _, _, bt = one_node
+        wallet = WalletTool(bt.constants)
+        coinbase_puzzlehash = wallet.get_new_puzzlehash()
+        timelord_api, _ = timelord
+        blocks = bt.get_consecutive_blocks(
+            num_blocks=10,
+            block_list_input=default_1000_blocks,
+            skip_overflow=True,
+            force_overflow=False,
+            farmer_reward_puzzle_hash=coinbase_puzzlehash,
+            guarantee_transaction_block=True,
+        )
         async with create_blockchain(bt.constants, 2) as (b1, _):
-            timelord_api, _ = timelord
-            for block in default_1000_blocks:
+            for block in blocks:
                 await _validate_and_add_block(b1, block)
 
-            peak = timelord_peak_from_block(b1, default_1000_blocks[-1])
-            assert peak is not None
-            assert timelord_api.timelord.new_peak is None
+            peak = timelord_peak_from_block(b1, blocks[-1])
+            assert peak is not None and timelord_api.timelord.new_peak is None
             await timelord_api.new_peak_timelord(peak)
             assert timelord_api.timelord.new_peak is not None
             await time_out_assert(60, tl_new_peak_is_none, True, timelord_api)
-            assert timelord_api.timelord.last_state.peak is not None
             assert (
-                timelord_api.timelord.last_state.peak.reward_chain_block.get_hash()
+                timelord_api.timelord.last_state.peak is not None
+                and timelord_api.timelord.last_state.peak.reward_chain_block.get_hash()
                 == peak.reward_chain_block.get_hash()
             )
 
-            # make two new blocks on tip, block_2 has higher total iterations
-            block_1 = bt.get_consecutive_blocks(1, default_1000_blocks)[-1]
+            block_1 = bt.get_consecutive_blocks(
+                block_list_input=blocks,
+                num_blocks=1,
+                farmer_reward_puzzle_hash=coinbase_puzzlehash,
+                guarantee_transaction_block=True,
+                skip_overflow=True,
+            )[-1]
 
             await _validate_and_add_block(b1, block_1)
-
             block_record_1 = b1.block_record(block_1.header_hash)
-            sub_slot_iters, difficulty = get_next_sub_slot_iters_and_difficulty(
-                bt.constants,
-                len(block_1.finished_sub_slots) > 0,
-                b1.block_record(block_1.prev_header_hash),
-                b1,
-            )
+            if len(block_1.finished_sub_slots) > 0:
+                timelord_api.timelord.last_state.set_state(block_1.finished_sub_slots[-1])
 
-            timelord_unf_block = timelord_protocol.NewUnfinishedBlockTimelord(
-                block_1.reward_chain_block.get_unfinished(),
-                difficulty,
-                sub_slot_iters,
-                block_1.foliage,
-                next_sub_epoch_summary(bt.constants, b1, block_record_1.required_iters, block_1, True),
-                await get_rc_prev(b1, block_1),
-            )
+            block_1_diffrent_foliage = None
+            if not different_foliage:
+                timelord_unf_block = timelord_protocol.NewUnfinishedBlockTimelord(
+                    block_1.reward_chain_block.get_unfinished(),
+                    uint64(block_record_1.weight - blocks[-1].weight),
+                    block_record_1.sub_slot_iters,
+                    block_1.foliage,
+                    next_sub_epoch_summary(bt.constants, b1, block_record_1.required_iters, block_1, True),
+                    await get_rc_prev(b1, block_1),
+                )
+            else:
+                spend_coin = None
+                for coin in blocks[-8].get_included_reward_coins():
+                    if coin.puzzle_hash == coinbase_puzzlehash:
+                        spend_coin = coin
+
+                assert spend_coin is not None
+                sb = wallet.generate_signed_transaction(uint64(1000), bytes32(b"0" * 32), spend_coin)
+                block_1_diffrent_foliage = bt.get_consecutive_blocks(
+                    block_list_input=blocks,
+                    num_blocks=1,
+                    farmer_reward_puzzle_hash=coinbase_puzzlehash,
+                    guarantee_transaction_block=True,
+                    transaction_data=sb,
+                    skip_overflow=True,
+                )[-1]
+                timelord_unf_block = timelord_protocol.NewUnfinishedBlockTimelord(
+                    block_1_diffrent_foliage.reward_chain_block.get_unfinished(),
+                    uint64(block_1_diffrent_foliage.weight - blocks[-1].weight),
+                    block_record_1.sub_slot_iters,
+                    block_1_diffrent_foliage.foliage,
+                    next_sub_epoch_summary(bt.constants, b1, block_record_1.required_iters, block_1, True),
+                    await get_rc_prev(b1, block_1),
+                )
+
             await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
             assert timelord_api.timelord.unfinished_blocks[-1].get_hash() == timelord_unf_block.get_hash()
             assert (
                 timelord_api.timelord.unfinished_blocks[-1].reward_chain_block.get_hash()
                 == timelord_unf_block.reward_chain_block.get_hash()
             )
-            new_peak = timelord_peak_from_block(b1, block_1)
 
+            new_peak = timelord_peak_from_block(b1, block_1)
             assert timelord_unf_block.reward_chain_block.total_iters == new_peak.reward_chain_block.total_iters
             await timelord_api.new_peak_timelord(new_peak)
             await time_out_assert(60, tl_new_peak_is_none, True, timelord_api)

--- a/chia/_tests/timelord/test_new_peak.py
+++ b/chia/_tests/timelord/test_new_peak.py
@@ -520,6 +520,7 @@ class TestNewPeak:
                     transaction_data=sb,
                     skip_overflow=True,
                 )[-1]
+                assert block_1_diffrent_foliage.header_hash != block_1.header_hash
                 timelord_unf_block = timelord_protocol.NewUnfinishedBlockTimelord(
                     block_1_diffrent_foliage.reward_chain_block.get_unfinished(),
                     uint64(block_1_diffrent_foliage.weight - blocks[-1].weight),


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
add coverage to the case where we get a new finished peak that is in the unfinished cache (not infused yet) but has different foliage 

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
