### PR TITLE
spends that are eligible for FF can still be treated as regular spends

### DIFF
--- a/chia/_tests/core/mempool/test_singleton_fast_forward.py
+++ b/chia/_tests/core/mempool/test_singleton_fast_forward.py
@@ -663,4 +663,4 @@ async def test_double_spend_ff_spend_no_latest_unspent() -> None:
         status, error = await make_and_send_spend_bundle(sim, sim_client, [singleton_coin_spend], aggsig=sig)
         # It fails validation because it doesn't currently have a latest unspent
         assert status == MempoolInclusionStatus.FAILED
-        assert error == Err.DOUBLE_SPEND
+        assert error == Err.UNKNOWN_UNSPENT

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -607,11 +607,16 @@ class MempoolManager:
             eligible_for_ff = bool(spend_conds.flags & ELIGIBLE_FOR_FF) and supports_fast_forward(coin_spend)
             if eligible_for_ff:
                 # Make sure the fast forward spend still has a version that is
-                # still unspent, because if the singleton has been melted, the
-                # fast forward spend will never become valid.
+                # still unspent, because if the singleton has been spent in a
+                # non-FF spend, this fast forward spend will never become valid.
+                # So treat this as a normal spend, which requires the exact coin
+                # to exist and be unspent.
+                # Singletons that were created before the optimization of using
+                # spent_index will also fail this test, and such spends will
+                # fall back to be treated as non-FF spends.
                 lineage_info = await get_unspent_lineage_info_for_puzzle_hash(bytes32(spend_conds.puzzle_hash))
                 if lineage_info is None:
-                    return Err.DOUBLE_SPEND, None, []
+                    eligible_for_ff = False
 
             spend_additions = []
             for puzzle_hash, amount, _ in spend_conds.create_coin:


### PR DESCRIPTION
if the coin doesn't appear to support the rebase

See description in https://github.com/Chia-Network/chia-blockchain/pull/19889

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
