### PR TITLE
CHIA-3704 Optimize peak post processing by using transaction IDs instead of NewPeakItem elements

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -133,15 +133,8 @@ class SpendBundleAddInfo:
 
 @dataclass
 class NewPeakInfo:
-    items: list[NewPeakItem]
+    spend_bundle_ids: list[bytes32]
     removals: list[MempoolRemoveInfo]
-
-
-@dataclass
-class NewPeakItem:
-    transaction_id: bytes32
-    spend_bundle: SpendBundle
-    conds: SpendBundleConditions
 
 
 # For block overhead cost calculation
@@ -992,7 +985,7 @@ class MempoolManager:
                 lineage_cache.get_unspent_lineage_info,
             )
             if info.status == MempoolInclusionStatus.SUCCESS:
-                txs_added.append(NewPeakItem(item.spend_bundle_name, item.spend_bundle, item.conds))
+                txs_added.append(item.spend_bundle_name)
             mempool_item_removals.extend(info.removals)
         log.info(
             f"Size of mempool: {self.mempool.size()} spends, "


### PR DESCRIPTION
### Purpose:

When preparing `NewPeakInfo` to pass from the mempool to the full node for new peak post processing, we only end up using transaction IDs Out of `NewPeakItem` elements.

The origin of this logic seems to be PR #1174 but even then, the mempool item should cover the information needed in that context.

### Current Behavior:

We construct a list of `NewPeakItem`s as items in `NewPeakInfo`.

### New Behavior:

We construct a list of transaction IDs in `NewPeakInfo`.