### PR TITLE
CHIA-3595 Be explicit about falling back to coin_puzzle_hash index in get_unspent_lineage_info_for_puzzle_hash

### DIFF
--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -30,6 +30,9 @@ class CoinStore:
     """
 
     db_wrapper: DBWrapper2
+    # Fall back to the `coin_puzzle_hash` index if the ff unspent index
+    # does not exist.
+    _unspent_lineage_for_ph_idx: str = "coin_puzzle_hash"
 
     @classmethod
     async def create(cls, db_wrapper: DBWrapper2) -> CoinStore:
@@ -82,6 +85,12 @@ class CoinStore:
                         WHERE spent_index = -1
                     """
                 )
+            async with conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'coin_record_ph_ff_unspent_idx'"
+            ) as cursor:
+                has_ff_unspent_idx = await cursor.fetchone() is not None
+            if has_ff_unspent_idx:
+                self._unspent_lineage_for_ph_idx = "coin_record_ph_ff_unspent_idx"
 
         return self
 
@@ -639,6 +648,7 @@ class CoinStore:
                 "unspent.coin_parent, "
                 "parent.coin_parent "
                 "FROM coin_record AS unspent "
+                f"INDEXED BY {self._unspent_lineage_for_ph_idx} "
                 "LEFT JOIN coin_record AS parent ON unspent.coin_parent = parent.coin_name "
                 "WHERE unspent.spent_index = -1 "
                 "AND parent.spent_index > 0 "


### PR DESCRIPTION

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

Make sure we end up using the `coin_puzzle_hash` index in `get_unspent_lineage_info_for_puzzle_hash` if the new ff unspent index doesn't exist.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
