### PR TITLE
[CHIA-2859] improve user facing output for print_block_from_hash

### DIFF
--- a/chia/cmds/show_funcs.py
+++ b/chia/cmds/show_funcs.py
@@ -140,6 +140,14 @@ async def print_block_from_hash(
             if full_block.reward_chain_block.proof_of_space.pool_public_key is not None
             else "Pay to pool puzzle hash"
         )
+        pos_size = full_block.reward_chain_block.proof_of_space.size()
+        if pos_size.size_v1 is not None:
+            size = pos_size.size_v1
+            version = "(v1)"
+        else:
+            assert pos_size.size_v2 is not None
+            size = pos_size.size_v2
+            version = "(v2)"
         print(
             f"Block Height           {block.height}\n"
             f"Header Hash            0x{block.header_hash.hex()}\n"
@@ -152,8 +160,7 @@ async def print_block_from_hash(
             f"Total VDF Iterations   {block.total_iters}\n"
             f"Is a Transaction Block?{block.is_transaction_block}\n"
             f"Deficit                {block.deficit}\n"
-            f"PoSpace 'k' Size (v1)  {full_block.reward_chain_block.proof_of_space.size().size_v1}\n"
-            f"PoSpace 'k' Size (v2)  {full_block.reward_chain_block.proof_of_space.size().size_v2}\n"
+            f"PoSpace 'k' Size {version}  {size}\n"
             f"Plot Public Key        0x{full_block.reward_chain_block.proof_of_space.plot_public_key}\n"
             f"Pool Public Key        {pool_pk}\n"
             f"Tx Filter Hash         {tx_filter_hash}\n"


### PR DESCRIPTION
### Purpose:

With v2 plots, the output of `chia show -b` should be improved to support both v1 and v2.

### Current Behavior:

The output looks like this:

```
$ chia show -b 5311e0f737050d81d0e200eb34b89224d649f409c1c4c6de5ec4fb4da7cc5694
Block Height           5000003
Header Hash            0x5311e0f737050d81d0e200eb34b89224d649f409c1c4c6de5ec4fb4da7cc5694
Timestamp              Not a transaction block
Weight                 15697524880
Previous Block         0x620e460d6d1c9e09e344c482d1b7fc567d6123392edcb64cc2a6e97e972ea2f3
Difficulty             11904
Sub-slot iters         583008256
Cost                   Not a transaction block
Total VDF Iterations   28994114797189
Is a Transaction Block?False
Deficit                1
PoSpace 'k' Size (v1)  32
PoSpace 'k' Size (v2)  None
Plot Public Key        0x83b0593be4c2b395a36e8b638be70841726e45d2434dee336d6a93105ddfe12411ecc7bdba6cec439e4c72a9a9bdece7
Pool Public Key        a2f82c133a28ea693d9a4788e270572b45d1981d117cff9132b780ca1058c84e2d559a865b8576c8c422ffbec1f0b4d4
Tx Filter Hash         Not a transaction block
Farmer Address         xch1n777zmsr74wgtm8efjezvzplel38xl2wv2dfs8jak04qawvs0t6q6dhf2x
Pool Address           xch1n777zmsr74wgtm8efjezvzplel38xl2wv2dfs8jak04qawvs0t6q6dhf2x
Fees Amount            Not a transaction block
```

### New Behavior:

The output looks like this:

```
$ chia show -b 5311e0f737050d81d0e200eb34b89224d649f409c1c4c6de5ec4fb4da7cc5694
Block Height           5000003
Header Hash            0x5311e0f737050d81d0e200eb34b89224d649f409c1c4c6de5ec4fb4da7cc5694
Timestamp              Not a transaction block
Weight                 15697524880
Previous Block         0x620e460d6d1c9e09e344c482d1b7fc567d6123392edcb64cc2a6e97e972ea2f3
Difficulty             11904
Sub-slot iters         583008256
Cost                   Not a transaction block
Total VDF Iterations   28994114797189
Is a Transaction Block?False
Deficit                1
PoSpace 'k' Size (v1)  32
Plot Public Key        0x83b0593be4c2b395a36e8b638be70841726e45d2434dee336d6a93105ddfe12411ecc7bdba6cec439e4c72a9a9bdece7
Pool Public Key        a2f82c133a28ea693d9a4788e270572b45d1981d117cff9132b780ca1058c84e2d559a865b8576c8c422ffbec1f0b4d4
Tx Filter Hash         Not a transaction block
Farmer Address         xch1n777zmsr74wgtm8efjezvzplel38xl2wv2dfs8jak04qawvs0t6q6dhf2x
Pool Address           xch1n777zmsr74wgtm8efjezvzplel38xl2wv2dfs8jak04qawvs0t6q6dhf2x
Fees Amount            Not a transaction block
```

## Testing

This was tested manually, as we don't have unit tests for most CLI