### PR TITLE
CHIA-3113 Simplify test_num_unspent

### DIFF
--- a/chia/_tests/core/full_node/stores/test_coin_store.py
+++ b/chia/_tests/core/full_node/stores/test_coin_store.py
@@ -220,22 +220,12 @@ async def test_num_unspent(bt: BlockTools, db_version: int) -> None:
         for block in blocks:
             if not block.is_transaction_block():
                 continue
-
-            if block.is_transaction_block():
-                assert block.foliage_transaction_block is not None
-                removals: list[bytes32] = []
-                additions: list[Coin] = []
-                await coin_store.new_block(
-                    block.height,
-                    block.foliage_transaction_block.timestamp,
-                    block.get_included_reward_coins(),
-                    additions,
-                    removals,
-                )
-
-                expect_unspent += len(block.get_included_reward_coins())
-                assert await coin_store.num_unspent() == expect_unspent
-                test_excercised = expect_unspent > 0
+            assert block.foliage_transaction_block is not None
+            reward_coins = block.get_included_reward_coins()
+            await coin_store.new_block(block.height, block.foliage_transaction_block.timestamp, reward_coins, [], [])
+            expect_unspent += len(reward_coins)
+            assert await coin_store.num_unspent() == expect_unspent
+            test_excercised = expect_unspent > 0
 
     assert test_excercised
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

Simplify `test_num_unspent` by removing redundant transaction block check and values holding empty lists for additions and removals, and avoiding to recompute reward coins.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
