### PR TITLE
update testnet overrides in wallet

### DIFF
--- a/chia/server/start_wallet.py
+++ b/chia/server/start_wallet.py
@@ -10,7 +10,7 @@ from chia_rs import ConsensusConstants
 
 from chia.apis import ApiProtocolRegistry
 from chia.consensus.constants import replace_str_to_bytes
-from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.consensus.default_constants import DEFAULT_CONSTANTS, update_testnet_overrides
 from chia.protocols.outbound_message import NodeType
 from chia.server.aliases import WalletService
 from chia.server.resolve_peer_info import get_unresolved_peer_infos
@@ -43,6 +43,7 @@ def create_wallet_service(
 
     network_id = service_config["selected_network"]
     overrides = service_config["network_overrides"]["constants"][network_id]
+    update_testnet_overrides(network_id, overrides)
     updated_constants = replace_str_to_bytes(consensus_constants, **overrides)
     service_config.setdefault("short_sync_blocks_behind_threshold", 20)
 


### PR DESCRIPTION
### Purpose:

the wallet was not updating constant overrides correctly as some constants have been renamed