### PR TITLE
[CHIA-3158] Add dicts to streamable

### DIFF
--- a/chia/_tests/core/util/test_streamable.py
+++ b/chia/_tests/core/util/test_streamable.py
@@ -912,10 +912,8 @@ def test_streamable_inheritance_missing() -> None:
     [
         (function_to_parse_one_item, float),
         (function_to_parse_one_item, int),
-        (function_to_parse_one_item, dict),
         (function_to_stream_one_item, float),
         (function_to_stream_one_item, int),
-        (function_to_stream_one_item, dict),
         (recurse_jsonify, 1.0),
         (recurse_jsonify, recurse_jsonify),
     ],

--- a/chia/_tests/core/util/test_streamable.py
+++ b/chia/_tests/core/util/test_streamable.py
@@ -26,6 +26,7 @@ from chia.util.streamable import (
     UnsupportedType,
     function_to_parse_one_item,
     function_to_stream_one_item,
+    is_type_Dict,
     is_type_List,
     is_type_SpecificOptional,
     is_type_Tuple,
@@ -59,15 +60,6 @@ def test_float_not_supported() -> None:
         @dataclass(frozen=True)
         class TestClassFloat(Streamable):
             a: float
-
-
-def test_dict_not_suppported() -> None:
-    with pytest.raises(UnsupportedType):
-
-        @streamable
-        @dataclass(frozen=True)
-        class TestClassDict(Streamable):
-            a: dict[str, str]
 
 
 @dataclass(frozen=True)
@@ -159,6 +151,28 @@ class ConvertListFailures(Streamable):
     ],
 )
 def test_convert_list_failures(input_dict: dict[str, Any], error: Any) -> None:
+    with pytest.raises(error):
+        streamable_from_dict(ConvertListFailures, input_dict)
+
+
+@streamable
+@dataclass(frozen=True)
+class ConvertDictFailures(Streamable):
+    a: dict[str, str]
+    b: dict[str, dict[str, str]]
+
+
+@pytest.mark.parametrize(
+    "input_dict, error",
+    [
+        pytest.param({"a": [1, 1], "b": {"foo": [2, 2]}}, InvalidTypeError, id="a: invalid type list"),
+        pytest.param({"a": 1, "b": {"foo": "bar"}}, InvalidTypeError, id="a: invalid type int"),
+        pytest.param({"a": "11", "b": {"foo": "bar"}}, InvalidTypeError, id="a: invalid type str"),
+        pytest.param({"a": {"foo": "bar"}, "b": {1: {"foo": "bar"}}}, InvalidTypeError, id="b: invalid type int"),
+        pytest.param({"a": {"foo": "bar"}, "b": {"foo": {"foo": 1}}}, InvalidTypeError, id="b: invalid type int"),
+    ],
+)
+def test_convert_dict_failures(input_dict: dict[str, Any], error: Any) -> None:
     with pytest.raises(error):
         streamable_from_dict(ConvertListFailures, input_dict)
 
@@ -319,16 +333,21 @@ class TestFromJsonDictDefaultValues(Streamable):
     a: uint64 = uint64(1)
     b: str = "default"
     c: list[uint64] = field(default_factory=list)
+    d: dict[str, str] = field(default_factory=dict)
 
 
 @pytest.mark.parametrize(
     "input_dict, output_dict",
     [
-        [{}, {"a": 1, "b": "default", "c": []}],
-        [{"a": 2}, {"a": 2, "b": "default", "c": []}],
-        [{"b": "not_default"}, {"a": 1, "b": "not_default", "c": []}],
-        [{"c": [1, 2]}, {"a": 1, "b": "default", "c": [1, 2]}],
-        [{"a": 2, "b": "not_default", "c": [1, 2]}, {"a": 2, "b": "not_default", "c": [1, 2]}],
+        [{}, {"a": 1, "b": "default", "c": [], "d": {}}],
+        [{"a": 2}, {"a": 2, "b": "default", "c": [], "d": {}}],
+        [{"b": "not_default"}, {"a": 1, "b": "not_default", "c": [], "d": {}}],
+        [{"c": [1, 2]}, {"a": 1, "b": "default", "c": [1, 2], "d": {}}],
+        [{"d": {"foo": "bar"}}, {"a": 1, "b": "default", "c": [], "d": {"foo": "bar"}}],
+        [
+            {"a": 2, "b": "not_default", "c": [1, 2], "d": {"foo": "bar"}},
+            {"a": 2, "b": "not_default", "c": [1, 2], "d": {"foo": "bar"}},
+        ],
     ],
 )
 def test_from_json_dict_default_values(input_dict: dict[str, object], output_dict: dict[str, object]) -> None:
@@ -397,6 +416,13 @@ class PostInitTestClassTuple(Streamable):
     b: tuple[tuple[uint8, str], bytes32]
 
 
+@streamable
+@dataclass(frozen=True)
+class PostInitTestClassDict(Streamable):
+    a: dict[uint8, str]
+    b: dict[bytes32, dict[uint8, str]]
+
+
 @pytest.mark.parametrize(
     "test_class, args",
     [
@@ -405,6 +431,7 @@ class PostInitTestClassTuple(Streamable):
         (PostInitTestClassBad, (25,)),
         (PostInitTestClassList, ([1, 2, 3], [[G1Element(), bytes(G1Element())], [bytes(G1Element())]])),
         (PostInitTestClassTuple, ((1, "test"), ((200, "test_2"), b"\xba" * 32))),
+        (PostInitTestClassDict, ({1: "bar"}, {bytes32.zeros: {1: "bar"}})),
         (PostInitTestClassOptional, (12, None, 13, None)),
     ],
 )
@@ -420,6 +447,12 @@ def test_post_init_valid(test_class: type[Any], args: tuple[Any, ...]) -> None:
             list_type = get_args(type_in)[0]
             assert type(item) is list
             return all(validate_item_type(list_type, list_item) for list_item in item)
+        if is_type_Dict(type_in):
+            [key_type, value_type] = get_args(type_in)
+            assert type(item) is dict
+            return validate_item_type(key_type, next(iter(item.keys()))) and validate_item_type(
+                value_type, next(iter(item.values()))
+            )
         return isinstance(item, type_in)
 
     test_object = test_class(*args)
@@ -463,9 +496,19 @@ def test_basic() -> None:
         e: Optional[uint32]
         f: Optional[uint32]
         g: tuple[uint32, str, bytes]
+        h: dict[uint32, uint32]
 
     # we want to test invalid here, hence the ignore.
-    a = TestClass(24, 352, [1, 2, 4], [[1, 2, 3], [3, 4]], 728, None, (383, "hello", b"goodbye"))  # type: ignore[arg-type,list-item]
+    a = TestClass(
+        uint32(24),
+        uint32(352),
+        [uint32(1), uint32(2), uint32(4)],
+        [[uint32(1), uint32(2), uint32(3)], [uint32(3), uint32(4)]],
+        uint32(728),
+        None,
+        (uint32(383), "hello", b"goodbye"),
+        {uint32(1): uint32(1)},
+    )
 
     b: bytes = bytes(a)
     assert a == TestClass.from_bytes(b)

--- a/chia/_tests/core/util/test_streamable.py
+++ b/chia/_tests/core/util/test_streamable.py
@@ -497,7 +497,7 @@ def test_basic() -> None:
         e: Optional[uint32]
         f: Optional[uint32]
         g: tuple[uint32, str, bytes]
-        h: dict[uint32, uint32]
+        h: dict[uint32, str]
 
     # we want to test invalid here, hence the ignore.
     a = TestClass(
@@ -508,7 +508,7 @@ def test_basic() -> None:
         uint32(728),
         None,
         (uint32(383), "hello", b"goodbye"),
-        {uint32(1): uint32(1)},
+        {uint32(1): "foo"},
     )
 
     b: bytes = bytes(a)

--- a/chia/_tests/core/util/test_streamable.py
+++ b/chia/_tests/core/util/test_streamable.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import io
-import itertools
 import re
 from dataclasses import dataclass, field, fields
-from typing import Any, Callable, ClassVar, Optional, Union, get_type_hints
+from typing import Any, Callable, ClassVar, Optional, get_type_hints
 
 import pytest
 from chia_rs import FullBlock, G1Element, SubEpochChallengeSegment
@@ -921,48 +920,3 @@ def test_streamable_inheritance_missing() -> None:
 def test_unsupported_types(method: Callable[[object], object], input_type: object) -> None:
     with pytest.raises(UnsupportedType):
         method(input_type)
-
-
-@streamable
-@dataclass(frozen=True)
-class DictSerializationStrings(Streamable):
-    a: dict[str, str]
-
-
-@streamable
-@dataclass(frozen=True)
-class DictSerializationUInts(Streamable):
-    a: dict[uint8, str]
-
-
-@streamable
-@dataclass(frozen=True)
-class DictSerializationBytes(Streamable):
-    a: dict[bytes, str]
-
-
-@streamable
-@dataclass(frozen=True)
-class DictSerializationTuple(Streamable):
-    a: dict[tuple[str, str], str]
-
-
-@pytest.mark.parametrize(
-    "cls, args",
-    [
-        (DictSerializationStrings, [("foo", "bar"), ("baz", "bat"), ("qux", "quux")]),
-        (DictSerializationUInts, [(uint8(1), "bar"), (uint8(3), "bat"), (uint8(5), "quux")]),
-        (DictSerializationBytes, [((b"01"), "bar"), (b"02", "bat"), (b"3", "quux")]),
-        (DictSerializationTuple, [(("foo", "bar"), "bar"), (("baz", "bat"), "bat"), (("qux", "quux"), "quux")]),
-    ],
-)
-def test_dict_deterministic_serialization(
-    cls: type[Union[DictSerializationStrings, DictSerializationTuple, DictSerializationBytes, DictSerializationUInts]],
-    args: list[Any],
-) -> None:
-    byte_serialization: Optional[bytes] = None
-    for perm in itertools.permutations(args):
-        next_byte_serialization = bytes(cls({key: value for key, value in perm}))
-        if byte_serialization is not None:
-            assert byte_serialization == next_byte_serialization
-        byte_serialization = next_byte_serialization

--- a/chia/_tests/core/util/test_streamable.py
+++ b/chia/_tests/core/util/test_streamable.py
@@ -920,3 +920,22 @@ def test_streamable_inheritance_missing() -> None:
 def test_unsupported_types(method: Callable[[object], object], input_type: object) -> None:
     with pytest.raises(UnsupportedType):
         method(input_type)
+
+
+@streamable
+@dataclass(frozen=True)
+class UnsupportedDictToSerialize(Streamable):
+    a: list[tuple[str, uint8]]
+
+
+@streamable
+@dataclass(frozen=True)
+class UnsupportedDictToDeserialize(Streamable):
+    a: dict[str, uint8]
+
+
+def test_duplicate_dict_key_error() -> None:
+    with pytest.raises(ValueError, match="duplicate dict keys"):
+        UnsupportedDictToDeserialize.from_bytes(
+            bytes(UnsupportedDictToSerialize([("foo", uint8(1)), ("foo", uint8(2))]))
+        )

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -392,9 +392,10 @@ def parse_dict(
     keys_and_values: list[tuple[object, object]] = parse_list(  # type: ignore[assignment]
         f, lambda inner_f: parse_tuple(inner_f, [key_parse_inner_type_f, value_parse_inner_type_f])
     )
-    if len(set(key for key, _ in keys_and_values)) < len(tuple(key for key, _ in keys_and_values)):
+    parsed_dict: dict[object, object] = dict(keys_and_values)
+    if len(parsed_dict) < len(keys_and_values):
         raise ValueError("duplicate dict keys found when deserializing")
-    return {key: value for key, value in keys_and_values}
+    return parsed_dict
 
 
 def parse_str(f: BinaryIO) -> str:

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -476,7 +476,7 @@ def stream_dict(
         lambda inner_item, inner_f: stream_tuple(
             [key_stream_inner_type_func, value_stream_inner_type_func], inner_item, inner_f
         ),
-        list(item.items()),
+        list(sorted(item.items())),
         f,
     )
 

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -476,7 +476,7 @@ def stream_dict(
         lambda inner_item, inner_f: stream_tuple(
             [key_stream_inner_type_func, value_stream_inner_type_func], inner_item, inner_f
         ),
-        list(sorted(item.items())),
+        list(item.items()),
         f,
     )
 

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -434,7 +434,7 @@ def function_to_parse_one_item(f_type: type[Any]) -> ParseFunctionType:
     if is_type_Dict(f_type):
         inner_types = get_args(f_type)
         key_parse_inner_type_f = function_to_parse_one_item(inner_types[0])
-        value_parse_inner_type_f = function_to_parse_one_item(inner_types[0])
+        value_parse_inner_type_f = function_to_parse_one_item(inner_types[1])
         return lambda f: parse_dict(f, key_parse_inner_type_f, value_parse_inner_type_f)
     if f_type is str:
         return parse_str

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -126,6 +126,10 @@ def is_type_Tuple(f_type: object) -> bool:
     return get_origin(f_type) is tuple or f_type is tuple
 
 
+def is_type_Dict(f_type: object) -> bool:
+    return get_origin(f_type) is dict or f_type is dict
+
+
 def convert_optional(convert_func: ConvertFunctionType, item: Any) -> Any:
     if item is None:
         return None
@@ -144,6 +148,12 @@ def convert_list(convert_func: ConvertFunctionType, items: list[Any]) -> list[An
     if not isinstance(items, list):
         raise InvalidTypeError(list, type(items))
     return [convert_func(item) for item in items]
+
+
+def convert_dict(
+    key_converter: ConvertFunctionType, value_converter: ConvertFunctionType, mapping: dict[Any, Any]
+) -> dict[Any, Any]:
+    return {key_converter(key): value_converter(value) for key, value in mapping.items()}
 
 
 def convert_hex_string(item: str) -> bytes:
@@ -213,6 +223,11 @@ def function_to_convert_one_item(
         convert_inner_func = function_to_convert_one_item(inner_type, json_parser)
         # Ignoring for now as the proper solution isn't obvious
         return lambda items: convert_list(convert_inner_func, items)  # type: ignore[arg-type]
+    elif is_type_Dict(f_type):
+        inner_types = get_args(f_type)
+        key_converter = function_to_convert_one_item(inner_types[0], json_parser)
+        value_converter = function_to_convert_one_item(inner_types[1], json_parser)
+        return lambda mapping: convert_dict(key_converter, value_converter, mapping)  # type: ignore[arg-type]
     elif hasattr(f_type, "from_json_dict"):
         if json_parser is None:
             json_parser = f_type.from_json_dict
@@ -257,6 +272,11 @@ def function_to_post_init_process_one_item(f_type: type[object]) -> ConvertFunct
         inner_type = get_args(f_type)[0]
         process_inner_func = function_to_post_init_process_one_item(inner_type)
         return lambda items: convert_list(process_inner_func, items)  # type: ignore[arg-type]
+    if is_type_Dict(f_type):
+        inner_types = get_args(f_type)
+        key_converter = function_to_post_init_process_one_item(inner_types[0])
+        value_converter = function_to_post_init_process_one_item(inner_types[1])
+        return lambda mapping: convert_dict(key_converter, value_converter, mapping)  # type: ignore[arg-type]
     return lambda item: post_init_process_item(f_type, item)
 
 
@@ -365,6 +385,18 @@ def parse_tuple(f: BinaryIO, list_parse_inner_type_f: list[ParseFunctionType]) -
     return tuple(full_list)
 
 
+def parse_dict(
+    f: BinaryIO, key_parse_inner_type_f: ParseFunctionType, value_parse_inner_type_f: ParseFunctionType
+) -> dict[object, object]:
+    return {  # type: ignore[misc]
+        key: value  # type: ignore[has-type]
+        # We know this is a list of tuples but our parse_list hint doesn't help us here
+        for key, value in parse_list(
+            f, lambda inner_f: parse_tuple(inner_f, [key_parse_inner_type_f, value_parse_inner_type_f])
+        )
+    }
+
+
 def parse_str(f: BinaryIO) -> str:
     str_size = parse_uint32(f)
     str_read_bytes = f.read(str_size)
@@ -399,6 +431,11 @@ def function_to_parse_one_item(f_type: type[Any]) -> ParseFunctionType:
         inner_types = get_args(f_type)
         list_parse_inner_type_f = [function_to_parse_one_item(_) for _ in inner_types]
         return lambda f: parse_tuple(f, list_parse_inner_type_f)
+    if is_type_Dict(f_type):
+        inner_types = get_args(f_type)
+        key_parse_inner_type_f = function_to_parse_one_item(inner_types[0])
+        value_parse_inner_type_f = function_to_parse_one_item(inner_types[0])
+        return lambda f: parse_dict(f, key_parse_inner_type_f, value_parse_inner_type_f)
     if f_type is str:
         return parse_str
     raise UnsupportedType(f"Type {f_type} does not have parse")
@@ -427,6 +464,21 @@ def stream_tuple(stream_inner_type_funcs: list[StreamFunctionType], item: Any, f
     assert len(stream_inner_type_funcs) == len(item)
     for i in range(len(item)):
         stream_inner_type_funcs[i](item[i], f)
+
+
+def stream_dict(
+    key_stream_inner_type_func: StreamFunctionType,
+    value_stream_inner_type_func: StreamFunctionType,
+    item: Any,
+    f: BinaryIO,
+) -> None:
+    return stream_list(
+        lambda inner_item, inner_f: stream_tuple(
+            [key_stream_inner_type_func, value_stream_inner_type_func], inner_item, inner_f
+        ),
+        list(item.items()),
+        f,
+    )
 
 
 def stream_str(item: Any, f: BinaryIO) -> None:
@@ -469,6 +521,11 @@ def function_to_stream_one_item(f_type: type[Any]) -> StreamFunctionType:
         for i in range(len(inner_types)):
             stream_inner_type_funcs.append(function_to_stream_one_item(inner_types[i]))
         return lambda item, f: stream_tuple(stream_inner_type_funcs, item, f)
+    elif is_type_Dict(f_type):
+        inner_types = get_args(f_type)
+        key_stream_inner_type_func = function_to_stream_one_item(inner_types[0])
+        value_stream_inner_type_func = function_to_stream_one_item(inner_types[1])
+        return lambda item, f: stream_dict(key_stream_inner_type_func, value_stream_inner_type_func, item, f)
     elif f_type is str:
         return stream_str
     elif f_type is bool:

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -388,13 +388,13 @@ def parse_tuple(f: BinaryIO, list_parse_inner_type_f: list[ParseFunctionType]) -
 def parse_dict(
     f: BinaryIO, key_parse_inner_type_f: ParseFunctionType, value_parse_inner_type_f: ParseFunctionType
 ) -> dict[object, object]:
-    return {  # type: ignore[misc]
-        key: value  # type: ignore[has-type]
-        # We know this is a list of tuples but our parse_list hint doesn't help us here
-        for key, value in parse_list(
-            f, lambda inner_f: parse_tuple(inner_f, [key_parse_inner_type_f, value_parse_inner_type_f])
-        )
-    }
+    # We know this is a list of tuples but our parse_list hint doesn't help us here
+    keys_and_values: list[tuple[object, object]] = parse_list(  # type: ignore[assignment]
+        f, lambda inner_f: parse_tuple(inner_f, [key_parse_inner_type_f, value_parse_inner_type_f])
+    )
+    if len(set(key for key, _ in keys_and_values)) < len(tuple(key for key, _ in keys_and_values)):
+        raise ValueError("duplicate dict keys found when deserializing")
+    return {key: value for key, value in keys_and_values}
 
 
 def parse_str(f: BinaryIO) -> str:


### PR DESCRIPTION
This PR adds support for `dict`s to the `streamable` protocol.  I'm unaware why this was not part of the existing design, but it will make certain uses much easier going forward.

Probably worth noting that this serialization makes the design decision to preserve order of insertion of the dictionary items in the serialization, so two objects that match with `__eq__` may not necessarily match with serialization.