### PR TITLE
optimize get_spends RPC

### DIFF
--- a/chia/_tests/core/full_node/stores/test_block_store.py
+++ b/chia/_tests/core/full_node/stores/test_block_store.py
@@ -91,7 +91,10 @@ async def test_block_store(tmp_dir: Path, db_version: int, bt: BlockTools, use_c
             assert block == await store.get_full_block(block.header_hash)
             assert bytes(block) == await store.get_full_block_bytes(block.header_hash)
             assert GeneratorBlockInfo(
-                block.foliage.prev_block_hash, block.transactions_generator, block.transactions_generator_ref_list
+                block.foliage.prev_block_hash,
+                block.height,
+                block.transactions_generator,
+                block.transactions_generator_ref_list,
             ) == await store.get_block_info(block.header_hash)
             assert maybe_serialize(block.transactions_generator) == await store.get_generator(block.header_hash)
             assert block_record == (await store.get_block_record(block_record_hh))

--- a/chia/_tests/util/test_full_block_utils.py
+++ b/chia/_tests/util/test_full_block_utils.py
@@ -275,6 +275,7 @@ async def test_parser():
         assert block.transactions_generator == bi.transactions_generator
         assert block.prev_header_hash == bi.prev_header_hash
         assert block.transactions_generator_ref_list == bi.transactions_generator_ref_list
+        assert block.height == bi.height
         # this doubles the run-time of this test, with questionable utility
         # assert gen == FullBlock.from_bytes(block_bytes).transactions_generator
 

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -251,7 +251,10 @@ class BlockStore:
         cached = self.block_cache.get(header_hash)
         if cached is not None:
             return GeneratorBlockInfo(
-                cached.foliage.prev_block_hash, cached.transactions_generator, cached.transactions_generator_ref_list
+                cached.foliage.prev_block_hash,
+                cached.height,
+                cached.transactions_generator,
+                cached.transactions_generator_ref_list,
             )
 
         formatted_str = "SELECT block, height from full_blocks WHERE header_hash=?"
@@ -270,7 +273,7 @@ class BlockStore:
                 # definition of parsing a block
                 b = FullBlock.from_bytes(block_bytes)
                 return GeneratorBlockInfo(
-                    b.foliage.prev_block_hash, b.transactions_generator, b.transactions_generator_ref_list
+                    b.foliage.prev_block_hash, b.height, b.transactions_generator, b.transactions_generator_ref_list
                 )
 
     async def get_generator(self, header_hash: bytes32) -> Optional[bytes]:


### PR DESCRIPTION
### Purpose:

Make some of the RPCs a bit cheaper.

* make `GeneratorBlockInfo` include block height. This makes it possible to run the block generator just from this information.
* change a few calls to `get_full_block()` -> `get_block_info()` in the RPCs that run blocks (which is cheaper).
* run `get_puzzle_and_solution_for_coin()` in the thread pool for RPCs.
* `get_additions_and_removals` is really just a coin store lookup. We currently get the full block just to map the header hash to a height. Change this to parse out the block height with `get_height_and_tx_status_from_block()` instead of constructing a full block.

### Current Behavior:

```
python tools/validate_rpcs.py -ar -r 100 -s 6758739

2025-08-15 10:12:15,313 INFO     block header hashes loaded from height-to-hash file.
2025-08-15 10:12:20,360 INFO     Processed 887 RPCs in 5.05s, 0.0057s per RPC (985 Blocks completed out of 713016)
2025-08-15 10:12:25,362 INFO     Processed 1249 RPCs in 5.00s, 0.0040s per RPC (2234 Blocks completed out of 713016)
2025-08-15 10:12:30,514 INFO     Processed 1078 RPCs in 5.15s, 0.0048s per RPC (3312 Blocks completed out of 713016)
2025-08-15 10:12:35,546 INFO     Processed 972 RPCs in 5.03s, 0.0052s per RPC (4284 Blocks completed out of 713016)
2025-08-15 10:12:40,563 INFO     Processed 803 RPCs in 5.02s, 0.0062s per RPC (5087 Blocks completed out of 713016)
2025-08-15 10:12:45,566 INFO     Processed 931 RPCs in 5.00s, 0.0054s per RPC (6018 Blocks completed out of 713016)
2025-08-15 10:12:50,569 INFO     Processed 885 RPCs in 5.00s, 0.0057s per RPC (6903 Blocks completed out of 713016)
```

<img width="8930" height="1469" alt="chia-hotspot-88-123" src="https://github.com/user-attachments/assets/7105ce2f-61ca-4007-8f52-ab790bd16649" />

### New Behavior:

```
python tools/validate_rpcs.py -ar -r 100 -s 6758739

2025-08-15 10:16:21,376 INFO     block header hashes loaded from height-to-hash file.
2025-08-15 10:16:26,602 INFO     Processed 1210 RPCs in 5.23s, 0.0043s per RPC (1308 Blocks completed out of 713021)
2025-08-15 10:16:31,720 INFO     Processed 605 RPCs in 5.12s, 0.0085s per RPC (1913 Blocks completed out of 713021)
2025-08-15 10:16:36,727 INFO     Processed 1483 RPCs in 5.01s, 0.0034s per RPC (3396 Blocks completed out of 713021)
2025-08-15 10:16:41,735 INFO     Processed 1494 RPCs in 5.01s, 0.0034s per RPC (4890 Blocks completed out of 713021)
2025-08-15 10:16:46,735 INFO     Processed 1366 RPCs in 5.00s, 0.0037s per RPC (6256 Blocks completed out of 713021)
2025-08-15 10:16:51,778 INFO     Processed 1250 RPCs in 5.04s, 0.0040s per RPC (7506 Blocks completed out of 713021)
2025-08-15 10:16:56,778 INFO     Processed 538 RPCs in 5.00s, 0.0093s per RPC (8044 Blocks completed out of 713021)
```

<img width="7317" height="1387" alt="chia-hotspot-64-111" src="https://github.com/user-attachments/assets/f8f450d2-bc13-4e44-923c-2ec415fb4e52" />