### PR TITLE
[CHIA-3701] cleanup `check_plots`

### DIFF
--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -173,44 +173,15 @@ def check_plots(
                 # Some plot errors cause get_qualities_for_challenge to throw a RuntimeError
                 try:
                     quality_start_time = round(monotonic() * 1000)
-                    for index, quality_str in enumerate(pr.get_qualities_for_challenge(challenge)):
-                        quality_spent_time = round(monotonic() * 1000) - quality_start_time
-                        if quality_spent_time > 8000:
-                            log.warning(
-                                f"\tLooking up qualities took: {quality_spent_time} ms. This should be below 8 seconds "
-                                f"to minimize risk of losing rewards. Filepath: {plot_path}"
-                            )
-                        else:
-                            log.info(f"\tLooking up qualities took: {quality_spent_time} ms. Filepath: {plot_path}")
-
-                        # Other plot errors cause get_full_proof or validate_proof to throw an AssertionError
-                        try:
-                            proof_start_time = round(monotonic() * 1000)
-                            # TODO : todo_v2_plots handle v2 plots
-                            proof = pr.get_full_proof(challenge, index, parallel_read)
-                            proof_spent_time = round(monotonic() * 1000) - proof_start_time
-                            if proof_spent_time > 15000:
-                                log.warning(
-                                    f"\tFinding proof took: {proof_spent_time} ms. This should be below 15 seconds "
-                                    f"to minimize risk of losing rewards. Filepath: {plot_path}"
-                                )
-                            else:
-                                log.info(f"\tFinding proof took: {proof_spent_time} ms. Filepath: {plot_path}")
-
-                            ver_quality_str = v.validate_proof(pr.get_id(), pr.get_size(), challenge, proof)
-                            if quality_str == ver_quality_str:
-                                total_proofs += 1
-                            else:
-                                log.warning(
-                                    f"\tQuality doesn't match with proof. Filepath: {plot_path} "
-                                    "This can occasionally happen with a compressed plot."
-                                )
-                        except AssertionError as e:
-                            log.error(
-                                f"{type(e)}: {e} error in proving/verifying for plot {plot_path}. Filepath: {plot_path}"
-                            )
-                            caught_exception = True
-                        quality_start_time = round(monotonic() * 1000)
+                    qualities = pr.get_qualities_for_challenge(challenge)
+                    quality_spent_time = round(monotonic() * 1000) - quality_start_time
+                    if quality_spent_time > 8000:
+                        log.warning(
+                            f"\tLooking up qualities took: {quality_spent_time} ms. This should be below 8 seconds "
+                            f"to minimize risk of losing rewards. Filepath: {plot_path}"
+                        )
+                    else:
+                        log.info(f"\tLooking up qualities took: {quality_spent_time} ms. Filepath: {plot_path}")
                 except KeyboardInterrupt:
                     log.warning("Interrupted, closing")
                     return
@@ -224,9 +195,40 @@ def check_plots(
                     else:
                         log.error(f"{type(e)}: {e} error in getting challenge qualities for plot {plot_path}")
                         caught_exception = True
+                        continue
                 except Exception as e:
                     log.error(f"{type(e)}: {e} error in getting challenge qualities for plot {plot_path}")
                     caught_exception = True
+                    break
+
+                for index, quality_str in enumerate(qualities):
+                    # Other plot errors cause get_full_proof or validate_proof to throw an AssertionError
+                    try:
+                        proof_start_time = round(monotonic() * 1000)
+                        # TODO : todo_v2_plots handle v2 plots
+                        proof = pr.get_full_proof(challenge, index, parallel_read)
+                        proof_spent_time = round(monotonic() * 1000) - proof_start_time
+                        if proof_spent_time > 15000:
+                            log.warning(
+                                f"\tFinding proof took: {proof_spent_time} ms. This should be below 15 seconds "
+                                f"to minimize risk of losing rewards. Filepath: {plot_path}"
+                            )
+                        else:
+                            log.info(f"\tFinding proof took: {proof_spent_time} ms. Filepath: {plot_path}")
+
+                        ver_quality_str = v.validate_proof(pr.get_id(), pr.get_size(), challenge, proof)
+                        if quality_str == ver_quality_str:
+                            total_proofs += 1
+                        else:
+                            log.warning(
+                                f"\tQuality doesn't match with proof. Filepath: {plot_path} "
+                                "This can occasionally happen with a compressed plot."
+                            )
+                    except AssertionError as e:
+                        log.error(
+                            f"{type(e)}: {e} error in proving/verifying for plot {plot_path}. Filepath: {plot_path}"
+                        )
+                        caught_exception = True
                 if caught_exception is True:
                     break
 

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -216,7 +216,7 @@ def check_plots(
                         else:
                             log.info(f"\tFinding proof took: {proof_spent_time} ms. Filepath: {plot_path}")
 
-                        ver_quality_str = v.validate_proof(pr.get_id(), pr.get_size(), challenge, proof)
+                        ver_quality_str = v.validate_proof(pr.get_id(), pr.get_size().size_v1, challenge, proof)
                         if quality_str == ver_quality_str:
                             total_proofs += 1
                         else:

--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -5,7 +5,7 @@ import logging
 from collections import Counter
 from pathlib import Path
 from threading import Lock
-from time import sleep, time
+from time import monotonic, sleep
 from typing import Optional
 
 from chia_rs import G1Element
@@ -172,9 +172,9 @@ def check_plots(
                 challenge = std_hash(i.to_bytes(32, "big"))
                 # Some plot errors cause get_qualities_for_challenge to throw a RuntimeError
                 try:
-                    quality_start_time = round(time() * 1000)
+                    quality_start_time = round(monotonic() * 1000)
                     for index, quality_str in enumerate(pr.get_qualities_for_challenge(challenge)):
-                        quality_spent_time = round(time() * 1000) - quality_start_time
+                        quality_spent_time = round(monotonic() * 1000) - quality_start_time
                         if quality_spent_time > 8000:
                             log.warning(
                                 f"\tLooking up qualities took: {quality_spent_time} ms. This should be below 8 seconds "
@@ -185,10 +185,10 @@ def check_plots(
 
                         # Other plot errors cause get_full_proof or validate_proof to throw an AssertionError
                         try:
-                            proof_start_time = round(time() * 1000)
+                            proof_start_time = round(monotonic() * 1000)
                             # TODO : todo_v2_plots handle v2 plots
                             proof = pr.get_full_proof(challenge, index, parallel_read)
-                            proof_spent_time = round(time() * 1000) - proof_start_time
+                            proof_spent_time = round(monotonic() * 1000) - proof_start_time
                             if proof_spent_time > 15000:
                                 log.warning(
                                     f"\tFinding proof took: {proof_spent_time} ms. This should be below 15 seconds "
@@ -210,7 +210,7 @@ def check_plots(
                                 f"{type(e)}: {e} error in proving/verifying for plot {plot_path}. Filepath: {plot_path}"
                             )
                             caught_exception = True
-                        quality_start_time = round(time() * 1000)
+                        quality_start_time = round(monotonic() * 1000)
                 except KeyboardInterrupt:
                     log.warning("Interrupted, closing")
                     return


### PR DESCRIPTION
This is best reviewed one commit at a time, and ignoring whitespace.

### Purpose:

Simplify check plots:
1. use `monotonic()` clock when measuring time of operations
2. move exception handling blocks to reduce indentation level. This commit is best viewed ignoring whitespace.
3. Fix type error, not caught because `chiapos` doesn't have type stubs

### Testing

This was tested manually, via the command line `chia plots check`