### PR TITLE
CHIA-3157 Consolidate including block spends into ForkInfo's include_spends

### DIFF
--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -112,36 +112,6 @@ class ForkInfo:
             assert coin.name() not in self.additions_since_fork
             self.additions_since_fork[coin.name()] = ForkAdd(coin, block.height, timestamp, None, True)
 
-    def include_block(
-        self,
-        additions: list[tuple[Coin, Optional[bytes]]],
-        removals: list[Coin],
-        block: FullBlock,
-        header_hash: bytes32,
-    ) -> None:
-        height = block.height
-
-        assert self.peak_height == height - 1
-
-        assert len(self.block_hashes) == self.peak_height - self.fork_height
-        assert block.height == self.fork_height + 1 + len(self.block_hashes)
-        self.block_hashes.append(header_hash)
-
-        self.peak_height = int(block.height)
-        self.peak_hash = header_hash
-
-        if block.foliage_transaction_block is not None:
-            timestamp = block.foliage_transaction_block.timestamp
-            for spend in removals:
-                self.removals_since_fork[bytes32(spend.name())] = ForkRem(bytes32(spend.puzzle_hash), height)
-            for coin, hint in additions:
-                self.additions_since_fork[coin.name()] = ForkAdd(coin, height, timestamp, hint, False)
-        for coin in block.get_included_reward_coins():
-            assert block.foliage_transaction_block is not None
-            timestamp = block.foliage_transaction_block.timestamp
-            assert coin.name() not in self.additions_since_fork
-            self.additions_since_fork[coin.name()] = ForkAdd(coin, block.height, timestamp, None, True)
-
     def rollback(self, header_hash: bytes32, height: int) -> None:
         assert height <= self.peak_height
         self.peak_height = height


### PR DESCRIPTION
### Purpose:

This is extracted from PR #19713 to address https://github.com/Chia-Network/chia-blockchain/pull/19713/files#r2149578080

Consolidating block spends inclusion into one class function instead of two functions that behave the exact same way allows us to extend that behavior's logic centrally.

### Current Behavior:

We use `ForkInfo`'s `include_spends` everywhere except one place where `include_block` is used. 

### New Behavior:

We use `ForkInfo`'s `include_spends` everywhere.