### PR TITLE
[CHIA-3654] previous transaction block height in BlockTools

### DIFF
--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -965,7 +965,6 @@ class BlockTools:
                         block_list.append(full_block)
 
                         if include_transactions:
-                            prev_tx_height = full_block.height
                             for coin in full_block.get_included_reward_coins():
                                 if coin.puzzle_hash == self.farmer_ph:
                                     pending_rewards.append(coin)
@@ -979,6 +978,7 @@ class BlockTools:
 
                         if full_block.transactions_generator is not None:
                             tx_block_heights.append(full_block.height)
+                            prev_tx_height = full_block.height
 
                         blocks_added_this_sub_slot += 1
                         blocks[full_block.header_hash] = block_record
@@ -1259,7 +1259,6 @@ class BlockTools:
                         block_list.append(full_block)
 
                         if include_transactions:
-                            prev_tx_height = full_block.height
                             for coin in full_block.get_included_reward_coins():
                                 if coin.puzzle_hash == self.farmer_ph:
                                     pending_rewards.append(coin)
@@ -1273,6 +1272,7 @@ class BlockTools:
 
                         if full_block.transactions_generator is not None:
                             tx_block_heights.append(full_block.height)
+                            prev_tx_height = full_block.height
 
                         blocks_added_this_sub_slot += 1
                         blocks[full_block.header_hash] = block_record
@@ -1755,6 +1755,7 @@ def load_block_list(
     sub_slot_iters = uint64(constants.SUB_SLOT_ITERS_STARTING)
     height_to_hash: dict[uint32, bytes32] = {}
     blocks: dict[bytes32, BlockRecord] = {}
+    prev_transaction_b_height = uint32(0)
     for full_block in block_list:
         if full_block.height != 0:
             if len(full_block.finished_sub_slots) > 0:
@@ -1771,7 +1772,6 @@ def load_block_list(
             sp_hash = full_block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
 
         cache = BlockCache(blocks)
-        prev_transaction_b_height = uint32(0)  # TODO: todo_v2_plots
 
         required_iters = validate_pospace_and_get_required_iters(
             constants,
@@ -1784,6 +1784,9 @@ def load_block_list(
             prev_transaction_b_height,
         )
         assert required_iters is not None
+
+        if full_block.is_transaction_block():
+            prev_transaction_b_height = full_block.height
 
         blocks[full_block.header_hash] = block_to_block_record(
             constants,


### PR DESCRIPTION
### Purpose:

pass the correct `previous_transaction_block_height` into `validate_pospace_and_get_required_iters()` in `BlockTools`.

The main change is in `load_block_list()` in `BlockTools`. We call this function when block tools is asked to generate blocks on top of an existing chain. Rather than always setting `prev_transaction_b_height` to 0, we hoist it out of the loop and update it as we encounter transaction blocks.

The other change is the tracking of previous transaction blocks in the main loop in `get_consecutive_blocks()`, only update `prev_tx_height` when we actually produce a transaction block.