### PR TITLE
CHIA-3207 Pass coin IDs from Blockchain's _reconsider_peak to CoinStore's new_block to avoid recomputing them

### DIFF
--- a/benchmarks/coin_store.py
+++ b/benchmarks/coin_store.py
@@ -28,13 +28,14 @@ def make_coin() -> Coin:
     return Coin(rand_hash(), rand_hash(), uint64(1))
 
 
-def make_coins(num: int) -> tuple[list[Coin], list[bytes32]]:
-    additions: list[Coin] = []
+def make_coins(num: int) -> tuple[list[tuple[bytes32, Coin]], list[bytes32]]:
+    additions: list[tuple[bytes32, Coin]] = []
     hashes: list[bytes32] = []
     for i in range(num):
         c = make_coin()
-        additions.append(c)
-        hashes.append(c.name())
+        coin_id = c.name()
+        additions.append((coin_id, c))
+        hashes.append(coin_id)
 
     return additions, hashes
 
@@ -145,7 +146,7 @@ async def run_new_block_benchmark(version: int) -> None:
             # add one new coins
             c = make_coin()
             coin_id = c.name()
-            additions.append(c)
+            additions.append((coin_id, c))
             total_add += 1
 
             farmer_coin, pool_coin = rewards(uint32(height))

--- a/chia/_tests/core/full_node/stores/test_coin_store.py
+++ b/chia/_tests/core/full_node/stores/test_coin_store.py
@@ -117,7 +117,7 @@ async def test_basic_coin_store(db_version: int, softfork_height: uint32, bt: Bl
                 block.height,
                 block.foliage_transaction_block.timestamp,
                 reward_coins,
-                tx_additions,
+                [(a.name(), a) for a in tx_additions],
                 tx_removals,
             )
 
@@ -127,7 +127,7 @@ async def test_basic_coin_store(db_version: int, softfork_height: uint32, bt: Bl
                         block.height,
                         block.foliage_transaction_block.timestamp,
                         reward_coins,
-                        tx_additions,
+                        [(a.name(), a) for a in tx_additions],
                         tx_removals,
                     )
 

--- a/chia/_tests/util/spend_sim.py
+++ b/chia/_tests/util/spend_sim.py
@@ -279,7 +279,7 @@ class SpendSim:
                         await self.hint_store.add_hints(hints)
                         spent_coins_ids.append(spend.coin.name())
                         tx_removals.append(spend.coin)
-                    tx_additions = additions
+                    tx_additions = [(addition.name(), addition) for addition in additions]
         await self.coin_store.new_block(
             height=uint32(self.block_height + 1),
             timestamp=self.timestamp,
@@ -299,7 +299,7 @@ class SpendSim:
         await self.new_peak(spent_coins_ids)
 
         # return some debugging data
-        return tx_additions, tx_removals
+        return [a for _, a in tx_additions], tx_removals
 
     def get_height(self) -> uint32:
         return self.block_height

--- a/chia/_tests/wallet/test_new_wallet_protocol.py
+++ b/chia/_tests/wallet/test_new_wallet_protocol.py
@@ -828,7 +828,7 @@ async def raw_mpu_setup(one_node: OneNode, self_hostname: str, no_capability: bo
     reward_1 = Coin(std_hash(b"reward 1"), std_hash(b"reward puzzle hash"), uint64(1000))
     reward_2 = Coin(std_hash(b"reward 2"), std_hash(b"reward puzzle hash"), uint64(2000))
     await simulator.full_node.coin_store.new_block(
-        uint32(2), uint64(10000), [reward_1, reward_2], [coin for coin, _ in new_coins], []
+        uint32(2), uint64(10000), [reward_1, reward_2], [(coin.name(), coin) for coin, _ in new_coins], []
     )
     await simulator.full_node.hint_store.add_hints([(coin.name(), hint) for coin, hint in new_coins])
 
@@ -855,7 +855,9 @@ async def make_coin(full_node: FullNode) -> tuple[Coin, bytes32]:
 
     reward_1 = Coin(std_hash(b"reward 1"), std_hash(b"reward puzzle hash"), uint64(3000))
     reward_2 = Coin(std_hash(b"reward 2"), std_hash(b"reward puzzle hash"), uint64(4000))
-    await full_node.coin_store.new_block(uint32(height + 1), uint64(200000), [reward_1, reward_2], [coin], [])
+    await full_node.coin_store.new_block(
+        uint32(height + 1), uint64(200000), [reward_1, reward_2], [(coin.name(), coin)], []
+    )
     await full_node.hint_store.add_hints([(coin.name(), hint)])
 
     return coin, hint

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -564,8 +564,8 @@ class Blockchain:
                 if fork_add.confirmed_height == height and fork_add.is_coinbase
             ]
             tx_additions = [
-                fork_add.coin
-                for fork_add in fork_info.additions_since_fork.values()
+                (coin_id, fork_add.coin)
+                for coin_id, fork_add in fork_info.additions_since_fork.items()
                 if fork_add.confirmed_height == height and not fork_add.is_coinbase
             ]
             tx_removals = [
@@ -586,7 +586,7 @@ class Blockchain:
                     f"height: {fetched_block_record.height}), {len(tx_removals)} spends"
                 )
                 log.info("rewards: %s", ",".join([add.name().hex()[0:6] for add in included_reward_coins]))
-                log.info("additions: %s", ",".join([add.name().hex()[0:6] for add in tx_additions]))
+                log.info("additions: %s", ",".join([add[0].hex()[0:6] for add in tx_additions]))
                 log.info("removals: %s", ",".join([f"{rem}"[0:6] for rem in tx_removals]))
 
         # we made it to the end successfully

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -82,7 +82,7 @@ class CoinStore:
         height: uint32,
         timestamp: uint64,
         included_reward_coins: Collection[Coin],
-        tx_additions: Collection[Coin],
+        tx_additions: Collection[tuple[bytes32, Coin]],
         tx_removals: list[bytes32],
     ) -> None:
         """
@@ -93,10 +93,10 @@ class CoinStore:
 
         db_values_to_insert = []
 
-        for coin in tx_additions:
+        for coin_id, coin in tx_additions:
             db_values_to_insert.append(
                 (
-                    coin.name(),
+                    coin_id,
                     # confirmed_index
                     height,
                     # spent_index


### PR DESCRIPTION
### Purpose:

We already have additions coin IDs so pass them from `Blockchain`'s `_reconsider_peak` instead of recomputing them in `CoinStore`'s `new_block`.

### Current Behavior:

We compute additions coin IDs in `CoinStore`'s `new_block`.

### New Behavior:

We receive them from `Blockchain`'s `_reconsider_peak` instead of recomputing them in `CoinStore`'s `new_block`.

