### PR TITLE
[CHIA-2859] add ConsensusMode in tests to cover the new hard fork

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -196,11 +196,12 @@ def get_keychain():
 class ConsensusMode(ComparableEnum):
     PLAIN = 0
     HARD_FORK_2_0 = 1
+    HARD_FORK_3_0 = 2
 
 
 @pytest.fixture(
     scope="session",
-    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0],
+    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.HARD_FORK_3_0],
 )
 def consensus_mode(request):
     return request.param
@@ -216,6 +217,16 @@ def blockchain_constants(consensus_mode: ConsensusMode) -> ConsensusConstants:
             PLOT_FILTER_64_HEIGHT=uint32(15),
             PLOT_FILTER_32_HEIGHT=uint32(20),
         )
+
+    if consensus_mode >= ConsensusMode.HARD_FORK_3_0:
+        ret = ret.replace(
+            HARD_FORK_HEIGHT=uint32(2),
+            PLOT_FILTER_128_HEIGHT=uint32(10),
+            PLOT_FILTER_64_HEIGHT=uint32(15),
+            PLOT_FILTER_32_HEIGHT=uint32(20),
+            HARD_FORK2_HEIGHT=uint32(2),
+        )
+
     return ret
 
 

--- a/chia/_tests/core/full_node/test_conditions.py
+++ b/chia/_tests/core/full_node/test_conditions.py
@@ -356,6 +356,9 @@ class TestConditions:
             ("", "(66 0x3f {msg} {coin})", "(67 0x3f {msg} {coin})", 513, Err.TOO_MANY_ANNOUNCEMENTS),
         ],
     )
+    @pytest.mark.limit_consensus_modes(
+        allowed=[ConsensusMode.HARD_FORK_2_0], reason="announce conditions limit was removed in hard-fork 3.0"
+    )
     async def test_announce_conditions_limit(
         self,
         consensus_mode: ConsensusMode,

--- a/chia/consensus/condition_costs.py
+++ b/chia/consensus/condition_costs.py
@@ -7,3 +7,7 @@ class ConditionCost(Enum):
     # Condition Costs
     AGG_SIG = 1200000  # the cost of one G1 subgroup check + aggregated signature validation
     CREATE_COIN = 1800000
+
+    # with hard fork 2 (Chia 3.0) all conditions past the first 100 (per spend)
+    # has an additional cost of 500
+    GENERIC_CONDITION_COST = 500

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -167,7 +167,9 @@ def compute_additions_unchecked(sb: SpendBundle) -> list[Coin]:
     return ret
 
 
-def compute_block_cost(generator: SerializedProgram, constants: ConsensusConstants, height: uint32) -> uint64:
+def compute_block_cost(
+    generator: SerializedProgram, constants: ConsensusConstants, height: uint32, prev_tx_height: uint32
+) -> uint64:
     # this function cannot *validate* the block or any of the transactions. We
     # deliberately create invalid blocks as parts of the tests, and we still
     # need to be able to compute the cost of it
@@ -188,7 +190,9 @@ def compute_block_cost(generator: SerializedProgram, constants: ConsensusConstan
 
             cost, result = _run(puzzle, INFINITE_COST, DEFAULT_FLAGS, solution)
             clvm_cost += cost
-            condition_cost += conditions_cost(result)
+            condition_cost += conditions_cost(
+                result, charge_for_conditions=prev_tx_height >= constants.HARD_FORK2_HEIGHT
+            )
 
     else:
         block_program_args = SerializedProgram.to([[]])
@@ -198,7 +202,7 @@ def compute_block_cost(generator: SerializedProgram, constants: ConsensusConstan
             # each condition item is:
             # (parent-coin-id puzzle-hash amount conditions)
             conditions = res.at("rrrf")
-            condition_cost += conditions_cost(conditions)
+            condition_cost += conditions_cost(conditions, charge_for_conditions=False)
 
     size_cost = len(bytes(generator)) * constants.COST_PER_BYTE
 
@@ -347,6 +351,7 @@ class BlockTools:
         rng: Optional[random.Random],
         available_coins: list[Coin],
         *,
+        prev_tx_height: uint32,
         dummy_block_references: bool,
         include_transactions: bool,
         transaction_data: Optional[SpendBundle],
@@ -377,7 +382,7 @@ class BlockTools:
             else:
                 program = simple_solution_generator(transaction_data).program
             block_refs = []
-            cost = compute_block_cost(program, self.constants, uint32(curr.height + 1))
+            cost = compute_block_cost(program, self.constants, uint32(curr.height + 1), prev_tx_height)
             return NewBlockGenerator(
                 program,
                 [],
@@ -397,7 +402,7 @@ class BlockTools:
             bundle, additions = make_spend_bundle(available_coins, wallet, rng)
             removals = bundle.removals()
             program = simple_solution_generator(bundle).program
-            cost = compute_block_cost(program, self.constants, uint32(curr.height + 1))
+            cost = compute_block_cost(program, self.constants, uint32(curr.height + 1), prev_tx_height)
             return NewBlockGenerator(
                 program,
                 [],
@@ -410,7 +415,7 @@ class BlockTools:
 
         if dummy_block_references:
             program = SerializedProgram.from_bytes(solution_generator([]))
-            cost = compute_block_cost(program, self.constants, uint32(curr.height + 1))
+            cost = compute_block_cost(program, self.constants, uint32(curr.height + 1), prev_tx_height)
             return NewBlockGenerator(program, [], block_refs + dummy_refs, G2Element(), [], [], cost)
 
         return None
@@ -792,6 +797,7 @@ class BlockTools:
             curr = blocks[curr.prev_hash]
         assert curr.timestamp is not None
         last_timestamp = float(curr.timestamp)
+        prev_tx_height = curr.height
 
         curr = latest_block
         blocks_added_this_sub_slot = 1
@@ -902,6 +908,7 @@ class BlockTools:
                             wallet,
                             rng,
                             available_coins,
+                            prev_tx_height=prev_tx_height,
                             dummy_block_references=dummy_block_references,
                             transaction_data=transaction_data,
                             include_transactions=include_transactions,
@@ -957,6 +964,7 @@ class BlockTools:
                         block_list.append(full_block)
 
                         if include_transactions:
+                            prev_tx_height = full_block.height
                             for coin in full_block.get_included_reward_coins():
                                 if coin.puzzle_hash == self.farmer_ph:
                                     pending_rewards.append(coin)
@@ -1195,6 +1203,7 @@ class BlockTools:
                             wallet,
                             rng,
                             available_coins,
+                            prev_tx_height=prev_tx_height,
                             dummy_block_references=dummy_block_references,
                             transaction_data=transaction_data,
                             include_transactions=include_transactions,
@@ -1233,7 +1242,6 @@ class BlockTools:
                             overflow_cc_challenge=overflow_cc_challenge,
                             overflow_rc_challenge=overflow_rc_challenge,
                         )
-
                         if block_record.is_transaction_block:
                             transaction_data = None
                             block_refs = []
@@ -1251,6 +1259,7 @@ class BlockTools:
                         block_list.append(full_block)
 
                         if include_transactions:
+                            prev_tx_height = full_block.height
                             for coin in full_block.get_included_reward_coins():
                                 if coin.puzzle_hash == self.farmer_ph:
                                     pending_rewards.append(coin)
@@ -1958,10 +1967,19 @@ def compute_cost_table() -> list[int]:
 CONDITION_COSTS = compute_cost_table()
 
 
-def conditions_cost(conds: Program) -> uint64:
+def conditions_cost(conds: Program, *, charge_for_conditions: bool) -> uint64:
+    free_conditions = 100
+
     condition_cost = 0
     for cond in conds.as_iter():
         condition = cond.first().as_atom()
+
+        # this is new in hard fork 2
+        if free_conditions > 0:
+            free_conditions -= 1
+        elif charge_for_conditions:
+            condition_cost += ConditionCost.GENERIC_CONDITION_COST.value
+
         if condition == ConditionOpcode.CREATE_COIN:
             condition_cost += ConditionCost.CREATE_COIN.value
         # after the 2.0 hard fork, two byte conditions (with no leading 0)


### PR DESCRIPTION
### Purpose:

extend test the 3.0 hard fork.

The hard fork changes the cost of conditions. Each spend has 100 free conditions. After that, each condition cost 500. The simulator's `BlockTools` needed to be updated to take that into account when generating blocks, to get the cost right.