### PR TITLE
[CHIA-3890] require block generators to use canonical CLVM serialization after 3.0-hard fork

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -22,6 +22,7 @@ from chia_rs import (
     SpendBundle,
     TransactionsInfo,
     UnfinishedBlock,
+    is_canonical_serialization,
 )
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
@@ -3647,6 +3648,41 @@ class TestReorgs:
         assert blocks
         assert len(blocks) == 200
         assert blocks[-1].height == 199
+
+    @pytest.mark.anyio
+    async def test_overlong_generator_encoding(
+        self, empty_blockchain: Blockchain, bt: BlockTools, consensus_mode: ConsensusMode
+    ) -> None:
+        # add enough blocks to pass the hard fork
+        blocks = bt.get_consecutive_blocks(10)
+        for b in blocks[:-1]:
+            await _validate_and_add_block(empty_blockchain, b)
+
+        while not blocks[-1].is_transaction_block():
+            await _validate_and_add_block(empty_blockchain, blocks[-1])
+            blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
+        original_block: FullBlock = blocks[-1]
+
+        # overlong encoding
+        generator = SerializedProgram.fromhex("c00101")
+        assert not is_canonical_serialization(bytes(generator))
+
+        block = recursive_replace(original_block, "transactions_generator", generator)
+        block = recursive_replace(block, "transactions_info.generator_root", std_hash(bytes(generator)))
+        block = recursive_replace(
+            block, "foliage_transaction_block.transactions_info_hash", std_hash(bytes(block.transactions_info))
+        )
+        block = recursive_replace(
+            block, "foliage.foliage_transaction_block_hash", std_hash(bytes(block.foliage_transaction_block))
+        )
+
+        # overlong encoding became invalid in the 3.0 hard fork
+        if consensus_mode == ConsensusMode.HARD_FORK_3_0:
+            expected_error = Err.INVALID_TRANSACTIONS_GENERATOR_ENCODING
+        else:
+            expected_error = None
+
+        await _validate_and_add_block(empty_blockchain, block, expected_error=expected_error, skip_prevalidation=True)
 
 
 @pytest.mark.anyio

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -13,6 +13,7 @@ from chia_rs import (
     SpendBundleConditions,
     UnfinishedBlock,
     compute_merkle_set_root,
+    is_canonical_serialization,
 )
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
@@ -369,6 +370,10 @@ async def validate_block_body(
         # 8. The CLVM program must not return any errors
         assert conds is not None
         assert conds.validated_signature
+
+        if prev_transaction_block_height >= constants.HARD_FORK2_HEIGHT:
+            if not is_canonical_serialization(bytes(block.transactions_generator)):
+                return Err.INVALID_TRANSACTIONS_GENERATOR_ENCODING
 
         for spend in conds.spends:
             removals.append(bytes32(spend.coin_id))

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -194,6 +194,9 @@ class Err(Enum):
     INVALID_COIN_ID = 146
     # message not sent/received
     MESSAGE_NOT_SENT_OR_RECEIVED = 147
+    # the transactions generator uses overlong encoding of CLVM atoms in its
+    # serialization
+    INVALID_TRANSACTIONS_GENERATOR_ENCODING = 148
 
 
 class ValidationError(Exception):


### PR DESCRIPTION
### Purpose:

Reject CLVM serializations with overlong encodings, once the hard fork activates.

Technically, this is a soft-fork, but we're lumping it in with the hard fork for simplicity.

The motivation is to remove surprising behavior where the same CLVM tree structure (or program) can be serialized into different byte representations.