### PR TITLE
[CHIA-3659] ignore unreasonably small v2 plots

### DIFF
--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -333,22 +333,20 @@ class PlotManager:
                     # TODO: consider checking if the file was just written to (which would mean that the file is still
                     # being copied). A segfault might happen in this edge case.
 
-                    version_and_size = prover.get_size()
-                    if version_and_size.size_v1 is not None:
-                        k = version_and_size.size_v1
-                        level = prover.get_compression_level()
-                        if level == 0:
-                            if k >= 30 and stat_info.st_size < 0.98 * expected_size:
-                                log.warning(
-                                    f"Not farming plot {file_path}. "
-                                    f"Size is {stat_info.st_size / (1024**3)} GiB, "
-                                    f"but expected at least: {expected_size / (1024**3)} GiB. "
-                                    "We assume the file is being copied."
-                                )
-                                return None
-                    else:
-                        # TODO: todo_v2_plots do we need to check v2 plots?
-                        pass
+                    k = prover.get_size()
+                    level = prover.get_compression_level()
+                    if (
+                        level == 0
+                        and stat_info.st_size < 0.98 * expected_size
+                        and ((k.size_v1 is not None and k.size_v1 >= 30) or (k.size_v2 is not None and k.size_v2 >= 28))
+                    ):
+                        log.warning(
+                            f"Not farming plot {file_path}. "
+                            f"Size is {stat_info.st_size / (1024**3)} GiB, "
+                            f"but expected at least: {expected_size / (1024**3)} GiB. "
+                            "We assume the file is being copied."
+                        )
+                        return None
 
                     cache_entry = CacheEntry.from_prover(prover)
                     self.cache.update(file_path, cache_entry)


### PR DESCRIPTION
### Purpose:

Uncompressed v1 plots that are too small, we assume are currently being copied, and not valid. This patch extends that logic to v2 plots as well