### PR TITLE
CHIA-2963 Avoid recomputing coin record names in rollback_to_block when we have access to them

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -534,13 +534,14 @@ class CoinStore:
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             async with conn.execute(
                 "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-                "coin_parent, amount, timestamp FROM coin_record WHERE confirmed_index>?",
+                "coin_parent, amount, timestamp, coin_name FROM coin_record WHERE confirmed_index>?",
                 (block_index,),
             ) as cursor:
                 for row in await cursor.fetchall():
                     coin = self.row_to_coin(row)
                     record = CoinRecord(coin, uint32(0), row[1], row[2], uint64(0))
-                    coin_changes[record.name] = record
+                    coin_name = bytes32(row[7])
+                    coin_changes[coin_name] = record
 
             # Delete reverted blocks from storage
             await conn.execute("DELETE FROM coin_record WHERE confirmed_index>?", (block_index,))
@@ -548,14 +549,15 @@ class CoinStore:
             # Add coins that are confirmed in the reverted blocks to the list of changed coins.
             async with conn.execute(
                 "SELECT confirmed_index, spent_index, coinbase, puzzle_hash, "
-                "coin_parent, amount, timestamp FROM coin_record WHERE spent_index>?",
+                "coin_parent, amount, timestamp, coin_name FROM coin_record WHERE spent_index>?",
                 (block_index,),
             ) as cursor:
                 for row in await cursor.fetchall():
                     coin = self.row_to_coin(row)
                     record = CoinRecord(coin, row[0], uint32(0), row[2], row[6])
-                    if record.name not in coin_changes:
-                        coin_changes[record.name] = record
+                    coin_name = bytes32(row[7])
+                    if coin_name not in coin_changes:
+                        coin_changes[coin_name] = record
 
             await conn.execute("UPDATE coin_record SET spent_index=0 WHERE spent_index>?", (block_index,))
         return list(coin_changes.values())


### PR DESCRIPTION
### Purpose:

`CoinRecord`'s `name` property is actually a `Coin` `name` function call, and we have access to coin names at these points in `rollback_to_block` so there is no need to recompute them.

### Current Behavior:

We keep recomputing coin record names even though we have access to them.

### New Behavior:

We avoid recomputing coin record names.