### PR TITLE
update constant testnet overrides for timelord

### DIFF
--- a/chia/server/start_timelord.py
+++ b/chia/server/start_timelord.py
@@ -9,7 +9,7 @@ from chia_rs import ConsensusConstants
 
 from chia.apis import ApiProtocolRegistry
 from chia.consensus.constants import replace_str_to_bytes
-from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.consensus.default_constants import DEFAULT_CONSTANTS, update_testnet_overrides
 from chia.protocols.outbound_message import NodeType
 from chia.server.aliases import TimelordService
 from chia.server.resolve_peer_info import get_unresolved_peer_infos
@@ -39,6 +39,7 @@ def create_timelord_service(
 
     network_id = service_config["selected_network"]
     overrides = service_config["network_overrides"]["constants"][network_id]
+    update_testnet_overrides(network_id, overrides)
     updated_constants = replace_str_to_bytes(consensus_constants, **overrides)
 
     node = Timelord(root_path, service_config, updated_constants)


### PR DESCRIPTION
### Purpose:

Along with the hardfork, some constants changed names (which might have been a mistake in hindsight). This exposed a few services (harvester and now timelord) that were not updating their overrides on startup. Since the overrides are saved in the config, certain updates (like soft forks and hard forks) may require adding new overrides for testnet. That's the purpose of this function.

### Current Behavior:

Timelord running `main` cannot serve testnet11 because the `MIN_PLOT_SIZE` override changed name.

### New Behavior:

Timelord running `main` can serve testnet11.