### PR TITLE
Addendum to PR #19967

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ all components.
 run 2.5.5 but later wish to downgrade to an earlier version, you will need to downgrade your database schema by
 running the following command:
 
-python -c "import sqlite3, sys, os; conn = sqlite3.connect(os.path.expanduser(sys.argv[1]));
-cursor = conn.execute('UPDATE coin_record SET spent_index = 0 WHERE spent_index = -1');
-print(f'Updated {cursor.rowcount} records'); conn.commit(); conn.close()" <path to the db>
+```
+python -c "import sqlite3, sys, os; conn = sqlite3.connect(os.path.expanduser(sys.argv[1])); cursor = conn.execute('UPDATE coin_record SET spent_index = 0 WHERE spent_index = -1'); print(f'Updated {cursor.rowcount} records'); conn.commit(); conn.close()" <path to the db>
+```
+
+Replacing `<path to the db>` with your actual database path.
 
 ## What's Changed
 


### PR DESCRIPTION
### Purpose:

In PR #19967 the DB downgrade command in its current form won't show the last part (`<path to the db>`). Fix the command formatting and allow it to be copied conveniently.

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

<img width="1273" height="66" alt="image" src="https://github.com/user-attachments/assets/c9b04dda-181f-4a1d-8d2e-df7033d2d608" />


### New Behavior:

<img width="1309" height="160" alt="image" src="https://github.com/user-attachments/assets/8a422171-738d-414f-8b3e-468ff7c0cd08" />

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
