### PR TITLE
integrate `PLOT_V1_PHASE_OUT` constant

### DIFF
--- a/chia/_tests/core/consensus/test_pot_iterations.py
+++ b/chia/_tests/core/consensus/test_pot_iterations.py
@@ -7,7 +7,6 @@ from pytest import raises
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.pos_quality import _expected_plot_size
 from chia.consensus.pot_iterations import (
-    PHASE_OUT_PERIOD,
     calculate_ip_iters,
     calculate_iterations_quality,
     calculate_phase_out,
@@ -135,14 +134,16 @@ class TestPotIterations:
         # after HARD_FORK2_HEIGHT, should return value = delta/phase_out_period * sp_interval
         assert (
             calculate_phase_out(constants, sub_slot_iters, constants.HARD_FORK2_HEIGHT + 1)
-            == sp_interval // PHASE_OUT_PERIOD
+            == sp_interval // constants.PLOT_V1_PHASE_OUT
         )
         assert (
-            calculate_phase_out(constants, sub_slot_iters, constants.HARD_FORK2_HEIGHT + PHASE_OUT_PERIOD // 2)
+            calculate_phase_out(
+                constants, sub_slot_iters, constants.HARD_FORK2_HEIGHT + constants.PLOT_V1_PHASE_OUT // 2
+            )
             == sp_interval // 2
         )
         assert (
-            calculate_phase_out(constants, sub_slot_iters, constants.HARD_FORK2_HEIGHT + PHASE_OUT_PERIOD)
+            calculate_phase_out(constants, sub_slot_iters, constants.HARD_FORK2_HEIGHT + constants.PLOT_V1_PHASE_OUT)
             == sp_interval
         )
 

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -25,6 +25,7 @@ from chia_rs.sized_ints import uint32, uint64, uint128
 from chiabip158 import PyBIP158
 from colorlog import getLogger
 
+from chia._tests.conftest import ConsensusMode
 from chia._tests.connection_utils import connect_and_get_peer, disconnect_all, disconnect_all_and_reconnect
 from chia._tests.util.blockchain_mock import BlockchainMock
 from chia._tests.util.misc import patch_request_handler, wallet_height_at_least
@@ -1702,6 +1703,11 @@ async def test_long_sync_untrusted_break(
 @pytest.mark.anyio
 @pytest.mark.parametrize("chain_length", [0, 100])
 @pytest.mark.parametrize("fork_point", [500, 1500])
+# TODO: todo_v2_plots once we have new test chains, we can probably re-enable this
+@pytest.mark.limit_consensus_modes(
+    allows=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0],
+    reason="after plot-v1 phase-out, the chains aren't valid anymore",
+)
 async def test_long_reorg_nodes_and_wallet(
     chain_length: int,
     fork_point: int,

--- a/chia/consensus/pot_iterations.py
+++ b/chia/consensus/pot_iterations.py
@@ -10,9 +10,6 @@ from chia.consensus.pos_quality import _expected_plot_size
 from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
 from chia.util.hash import std_hash
 
-# TODO: todo_v2_plots add to chia_rs and get from constants
-PHASE_OUT_PERIOD = uint32(10000000)
-
 
 def is_overflow_block(constants: ConsensusConstants, signage_point_index: uint8) -> bool:
     if signage_point_index >= constants.NUM_SPS_SUB_SLOT:
@@ -38,7 +35,7 @@ def calculate_phase_out(
 ) -> uint64:
     if prev_transaction_block_height <= constants.HARD_FORK2_HEIGHT:
         return uint64(0)
-    elif uint32(prev_transaction_block_height - constants.HARD_FORK2_HEIGHT) >= PHASE_OUT_PERIOD:
+    elif uint32(prev_transaction_block_height - constants.HARD_FORK2_HEIGHT) >= constants.PLOT_V1_PHASE_OUT:
         return uint64(calculate_sp_interval_iters(constants, sub_slot_iters))
 
     return uint64(
@@ -46,7 +43,7 @@ def calculate_phase_out(
             uint32(prev_transaction_block_height - constants.HARD_FORK2_HEIGHT)
             * calculate_sp_interval_iters(constants, sub_slot_iters)
         )
-        // PHASE_OUT_PERIOD
+        // constants.PLOT_V1_PHASE_OUT
     )
 
 

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1623,6 +1623,7 @@ class FullNode:
         for i, block in enumerate(blocks_to_validate):
             header_hash = block.header_hash
             assert vs.prev_ses_block is None or vs.prev_ses_block.height < block.height
+            assert pre_validation_results[i].error is None
             assert pre_validation_results[i].required_iters is not None
             state_change_summary: Optional[StateChangeSummary]
             # when adding blocks in batches, we won't have any overlapping


### PR DESCRIPTION
### Purpose:

remove temporary phase-out constant and use the one from `ConsensusConstants`.