### PR TITLE
CHIA-3050 Extract _add_coin_records out of CoinStore and simplify it

### DIFF
--- a/chia/_tests/core/full_node/stores/test_coin_store.py
+++ b/chia/_tests/core/full_node/stores/test_coin_store.py
@@ -12,6 +12,7 @@ from chia_rs.sized_ints import uint32, uint64
 from clvm.casts import int_to_bytes
 
 from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
+from chia._tests.util.coin_store import add_coin_records_to_db
 from chia._tests.util.db_connection import DBConnection
 from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia._tests.util.misc import Marks, datacases
@@ -434,7 +435,7 @@ async def test_get_coin_states(db_version: int) -> None:
             for i in range(1, 301)
         ]
         coin_store = await CoinStore.create(db_wrapper)
-        await coin_store._add_coin_records(crs)
+        await add_coin_records_to_db(coin_store.db_wrapper, crs)
 
         assert len(await coin_store.get_coin_states_by_puzzle_hashes(True, {std_hash(b"2")}, uint32(0))) == 300
         assert len(await coin_store.get_coin_states_by_puzzle_hashes(False, {std_hash(b"2")}, uint32(0))) == 0
@@ -562,7 +563,7 @@ async def test_coin_state_batches(
         coin_store = await CoinStore.create(db_wrapper)
         hint_store = await HintStore.create(db_wrapper)
 
-        await coin_store._add_coin_records(random_coin_records.items)
+        await add_coin_records_to_db(coin_store.db_wrapper, random_coin_records.items)
         await hint_store.add_hints(random_coin_records.hints)
 
         # Make sure all of the coin states are found when batching.
@@ -656,7 +657,7 @@ async def test_batch_many_coin_states(db_version: int, cut_off_middle: bool) -> 
         coin_store = await CoinStore.create(db_wrapper)
         await HintStore.create(db_wrapper)
 
-        await coin_store._add_coin_records(coin_records)
+        await add_coin_records_to_db(coin_store.db_wrapper, coin_records)
 
         # Make sure all of the coin states are found.
         (all_coin_states, next_height) = await coin_store.batch_coin_states_by_puzzle_hashes([ph])
@@ -669,7 +670,8 @@ async def test_batch_many_coin_states(db_version: int, cut_off_middle: bool) -> 
             assert coin_records[i].coin.name().hex() == all_coin_states[i].coin.name().hex(), i
 
         # For the middle case, insert a coin record between the two heights 10 and 12.
-        await coin_store._add_coin_records(
+        await add_coin_records_to_db(
+            coin_store.db_wrapper,
             [
                 CoinRecord(
                     coin=Coin(std_hash(b"extra coin"), ph, uint64(0)),
@@ -680,7 +682,7 @@ async def test_batch_many_coin_states(db_version: int, cut_off_middle: bool) -> 
                     coinbase=False,
                     timestamp=uint64(0),
                 )
-            ]
+            ],
         )
 
         (all_coin_states, next_height) = await coin_store.batch_coin_states_by_puzzle_hashes([ph])
@@ -717,7 +719,7 @@ async def test_duplicate_by_hint(db_version: int) -> None:
             uint64(12321312),
         )
 
-        await coin_store._add_coin_records([cr])
+        await add_coin_records_to_db(coin_store.db_wrapper, [cr])
         await hint_store.add_hints([(cr.coin.name(), cr.coin.puzzle_hash)])
 
         coin_states, height = await coin_store.batch_coin_states_by_puzzle_hashes([cr.coin.puzzle_hash])
@@ -878,3 +880,25 @@ async def test_get_unspent_lineage_info_for_puzzle_hash(case: UnspentLineageInfo
             )
         else:
             assert result is None
+
+
+@pytest.mark.anyio
+async def test_add_coin_records_to_db() -> None:
+    async with DBConnection(2) as db_wrapper:
+        coin_store = await CoinStore.create(db_wrapper)
+        test_records = [
+            CoinRecord(
+                coin=Coin(bytes32([i * 2] * 32), bytes32([i * 2 + 1] * 32), uint64(i)),
+                confirmed_block_index=uint32(i + 1),
+                spent_block_index=uint32(i),
+                coinbase=i % 2 == 0,
+                timestamp=uint64(i),
+            )
+            for i in range(5)
+        ]
+        await add_coin_records_to_db(db_wrapper, test_records)
+        # Verify all records got inserted correctly
+        for record in test_records:
+            resulting_record = await coin_store.get_coin_record(record.coin.name())
+            assert resulting_record is not None
+            assert resulting_record == record

--- a/chia/_tests/util/coin_store.py
+++ b/chia/_tests/util/coin_store.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from chia.types.coin_record import CoinRecord
+from chia.util.db_wrapper import DBWrapper2
+
+
+async def add_coin_records_to_db(db_wrapper: DBWrapper2, records: list[CoinRecord]) -> None:
+    if len(records) == 0:
+        return
+    async with db_wrapper.writer_maybe_transaction() as conn:
+        await conn.executemany(
+            "INSERT INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                (
+                    record.coin.name(),
+                    record.confirmed_block_index,
+                    record.spent_block_index,
+                    int(record.coinbase),
+                    record.coin.puzzle_hash,
+                    record.coin.parent_coin_info,
+                    record.coin.amount.stream_to_bytes(),
+                    record.timestamp,
+                )
+                for record in records
+            ),
+        )

--- a/chia/_tests/util/spend_sim.py
+++ b/chia/_tests/util/spend_sim.py
@@ -23,6 +23,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 from typing_extensions import Self
 
+from chia._tests.util.coin_store import add_coin_records_to_db
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
@@ -254,8 +255,8 @@ class SpendSim:
             uint64(calculate_base_farmer_reward(next_block_height) + fees),
             self.defaults.GENESIS_CHALLENGE,
         )
-        await self.coin_store._add_coin_records(
-            [self.new_coin_record(pool_coin, True), self.new_coin_record(farmer_coin, True)]
+        await add_coin_records_to_db(
+            self.coin_store.db_wrapper, [self.new_coin_record(pool_coin, True), self.new_coin_record(farmer_coin, True)]
         )
 
         # Coin store gets updated
@@ -281,7 +282,9 @@ class SpendSim:
                     return_additions = additions
                     return_removals = bundle.removals()
                     spent_coins_ids = [r.name() for r in return_removals]
-                    await self.coin_store._add_coin_records([self.new_coin_record(addition) for addition in additions])
+                    await add_coin_records_to_db(
+                        self.coin_store.db_wrapper, [self.new_coin_record(addition) for addition in additions]
+                    )
                     await self.coin_store._set_spent(spent_coins_ids, uint32(self.block_height + 1))
 
         # SimBlockRecord is created

--- a/chia/_tests/wallet/test_new_wallet_protocol.py
+++ b/chia/_tests/wallet/test_new_wallet_protocol.py
@@ -13,6 +13,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64
 
 from chia._tests.connection_utils import add_dummy_connection
+from chia._tests.util.coin_store import add_coin_records_to_db
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.full_node import FullNode
 from chia.full_node.mempool import MempoolRemoveReason
@@ -277,7 +278,7 @@ async def test_request_coin_state(one_node: OneNode, self_hostname: str) -> None
         coinbase=False,
         timestamp=uint64(1),
     )
-    await simulator.full_node.coin_store._add_coin_records([*coin_records, ignored_coin])
+    await add_coin_records_to_db(simulator.full_node.coin_store.db_wrapper, [*coin_records, ignored_coin])
 
     # Request no coin states
     resp = await simulator.request_coin_state(wallet_protocol.RequestCoinState([], None, genesis, False), peer)
@@ -377,7 +378,7 @@ async def test_request_coin_state_limit(one_node: OneNode, self_hostname: str) -
             )
             coin_records[coin_record.coin.name()] = coin_record
 
-    await simulator.full_node.coin_store._add_coin_records(list(coin_records.values()))
+    await add_coin_records_to_db(simulator.full_node.coin_store.db_wrapper, list(coin_records.values()))
 
     # Fetch the coin records using the wallet protocol,
     # with more coin ids than the limit of 100,000, but only after height 10000.
@@ -440,7 +441,7 @@ async def test_request_puzzle_state(one_node: OneNode, self_hostname: str) -> No
         timestamp=uint64(1),
     )
 
-    await simulator.full_node.coin_store._add_coin_records([*coin_records, ignored_coin])
+    await add_coin_records_to_db(simulator.full_node.coin_store.db_wrapper, [*coin_records, ignored_coin])
 
     # We already test permutations of CoinStateFilters in the CoinStore tests
     # So it's redundant to do so here
@@ -569,7 +570,7 @@ async def test_request_puzzle_state_limit(one_node: OneNode, self_hostname: str)
             )
             coin_records[coin_record.coin.name()] = coin_record
 
-    await simulator.full_node.coin_store._add_coin_records(list(coin_records.values()))
+    await add_coin_records_to_db(simulator.full_node.coin_store.db_wrapper, list(coin_records.values()))
 
     # Fetch the coin records using the wallet protocol,
     # only after height 10000, so that the limit of 100000 isn't exceeded
@@ -723,7 +724,7 @@ async def test_sync_puzzle_state(
             if coin_ph != puzzle_hash:
                 hints.append((coin.name(), puzzle_hash))
 
-    await simulator.full_node.coin_store._add_coin_records(list(coin_records.values()))
+    await add_coin_records_to_db(simulator.full_node.coin_store.db_wrapper, list(coin_records.values()))
     await simulator.full_node.hint_store.add_hints(hints)
 
     # Farm peak

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -574,29 +574,6 @@ class CoinStore:
             await conn.execute("UPDATE coin_record SET spent_index=0 WHERE spent_index>?", (block_index,))
         return list(coin_changes.values())
 
-    # Store CoinRecord in DB
-    async def _add_coin_records(self, records: list[CoinRecord]) -> None:
-        values2 = []
-        for record in records:
-            values2.append(
-                (
-                    record.coin.name(),
-                    record.confirmed_block_index,
-                    record.spent_block_index,
-                    int(record.coinbase),
-                    record.coin.puzzle_hash,
-                    record.coin.parent_coin_info,
-                    uint64(record.coin.amount).stream_to_bytes(),
-                    record.timestamp,
-                )
-            )
-        if len(values2) > 0:
-            async with self.db_wrapper.writer_maybe_transaction() as conn:
-                await conn.executemany(
-                    "INSERT INTO coin_record VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
-                    values2,
-                )
-
     # Update coin_record to be spent in DB
     async def _set_spent(self, coin_names: list[bytes32], index: uint32) -> None:
         assert len(coin_names) == 0 or index > 0


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

Now that `_add_coin_records` is not used in production code, extract it out of the class and simplify it by exiting early if there is nothing to add, leveraging generator expression instead of constructing a list, avoiding to construct a `uint64` out of `record.coin.amount` which is already `uint64`...etc. 

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
