### PR TITLE
Bump chia rs 0.28

### DIFF
--- a/chia/_tests/clvm/coin_store.py
+++ b/chia/_tests/clvm/coin_store.py
@@ -73,7 +73,7 @@ class CoinStore:
         assert result.conds is not None
         for spend in result.conds.spends:
             for puzzle_hash, amount, hint in spend.create_coin:
-                coin = Coin(bytes32(spend.coin_id), bytes32(puzzle_hash), uint64(amount))
+                coin = Coin(spend.coin_id, puzzle_hash, uint64(amount))
                 name = coin.name()
                 ephemeral_db[name] = CoinRecord(
                     coin,

--- a/chia/_tests/core/full_node/test_generator_tools.py
+++ b/chia/_tests/core/full_node/test_generator_tools.py
@@ -8,7 +8,6 @@ from chia_rs import (
     get_spends_for_trusted_block,
     get_spends_for_trusted_block_with_conditions,
 )
-from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
 from chia.consensus.generator_tools import tx_removals_and_additions
@@ -86,7 +85,7 @@ def test_tx_removals_and_additions() -> None:
     expected_additions = []
     for spend in spends:
         for puzzle_hash, am, _ in spend.create_coin:
-            expected_additions.append(Coin(bytes32(spend.coin_id), bytes32(puzzle_hash), uint64(am)))
+            expected_additions.append(Coin(spend.coin_id, puzzle_hash, uint64(am)))
     rems, adds = tx_removals_and_additions(conditions)
     assert rems == expected_rems
     assert adds == expected_additions

--- a/chia/_tests/core/full_node/test_generator_tools.py
+++ b/chia/_tests/core/full_node/test_generator_tools.py
@@ -109,7 +109,7 @@ def test_get_spends_for_block(caplog: pytest.LogCaptureFixture) -> None:
     conditions = get_spends_for_trusted_block(
         test_constants, TEST_GENERATOR.program, TEST_GENERATOR.generator_refs, 100
     )
-    assert conditions[0]["block_spends"] == []
+    assert conditions["block_spends"] == []
 
 
 def test_get_spends_for_block_with_conditions(caplog: pytest.LogCaptureFixture) -> None:

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -3197,7 +3197,9 @@ def test_dedup_by_fee(old: bool) -> None:
 
 def test_get_puzzle_and_solution_for_coin_failure() -> None:
     with pytest.raises(
-        ValueError, match=f"Failed to get puzzle and solution for coin {TEST_COIN}, error: \\('coin not found', '80'\\)"
+        ValueError,
+        match=f"Failed to get puzzle and solution for coin {TEST_COIN}, "
+        "error: \\('InvalidOperatorArg: coin not found', '80'\\)",
     ):
         try:
             get_puzzle_and_solution_for_coin(

--- a/chia/_tests/generator/test_rom.py
+++ b/chia/_tests/generator/test_rom.py
@@ -146,7 +146,7 @@ class TestROM:
             before_seconds_relative=None,
             birth_height=None,
             birth_seconds=None,
-            create_coin=[(bytes([0] * 31 + [1]), 500, None)],
+            create_coin=[(bytes32([0] * 31 + [1]), 500, None)],
             agg_sig_me=[],
             agg_sig_parent=[],
             agg_sig_puzzle=[],

--- a/chia/cmds/show_funcs.py
+++ b/chia/cmds/show_funcs.py
@@ -39,7 +39,7 @@ async def print_blockchain_state(node_client: FullNodeRpcClient, config: dict[st
 
     if synced:
         print("Current Blockchain Status: Full Node Synced")
-        print("\nPeak: Hash:", bytes32(peak.header_hash) if peak is not None else "")
+        print("\nPeak: Hash:", peak.header_hash if peak is not None else "")
     elif peak is not None and sync_mode:
         sync_max_block = blockchain_state["sync"]["sync_tip_height"]
         sync_current_block = blockchain_state["sync"]["sync_progress_height"]
@@ -48,7 +48,7 @@ async def print_blockchain_state(node_client: FullNodeRpcClient, config: dict[st
             f"({sync_max_block - sync_current_block} behind). "
             f"({sync_current_block * 100.0 / sync_max_block:2.2f}% synced)"
         )
-        print("Peak: Hash:", bytes32(peak.header_hash) if peak is not None else "")
+        print("Peak: Hash:", peak.header_hash if peak is not None else "")
     elif peak is not None:
         print(f"Current Blockchain Status: Not Synced. Peak height: {peak.height}")
     else:
@@ -59,7 +59,7 @@ async def print_blockchain_state(node_client: FullNodeRpcClient, config: dict[st
         if peak.is_transaction_block:
             peak_time = peak.timestamp
         else:
-            peak_hash = bytes32(peak.header_hash)
+            peak_hash = peak.header_hash
             curr = await node_client.get_block_record(peak_hash)
             while curr is not None and not curr.is_transaction_block:
                 curr = await node_client.get_block_record(curr.prev_hash)
@@ -88,7 +88,7 @@ async def print_blockchain_state(node_client: FullNodeRpcClient, config: dict[st
             curr = await node_client.get_block_record(curr.prev_hash)
 
         for b in added_blocks:
-            print(f"{b.height:>9} | {bytes32(b.header_hash)}")
+            print(f"{b.height:>9} | {b.header_hash}")
     else:
         print("Blockchain has no blocks yet")
     return False
@@ -125,7 +125,7 @@ async def print_block_from_hash(
             cost = str(full_block.transactions_info.cost)
             tx_filter_hash: Union[str, bytes32] = "Not a transaction block"
             if full_block.foliage_transaction_block:
-                tx_filter_hash = bytes32(full_block.foliage_transaction_block.filter_hash)
+                tx_filter_hash = full_block.foliage_transaction_block.filter_hash
             fees: Any = block.fees
         else:
             block_time_string = "Not a transaction block"

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -116,9 +116,9 @@ class ForkInfo:
             timestamp = block.foliage_transaction_block.timestamp
             for spend in conds.spends:
                 spend_coin_id = bytes32(spend.coin_id)
-                self.removals_since_fork[spend_coin_id] = ForkRem(bytes32(spend.puzzle_hash), block.height)
+                self.removals_since_fork[spend_coin_id] = ForkRem(spend.puzzle_hash, block.height)
                 for puzzle_hash, amount, hint in spend.create_coin:
-                    coin = Coin(spend_coin_id, bytes32(puzzle_hash), uint64(amount))
+                    coin = Coin(spend_coin_id, puzzle_hash, uint64(amount))
                     same_as_parent = coin.puzzle_hash == spend.puzzle_hash and amount == spend.coin_amount
                     self.additions_since_fork[coin.name()] = ForkAdd(
                         coin, block.height, timestamp, hint=hint, is_coinbase=False, same_as_parent=same_as_parent
@@ -137,8 +137,8 @@ class ForkInfo:
             timestamp = block.foliage_transaction_block.timestamp
             spent_coins: dict[bytes32, Coin] = {}
             for spend_id, spend in removals:
-                spent_coins[bytes32(spend_id)] = spend
-                self.removals_since_fork[bytes32(spend_id)] = ForkRem(bytes32(spend.puzzle_hash), block.height)
+                spent_coins[spend_id] = spend
+                self.removals_since_fork[spend_id] = ForkRem(spend.puzzle_hash, block.height)
             for coin, hint in additions:
                 parent = spent_coins.get(coin.parent_coin_info)
                 assert parent is not None
@@ -382,9 +382,9 @@ async def validate_block_body(
 
         for spend in conds.spends:
             removals.append(bytes32(spend.coin_id))
-            removals_puzzle_dic[bytes32(spend.coin_id)] = bytes32(spend.puzzle_hash)
+            removals_puzzle_dic[spend.coin_id] = spend.puzzle_hash
             for puzzle_hash, amount, _ in spend.create_coin:
-                c = Coin(bytes32(spend.coin_id), bytes32(puzzle_hash), uint64(amount))
+                c = Coin(spend.coin_id, puzzle_hash, uint64(amount))
                 additions.append((c, c.name()))
     else:
         assert conds is None

--- a/chia/consensus/generator_tools.py
+++ b/chia/consensus/generator_tools.py
@@ -65,6 +65,6 @@ def tx_removals_and_additions(results: Optional[SpendBundleConditions]) -> tuple
     for spend in results.spends:
         removals.append(bytes32(spend.coin_id))
         for puzzle_hash, amount, _ in spend.create_coin:
-            additions.append(Coin(bytes32(spend.coin_id), bytes32(puzzle_hash), uint64(amount)))
+            additions.append(Coin(spend.coin_id, puzzle_hash, uint64(amount)))
 
     return removals, additions

--- a/chia/full_node/full_node_rpc_api.py
+++ b/chia/full_node/full_node_rpc_api.py
@@ -481,10 +481,10 @@ class FullNodeRpcApi:
         if full_block is None:
             raise ValueError(f"Block {header_hash.hex()} not found")
 
-        spends: list[dict[str, list[CoinSpend]]] = []
+        spends: dict[str, list[CoinSpend]]
         block_generator = await get_block_generator(self.service.blockchain.lookup_block_generators, full_block)
         if block_generator is None:  # if block is not a transaction block.
-            return {"block_spends": spends}
+            return {"block_spends": []}
 
         spends = get_spends_for_trusted_block(
             self.service.constants,
@@ -493,9 +493,7 @@ class FullNodeRpcApi:
             get_flags_for_height_and_constants(full_block.height, self.service.constants),
         )
 
-        # chia_rs returning a list is a mistake that will be fixed in the next release
-        # it ought to be returning a dict of {"block_spends": [spends]}
-        return spends[0]
+        return spends
 
     async def get_block_spends_with_conditions(self, request: dict[str, Any]) -> EndpointResult:
         if "header_hash" not in request:

--- a/chia/full_node/full_node_rpc_api.py
+++ b/chia/full_node/full_node_rpc_api.py
@@ -481,7 +481,6 @@ class FullNodeRpcApi:
         if full_block is None:
             raise ValueError(f"Block {header_hash.hex()} not found")
 
-        spends: dict[str, list[CoinSpend]]
         block_generator = await get_block_generator(self.service.blockchain.lookup_block_generators, full_block)
         if block_generator is None:  # if block is not a transaction block.
             return {"block_spends": []}

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -609,7 +609,7 @@ class MempoolManager:
                 # Make sure the fast forward spend still has a version that is
                 # still unspent, because if the singleton has been melted, the
                 # fast forward spend will never become valid.
-                lineage_info = await get_unspent_lineage_info_for_puzzle_hash(bytes32(spend_conds.puzzle_hash))
+                lineage_info = await get_unspent_lineage_info_for_puzzle_hash(spend_conds.puzzle_hash)
                 if lineage_info is None:
                     return Err.DOUBLE_SPEND, None, []
 

--- a/chia/full_node/subscriptions.py
+++ b/chia/full_node/subscriptions.py
@@ -225,11 +225,11 @@ def peers_for_spend_bundle(
 
     for spend in conds.spends:
         coin_ids.add(bytes32(spend.coin_id))
-        puzzle_hashes.add(bytes32(spend.puzzle_hash))
+        puzzle_hashes.add(spend.puzzle_hash)
 
         for puzzle_hash, amount, memo in spend.create_coin:
             coin_ids.add(Coin(spend.coin_id, puzzle_hash, uint64(amount)).name())
-            puzzle_hashes.add(bytes32(puzzle_hash))
+            puzzle_hashes.add(puzzle_hash)
 
             if memo is not None and len(memo) == 32:
                 puzzle_hashes.add(bytes32(memo))

--- a/poetry.lock
+++ b/poetry.lock
@@ -825,33 +825,38 @@ pytest = ">=8.3.3,<9.0.0"
 
 [[package]]
 name = "chia-rs"
-version = "0.27.0"
-description = "Code useful for implementing chia consensus."
+version = "0.28.2"
+description = ""
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "chia_rs-0.27.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:6f7305dbba01d85470815135ff4d25934ed21c9870c53a5a3c6ed9989c93adfe"},
-    {file = "chia_rs-0.27.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:6c1cc7ee4f8858f0f1647b3574f3a4b930c184c43f581ded562b33470110236e"},
-    {file = "chia_rs-0.27.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:4fe4f2fa4e1f7e80f17bf87a8b1b3f3012dfc600b42f7b443c989e200dd29acc"},
-    {file = "chia_rs-0.27.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:5de5a3db32c75d6dd8d8828c078a38400caa7a9330da24f5cfe935d21e74a6c0"},
-    {file = "chia_rs-0.27.0-cp310-cp310-win_amd64.whl", hash = "sha256:624d6d2f6e1de79711bb54d18e470392cb8345271173a8b541816e9d58631e80"},
-    {file = "chia_rs-0.27.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:4ae7d0e84fab83f0be88006dc0a00fe3b042c26a8b6cece584a136e879c516f6"},
-    {file = "chia_rs-0.27.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:271d94b32f9dc32fe53601c1aa70855019ead2b9da0e5b67a38ae87214601965"},
-    {file = "chia_rs-0.27.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:72f5bbeb0b6dbf6e05db33451c8adf9df25f97808846a3faf97cf7027e3dfe16"},
-    {file = "chia_rs-0.27.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f435e59379e7244cf6b4f5b2701a859986bfed3adc1ad1ca2357b6ecc6d1a2da"},
-    {file = "chia_rs-0.27.0-cp311-cp311-win_amd64.whl", hash = "sha256:3fed290e15d9b43de30e24a108eb4141b35547fe6638d89bd987bba6f44bea06"},
-    {file = "chia_rs-0.27.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:52ac4d90cd8a926f951c4dcc5d477a392ee43ddb7dc34075f047044ca4337780"},
-    {file = "chia_rs-0.27.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:88ed91ab0da1b02f4f463aa1a9f9c6e1dfa6f315f6746ce8d105b081e5af87ff"},
-    {file = "chia_rs-0.27.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:24108c3c271c288d8c67a7e043ae4414b1f715a4a5a85817978871986ac8fdf8"},
-    {file = "chia_rs-0.27.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:69093f69c46f345b7c4c5b863024b0eb2792dfe20e528deb1d4aa27f90bab688"},
-    {file = "chia_rs-0.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:c5e3a51a79c0abd1932be2c8a2c3a4723702b2ba367fa769046c4dfcbb000859"},
-    {file = "chia_rs-0.27.0-cp39-cp39-macosx_13_0_arm64.whl", hash = "sha256:35901a6c6042373226992c6bc6f3e3b88b8fc6acdb6a4bfaf84635a4b7ccb41f"},
-    {file = "chia_rs-0.27.0-cp39-cp39-macosx_13_0_x86_64.whl", hash = "sha256:7747b5e7738f70bd8e1c05ece5884fc7c717aec9aa9dd7036f5ac5fd3e9d0ee9"},
-    {file = "chia_rs-0.27.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:e97245a9ef89a08d68b7dc44201624bfd3aa401303da4ff48f04a052043e0ce0"},
-    {file = "chia_rs-0.27.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:1cbfff18f3d1200382b768ce042eff3309291dfd7b79910345358a047764f628"},
-    {file = "chia_rs-0.27.0-cp39-cp39-win_amd64.whl", hash = "sha256:da590ac41d389ee6bedc418f1277565c8e42d000d1ae29b1971698a519ad898a"},
-    {file = "chia_rs-0.27.0.tar.gz", hash = "sha256:7ce89cbc06a888eb05a84f190e399eca015caae340a3d65696d7c0cb16a374ab"},
+    {file = "chia_rs-0.28.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:d6451de733bd1f6a1700eeb97e35539a54fde82f5eb4596e748eee4603d3c792"},
+    {file = "chia_rs-0.28.2-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:b12de327a6fb6df7678d3160209aa2d69d783777bea152567183e62dc2496c80"},
+    {file = "chia_rs-0.28.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:76c0553819e7b8702173bb017f11c03f672f34daf2ffa2de98192774d68821ba"},
+    {file = "chia_rs-0.28.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:bb5e02d25e3a5014b2f981f948f67d5741bb184d55c48f63ff059ade793de71d"},
+    {file = "chia_rs-0.28.2-cp310-cp310-win_amd64.whl", hash = "sha256:0f596f04e6b068439310da88b12a1c1cf962a8b21ab0622d0043115549724c7b"},
+    {file = "chia_rs-0.28.2-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:208d89c5ef3a8f64547dc7ed815fd0aade48dc8a971cc54b1b2588a8e6e52538"},
+    {file = "chia_rs-0.28.2-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:4fd1e0a834ac6df4eea0f89960199086f83279dae5b73c4a6e5e93b3289401e7"},
+    {file = "chia_rs-0.28.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:87b68f2fa91e652124320ce2a94e4ed30eca3c7a670b604192f99551814dc1ca"},
+    {file = "chia_rs-0.28.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0f1f7b54d3c14d2b1fba0ff9d001ee04c4e5f81eccc820a30c3368e47bab92ca"},
+    {file = "chia_rs-0.28.2-cp311-cp311-win_amd64.whl", hash = "sha256:07cbdbf9f1c23531638a4b61109f1fa1e20b01d87895cd0a14e9dd151a0826fa"},
+    {file = "chia_rs-0.28.2-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:2fdfc99c690c828619c01a03db855597da3b21f7d16e538897055dd3d0e5b39e"},
+    {file = "chia_rs-0.28.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:931b064788c02e69b2f69b49c2eba0fe51cb0bcc2302f83ca13e05c9e5a63315"},
+    {file = "chia_rs-0.28.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d27b9e509859015f8d11e0b6b39b4f7742c3294c8d30d831541dad2efcc41d52"},
+    {file = "chia_rs-0.28.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f90213ac8ed4b442c847024122b839ea2a4fa246b93c2a009decddadbd81e6ff"},
+    {file = "chia_rs-0.28.2-cp312-cp312-win_amd64.whl", hash = "sha256:4598a3bcb896066aee27d1c2f7b593fd234d965e5eea2f6692297830fce3557d"},
+    {file = "chia_rs-0.28.2-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:610dbed79d9bb84369b8d0a402af26e382ac1b97eaa6d78b410e228b0d3deab1"},
+    {file = "chia_rs-0.28.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:f58ab82ffc8e7dcba080400c9a3a96a7857ecf3257c5b5955d2c20fbaa553411"},
+    {file = "chia_rs-0.28.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:8797c6b730ed82f9893982b7ef50fd7dcbdffb6698ea68b739f0ed277073cc2a"},
+    {file = "chia_rs-0.28.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4586cd8a7aa03e856c5251b456fe7bb5048b126546bc1369d29138f74667a1df"},
+    {file = "chia_rs-0.28.2-cp313-cp313-win_amd64.whl", hash = "sha256:e63bc97ca973efc06ea5322ad0668e564c178e938f708050adecb89157599831"},
+    {file = "chia_rs-0.28.2-cp39-cp39-macosx_13_0_arm64.whl", hash = "sha256:12bb13cfda1cb9c45dfd9536b32efca6969c4da5679ebde148df1f2220614c81"},
+    {file = "chia_rs-0.28.2-cp39-cp39-macosx_13_0_x86_64.whl", hash = "sha256:71682f048980ad2c269cc6ec16de2e3846affdc48eb9ff4a130adb73acab4b91"},
+    {file = "chia_rs-0.28.2-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:99e960abaa8dcf4050717cf049c7b49202d4437dc8ed92df3a05583790eb1842"},
+    {file = "chia_rs-0.28.2-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:f1408fbef138cfd90829f6f81d55000b8709683db6fed837c08e88c47a73db30"},
+    {file = "chia_rs-0.28.2-cp39-cp39-win_amd64.whl", hash = "sha256:c90298f8c4339f293843c9306d3dcb11df937838c3caaf011699d94ee4da473e"},
+    {file = "chia_rs-0.28.2.tar.gz", hash = "sha256:764ab78e9fd2af266f211cba9a5576a9cf88db47c4f41fe9e5f83ab6bc267f76"},
 ]
 
 [package.dependencies]
@@ -2035,6 +2040,11 @@ files = [
     {file = "miniupnpc-2.3.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a693cfad0a04c072203a62687c5ce412ec4b7d71f9ea6557b9056980ed5b1ef4"},
     {file = "miniupnpc-2.3.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:67e9821fd1e1a07d3fc26e7bb6a44f3b91353ab1ed0fdee6e25aa821af3e8adb"},
     {file = "miniupnpc-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:be09644534d4e3ff527af9702c442ab9ad9fd0ae2ddeb7b7809997e35148d5e5"},
+    {file = "miniupnpc-2.3.3-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:82d14cab9e3d18a68878fa6905eb4abe303eda7b25aadbd46efc1508a2016ccf"},
+    {file = "miniupnpc-2.3.3-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:1ec34592c1bd28b009d23daa7cba1b9e9117387765c708b5093f2c75bc3ac157"},
+    {file = "miniupnpc-2.3.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3bb74ac15c222c297b0a6c1a3812a1a2415c4feebcd87582066274f830a815ab"},
+    {file = "miniupnpc-2.3.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41727c2cf6378f95fcc355215efb8fd43d6fea359714b4d27d41ceafa737f8a7"},
+    {file = "miniupnpc-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:73eaf03185b71e46362f1ff39f57b24e8e3dc12f2ec2d9404398d586d5ceae9f"},
     {file = "miniupnpc-2.3.3-cp39-cp39-macosx_13_0_arm64.whl", hash = "sha256:f1d6b0c99687244c9b4eae36017db54e19442b4204d95632f27543cf351f40b1"},
     {file = "miniupnpc-2.3.3-cp39-cp39-macosx_13_0_x86_64.whl", hash = "sha256:9892df1b8b09279ed2addb7ab42b5a04c8c415d0f83d870e6c469199729b07b6"},
     {file = "miniupnpc-2.3.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb84588afe6c9afa2d53f81baae211c66e32b7a0524de44a8adf04563bb4cdb2"},
@@ -3796,4 +3806,4 @@ upnp = ["miniupnpc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9, <4, !=3.9.0, !=3.9.1"
-content-hash = "36e836838243af6b5a52a42f9d37acff1be0d05680718749b463c0c1a404ae01"
+content-hash = "66bff7b36a67a1a94decf6d05976020464196169894262703c9710b7f39abfd2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ boto3 = ">=1.35.43"  # AWS S3 for Data Layer S3 plugin
 chiabip158 = ">=1.5.2"  # bip158-style wallet filters
 chiapos = ">=2.0.10"  # proof of space
 chia-puzzles-py = ">=0.20.1"
-chia_rs = ">=0.27, <0.28"
+chia_rs = ">=0.28.2, <0.29"
 chiavdf = ">=1.1.10"  # timelord and vdf verification
 click = ">=8.1.7"  # For the CLI
 clvm = ">=0.9.14"


### PR DESCRIPTION
### Purpose:

This PR is best reviewed one commit at a time. It updates `chia_rs` to the latest version:

1. correct the return value from `get_spends_for_trusted_block()` which matt fixed recently.
2. remove casts that are no longer necessary, with the fixed type stubs
3. adjust a test to expect a slightly different error message, related to the work on error codes in clvm_rs Jack did.
