### PR TITLE
[CHIA-3703] Add Enum support to streamable

### DIFF
--- a/chia/_tests/core/util/test_streamable.py
+++ b/chia/_tests/core/util/test_streamable.py
@@ -726,6 +726,17 @@ def test_ambiguous_deserialization_str_enum() -> None:
         TestClassStr.from_bytes(bytes([0, 0, 100, 24, 52]))
 
 
+def test_deserialization_to_invalid_enum() -> None:
+    @streamable
+    @dataclass(frozen=True)
+    class TestClassStr(Streamable):
+        a: StringEnum
+
+    # encodes the string "baz" which is not a valid value for StringEnum
+    with pytest.raises(ValueError, match=re.escape("'baz' is not a valid StringEnum")):
+        TestClassStr.from_bytes(bytes([0, 0, 0, 3, 98, 97, 122]))
+
+
 def test_ambiguous_deserialization_bytes() -> None:
     @streamable
     @dataclass(frozen=True)

--- a/chia/_tests/core/util/test_streamable.py
+++ b/chia/_tests/core/util/test_streamable.py
@@ -496,7 +496,7 @@ def test_post_init_valid(test_class: type[Any], args: tuple[Any, ...]) -> None:
                 value_type, next(iter(item.values()))
             )
         if is_type_Enum(type_in):
-            return validate_item_type(type_in._streamable_proxy, item)
+            return validate_item_type(type_in._streamable_proxy, type_in._streamable_proxy(item.value))  # type: ignore[attr-defined]
         return isinstance(item, type_in)
 
     test_object = test_class(*args)

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -8,7 +8,7 @@ import os
 import pprint
 import traceback
 from collections.abc import Collection
-from enum import Enum, EnumType
+from enum import Enum, EnumMeta
 from typing import TYPE_CHECKING, Any, BinaryIO, Callable, ClassVar, Optional, TypeVar, Union, get_type_hints
 
 from chia_rs.sized_bytes import bytes32
@@ -131,7 +131,7 @@ def is_type_Dict(f_type: object) -> bool:
 
 
 def is_type_Enum(f_type: object) -> bool:
-    return type(f_type) is EnumType
+    return type(f_type) is EnumMeta
 
 
 def convert_optional(convert_func: ConvertFunctionType, item: Any) -> Any:
@@ -727,7 +727,7 @@ class UInt64Range(Streamable):
     stop: uint64 = uint64.MAXIMUM
 
 
-_T_Enum = TypeVar("_T_Enum", bound=EnumType)
+_T_Enum = TypeVar("_T_Enum", bound=EnumMeta)
 
 
 def streamable_enum(proxy: type[Any]) -> Callable[[_T_Enum], _T_Enum]:

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -459,7 +459,7 @@ def function_to_parse_one_item(f_type: type[Any]) -> ParseFunctionType:
     if is_type_Enum(f_type):
         if not hasattr(f_type, "_streamable_proxy"):
             raise UnsupportedType(f"Using Enum ({f_type}) in streamable requires a 'streamable_enum' wrapper.")
-        return function_to_parse_one_item(f_type._streamable_proxy)
+        return lambda f: f_type(function_to_parse_one_item(f_type._streamable_proxy)(f))
     if f_type is str:
         return parse_str
     raise UnsupportedType(f"Type {f_type} does not have parse")

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -719,7 +719,7 @@ class UInt64Range(Streamable):
 _T_Enum = TypeVar("_T_Enum", bound=EnumMeta)
 
 
-def streamable_enum(proxy: type[Any]) -> Callable[[_T_Enum], _T_Enum]:
+def streamable_enum(proxy: type[object]) -> Callable[[_T_Enum], _T_Enum]:
     def streamable_enum_wrapper(cls: _T_Enum) -> _T_Enum:
         setattr(cls, "_streamable_proxy", proxy)
         setattr(cls, "_ignore_", ["_streamable_proxy"])


### PR DESCRIPTION
This PR adds support for `Enum`s to the streamable framework.

In order to support an `Enum` in your streamable class you must decorate it with the `streamable_enum` decorator and specify a proxy streamable object to use for serializing the enum's values.  Once you've done this, the object can be used in a streamble object.