### PR TITLE
[CHIA-3598] Port easy wallet endpoints to `@marshal`

### DIFF
--- a/chia/_tests/cmds/cmd_test_utils.py
+++ b/chia/_tests/cmds/cmd_test_utils.py
@@ -48,6 +48,8 @@ from chia.wallet.wallet_request_types import (
     SendTransactionMultiResponse,
     SignMessageByAddress,
     SignMessageByAddressResponse,
+    SignMessageByID,
+    SignMessageByIDResponse,
     WalletInfoResponse,
 )
 from chia.wallet.wallet_rpc_client import WalletRpcClient
@@ -167,12 +169,21 @@ class TestWalletRpcClient(TestRpcClient):
         signing_mode = SigningMode.CHIP_0002.value
         return SignMessageByAddressResponse(pubkey, signature, signing_mode)
 
-    async def sign_message_by_id(self, id: str, message: str) -> tuple[str, str, str]:
-        self.add_to_log("sign_message_by_id", (id, message))
-        pubkey = bytes([4] * 48).hex()
-        signature = bytes([7] * 576).hex()
+    async def sign_message_by_id(self, request: SignMessageByID) -> SignMessageByIDResponse:
+        self.add_to_log("sign_message_by_id", (request.id, request.message))
+        pubkey = G1Element.from_bytes(
+            bytes.fromhex(
+                "a9e652cb551d5978a9ee4b7aa52a4e826078a54b08a3d903c38611cb8a804a9a29c926e4f8549314a079e04ecde10cc1"
+            )
+        )
+        signature = G2Element.from_bytes(
+            bytes.fromhex(
+                "c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            )
+        )
         signing_mode = SigningMode.CHIP_0002.value
-        return pubkey, signature, signing_mode
+        return SignMessageByIDResponse(pubkey, signature, bytes32.zeros, signing_mode)
 
     async def cat_asset_id_to_name(self, asset_id: bytes32) -> Optional[tuple[Optional[uint32], str]]:
         """

--- a/chia/_tests/cmds/cmd_test_utils.py
+++ b/chia/_tests/cmds/cmd_test_utils.py
@@ -34,8 +34,6 @@ from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import CoinSelectionConfig, TXConfig
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_request_types import (
-    GetNextAddress,
-    GetNextAddressResponse,
     GetSyncStatusResponse,
     GetTransaction,
     GetTransactionResponse,
@@ -273,14 +271,6 @@ class TestWalletRpcClient(TestRpcClient):
         ]
         unconfirmed_additions = [Coin(bytes32([7] * 32), bytes32([8] * 32), uint64(1234580000))]
         return confirmed_records, unconfirmed_removals, unconfirmed_additions
-
-    async def get_next_address(self, request: GetNextAddress) -> GetNextAddressResponse:
-        self.add_to_log("get_next_address", (request.wallet_id, request.new_address))
-        addr = encode_puzzle_hash(bytes32([self.wallet_index] * 32), "xch")
-        self.wallet_index += 1
-        if self.wallet_index > 254:
-            self.wallet_index = 1
-        return GetNextAddressResponse(request.wallet_id, addr)
 
     async def send_transaction_multi(
         self,

--- a/chia/_tests/cmds/cmd_test_utils.py
+++ b/chia/_tests/cmds/cmd_test_utils.py
@@ -34,6 +34,8 @@ from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import CoinSelectionConfig, TXConfig
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_request_types import (
+    GetNextAddress,
+    GetNextAddressResponse,
     GetSyncStatusResponse,
     GetTransaction,
     GetTransactionResponse,
@@ -250,13 +252,13 @@ class TestWalletRpcClient(TestRpcClient):
         unconfirmed_additions = [Coin(bytes32([7] * 32), bytes32([8] * 32), uint64(1234580000))]
         return confirmed_records, unconfirmed_removals, unconfirmed_additions
 
-    async def get_next_address(self, wallet_id: int, new_address: bool) -> str:
-        self.add_to_log("get_next_address", (wallet_id, new_address))
+    async def get_next_address(self, request: GetNextAddress) -> GetNextAddressResponse:
+        self.add_to_log("get_next_address", (request.wallet_id, request.new_address))
         addr = encode_puzzle_hash(bytes32([self.wallet_index] * 32), "xch")
         self.wallet_index += 1
         if self.wallet_index > 254:
             self.wallet_index = 1
-        return addr
+        return GetNextAddressResponse(request.wallet_id, addr)
 
     async def send_transaction_multi(
         self,

--- a/chia/_tests/cmds/cmd_test_utils.py
+++ b/chia/_tests/cmds/cmd_test_utils.py
@@ -153,8 +153,17 @@ class TestWalletRpcClient(TestRpcClient):
 
     async def sign_message_by_address(self, request: SignMessageByAddress) -> SignMessageByAddressResponse:
         self.add_to_log("sign_message_by_address", (request.address, request.message))
-        pubkey = G1Element.from_bytes(bytes([3] * 48))
-        signature = G2Element.from_bytes(bytes([6] * 576))
+        pubkey = G1Element.from_bytes(
+            bytes.fromhex(
+                "b5acf3599bc5fa5da1c00f6cc3d5bcf1560def67778b7f50a8c373a83f78761505b6250ab776e38a292e26628009aec4"
+            )
+        )
+        signature = G2Element.from_bytes(
+            bytes.fromhex(
+                "c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            )
+        )
         signing_mode = SigningMode.CHIP_0002.value
         return SignMessageByAddressResponse(pubkey, signature, signing_mode)
 

--- a/chia/_tests/cmds/cmd_test_utils.py
+++ b/chia/_tests/cmds/cmd_test_utils.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional, cast
 
-from chia_rs import BlockRecord, Coin, G2Element
+from chia_rs import BlockRecord, Coin, G1Element, G2Element
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64
 
@@ -46,6 +46,8 @@ from chia.wallet.wallet_request_types import (
     NFTGetInfo,
     NFTGetInfoResponse,
     SendTransactionMultiResponse,
+    SignMessageByAddress,
+    SignMessageByAddressResponse,
     WalletInfoResponse,
 )
 from chia.wallet.wallet_rpc_client import WalletRpcClient
@@ -149,12 +151,12 @@ class TestWalletRpcClient(TestRpcClient):
         self.add_to_log("get_cat_name", (wallet_id,))
         return "test" + str(wallet_id)
 
-    async def sign_message_by_address(self, address: str, message: str) -> tuple[str, str, str]:
-        self.add_to_log("sign_message_by_address", (address, message))
-        pubkey = bytes([3] * 48).hex()
-        signature = bytes([6] * 576).hex()
+    async def sign_message_by_address(self, request: SignMessageByAddress) -> SignMessageByAddressResponse:
+        self.add_to_log("sign_message_by_address", (request.address, request.message))
+        pubkey = G1Element.from_bytes(bytes([3] * 48))
+        signature = G2Element.from_bytes(bytes([6] * 576))
         signing_mode = SigningMode.CHIP_0002.value
-        return pubkey, signature, signing_mode
+        return SignMessageByAddressResponse(pubkey, signature, signing_mode)
 
     async def sign_message_by_id(self, id: str, message: str) -> tuple[str, str, str]:
         self.add_to_log("sign_message_by_id", (id, message))

--- a/chia/_tests/cmds/wallet/test_did.py
+++ b/chia/_tests/cmds/wallet/test_did.py
@@ -116,8 +116,9 @@ def test_did_sign_message(capsys: object, get_test_cli_clients: tuple[TestRpcCli
     # these are various things that should be in the output
     assert_list = [
         f"Message: {message.hex()}",
-        f"Public Key: {bytes([4] * 48).hex()}",
-        f"Signature: {bytes([7] * 576).hex()}",
+        "Public Key: a9e652cb551d5978a9ee4b7aa52a4e826078a54b08a3d903c38611cb8a804a9a29c926e4f8549314a079e04ecde10cc1",
+        "Signature: c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         f"Signing Mode: {SigningMode.CHIP_0002.value}",
     ]
     run_cli_command_and_assert(capsys, root_dir, [*command_args, f"-i{did_id}"], assert_list)

--- a/chia/_tests/cmds/wallet/test_did.py
+++ b/chia/_tests/cmds/wallet/test_did.py
@@ -117,8 +117,7 @@ def test_did_sign_message(capsys: object, get_test_cli_clients: tuple[TestRpcCli
     assert_list = [
         f"Message: {message.hex()}",
         "Public Key: a9e652cb551d5978a9ee4b7aa52a4e826078a54b08a3d903c38611cb8a804a9a29c926e4f8549314a079e04ecde10cc1",
-        "Signature: c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "Signature: c0" + "00" * (42 - 1),
         f"Signing Mode: {SigningMode.CHIP_0002.value}",
     ]
     run_cli_command_and_assert(capsys, root_dir, [*command_args, f"-i{did_id}"], assert_list)

--- a/chia/_tests/cmds/wallet/test_nft.py
+++ b/chia/_tests/cmds/wallet/test_nft.py
@@ -71,8 +71,7 @@ def test_nft_sign_message(capsys: object, get_test_cli_clients: tuple[TestRpcCli
     assert_list = [
         f"Message: {message.hex()}",
         "Public Key: a9e652cb551d5978a9ee4b7aa52a4e826078a54b08a3d903c38611cb8a804a9a29c926e4f8549314a079e04ecde10cc1",
-        "Signature: c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "Signature: c0" + "00" * (42 - 1),
         f"Signing Mode: {SigningMode.CHIP_0002.value}",
     ]
     run_cli_command_and_assert(capsys, root_dir, [*command_args, f"-i{nft_id}"], assert_list)

--- a/chia/_tests/cmds/wallet/test_nft.py
+++ b/chia/_tests/cmds/wallet/test_nft.py
@@ -70,8 +70,9 @@ def test_nft_sign_message(capsys: object, get_test_cli_clients: tuple[TestRpcCli
     # these are various things that should be in the output
     assert_list = [
         f"Message: {message.hex()}",
-        f"Public Key: {bytes([4] * 48).hex()}",
-        f"Signature: {bytes([7] * 576).hex()}",
+        "Public Key: a9e652cb551d5978a9ee4b7aa52a4e826078a54b08a3d903c38611cb8a804a9a29c926e4f8549314a079e04ecde10cc1",
+        "Signature: c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         f"Signing Mode: {SigningMode.CHIP_0002.value}",
     ]
     run_cli_command_and_assert(capsys, root_dir, [*command_args, f"-i{did_id}"], assert_list)

--- a/chia/_tests/cmds/wallet/test_nft.py
+++ b/chia/_tests/cmds/wallet/test_nft.py
@@ -64,9 +64,9 @@ def test_nft_sign_message(capsys: object, get_test_cli_clients: tuple[TestRpcCli
 
     inst_rpc_client = TestWalletRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
-    did_id = encode_puzzle_hash(get_bytes32(1), "nft")
+    nft_id = encode_puzzle_hash(get_bytes32(1), "nft")
     message = b"hello nft world!!"
-    command_args = ["wallet", "did", "sign_message", FINGERPRINT_ARG, f"-m{message.hex()}"]
+    command_args = ["wallet", "nft", "sign_message", FINGERPRINT_ARG, f"-m{message.hex()}"]
     # these are various things that should be in the output
     assert_list = [
         f"Message: {message.hex()}",
@@ -75,9 +75,9 @@ def test_nft_sign_message(capsys: object, get_test_cli_clients: tuple[TestRpcCli
         "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         f"Signing Mode: {SigningMode.CHIP_0002.value}",
     ]
-    run_cli_command_and_assert(capsys, root_dir, [*command_args, f"-i{did_id}"], assert_list)
+    run_cli_command_and_assert(capsys, root_dir, [*command_args, f"-i{nft_id}"], assert_list)
     expected_calls: logType = {
-        "sign_message_by_id": [(did_id, message.hex())],  # xch std
+        "sign_message_by_id": [(nft_id, message.hex())],  # xch std
     }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
 

--- a/chia/_tests/cmds/wallet/test_notifications.py
+++ b/chia/_tests/cmds/wallet/test_notifications.py
@@ -118,7 +118,7 @@ def test_notifications_delete(capsys: object, get_test_cli_clients: tuple[TestRp
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
     command_args = ["wallet", "notifications", "delete", FINGERPRINT_ARG, "--all"]
     # these are various things that should be in the output
-    assert_list = ["Success: True"]
+    assert_list = ["Success!"]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     expected_calls: logType = {"delete_notifications": [(None,)]}
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)

--- a/chia/_tests/cmds/wallet/test_notifications.py
+++ b/chia/_tests/cmds/wallet/test_notifications.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional, cast
+from typing import cast
 
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
@@ -12,7 +12,7 @@ from chia.util.bech32m import encode_puzzle_hash
 from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.notification_store import Notification
 from chia.wallet.transaction_record import TransactionRecord
-from chia.wallet.wallet_request_types import GetNotifications, GetNotificationsResponse
+from chia.wallet.wallet_request_types import DeleteNotifications, GetNotifications, GetNotificationsResponse
 
 test_condition_valid_times: ConditionValidTimes = ConditionValidTimes(min_time=uint64(100), max_time=uint64(150))
 
@@ -111,9 +111,8 @@ def test_notifications_delete(capsys: object, get_test_cli_clients: tuple[TestRp
 
     # set RPC Client
     class NotificationsDeleteRpcClient(TestWalletRpcClient):
-        async def delete_notifications(self, ids: Optional[list[bytes32]] = None) -> bool:
-            self.add_to_log("delete_notifications", (ids,))
-            return True
+        async def delete_notifications(self, request: DeleteNotifications) -> None:
+            self.add_to_log("delete_notifications", (request.ids,))
 
     inst_rpc_client = NotificationsDeleteRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client

--- a/chia/_tests/cmds/wallet/test_notifications.py
+++ b/chia/_tests/cmds/wallet/test_notifications.py
@@ -116,9 +116,26 @@ def test_notifications_delete(capsys: object, get_test_cli_clients: tuple[TestRp
 
     inst_rpc_client = NotificationsDeleteRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
+    # Try all first
     command_args = ["wallet", "notifications", "delete", FINGERPRINT_ARG, "--all"]
     # these are various things that should be in the output
     assert_list = ["Success!"]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
     expected_calls: logType = {"delete_notifications": [(None,)]}
+    test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
+    # Next try specifying IDs
+    command_args = [
+        "wallet",
+        "notifications",
+        "delete",
+        FINGERPRINT_ARG,
+        "--id",
+        bytes32.zeros.hex(),
+        "--id",
+        bytes32.zeros.hex(),
+    ]
+    # these are various things that should be in the output
+    assert_list = ["Success!"]
+    run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
+    expected_calls = {"delete_notifications": [([bytes32.zeros, bytes32.zeros],)]}
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)

--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -45,6 +45,7 @@ from chia.wallet.wallet_request_types import (
     CancelOfferResponse,
     CATSpendResponse,
     CreateOfferForIDsResponse,
+    DeleteUnconfirmedTransactions,
     FungibleAsset,
     GetHeightInfoResponse,
     GetNextAddress,
@@ -571,8 +572,8 @@ def test_del_unconfirmed_tx(capsys: object, get_test_cli_clients: tuple[TestRpcC
 
     # set RPC Client
     class UnconfirmedTxRpcClient(TestWalletRpcClient):
-        async def delete_unconfirmed_transactions(self, wallet_id: int) -> None:
-            self.add_to_log("delete_unconfirmed_transactions", (wallet_id,))
+        async def delete_unconfirmed_transactions(self, request: DeleteUnconfirmedTransactions) -> None:
+            self.add_to_log("delete_unconfirmed_transactions", (request.wallet_id,))
 
     inst_rpc_client = UnconfirmedTxRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client

--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -47,6 +47,8 @@ from chia.wallet.wallet_request_types import (
     CreateOfferForIDsResponse,
     FungibleAsset,
     GetHeightInfoResponse,
+    GetNextAddress,
+    GetNextAddressResponse,
     GetTransaction,
     GetTransactions,
     GetTransactionsResponse,
@@ -493,11 +495,11 @@ def test_get_address(capsys: object, get_test_cli_clients: tuple[TestRpcClients,
 
     # set RPC Client
     class GetAddressWalletRpcClient(TestWalletRpcClient):
-        async def get_next_address(self, wallet_id: int, new_address: bool) -> str:
-            self.add_to_log("get_next_address", (wallet_id, new_address))
-            if new_address:
-                return encode_puzzle_hash(get_bytes32(3), "xch")
-            return encode_puzzle_hash(get_bytes32(4), "xch")
+        async def get_next_address(self, request: GetNextAddress) -> GetNextAddressResponse:
+            self.add_to_log("get_next_address", (request.wallet_id, request.new_address))
+            if request.new_address:
+                return GetNextAddressResponse(request.wallet_id, encode_puzzle_hash(get_bytes32(3), "xch"))
+            return GetNextAddressResponse(request.wallet_id, encode_puzzle_hash(get_bytes32(4), "xch"))
 
     inst_rpc_client = GetAddressWalletRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client

--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -631,8 +631,9 @@ def test_sign_message(capsys: object, get_test_cli_clients: tuple[TestRpcClients
     # these are various things that should be in the output
     assert_list = [
         f"Message: {message.hex()}",
-        f"Public Key: {bytes([3] * 48).hex()}",
-        f"Signature: {bytes([6] * 576).hex()}",
+        "Public Key: b5acf3599bc5fa5da1c00f6cc3d5bcf1560def67778b7f50a8c373a83f78761505b6250ab776e38a292e26628009aec4",
+        "Signature: c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
         f"Signing Mode: {SigningMode.CHIP_0002.value}",
     ]
     run_cli_command_and_assert(capsys, root_dir, [*command_args, f"-a{xch_addr}"], assert_list)

--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -46,6 +46,8 @@ from chia.wallet.wallet_request_types import (
     CATSpendResponse,
     CreateOfferForIDsResponse,
     DeleteUnconfirmedTransactions,
+    ExtendDerivationIndex,
+    ExtendDerivationIndexResponse,
     FungibleAsset,
     GetCurrentDerivationIndexResponse,
     GetHeightInfoResponse,
@@ -645,9 +647,9 @@ def test_update_derivation_index(capsys: object, get_test_cli_clients: tuple[Tes
 
     # set RPC Client
     class UpdateDerivationIndexRpcClient(TestWalletRpcClient):
-        async def extend_derivation_index(self, index: int) -> str:
-            self.add_to_log("extend_derivation_index", (index,))
-            return str(index)
+        async def extend_derivation_index(self, request: ExtendDerivationIndex) -> ExtendDerivationIndexResponse:
+            self.add_to_log("extend_derivation_index", (request.index,))
+            return ExtendDerivationIndexResponse(request.index)
 
     inst_rpc_client = UpdateDerivationIndexRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client

--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -47,6 +47,7 @@ from chia.wallet.wallet_request_types import (
     CreateOfferForIDsResponse,
     DeleteUnconfirmedTransactions,
     FungibleAsset,
+    GetCurrentDerivationIndexResponse,
     GetHeightInfoResponse,
     GetNextAddress,
     GetNextAddressResponse,
@@ -597,9 +598,9 @@ def test_get_derivation_index(capsys: object, get_test_cli_clients: tuple[TestRp
 
     # set RPC Client
     class GetDerivationIndexRpcClient(TestWalletRpcClient):
-        async def get_current_derivation_index(self) -> str:
+        async def get_current_derivation_index(self) -> GetCurrentDerivationIndexResponse:
             self.add_to_log("get_current_derivation_index", ())
-            return str(520)
+            return GetCurrentDerivationIndexResponse(uint32(520))
 
     inst_rpc_client = GetDerivationIndexRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client

--- a/chia/_tests/pools/test_pool_rpc.py
+++ b/chia/_tests/pools/test_pool_rpc.py
@@ -41,6 +41,7 @@ from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_request_types import (
+    DeleteUnconfirmedTransactions,
     GetTransactions,
     GetWalletBalance,
     GetWallets,
@@ -463,7 +464,7 @@ class TestPoolWalletRpc:
         def mempool_empty() -> bool:
             return full_node_api.full_node.mempool_manager.mempool.size() == 0
 
-        await client.delete_unconfirmed_transactions(1)
+        await client.delete_unconfirmed_transactions(DeleteUnconfirmedTransactions(uint32(1)))
         await full_node_api.process_all_wallet_transactions(wallet=wallet)
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -23,6 +23,7 @@ from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.peer_info import PeerInfo
 from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
+from chia.util.byte_types import hexstr_to_bytes
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.singleton import (
     create_singleton_puzzle,
@@ -1091,9 +1092,9 @@ async def test_did_sign_message(wallet_environments: WalletTestFramework):
     )
     puzzle: Program = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message))
     assert AugSchemeMPL.verify(
-        G1Element.from_bytes(bytes.fromhex(response["pubkey"])),
+        G1Element.from_bytes(hexstr_to_bytes(response["pubkey"])),
         puzzle.get_tree_hash(),
-        G2Element.from_bytes(bytes.fromhex(response["signature"])),
+        G2Element.from_bytes(hexstr_to_bytes(response["signature"])),
     )
     # Test hex string
     message = "0123456789ABCDEF"
@@ -1107,9 +1108,9 @@ async def test_did_sign_message(wallet_environments: WalletTestFramework):
     puzzle = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message)))
 
     assert AugSchemeMPL.verify(
-        G1Element.from_bytes(bytes.fromhex(response["pubkey"])),
+        G1Element.from_bytes(hexstr_to_bytes(response["pubkey"])),
         puzzle.get_tree_hash(),
-        G2Element.from_bytes(bytes.fromhex(response["signature"])),
+        G2Element.from_bytes(hexstr_to_bytes(response["signature"])),
     )
 
     # Test BLS sign string
@@ -1119,15 +1120,15 @@ async def test_did_sign_message(wallet_environments: WalletTestFramework):
         {
             "id": encode_puzzle_hash(did_wallet_1.did_info.origin_coin.name(), AddressType.DID.value),
             "message": message,
-            "is_hex": "False",
-            "safe_mode": "False",
+            "is_hex": False,
+            "safe_mode": False,
         }
     )
 
     assert AugSchemeMPL.verify(
-        G1Element.from_bytes(bytes.fromhex(response["pubkey"])),
+        G1Element.from_bytes(hexstr_to_bytes(response["pubkey"])),
         bytes(message, "utf-8"),
-        G2Element.from_bytes(bytes.fromhex(response["signature"])),
+        G2Element.from_bytes(hexstr_to_bytes(response["signature"])),
     )
     # Test BLS sign hex
     message = "0123456789ABCDEF"
@@ -1142,9 +1143,9 @@ async def test_did_sign_message(wallet_environments: WalletTestFramework):
     )
 
     assert AugSchemeMPL.verify(
-        G1Element.from_bytes(bytes.fromhex(response["pubkey"])),
-        bytes.fromhex(message),
-        G2Element.from_bytes(bytes.fromhex(response["signature"])),
+        G1Element.from_bytes(hexstr_to_bytes(response["pubkey"])),
+        hexstr_to_bytes(message),
+        G2Element.from_bytes(hexstr_to_bytes(response["signature"])),
     )
 
 

--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -5,7 +5,7 @@ import time
 from typing import Any, Callable
 
 import pytest
-from chia_rs import AugSchemeMPL, G1Element, G2Element
+from chia_rs import AugSchemeMPL
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint16, uint32, uint64
 from clvm_tools.binutils import disassemble
@@ -41,6 +41,7 @@ from chia.wallet.wallet_request_types import (
     NFTTransferBulk,
     NFTTransferNFT,
     NFTWalletWithDID,
+    SignMessageByID,
 )
 from chia.wallet.wallet_rpc_api import MAX_NFT_CHUNK_SIZE
 from chia.wallet.wallet_state_manager import WalletStateManager
@@ -2757,51 +2758,55 @@ async def test_nft_sign_message(wallet_environments: WalletTestFramework) -> Non
     assert not coin.pending_transaction
     # Test general string
     message = "Hello World"
-    pubkey, sig, _ = await env.rpc_client.sign_message_by_id(
-        id=encode_puzzle_hash(coin.launcher_id, AddressType.NFT.value), message=message
+    sign_by_id_res = await env.rpc_client.sign_message_by_id(
+        SignMessageByID(id=encode_puzzle_hash(coin.launcher_id, AddressType.NFT.value), message=message)
     )
     puzzle = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message))
     assert AugSchemeMPL.verify(
-        G1Element.from_bytes(bytes.fromhex(pubkey)),
+        sign_by_id_res.pubkey,
         puzzle.get_tree_hash(),
-        G2Element.from_bytes(bytes.fromhex(sig)),
+        sign_by_id_res.signature,
     )
     # Test hex string
     message = "0123456789ABCDEF"
-    pubkey, sig, _ = await env.rpc_client.sign_message_by_id(
-        id=encode_puzzle_hash(coin.launcher_id, AddressType.NFT.value), message=message, is_hex=True
+    sign_by_id_res = await env.rpc_client.sign_message_by_id(
+        SignMessageByID(id=encode_puzzle_hash(coin.launcher_id, AddressType.NFT.value), message=message, is_hex=True)
     )
     puzzle = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message)))
     assert AugSchemeMPL.verify(
-        G1Element.from_bytes(bytes.fromhex(pubkey)),
+        sign_by_id_res.pubkey,
         puzzle.get_tree_hash(),
-        G2Element.from_bytes(bytes.fromhex(sig)),
+        sign_by_id_res.signature,
     )
     # Test BLS sign string
     message = "Hello World"
-    pubkey, sig, _ = await env.rpc_client.sign_message_by_id(
-        id=encode_puzzle_hash(coin.launcher_id, AddressType.NFT.value),
-        message=message,
-        is_hex=False,
-        safe_mode=False,
+    sign_by_id_res = await env.rpc_client.sign_message_by_id(
+        SignMessageByID(
+            id=encode_puzzle_hash(coin.launcher_id, AddressType.NFT.value),
+            message=message,
+            is_hex=False,
+            safe_mode=False,
+        )
     )
 
     assert AugSchemeMPL.verify(
-        G1Element.from_bytes(bytes.fromhex(pubkey)),
-        bytes(message, "utf-8"),
-        G2Element.from_bytes(bytes.fromhex(sig)),
+        sign_by_id_res.pubkey,
+        puzzle.get_tree_hash(),
+        sign_by_id_res.signature,
     )
     # Test BLS sign hex
     message = "0123456789ABCDEF"
-    pubkey, sig, _ = await env.rpc_client.sign_message_by_id(
-        id=encode_puzzle_hash(coin.launcher_id, AddressType.NFT.value),
-        message=message,
-        is_hex=True,
-        safe_mode=False,
+    sign_by_id_res = await env.rpc_client.sign_message_by_id(
+        SignMessageByID(
+            id=encode_puzzle_hash(coin.launcher_id, AddressType.NFT.value),
+            message=message,
+            is_hex=True,
+            safe_mode=False,
+        )
     )
 
     assert AugSchemeMPL.verify(
-        G1Element.from_bytes(bytes.fromhex(pubkey)),
-        bytes.fromhex(message),
-        G2Element.from_bytes(bytes.fromhex(sig)),
+        sign_by_id_res.pubkey,
+        puzzle.get_tree_hash(),
+        sign_by_id_res.signature,
     )

--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -2791,7 +2791,7 @@ async def test_nft_sign_message(wallet_environments: WalletTestFramework) -> Non
 
     assert AugSchemeMPL.verify(
         sign_by_id_res.pubkey,
-        puzzle.get_tree_hash(),
+        bytes(message, "utf-8"),
         sign_by_id_res.signature,
     )
     # Test BLS sign hex
@@ -2807,6 +2807,6 @@ async def test_nft_sign_message(wallet_environments: WalletTestFramework) -> Non
 
     assert AugSchemeMPL.verify(
         sign_by_id_res.pubkey,
-        puzzle.get_tree_hash(),
+        bytes.fromhex(message),
         sign_by_id_res.signature,
     )

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -108,6 +108,7 @@ from chia.wallet.wallet_request_types import (
     CombineCoins,
     DefaultCAT,
     DeleteKey,
+    DeleteNotifications,
     DeleteUnconfirmedTransactions,
     DIDCreateBackupFile,
     DIDGetDID,
@@ -2559,7 +2560,7 @@ async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironmen
     assert [notification] == (await client_2.get_notifications(GetNotifications(None, None, uint32(1)))).notifications
     assert [] == (await client_2.get_notifications(GetNotifications(None, uint32(1), None))).notifications
     assert [notification] == (await client_2.get_notifications(GetNotifications(None, None, None))).notifications
-    assert await client_2.delete_notifications()
+    await client_2.delete_notifications(DeleteNotifications())
     assert [] == (await client_2.get_notifications(GetNotifications([notification.id]))).notifications
 
     async with wallet_2.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
@@ -2581,7 +2582,7 @@ async def test_notification_rpcs(wallet_rpc_environment: WalletRpcTestEnvironmen
     await time_out_assert(20, env.wallet_2.wallet.get_confirmed_balance, uint64(200000000000))
 
     notification = (await client_2.get_notifications(GetNotifications())).notifications[0]
-    assert await client_2.delete_notifications([notification.id])
+    await client_2.delete_notifications(DeleteNotifications([notification.id]))
     assert [] == (await client_2.get_notifications(GetNotifications([notification.id]))).notifications
 
 

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -108,6 +108,7 @@ from chia.wallet.wallet_request_types import (
     CombineCoins,
     DefaultCAT,
     DeleteKey,
+    DeleteUnconfirmedTransactions,
     DIDCreateBackupFile,
     DIDGetDID,
     DIDGetMetadata,
@@ -2169,7 +2170,7 @@ async def test_key_and_address_endpoints(wallet_rpc_environment: WalletRpcTestEn
 
     await time_out_assert(20, tx_in_mempool, True, client, created_tx.name)
     assert len(await wallet.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(1)) == 1
-    await client.delete_unconfirmed_transactions(1)
+    await client.delete_unconfirmed_transactions(DeleteUnconfirmedTransactions(uint32(1)))
     assert len(await wallet.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(1)) == 0
 
     sk_resp = await client.get_private_key(GetPrivateKey(pks[0]))

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -123,6 +123,7 @@ from chia.wallet.wallet_request_types import (
     GetSyncStatusResponse,
     GetTimestampForHeight,
     GetTransaction,
+    GetTransactionCount,
     GetTransactions,
     GetWalletBalance,
     GetWalletBalances,
@@ -1096,14 +1097,16 @@ async def test_get_transaction_count(wallet_rpc_environment: WalletRpcTestEnviro
 
     all_transactions = (await client.get_transactions(GetTransactions(uint32(1)))).transactions
     assert len(all_transactions) > 0
-    transaction_count = await client.get_transaction_count(1)
-    assert transaction_count == len(all_transactions)
-    transaction_count = await client.get_transaction_count(1, confirmed=False)
-    assert transaction_count == 0
-    transaction_count = await client.get_transaction_count(
-        1, type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_SEND])
+    transaction_count_response = await client.get_transaction_count(GetTransactionCount(uint32(1)))
+    assert transaction_count_response.count == len(all_transactions)
+    transaction_count_response = await client.get_transaction_count(GetTransactionCount(uint32(1), confirmed=False))
+    assert transaction_count_response.count == 0
+    transaction_count_response = await client.get_transaction_count(
+        GetTransactionCount(
+            uint32(1), type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CLAWBACK_SEND])
+        )
     )
-    assert transaction_count == 0
+    assert transaction_count_response.count == 0
 
 
 @pytest.mark.parametrize(

--- a/chia/_tests/wallet/test_notifications.py
+++ b/chia/_tests/wallet/test_notifications.py
@@ -17,6 +17,7 @@ from chia.types.peer_info import PeerInfo
 from chia.util.db_wrapper import DBWrapper2
 from chia.wallet.notification_store import NotificationStore
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
+from chia.wallet.wallet_request_types import DeleteNotifications
 
 
 # For testing backwards compatibility with a DB change to add height
@@ -190,7 +191,9 @@ async def test_notifications(
     await notification_manager_2.notification_store.delete_all_notifications()
     assert len(await notification_manager_2.notification_store.get_all_notifications()) == 0
     await notification_manager_2.notification_store.add_notification(notifications[0])
-    await notification_manager_2.notification_store.delete_notifications([n.id for n in notifications])
+    await notification_manager_2.notification_store.delete_notifications(
+        DeleteNotifications([n.id for n in notifications])
+    )
     assert len(await notification_manager_2.notification_store.get_all_notifications()) == 0
 
     assert not await func(*notification_manager_2.most_recent_args)

--- a/chia/_tests/wallet/test_notifications.py
+++ b/chia/_tests/wallet/test_notifications.py
@@ -17,7 +17,6 @@ from chia.types.peer_info import PeerInfo
 from chia.util.db_wrapper import DBWrapper2
 from chia.wallet.notification_store import NotificationStore
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
-from chia.wallet.wallet_request_types import DeleteNotifications
 
 
 # For testing backwards compatibility with a DB change to add height
@@ -191,9 +190,7 @@ async def test_notifications(
     await notification_manager_2.notification_store.delete_all_notifications()
     assert len(await notification_manager_2.notification_store.get_all_notifications()) == 0
     await notification_manager_2.notification_store.add_notification(notifications[0])
-    await notification_manager_2.notification_store.delete_notifications(
-        DeleteNotifications([n.id for n in notifications])
-    )
+    await notification_manager_2.notification_store.delete_notifications([n.id for n in notifications])
     assert len(await notification_manager_2.notification_store.get_all_notifications()) == 0
 
     assert not await func(*notification_manager_2.most_recent_args)

--- a/chia/_tests/wallet/test_wallet.py
+++ b/chia/_tests/wallet/test_wallet.py
@@ -19,6 +19,7 @@ from chia.types.blockchain_format.program import Program
 from chia.types.peer_info import PeerInfo
 from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX
 from chia.util.bech32m import encode_puzzle_hash
+from chia.util.byte_types import hexstr_to_bytes
 from chia.util.errors import Err
 from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.derive_keys import master_sk_to_wallet_sk
@@ -2008,9 +2009,9 @@ class TestWalletSimulator:
         puzzle: Program = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message))
 
         assert AugSchemeMPL.verify(
-            G1Element.from_bytes(bytes.fromhex(response["pubkey"])),
+            G1Element.from_bytes(hexstr_to_bytes(response["pubkey"])),
             puzzle.get_tree_hash(),
-            G2Element.from_bytes(bytes.fromhex(response["signature"])),
+            G2Element.from_bytes(hexstr_to_bytes(response["signature"])),
         )
         # Test hex string
         message = "0123456789ABCDEF"
@@ -2020,9 +2021,9 @@ class TestWalletSimulator:
         puzzle = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message)))
 
         assert AugSchemeMPL.verify(
-            G1Element.from_bytes(bytes.fromhex(response["pubkey"])),
+            G1Element.from_bytes(hexstr_to_bytes(response["pubkey"])),
             puzzle.get_tree_hash(),
-            G2Element.from_bytes(bytes.fromhex(response["signature"])),
+            G2Element.from_bytes(hexstr_to_bytes(response["signature"])),
         )
         # Test informal input
         message = "0123456789ABCDEF"
@@ -2032,9 +2033,9 @@ class TestWalletSimulator:
         puzzle = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message)))
 
         assert AugSchemeMPL.verify(
-            G1Element.from_bytes(bytes.fromhex(response["pubkey"])),
+            G1Element.from_bytes(hexstr_to_bytes(response["pubkey"])),
             puzzle.get_tree_hash(),
-            G2Element.from_bytes(bytes.fromhex(response["signature"])),
+            G2Element.from_bytes(hexstr_to_bytes(response["signature"])),
         )
         # Test BLS sign string
         message = "Hello World"
@@ -2043,9 +2044,9 @@ class TestWalletSimulator:
         )
 
         assert AugSchemeMPL.verify(
-            G1Element.from_bytes(bytes.fromhex(response["pubkey"])),
+            G1Element.from_bytes(hexstr_to_bytes(response["pubkey"])),
             bytes(message, "utf-8"),
-            G2Element.from_bytes(bytes.fromhex(response["signature"])),
+            G2Element.from_bytes(hexstr_to_bytes(response["signature"])),
         )
         # Test BLS sign hex
         message = "0123456789ABCDEF"
@@ -2054,9 +2055,9 @@ class TestWalletSimulator:
         )
 
         assert AugSchemeMPL.verify(
-            G1Element.from_bytes(bytes.fromhex(response["pubkey"])),
-            bytes.fromhex(message),
-            G2Element.from_bytes(bytes.fromhex(response["signature"])),
+            G1Element.from_bytes(hexstr_to_bytes(response["pubkey"])),
+            hexstr_to_bytes(message),
+            G2Element.from_bytes(hexstr_to_bytes(response["signature"])),
         )
 
     @pytest.mark.parametrize(

--- a/chia/_tests/wallet/test_wallet_state_manager.py
+++ b/chia/_tests/wallet/test_wallet_state_manager.py
@@ -286,6 +286,11 @@ async def test_puzzle_hash_requests(wallet_environments: WalletTestFramework) ->
 
     expected_state = await get_puzzle_hash_state()
 
+    # Quick test of this RPC
+    assert (
+        await wallet_environments.environments[0].rpc_client.get_current_derivation_index()
+    ).index == expected_state.highest_index
+
     # `create_more_puzzle_hashes`
     # No-op
     result = await wsm.create_more_puzzle_hashes()

--- a/chia/_tests/wallet/test_wallet_state_manager.py
+++ b/chia/_tests/wallet/test_wallet_state_manager.py
@@ -21,7 +21,7 @@ from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import WalletType
-from chia.wallet.wallet_request_types import PushTransactions
+from chia.wallet.wallet_request_types import ExtendDerivationIndex, PushTransactions
 from chia.wallet.wallet_rpc_api import MAX_DERIVATION_INDEX_DELTA
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 from chia.wallet.wallet_state_manager import WalletStateManager
@@ -420,7 +420,7 @@ async def test_puzzle_hash_requests(wallet_environments: WalletTestFramework) ->
             (0,),
         )
     with pytest.raises(ValueError):
-        await rpc_client.extend_derivation_index(0)
+        await rpc_client.extend_derivation_index(ExtendDerivationIndex(uint32(0)))
 
     # Reset to a normal state
     await wsm.puzzle_store.delete_wallet(wsm.main_wallet.id())
@@ -431,15 +431,17 @@ async def test_puzzle_hash_requests(wallet_environments: WalletTestFramework) ->
 
     # Test an index already created
     with pytest.raises(ValueError):
-        await rpc_client.extend_derivation_index(0)
+        await rpc_client.extend_derivation_index(ExtendDerivationIndex(uint32(0)))
 
     # Test an index too far in the future
     with pytest.raises(ValueError):
-        await rpc_client.extend_derivation_index(MAX_DERIVATION_INDEX_DELTA + expected_state.highest_index + 1)
+        await rpc_client.extend_derivation_index(
+            ExtendDerivationIndex(uint32(MAX_DERIVATION_INDEX_DELTA + expected_state.highest_index + 1))
+        )
 
     # Test the actual functionality
-    assert await rpc_client.extend_derivation_index(expected_state.highest_index + 5) == str(
-        expected_state.highest_index + 5
-    )
+    assert (
+        await rpc_client.extend_derivation_index(ExtendDerivationIndex(uint32(expected_state.highest_index + 5)))
+    ).index == expected_state.highest_index + 5
     expected_state = PuzzleHashState(expected_state.highest_index + 5, expected_state.used_up_to_index)
     assert await get_puzzle_hash_state() == expected_state

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -53,6 +53,7 @@ from chia.wallet.wallet_request_types import (
     DIDTransferDID,
     DIDUpdateMetadata,
     FungibleAsset,
+    GetNextAddress,
     GetNotifications,
     GetTransaction,
     GetTransactions,
@@ -418,7 +419,7 @@ async def get_address(
     root_path: pathlib.Path, wallet_rpc_port: Optional[int], fp: Optional[int], wallet_id: int, new_address: bool
 ) -> None:
     async with get_wallet_client(root_path, wallet_rpc_port, fp) as (wallet_client, _, _):
-        res = await wallet_client.get_next_address(wallet_id, new_address)
+        res = (await wallet_client.get_next_address(GetNextAddress(uint32(wallet_id), new_address))).address
         print(res)
 
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -1626,13 +1626,14 @@ async def sign_message(
     nft_id: Optional[CliAddress] = None,
 ) -> None:
     async with get_wallet_client(root_path, wallet_rpc_port, fp) as (wallet_client, _, _):
+        response: Union[SignMessageByAddressResponse, SignMessageByIDResponse]
         if addr_type == AddressType.XCH:
             if address is None:
                 print("Address is required for XCH address type.")
                 return
-            response: Union[
-                SignMessageByAddressResponse, SignMessageByIDResponse
-            ] = await wallet_client.sign_message_by_address(SignMessageByAddress(address.original_address, message))
+            response = await wallet_client.sign_message_by_address(
+                SignMessageByAddress(address.original_address, message)
+            )
         elif addr_type == AddressType.DID:
             if did_id is None:
                 print("DID id is required for DID address type.")

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -73,6 +73,7 @@ from chia.wallet.wallet_request_types import (
     NFTTransferNFT,
     RoyaltyAsset,
     SendTransactionResponse,
+    SignMessageByAddress,
     VCAddProofs,
     VCGet,
     VCGetList,
@@ -1626,9 +1627,12 @@ async def sign_message(
             if address is None:
                 print("Address is required for XCH address type.")
                 return
-            pubkey, signature, signing_mode = await wallet_client.sign_message_by_address(
-                address.original_address, message
+            response = await wallet_client.sign_message_by_address(
+                SignMessageByAddress(address.original_address, message)
             )
+            pubkey = str(response.pubkey)
+            signature = str(response.signature)
+            signing_mode = response.signing_mode
         elif addr_type == AddressType.DID:
             if did_id is None:
                 print("DID id is required for DID address type.")

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -45,6 +45,7 @@ from chia.wallet.vc_wallet.vc_store import VCProofs
 from chia.wallet.wallet_coin_store import GetCoinRecords
 from chia.wallet.wallet_request_types import (
     CATSpendResponse,
+    DeleteNotifications,
     DeleteUnconfirmedTransactions,
     DIDFindLostDID,
     DIDGetDID,
@@ -1602,9 +1603,11 @@ async def delete_notifications(
 ) -> None:
     async with get_wallet_client(root_path, wallet_rpc_port, fp) as (wallet_client, _, _):
         if delete_all:
-            print(f"Success: {await wallet_client.delete_notifications()}")
+            await wallet_client.delete_notifications(DeleteNotifications())
+            print("Success!")
         else:
-            print(f"Success: {await wallet_client.delete_notifications(ids=list(ids))}")
+            await wallet_client.delete_notifications(DeleteNotifications(ids=list(ids)))
+            print("Success!")
 
 
 async def sign_message(

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -45,6 +45,7 @@ from chia.wallet.vc_wallet.vc_store import VCProofs
 from chia.wallet.wallet_coin_store import GetCoinRecords
 from chia.wallet.wallet_request_types import (
     CATSpendResponse,
+    DeleteUnconfirmedTransactions,
     DIDFindLostDID,
     DIDGetDID,
     DIDGetInfo,
@@ -427,7 +428,7 @@ async def delete_unconfirmed_transactions(
     root_path: pathlib.Path, wallet_rpc_port: Optional[int], fp: Optional[int], wallet_id: int
 ) -> None:
     async with get_wallet_client(root_path, wallet_rpc_port, fp) as (wallet_client, fingerprint, _):
-        await wallet_client.delete_unconfirmed_transactions(wallet_id)
+        await wallet_client.delete_unconfirmed_transactions(DeleteUnconfirmedTransactions(uint32(wallet_id)))
         print(f"Successfully deleted all unconfirmed transactions for wallet id {wallet_id} on key {fingerprint}")
 
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -53,6 +53,7 @@ from chia.wallet.wallet_request_types import (
     DIDSetWalletName,
     DIDTransferDID,
     DIDUpdateMetadata,
+    ExtendDerivationIndex,
     FungibleAsset,
     GetNextAddress,
     GetNotifications,
@@ -443,8 +444,8 @@ async def update_derivation_index(
 ) -> None:
     async with get_wallet_client(root_path, wallet_rpc_port, fp) as (wallet_client, _, _):
         print("Updating derivation index... This may take a while.")
-        res = await wallet_client.extend_derivation_index(index)
-        print(f"Updated derivation index: {res}")
+        res = await wallet_client.extend_derivation_index(ExtendDerivationIndex(uint32(index)))
+        print(f"Updated derivation index: {res.index}")
         print("Your balances may take a while to update.")
 
 

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -74,6 +74,9 @@ from chia.wallet.wallet_request_types import (
     RoyaltyAsset,
     SendTransactionResponse,
     SignMessageByAddress,
+    SignMessageByAddressResponse,
+    SignMessageByID,
+    SignMessageByIDResponse,
     VCAddProofs,
     VCGet,
     VCGetList,
@@ -1627,30 +1630,27 @@ async def sign_message(
             if address is None:
                 print("Address is required for XCH address type.")
                 return
-            response = await wallet_client.sign_message_by_address(
-                SignMessageByAddress(address.original_address, message)
-            )
-            pubkey = str(response.pubkey)
-            signature = str(response.signature)
-            signing_mode = response.signing_mode
+            response: Union[
+                SignMessageByAddressResponse, SignMessageByIDResponse
+            ] = await wallet_client.sign_message_by_address(SignMessageByAddress(address.original_address, message))
         elif addr_type == AddressType.DID:
             if did_id is None:
                 print("DID id is required for DID address type.")
                 return
-            pubkey, signature, signing_mode = await wallet_client.sign_message_by_id(did_id.original_address, message)
+            response = await wallet_client.sign_message_by_id(SignMessageByID(did_id.original_address, message))
         elif addr_type == AddressType.NFT:
             if nft_id is None:
                 print("NFT id is required for NFT address type.")
                 return
-            pubkey, signature, signing_mode = await wallet_client.sign_message_by_id(nft_id.original_address, message)
+            response = await wallet_client.sign_message_by_id(SignMessageByID(nft_id.original_address, message))
         else:
             print("Invalid wallet type.")
             return
         print("")
         print(f"Message: {message}")
-        print(f"Public Key: {pubkey}")
-        print(f"Signature: {signature}")
-        print(f"Signing Mode: {signing_mode}")
+        print(f"Public Key: {response.pubkey!s}")
+        print(f"Signature: {response.signature!s}")
+        print(f"Signing Mode: {response.signing_mode}")
 
 
 async def spend_clawback(

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -435,7 +435,7 @@ async def delete_unconfirmed_transactions(
 async def get_derivation_index(root_path: pathlib.Path, wallet_rpc_port: Optional[int], fp: Optional[int]) -> None:
     async with get_wallet_client(root_path, wallet_rpc_port, fp) as (wallet_client, _, _):
         res = await wallet_client.get_current_derivation_index()
-        print(f"Last derivation index: {res}")
+        print(f"Last derivation index: {res.index}")
 
 
 async def update_derivation_index(

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -378,6 +378,23 @@ class VerifySignatureResponse(Streamable):
 
 @streamable
 @dataclass(frozen=True)
+class SignMessageByAddress(Streamable):
+    address: str
+    message: str
+    is_hex: bool = False
+    safe_mode: bool = True
+
+
+@streamable
+@dataclass(frozen=True)
+class SignMessageByAddressResponse(Streamable):
+    pubkey: G1Element
+    signature: G2Element
+    signing_mode: str
+
+
+@streamable
+@dataclass(frozen=True)
 class GetTransactionMemo(Streamable):
     transaction_id: bytes32
 

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -404,6 +404,21 @@ class GetTransactionMemoResponse(Streamable):
 
 @streamable
 @dataclass(frozen=True)
+class GetTransactionCount(Streamable):
+    wallet_id: uint32
+    confirmed: Optional[bool] = None
+    type_filter: Optional[TransactionTypeFilter] = None
+
+
+@streamable
+@dataclass(frozen=True)
+class GetTransactionCountResponse(Streamable):
+    wallet_id: uint32
+    count: uint16
+
+
+@streamable
+@dataclass(frozen=True)
 class GetOffersCountResponse(Streamable):
     total: uint16
     my_offers_count: uint16

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -419,6 +419,21 @@ class GetTransactionCountResponse(Streamable):
 
 @streamable
 @dataclass(frozen=True)
+class GetNextAddress(Streamable):
+    wallet_id: uint32
+    new_address: bool = False
+    save_derivations: bool = True
+
+
+@streamable
+@dataclass(frozen=True)
+class GetNextAddressResponse(Streamable):
+    wallet_id: uint32
+    address: str
+
+
+@streamable
+@dataclass(frozen=True)
 class GetOffersCountResponse(Streamable):
     total: uint16
     my_offers_count: uint16

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -355,6 +355,12 @@ class GetNotificationsResponse(Streamable):
 
 @streamable
 @dataclass(frozen=True)
+class DeleteNotifications(Streamable):
+    ids: Optional[list[bytes32]] = None
+
+
+@streamable
+@dataclass(frozen=True)
 class VerifySignature(Streamable):
     message: str
     pubkey: G1Element

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -395,6 +395,24 @@ class SignMessageByAddressResponse(Streamable):
 
 @streamable
 @dataclass(frozen=True)
+class SignMessageByID(Streamable):
+    id: str
+    message: str
+    is_hex: bool = False
+    safe_mode: bool = True
+
+
+@streamable
+@dataclass(frozen=True)
+class SignMessageByIDResponse(Streamable):
+    pubkey: G1Element
+    signature: G2Element
+    latest_coin_id: bytes32
+    signing_mode: str
+
+
+@streamable
+@dataclass(frozen=True)
 class GetTransactionMemo(Streamable):
     transaction_id: bytes32
 

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -440,6 +440,12 @@ class DeleteUnconfirmedTransactions(Streamable):
 
 @streamable
 @dataclass(frozen=True)
+class GetCurrentDerivationIndexResponse(Streamable):
+    index: Optional[uint32]
+
+
+@streamable
+@dataclass(frozen=True)
 class GetOffersCountResponse(Streamable):
     total: uint16
     my_offers_count: uint16

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -446,6 +446,18 @@ class GetCurrentDerivationIndexResponse(Streamable):
 
 @streamable
 @dataclass(frozen=True)
+class ExtendDerivationIndex(Streamable):
+    index: uint32
+
+
+@streamable
+@dataclass(frozen=True)
+class ExtendDerivationIndexResponse(Streamable):
+    index: Optional[uint32]
+
+
+@streamable
+@dataclass(frozen=True)
 class GetOffersCountResponse(Streamable):
     total: uint16
     my_offers_count: uint16

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -434,6 +434,12 @@ class GetNextAddressResponse(Streamable):
 
 @streamable
 @dataclass(frozen=True)
+class DeleteUnconfirmedTransactions(Streamable):
+    wallet_id: uint32
+
+
+@streamable
+@dataclass(frozen=True)
 class GetOffersCountResponse(Streamable):
     total: uint16
     my_offers_count: uint16

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -169,6 +169,7 @@ from chia.wallet.wallet_request_types import (
     GatherSigningInfo,
     GatherSigningInfoResponse,
     GenerateMnemonicResponse,
+    GetCurrentDerivationIndexResponse,
     GetHeightInfoResponse,
     GetLoggedInFingerprintResponse,
     GetNextAddress,
@@ -1870,12 +1871,13 @@ class WalletRpcApi:
 
         return {"coin_records": [cr.to_json_dict() for cr in coin_records]}
 
-    async def get_current_derivation_index(self, request: dict[str, Any]) -> dict[str, Any]:
+    @marshal
+    async def get_current_derivation_index(self, request: Empty) -> GetCurrentDerivationIndexResponse:
         assert self.service.wallet_state_manager is not None
 
         index: Optional[uint32] = await self.service.wallet_state_manager.puzzle_store.get_last_derivation_path()
 
-        return {"success": True, "index": index}
+        return GetCurrentDerivationIndexResponse(index)
 
     async def extend_derivation_index(self, request: dict[str, Any]) -> dict[str, Any]:
         assert self.service.wallet_state_manager is not None

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -119,6 +119,7 @@ from chia.wallet.wallet_request_types import (
     CreateNewDL,
     CreateNewDLResponse,
     DeleteKey,
+    DeleteNotifications,
     DeleteUnconfirmedTransactions,
     DIDCreateBackupFile,
     DIDCreateBackupFileResponse,
@@ -1935,16 +1936,16 @@ class WalletRpcApi:
 
         return GetNotificationsResponse(notifications)
 
-    async def delete_notifications(self, request: dict[str, Any]) -> EndpointResult:
-        ids: Optional[list[str]] = request.get("ids", None)
-        if ids is None:
+    @marshal
+    async def delete_notifications(self, request: DeleteNotifications) -> Empty:
+        if request.ids is None:
             await self.service.wallet_state_manager.notification_manager.notification_store.delete_all_notifications()
         else:
             await self.service.wallet_state_manager.notification_manager.notification_store.delete_notifications(
-                [bytes32.from_hexstr(id) for id in ids]
+                request.ids
             )
 
-        return {}
+        return Empty()
 
     @tx_endpoint(push=True)
     async def send_notification(

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -87,6 +87,8 @@ from chia.wallet.wallet_request_types import (
     GetCATListResponse,
     GetHeightInfoResponse,
     GetLoggedInFingerprintResponse,
+    GetNextAddress,
+    GetNextAddressResponse,
     GetNotifications,
     GetNotificationsResponse,
     GetOffersCountResponse,
@@ -281,11 +283,8 @@ class WalletRpcClient(RpcClient):
             await self.fetch("get_transaction_count", request.to_json_dict())
         )
 
-    async def get_next_address(self, wallet_id: int, new_address: bool) -> str:
-        request = {"wallet_id": wallet_id, "new_address": new_address}
-        response = await self.fetch("get_next_address", request)
-        # TODO: casting due to lack of type checked deserialization
-        return cast(str, response["address"])
+    async def get_next_address(self, request: GetNextAddress) -> GetNextAddressResponse:
+        return GetNextAddressResponse.from_json_dict(await self.fetch("get_next_address", request.to_json_dict()))
 
     async def send_transaction(
         self,

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -17,7 +17,6 @@ from chia.wallet.trade_record import TradeRecord
 from chia.wallet.trading.offer import Offer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.clvm_streamable import json_deserialize_with_clvm_streamable
-from chia.wallet.util.query_filter import TransactionTypeFilter
 from chia.wallet.util.tx_config import CoinSelectionConfig, TXConfig
 from chia.wallet.wallet_coin_store import GetCoinRecords
 from chia.wallet.wallet_request_types import (
@@ -98,6 +97,8 @@ from chia.wallet.wallet_request_types import (
     GetTimestampForHeight,
     GetTimestampForHeightResponse,
     GetTransaction,
+    GetTransactionCount,
+    GetTransactionCountResponse,
     GetTransactionMemo,
     GetTransactionMemoResponse,
     GetTransactionResponse,
@@ -275,17 +276,10 @@ class WalletRpcClient(RpcClient):
     async def get_transactions(self, request: GetTransactions) -> GetTransactionsResponse:
         return GetTransactionsResponse.from_json_dict(await self.fetch("get_transactions", request.to_json_dict()))
 
-    async def get_transaction_count(
-        self, wallet_id: int, confirmed: Optional[bool] = None, type_filter: Optional[TransactionTypeFilter] = None
-    ) -> int:
-        request: dict[str, Any] = {"wallet_id": wallet_id}
-        if type_filter is not None:
-            request["type_filter"] = type_filter.to_json_dict()
-        if confirmed is not None:
-            request["confirmed"] = confirmed
-        res = await self.fetch("get_transaction_count", request)
-        # TODO: casting due to lack of type checked deserialization
-        return cast(int, res["count"])
+    async def get_transaction_count(self, request: GetTransactionCount) -> GetTransactionCountResponse:
+        return GetTransactionCountResponse.from_json_dict(
+            await self.fetch("get_transaction_count", request.to_json_dict())
+        )
 
     async def get_next_address(self, wallet_id: int, new_address: bool) -> str:
         request = {"wallet_id": wallet_id, "new_address": new_address}

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import Any, Optional, Union, cast
 
 from chia_rs.sized_bytes import bytes32
@@ -36,6 +35,7 @@ from chia.wallet.wallet_request_types import (
     CreateOfferForIDsResponse,
     CreateSignedTransactionsResponse,
     DeleteKey,
+    DeleteNotifications,
     DeleteUnconfirmedTransactions,
     DIDCreateBackupFile,
     DIDCreateBackupFileResponse,
@@ -1117,14 +1117,8 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("get_notifications", request.to_json_dict())
         return json_deserialize_with_clvm_streamable(response, GetNotificationsResponse)
 
-    async def delete_notifications(self, ids: Optional[Sequence[bytes32]] = None) -> bool:
-        request = {}
-        if ids is not None:
-            request["ids"] = [id.hex() for id in ids]
-        response = await self.fetch("delete_notifications", request)
-        # TODO: casting due to lack of type checked deserialization
-        result = cast(bool, response["success"])
-        return result
+    async def delete_notifications(self, request: DeleteNotifications) -> None:
+        await self.fetch("delete_notifications", request.to_json_dict())
 
     async def send_notification(
         self,

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -86,6 +86,7 @@ from chia.wallet.wallet_request_types import (
     GatherSigningInfoResponse,
     GenerateMnemonicResponse,
     GetCATListResponse,
+    GetCurrentDerivationIndexResponse,
     GetHeightInfoResponse,
     GetLoggedInFingerprintResponse,
     GetNextAddress,
@@ -369,10 +370,8 @@ class WalletRpcClient(RpcClient):
     async def delete_unconfirmed_transactions(self, request: DeleteUnconfirmedTransactions) -> None:
         await self.fetch("delete_unconfirmed_transactions", request.to_json_dict())
 
-    async def get_current_derivation_index(self) -> str:
-        response = await self.fetch("get_current_derivation_index", {})
-        index = response["index"]
-        return str(index)
+    async def get_current_derivation_index(self) -> GetCurrentDerivationIndexResponse:
+        return GetCurrentDerivationIndexResponse.from_json_dict(await self.fetch("get_current_derivation_index", {}))
 
     async def extend_derivation_index(self, index: int) -> str:
         response = await self.fetch("extend_derivation_index", {"index": index})

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -36,6 +36,7 @@ from chia.wallet.wallet_request_types import (
     CreateOfferForIDsResponse,
     CreateSignedTransactionsResponse,
     DeleteKey,
+    DeleteUnconfirmedTransactions,
     DIDCreateBackupFile,
     DIDCreateBackupFileResponse,
     DIDFindLostDID,
@@ -365,8 +366,8 @@ class WalletRpcClient(RpcClient):
         response = await self.fetch("spend_clawback_coins", request)
         return response
 
-    async def delete_unconfirmed_transactions(self, wallet_id: int) -> None:
-        await self.fetch("delete_unconfirmed_transactions", {"wallet_id": wallet_id})
+    async def delete_unconfirmed_transactions(self, request: DeleteUnconfirmedTransactions) -> None:
+        await self.fetch("delete_unconfirmed_transactions", request.to_json_dict())
 
     async def get_current_derivation_index(self) -> str:
         response = await self.fetch("get_current_derivation_index", {})

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -162,6 +162,8 @@ from chia.wallet.wallet_request_types import (
     SetWalletResyncOnStartup,
     SignMessageByAddress,
     SignMessageByAddressResponse,
+    SignMessageByID,
+    SignMessageByIDResponse,
     SplitCoins,
     SplitCoinsResponse,
     SubmitTransactions,
@@ -1151,13 +1153,8 @@ class WalletRpcClient(RpcClient):
             await self.fetch("sign_message_by_address", request.to_json_dict())
         )
 
-    async def sign_message_by_id(
-        self, id: str, message: str, is_hex: bool = False, safe_mode: bool = True
-    ) -> tuple[str, str, str]:
-        response = await self.fetch(
-            "sign_message_by_id", {"id": id, "message": message, "is_hex": is_hex, "safe_mode": safe_mode}
-        )
-        return response["pubkey"], response["signature"], response["signing_mode"]
+    async def sign_message_by_id(self, request: SignMessageByID) -> SignMessageByIDResponse:
+        return SignMessageByIDResponse.from_json_dict(await self.fetch("sign_message_by_id", request.to_json_dict()))
 
     async def verify_signature(self, request: VerifySignature) -> VerifySignatureResponse:
         return VerifySignatureResponse.from_json_dict(await self.fetch("verify_signature", {**request.to_json_dict()}))

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -82,6 +82,8 @@ from chia.wallet.wallet_request_types import (
     DLUpdateRootResponse,
     ExecuteSigningInstructions,
     ExecuteSigningInstructionsResponse,
+    ExtendDerivationIndex,
+    ExtendDerivationIndexResponse,
     GatherSigningInfo,
     GatherSigningInfoResponse,
     GenerateMnemonicResponse,
@@ -373,10 +375,10 @@ class WalletRpcClient(RpcClient):
     async def get_current_derivation_index(self) -> GetCurrentDerivationIndexResponse:
         return GetCurrentDerivationIndexResponse.from_json_dict(await self.fetch("get_current_derivation_index", {}))
 
-    async def extend_derivation_index(self, index: int) -> str:
-        response = await self.fetch("extend_derivation_index", {"index": index})
-        updated_index = response["index"]
-        return str(updated_index)
+    async def extend_derivation_index(self, request: ExtendDerivationIndex) -> ExtendDerivationIndexResponse:
+        return ExtendDerivationIndexResponse.from_json_dict(
+            await self.fetch("extend_derivation_index", request.to_json_dict())
+        )
 
     async def get_farmed_amount(self, include_pool_rewards: bool = False) -> dict[str, Any]:
         return await self.fetch("get_farmed_amount", {"include_pool_rewards": include_pool_rewards})

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -160,6 +160,8 @@ from chia.wallet.wallet_request_types import (
     SendTransactionMultiResponse,
     SendTransactionResponse,
     SetWalletResyncOnStartup,
+    SignMessageByAddress,
+    SignMessageByAddressResponse,
     SplitCoins,
     SplitCoinsResponse,
     SubmitTransactions,
@@ -1144,9 +1146,10 @@ class WalletRpcClient(RpcClient):
         )
         return TransactionRecord.from_json_dict(response["tx"])
 
-    async def sign_message_by_address(self, address: str, message: str) -> tuple[str, str, str]:
-        response = await self.fetch("sign_message_by_address", {"address": address, "message": message})
-        return response["pubkey"], response["signature"], response["signing_mode"]
+    async def sign_message_by_address(self, request: SignMessageByAddress) -> SignMessageByAddressResponse:
+        return SignMessageByAddressResponse.from_json_dict(
+            await self.fetch("sign_message_by_address", request.to_json_dict())
+        )
 
     async def sign_message_by_id(
         self, id: str, message: str, is_hex: bool = False, safe_mode: bool = True


### PR DESCRIPTION
Another PR following https://github.com/Chia-Network/chia-blockchain/pull/18593

Worth noting that in the `sign_message_by_*` endpoints, I've dropped support for `"True"` and `"False"` being registered as `true` and `false`.  We apparently did intentionally support this but I can't fathom why and at the very least it's not compliant with JSON.  (`"true"` and `"false"` will still register apparently because `streamable` supports that)