### PR TITLE
[CHIA-3391] Port `test_nft*offers.py` to be parametrized with R-CATs

### DIFF
--- a/chia/_tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -915,14 +915,14 @@ async def test_nft_offer_sell_nft_for_cat(
 
     # Create new CAT and wallets for maker and taker
     # Trade them between maker and taker to ensure multiple coins for each cat
-    cats_to_mint = 100000
+    cats_to_mint = uint64(100000)
     cats_to_trade = uint64(10000)
     cat_wallet_maker = await mint_cat(
         wallet_environments,
         env_maker,
         "xch",
         "cat",
-        uint64(cats_to_mint),
+        cats_to_mint,
         wallet_type,
         "cat",
     )
@@ -1241,14 +1241,14 @@ async def test_nft_offer_request_nft_for_cat(
 
     # Create new CAT and wallets for maker and taker
     # Trade them between maker and taker to ensure multiple coins for each cat
-    cats_to_mint = 100000
+    cats_to_mint = uint64(100000)
     cats_to_trade = uint64(20000)
     cat_wallet_maker = await mint_cat(
         wallet_environments,
         env_maker,
         "xch",
         "cat",
-        uint64(cats_to_mint),
+        cats_to_mint,
         wallet_type,
         "cat",
     )

--- a/chia/_tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -2066,7 +2066,8 @@ async def test_complex_nft_offer(
         + taker_royalty_summary[nft_to_offer_asset_id_taker_2][0]["amount"]
     )
 
-    xch_coins = int(XCH_REQUESTED / 1_750_000_000_000) + 2
+    # in the zero royalty case, exact change ends up being selected which complicates things a bit
+    xch_coins = int(XCH_REQUESTED / 1_750_000_000_000) + 2 - (1 if royalty_basis_pts_maker == 0 else 0)
     fee_coins = int(FEE / 1_750_000_000_000) + 1 if FEE > 1_750_000_000_000 else 1
     await wallet_environments.process_pending_states(
         [
@@ -2127,7 +2128,7 @@ async def test_complex_nft_offer(
                         "unconfirmed_wallet_balance": -XCH_REQUESTED - maker_xch_royalties_expected - FEE,
                         "<=#spendable_balance": -XCH_REQUESTED - maker_xch_royalties_expected - FEE,
                         "<=#max_send_amount": -XCH_REQUESTED - maker_xch_royalties_expected - FEE,
-                        ">=#pending_change": 1,
+                        ">=#pending_change": 0,
                         "pending_coin_removal_count": xch_coins + fee_coins,
                     },
                     "cat_taker": {
@@ -2149,9 +2150,9 @@ async def test_complex_nft_offer(
                 post_block_balance_updates={
                     "xch": {
                         "confirmed_wallet_balance": -XCH_REQUESTED - maker_xch_royalties_expected - FEE,
-                        ">=#spendable_balance": 1,
-                        ">=#max_send_amount": 1,
-                        "<=#pending_change": -1,
+                        ">=#spendable_balance": 0,
+                        ">=#max_send_amount": 0,
+                        "<=#pending_change": 0,
                         "pending_coin_removal_count": -fee_coins - xch_coins,
                         # Parametrizations make unspent_coin_count too complicated
                         "set_remainder": True,

--- a/chia/_tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -1654,8 +1654,11 @@ async def test_nft_offer_sell_cancel(wallet_environments: WalletTestFramework) -
     [{"num_environments": 2, "blocks_needed": [3, 3], "config_overrides": {"automatically_add_unknown_cats": True}}],
     indirect=True,
 )
+@pytest.mark.parametrize("wallet_type", [CATWallet, RCATWallet])
 @pytest.mark.anyio
-async def test_complex_nft_offer(wallet_environments: WalletTestFramework, royalty_pts: tuple[int, int, int]) -> None:
+async def test_complex_nft_offer(
+    wallet_environments: WalletTestFramework, royalty_pts: tuple[int, int, int], wallet_type: type[CATWallet]
+) -> None:
     """
     This test is going to create an offer where the maker offers 1 NFT and 1 CAT for 2 NFTs, an XCH and a CAT
     """
@@ -1693,20 +1696,24 @@ async def test_complex_nft_offer(wallet_environments: WalletTestFramework, royal
         ph_taker = await action_scope.get_puzzle_hash(wallet_taker.wallet_state_manager)
 
     CAT_AMOUNT = uint64(100000000)
-    async with wallet_maker.wallet_state_manager.new_action_scope(
-        wallet_environments.tx_config, push=True
-    ) as action_scope:
-        cat_wallet_maker = await CATWallet.create_new_cat_wallet(
-            wsm_maker, wallet_maker, {"identifier": "genesis_by_id"}, CAT_AMOUNT, action_scope
-        )
-    async with wallet_taker.wallet_state_manager.new_action_scope(
-        wallet_environments.tx_config, push=True
-    ) as action_scope:
-        cat_wallet_taker = await CATWallet.create_new_cat_wallet(
-            wsm_taker, wallet_taker, {"identifier": "genesis_by_id"}, CAT_AMOUNT, action_scope
-        )
-    await env_maker.change_balances({"cat_maker": {"init": True}})
-    await env_taker.change_balances({"cat_taker": {"init": True}})
+    cat_wallet_maker = await mint_cat(
+        wallet_environments,
+        env_maker,
+        "xch",
+        "cat_maker",
+        CAT_AMOUNT,
+        wallet_type,
+        "cat_maker",
+    )
+    cat_wallet_taker = await mint_cat(
+        wallet_environments,
+        env_taker,
+        "xch",
+        "cat_taker",
+        CAT_AMOUNT,
+        wallet_type,
+        "cat_taker",
+    )
 
     # We'll need these later
     basic_nft_wallet_maker = await NFTWallet.create_new_nft_wallet(wsm_maker, wallet_maker, name="NFT WALLET MAKER")
@@ -1989,6 +1996,11 @@ async def test_complex_nft_offer(wallet_environments: WalletTestFramework, royal
             {
                 "type": "CAT",
                 "tail": "0x" + cat_wallet_taker.get_asset_id(),
+                **(
+                    {}
+                    if wallet_type is CATWallet
+                    else {"also": {"type": "revocation layer", "hidden_puzzle_hash": "0x" + bytes32.zeros.hex()}}
+                ),
             }
         ),
     }

--- a/chia/_tests/wallet/nft_wallet/test_nft_offers.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_offers.py
@@ -789,13 +789,13 @@ async def test_nft_offer_nft_for_cat(wallet_environments: WalletTestFramework, w
     assert await nft_wallet_taker.get_nft_count() == 0
 
     # Create two new CATs and wallets for maker and taker
-    cats_to_mint = 10000
+    cats_to_mint = uint64(10000)
     cat_wallet_maker = await mint_cat(
         wallet_environments,
         env_0,
         "xch",
         "maker cat",
-        uint64(cats_to_mint),
+        cats_to_mint,
         wallet_type,
         "maker cat",
     )
@@ -805,7 +805,7 @@ async def test_nft_offer_nft_for_cat(wallet_environments: WalletTestFramework, w
         env_1,
         "xch",
         "taker cat",
-        uint64(cats_to_mint),
+        cats_to_mint,
         wallet_type,
         "taker cat",
     )
@@ -1428,13 +1428,13 @@ async def test_nft_offer_nft0_and_xch_for_cat(
 
     assert await nft_wallet_taker.get_nft_count() == 0
     # Create two new CATs and wallets for maker and taker
-    cats_to_mint = 10000
+    cats_to_mint = uint64(10000)
     cat_wallet_maker = await mint_cat(
         wallet_environments,
         env_0,
         "xch",
         "maker cat",
-        uint64(cats_to_mint),
+        cats_to_mint,
         CATWallet,
         "maker cat",
     )
@@ -1444,7 +1444,7 @@ async def test_nft_offer_nft0_and_xch_for_cat(
         env_1,
         "xch",
         "taker cat",
-        uint64(cats_to_mint),
+        cats_to_mint,
         CATWallet,
         "taker cat",
     )

--- a/chia/_tests/wallet/nft_wallet/test_nft_offers.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_offers.py
@@ -810,42 +810,6 @@ async def test_nft_offer_nft_for_cat(wallet_environments: WalletTestFramework, w
         "taker cat",
     )
 
-    # mostly set_remainder here as minting CATs is tested elsewhere
-    await wallet_environments.process_pending_states(
-        [
-            WalletStateTransition(
-                pre_block_balance_updates={
-                    "xch": {"set_remainder": True},
-                    "maker cat": {
-                        "init": True,
-                        "set_remainder": True,
-                    },
-                },
-                post_block_balance_updates={
-                    "xch": {"set_remainder": True},
-                    "maker cat": {
-                        "set_remainder": True,
-                    },
-                },
-            ),
-            WalletStateTransition(
-                pre_block_balance_updates={
-                    "xch": {"set_remainder": True},
-                    "taker cat": {
-                        "init": True,
-                        "set_remainder": True,
-                    },
-                },
-                post_block_balance_updates={
-                    "xch": {"set_remainder": True},
-                    "taker cat": {
-                        "set_remainder": True,
-                    },
-                },
-            ),
-        ]
-    )
-
     if wallet_type is RCATWallet:
         extra_args: Any = (bytes32.zeros,)
     else:
@@ -857,6 +821,9 @@ async def test_nft_offer_nft_for_cat(wallet_environments: WalletTestFramework, w
     await wallet_type.get_or_create_wallet_for_cat(
         env_1.wallet_state_manager, wallet_taker, cat_wallet_maker.get_asset_id(), *extra_args
     )
+
+    await env_0.change_balances({"taker cat": {"init": True}})
+    await env_1.change_balances({"maker cat": {"init": True}})
 
     # MAKE FIRST TRADE: 1 NFT for 10 taker cats
     nft_to_offer = coins_maker[0]
@@ -908,9 +875,7 @@ async def test_nft_offer_nft_for_cat(wallet_environments: WalletTestFramework, w
                         "<=#max_send_amount": -maker_fee,
                         "pending_coin_removal_count": 1,
                     },
-                    "taker cat": {
-                        "init": True,
-                    },
+                    "taker cat": {},
                     "nft": {
                         "pending_coin_removal_count": 1,
                     },
@@ -946,9 +911,7 @@ async def test_nft_offer_nft_for_cat(wallet_environments: WalletTestFramework, w
                         ">=#pending_change": 1,
                         "pending_coin_removal_count": 1,
                     },
-                    "maker cat": {
-                        "init": True,
-                    },
+                    "maker cat": {},
                     "taker cat": {
                         "unconfirmed_wallet_balance": -taker_cat_offered,
                         "<=#spendable_balance": -taker_cat_offered,


### PR DESCRIPTION
Another PR increasing R-CAT test coverage.

No production code changes as a result of this port.

There was one small change needed to the most complex test due to the different minting method resulting in a later exact change scenario which messed with a few of the balance calculations.