### PR TITLE
Set the correct commit author for mozilla cert workflow

### DIFF
--- a/.github/workflows/update-mozilla-ca-cert.yaml
+++ b/.github/workflows/update-mozilla-ca-cert.yaml
@@ -32,10 +32,14 @@ jobs:
           passphrase: ${{ secrets.CHIA_AUTOMATION_PRIVATE_GPG_PASSPHRASE }}
 
       - name: Create Pull Request if cacert.pem changed
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
+          base: main
           commit-message: "Update cacert.pem from Mozilla CA bundle"
           title: "Update cacert.pem from Mozilla CA bundle"
           body: "Automated update of cacert.pem from https://curl.se/ca/cacert.pem."
           branch: update-cacert-pem
           add-paths: chia/ssl/cacert.pem
+          delete-branch: true
+          committer: "ChiaAutomation <automation@chia.net>"
+          author: "ChiaAutomation <automation@chia.net>"


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

To fix the mozilla ca cert update job.

### Current Behavior:

When this workflow runs, the job logs output:
```
  remote: error: GH006: Protected branch update failed for refs/heads/update-cacert-pem.        
  remote: 
  remote: - Commits must have verified signatures.        
  remote:   Found 1 violation:        
  remote: 
  remote:   8edbcbe300a40af469074bbda694d670b74538ee        
  To https://github.com/Chia-Network/chia-blockchain
   ! [remote rejected] update-cacert-pem -> update-cacert-pem (protected branch hook declined)
```

This is likely because the commit author isn't being set correctly. The job logs also show the incorrect commit author for the gpg creds supplied to it.

### New Behavior:

I believe this will just fix that.

In addition, I set the `base` and `delete-branch` fields just to define some newly undefined behavior. And updated the create-pull-request Action to the version it used to be because it was downgraded for some reason.

### Testing Notes:

I just looked at some of the differences between the old workflow: https://github.com/Chia-Network/chia-blockchain/blob/d5e91a3b039da667f117629dc9c8335a2afb96a0/.github/workflows/mozilla-ca-cert.yml#L39

And the new one: https://github.com/Chia-Network/chia-blockchain/blob/main/.github/workflows/update-mozilla-ca-cert.yaml#L34

And applied the changes that are relevant to this job using the incorrect commit author.