### PR TITLE
update windows build to windows-2022

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -44,7 +44,7 @@ jobs:
 
   build:
     name: Build EXE
-    runs-on: [windows-2019]
+    runs-on: [windows-2022]
     needs:
       - version
     timeout-minutes: 65
@@ -317,14 +317,14 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - name: 2019
-            matrix: 2019
-            runs-on:
-              intel: windows-2019
           - name: 2022
             matrix: 2022
             runs-on:
               intel: windows-2022
+          - name: 2015
+            matrix: 2015
+            runs-on:
+              intel: windows-2015
         arch:
           - name: Intel
             matrix: intel

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -228,7 +228,7 @@ jobs:
         env:
           HAS_SIGNING_SECRET: ${{ steps.check_secrets.outputs.HAS_SIGNING_SECRET }}
         run: |
-          $env:path="C:\Program` Files` (x86)\Microsoft` Visual` Studio\2019\Enterprise\SDK\ScopeCppSDK\vc15\VC\bin\;$env:path"
+          $env:path="C:\Program` Files` (x86)\Microsoft` Visual` Studio\2022\Enterprise\SDK\ScopeCppSDK\vc15\VC\bin\;$env:path"
           $env:path="C:\Program` Files` (x86)\Windows` Kits\10\App` Certification` Kit;$env:path"
           cd .\build_scripts
           .\build_windows-2-installer.ps1

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -228,8 +228,7 @@ jobs:
         env:
           HAS_SIGNING_SECRET: ${{ steps.check_secrets.outputs.HAS_SIGNING_SECRET }}
         run: |
-          Get-ChildItem 'C:\Program Files' -Recurse -Include "editbin.exe"
-          $env:path="C:\Program` Files` (x86)\Microsoft` Visual` Studio\2022\Enterprise\SDK\ScopeCppSDK\vc15\VC\bin\;$env:path"
+          $env:path="C:\Program` Files\Microsoft` Visual` Studio\2022\Enterprise\SDK\ScopeCppSDK\vc15\VC\bin\;$env:path"
           $env:path="C:\Program` Files` (x86)\Windows` Kits\10\App` Certification` Kit;$env:path"
           cd .\build_scripts
           .\build_windows-2-installer.ps1

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -228,6 +228,7 @@ jobs:
         env:
           HAS_SIGNING_SECRET: ${{ steps.check_secrets.outputs.HAS_SIGNING_SECRET }}
         run: |
+          Get-ChildItem 'C:\Program Files' -Recurse -Include "editbin.exe"
           $env:path="C:\Program` Files` (x86)\Microsoft` Visual` Studio\2022\Enterprise\SDK\ScopeCppSDK\vc15\VC\bin\;$env:path"
           $env:path="C:\Program` Files` (x86)\Windows` Kits\10\App` Certification` Kit;$env:path"
           cd .\build_scripts

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -321,10 +321,10 @@ jobs:
             matrix: 2022
             runs-on:
               intel: windows-2022
-          - name: 2015
-            matrix: 2015
+          - name: 2025
+            matrix: 2025
             runs-on:
-              intel: windows-2015
+              intel: windows-2025
         arch:
           - name: Intel
             matrix: intel


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

https://github.com/Chia-Network/chia-blockchain/actions/runs/15418837197/job/43391307150?pr=19667 
> This is a scheduled Windows Server 2019 brownout. The Windows Server 2019 image will be removed on 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
