### PR TITLE
fast-forward spends can be treated as regular spends

### DIFF
--- a/chia/_tests/core/mempool/test_singleton_fast_forward.py
+++ b/chia/_tests/core/mempool/test_singleton_fast_forward.py
@@ -663,4 +663,4 @@ async def test_double_spend_ff_spend_no_latest_unspent() -> None:
         status, error = await make_and_send_spend_bundle(sim, sim_client, [singleton_coin_spend], aggsig=sig)
         # It fails validation because it doesn't currently have a latest unspent
         assert status == MempoolInclusionStatus.FAILED
-        assert error == Err.DOUBLE_SPEND
+        assert error == Err.UNKNOWN_UNSPENT

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -640,7 +640,7 @@ class MempoolManager:
                 assert eligibility_info.ff_puzzle_hash is not None
                 lineage_info = await get_unspent_lineage_info_for_puzzle_hash(eligibility_info.ff_puzzle_hash)
                 if lineage_info is None:
-                    return Err.DOUBLE_SPEND, None, []
+                    mark_as_fast_forward = False
             bundle_coin_spends[coin_id] = BundleCoinSpend(
                 coin_spend=coin_spend,
                 eligible_for_dedup=supports_dedup,


### PR DESCRIPTION
 if the coin doesn't appear to support the rebasing

### Purpose:

In https://github.com/Chia-Network/chia-blockchain/pull/19713 we introduced the optimization of using `spent_index = -1` to indicate whether a coin's parent has the same puzzle hash and amount. When accepting a FF spend into the mempool, we need to ensure that it will be possible to rebase it on top of the latest version (otherwise the mempool may have invalid spends in it, wasting space).

In https://github.com/Chia-Network/chia-blockchain/pull/19272, any spend submitted to the mempool, that supports fast forward, is checked that the coin it's spending has `spent_index = -1`. If not, the spend is rejected as `DOUBLE_SPEND`.

There's a problem with migration, since older nodes will have just left the `spent_index = 0`, even if coins support fast forward. Attempting to submit a FF spend to a new node with an old database will fail with this error.

This patch, instead, turns the spend into a normal spend. Not marking it as eligible for FF means the coin it's spending actually have to be *unspent*. This solves the transition problem as long as only one spend at a time happens first.

i.e. in the scenario of a new node with an old database, only a single FF spend will go through at first. Once the FF singleton has been spent once, FF will be fully enabled, since the new coin will have `spent_index = -1` set in the node's database.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
