### PR TITLE
Rate limits cleanup

### DIFF
--- a/chia/_tests/core/server/test_rate_limits.py
+++ b/chia/_tests/core/server/test_rate_limits.py
@@ -33,363 +33,372 @@ class SimClock:
         self.current_time += duration
 
 
-class TestRateLimits:
-    @pytest.mark.anyio
-    async def test_get_rate_limits_to_use(self):
-        assert get_rate_limits_to_use(rl_v2, rl_v2) != get_rate_limits_to_use(rl_v2, rl_v1)
-        assert get_rate_limits_to_use(rl_v1, rl_v1) == get_rate_limits_to_use(rl_v2, rl_v1)
-        assert get_rate_limits_to_use(rl_v1, rl_v1) == get_rate_limits_to_use(rl_v1, rl_v2)
+@pytest.mark.anyio
+async def test_get_rate_limits_to_use():
+    assert get_rate_limits_to_use(rl_v2, rl_v2) != get_rate_limits_to_use(rl_v2, rl_v1)
+    assert get_rate_limits_to_use(rl_v1, rl_v1) == get_rate_limits_to_use(rl_v2, rl_v1)
+    assert get_rate_limits_to_use(rl_v1, rl_v1) == get_rate_limits_to_use(rl_v1, rl_v2)
 
-    @pytest.mark.anyio
-    async def test_too_many_messages(self):
-        # Too many messages
-        timer = SimClock()
-        r = RateLimiter(incoming=True, get_time=timer.monotonic)
-        new_tx_message = make_msg(ProtocolMessageTypes.new_transaction, bytes([1] * 40))
-        for i in range(4999):
-            assert r.process_msg_and_check(new_tx_message, rl_v2, rl_v2) is None
 
-        saw_disconnect = False
-        for i in range(4999):
-            response = r.process_msg_and_check(new_tx_message, rl_v2, rl_v2)
-            if response is not None:
-                saw_disconnect = True
-        assert saw_disconnect
-
-        # Non-tx message
-        r = RateLimiter(incoming=True, get_time=timer.monotonic)
-        new_peak_message = make_msg(ProtocolMessageTypes.new_peak, bytes([1] * 40))
-        for i in range(200):
-            assert r.process_msg_and_check(new_peak_message, rl_v2, rl_v2) is None
-
-        saw_disconnect = False
-        for i in range(200):
-            response = r.process_msg_and_check(new_peak_message, rl_v2, rl_v2)
-            if response is not None:
-                saw_disconnect = True
-        assert saw_disconnect
-
-    @pytest.mark.anyio
-    async def test_large_message(self):
-        # Large tx
-        small_tx_message = make_msg(ProtocolMessageTypes.respond_transaction, bytes([1] * 500 * 1024))
-        large_tx_message = make_msg(ProtocolMessageTypes.new_transaction, bytes([1] * 3 * 1024 * 1024))
-
-        timer = SimClock()
-        r = RateLimiter(incoming=True, get_time=timer.monotonic)
-        assert r.process_msg_and_check(small_tx_message, rl_v2, rl_v2) is None
-        assert r.process_msg_and_check(large_tx_message, rl_v2, rl_v2) is not None
-
-        small_vdf_message = make_msg(ProtocolMessageTypes.respond_signage_point, bytes([1] * 5 * 1024))
-        large_vdf_message = make_msg(ProtocolMessageTypes.respond_signage_point, bytes([1] * 600 * 1024))
-        large_blocks_message = make_msg(ProtocolMessageTypes.respond_blocks, bytes([1] * 51 * 1024 * 1024))
-        r = RateLimiter(incoming=True, get_time=timer.monotonic)
-        assert r.process_msg_and_check(small_vdf_message, rl_v2, rl_v2) is None
-        assert r.process_msg_and_check(small_vdf_message, rl_v2, rl_v2) is None
-        assert r.process_msg_and_check(large_vdf_message, rl_v2, rl_v2) is not None
-        # this limit applies even though this message type is unlimited
-        assert r.process_msg_and_check(large_blocks_message, rl_v2, rl_v2) is not None
-
-    @pytest.mark.anyio
-    async def test_too_much_data(self):
-        # Too much data
-        timer = SimClock()
-        r = RateLimiter(incoming=True, get_time=timer.monotonic)
-        tx_message = make_msg(ProtocolMessageTypes.respond_transaction, bytes([1] * 500 * 1024))
-        for i in range(40):
-            assert r.process_msg_and_check(tx_message, rl_v2, rl_v2) is None
-
-        saw_disconnect = False
-        for i in range(300):
-            response = r.process_msg_and_check(tx_message, rl_v2, rl_v2)
-            if response is not None:
-                saw_disconnect = True
-        assert saw_disconnect
-
-        r = RateLimiter(incoming=True, get_time=timer.monotonic)
-        block_message = make_msg(ProtocolMessageTypes.respond_unfinished_block, bytes([1] * 1024 * 1024))
-        for i in range(10):
-            assert r.process_msg_and_check(block_message, rl_v2, rl_v2) is None
-
-        saw_disconnect = False
-        for i in range(40):
-            response = r.process_msg_and_check(block_message, rl_v2, rl_v2)
-            if response is not None:
-                saw_disconnect = True
-        assert saw_disconnect
-
-    @pytest.mark.anyio
-    async def test_non_tx_aggregate_limits(self):
-        # Frequency limits
-        timer = SimClock()
-        r = RateLimiter(incoming=True, get_time=timer.monotonic)
-        message_1 = make_msg(ProtocolMessageTypes.coin_state_update, bytes([1] * 32))
-        message_2 = make_msg(ProtocolMessageTypes.request_blocks, bytes([1] * 64))
-        message_3 = make_msg(ProtocolMessageTypes.plot_sync_start, bytes([1] * 64))
-
-        for i in range(500):
-            assert r.process_msg_and_check(message_1, rl_v2, rl_v2) is None
-
-        for i in range(500):
-            assert r.process_msg_and_check(message_2, rl_v2, rl_v2) is None
-
-        saw_disconnect = False
-        for i in range(500):
-            response = r.process_msg_and_check(message_3, rl_v2, rl_v2)
-            if response is not None:
-                saw_disconnect = True
-        assert saw_disconnect
-
-        # Size limits
-        r = RateLimiter(incoming=True, get_time=timer.monotonic)
-        message_4 = make_msg(ProtocolMessageTypes.respond_proof_of_weight, bytes([1] * 49 * 1024 * 1024))
-        message_5 = make_msg(ProtocolMessageTypes.request_blocks, bytes([1] * 49 * 1024 * 1024))
-
-        for i in range(2):
-            assert r.process_msg_and_check(message_4, rl_v2, rl_v2) is None
-
-        saw_disconnect = False
-        for i in range(2):
-            response = r.process_msg_and_check(message_5, rl_v2, rl_v2)
-            if response is not None:
-                saw_disconnect = True
-        assert saw_disconnect
-
-    @pytest.mark.anyio
-    async def test_periodic_reset(self):
-        timer = SimClock()
-        r = RateLimiter(True, 5, get_time=timer.monotonic)
-        tx_message = make_msg(ProtocolMessageTypes.respond_transaction, bytes([1] * 500 * 1024))
-        for i in range(10):
-            assert r.process_msg_and_check(tx_message, rl_v2, rl_v2) is None
-
-        saw_disconnect = False
-        for i in range(300):
-            response = r.process_msg_and_check(tx_message, rl_v2, rl_v2)
-            if response is not None:
-                saw_disconnect = True
-        assert saw_disconnect
-        assert r.process_msg_and_check(tx_message, rl_v2, rl_v2) is not None
-        timer.sleep(6)
-        assert r.process_msg_and_check(tx_message, rl_v2, rl_v2) is None
-
-        # Counts reset also
-        r = RateLimiter(True, 5, get_time=timer.monotonic)
-        new_tx_message = make_msg(ProtocolMessageTypes.new_transaction, bytes([1] * 40))
-        for i in range(4999):
-            assert r.process_msg_and_check(new_tx_message, rl_v2, rl_v2) is None
-
-        saw_disconnect = False
-        for i in range(4999):
-            response = r.process_msg_and_check(new_tx_message, rl_v2, rl_v2)
-            if response is not None:
-                saw_disconnect = True
-        assert saw_disconnect
-        timer.sleep(6)
+@pytest.mark.anyio
+async def test_too_many_messages():
+    # Too many messages
+    timer = SimClock()
+    r = RateLimiter(incoming=True, get_time=timer.monotonic)
+    new_tx_message = make_msg(ProtocolMessageTypes.new_transaction, bytes([1] * 40))
+    for i in range(4999):
         assert r.process_msg_and_check(new_tx_message, rl_v2, rl_v2) is None
 
-    @pytest.mark.anyio
-    async def test_percentage_limits(self):
-        timer = SimClock()
-        r = RateLimiter(True, 60, 40, get_time=timer.monotonic)
-        new_peak_message = make_msg(ProtocolMessageTypes.new_peak, bytes([1] * 40))
-        for i in range(50):
-            assert r.process_msg_and_check(new_peak_message, rl_v2, rl_v2) is None
+    saw_disconnect = False
+    for i in range(4999):
+        response = r.process_msg_and_check(new_tx_message, rl_v2, rl_v2)
+        if response is not None:
+            saw_disconnect = True
+    assert saw_disconnect
 
-        saw_disconnect = False
-        for i in range(50):
-            response = r.process_msg_and_check(new_peak_message, rl_v2, rl_v2)
-            if response is not None:
-                saw_disconnect = True
-        assert saw_disconnect
+    # Non-tx message
+    r = RateLimiter(incoming=True, get_time=timer.monotonic)
+    new_peak_message = make_msg(ProtocolMessageTypes.new_peak, bytes([1] * 40))
+    for i in range(200):
+        assert r.process_msg_and_check(new_peak_message, rl_v2, rl_v2) is None
 
-        r = RateLimiter(True, 60, 40, get_time=timer.monotonic)
-        block_message = make_msg(ProtocolMessageTypes.respond_unfinished_block, bytes([1] * 1024 * 1024))
-        for i in range(5):
-            assert r.process_msg_and_check(block_message, rl_v2, rl_v2) is None
+    saw_disconnect = False
+    for i in range(200):
+        response = r.process_msg_and_check(new_peak_message, rl_v2, rl_v2)
+        if response is not None:
+            saw_disconnect = True
+    assert saw_disconnect
 
-        saw_disconnect = False
-        for i in range(5):
-            response = r.process_msg_and_check(block_message, rl_v2, rl_v2)
-            if response is not None:
-                saw_disconnect = True
-        assert saw_disconnect
 
-        # Aggregate percentage limit count
-        r = RateLimiter(True, 60, 40, get_time=timer.monotonic)
-        message_1 = make_msg(ProtocolMessageTypes.coin_state_update, bytes([1] * 5))
-        message_2 = make_msg(ProtocolMessageTypes.request_blocks, bytes([1] * 32))
-        message_3 = make_msg(ProtocolMessageTypes.plot_sync_start, bytes([1] * 32))
+@pytest.mark.anyio
+async def test_large_message():
+    # Large tx
+    small_tx_message = make_msg(ProtocolMessageTypes.respond_transaction, bytes([1] * 500 * 1024))
+    large_tx_message = make_msg(ProtocolMessageTypes.new_transaction, bytes([1] * 3 * 1024 * 1024))
 
-        for i in range(180):
-            assert r.process_msg_and_check(message_1, rl_v2, rl_v2) is None
-        for i in range(180):
-            assert r.process_msg_and_check(message_2, rl_v2, rl_v2) is None
+    timer = SimClock()
+    r = RateLimiter(incoming=True, get_time=timer.monotonic)
+    assert r.process_msg_and_check(small_tx_message, rl_v2, rl_v2) is None
+    assert r.process_msg_and_check(large_tx_message, rl_v2, rl_v2) is not None
 
-        saw_disconnect = False
-        for i in range(100):
-            response = r.process_msg_and_check(message_3, rl_v2, rl_v2)
-            if response is not None:
-                saw_disconnect = True
-        assert saw_disconnect
+    small_vdf_message = make_msg(ProtocolMessageTypes.respond_signage_point, bytes([1] * 5 * 1024))
+    large_vdf_message = make_msg(ProtocolMessageTypes.respond_signage_point, bytes([1] * 600 * 1024))
+    large_blocks_message = make_msg(ProtocolMessageTypes.respond_blocks, bytes([1] * 51 * 1024 * 1024))
+    r = RateLimiter(incoming=True, get_time=timer.monotonic)
+    assert r.process_msg_and_check(small_vdf_message, rl_v2, rl_v2) is None
+    assert r.process_msg_and_check(small_vdf_message, rl_v2, rl_v2) is None
+    assert r.process_msg_and_check(large_vdf_message, rl_v2, rl_v2) is not None
+    # this limit applies even though this message type is unlimited
+    assert r.process_msg_and_check(large_blocks_message, rl_v2, rl_v2) is not None
 
-        # Aggregate percentage limit max total size
-        r = RateLimiter(True, 60, 40, get_time=timer.monotonic)
-        message_4 = make_msg(ProtocolMessageTypes.respond_proof_of_weight, bytes([1] * 18 * 1024 * 1024))
-        message_5 = make_msg(ProtocolMessageTypes.respond_unfinished_block, bytes([1] * 24 * 1024 * 1024))
 
-        for i in range(2):
-            assert r.process_msg_and_check(message_4, rl_v2, rl_v2) is None
+@pytest.mark.anyio
+async def test_too_much_data():
+    # Too much data
+    timer = SimClock()
+    r = RateLimiter(incoming=True, get_time=timer.monotonic)
+    tx_message = make_msg(ProtocolMessageTypes.respond_transaction, bytes([1] * 500 * 1024))
+    for i in range(40):
+        assert r.process_msg_and_check(tx_message, rl_v2, rl_v2) is None
 
-        saw_disconnect = False
-        for i in range(2):
-            response = r.process_msg_and_check(message_5, rl_v2, rl_v2)
-            if response is not None:
-                saw_disconnect = True
-        assert saw_disconnect
+    saw_disconnect = False
+    for i in range(300):
+        response = r.process_msg_and_check(tx_message, rl_v2, rl_v2)
+        if response is not None:
+            saw_disconnect = True
+    assert saw_disconnect
 
-    @pytest.mark.anyio
-    async def test_too_many_outgoing_messages(self):
-        # Too many messages
-        timer = SimClock()
-        r = RateLimiter(incoming=False, get_time=timer.monotonic)
-        new_peers_message = make_msg(ProtocolMessageTypes.respond_peers, bytes([1]))
-        non_tx_freq = get_rate_limits_to_use(rl_v2, rl_v2)["non_tx_freq"]
+    r = RateLimiter(incoming=True, get_time=timer.monotonic)
+    block_message = make_msg(ProtocolMessageTypes.respond_unfinished_block, bytes([1] * 1024 * 1024))
+    for i in range(10):
+        assert r.process_msg_and_check(block_message, rl_v2, rl_v2) is None
 
-        passed = 0
-        blocked = 0
-        for i in range(non_tx_freq):
-            if r.process_msg_and_check(new_peers_message, rl_v2, rl_v2) is None:
-                passed += 1
-            else:
-                blocked += 1
+    saw_disconnect = False
+    for i in range(40):
+        response = r.process_msg_and_check(block_message, rl_v2, rl_v2)
+        if response is not None:
+            saw_disconnect = True
+    assert saw_disconnect
 
-        assert passed == 10
-        assert blocked == non_tx_freq - passed
 
-        # ensure that *another* message type is not blocked because of this
+@pytest.mark.anyio
+async def test_non_tx_aggregate_limits():
+    # Frequency limits
+    timer = SimClock()
+    r = RateLimiter(incoming=True, get_time=timer.monotonic)
+    message_1 = make_msg(ProtocolMessageTypes.coin_state_update, bytes([1] * 32))
+    message_2 = make_msg(ProtocolMessageTypes.request_blocks, bytes([1] * 64))
+    message_3 = make_msg(ProtocolMessageTypes.plot_sync_start, bytes([1] * 64))
 
-        new_signatures_message = make_msg(ProtocolMessageTypes.respond_signatures, bytes([1]))
-        assert r.process_msg_and_check(new_signatures_message, rl_v2, rl_v2) is None
+    for i in range(500):
+        assert r.process_msg_and_check(message_1, rl_v2, rl_v2) is None
 
-    @pytest.mark.anyio
-    async def test_too_many_incoming_messages(self):
-        # Too many messages
-        timer = SimClock()
-        r = RateLimiter(incoming=True, get_time=timer.monotonic)
-        new_peers_message = make_msg(ProtocolMessageTypes.respond_peers, bytes([1]))
-        non_tx_freq = get_rate_limits_to_use(rl_v2, rl_v2)["non_tx_freq"]
+    for i in range(500):
+        assert r.process_msg_and_check(message_2, rl_v2, rl_v2) is None
 
-        passed = 0
-        blocked = 0
-        for i in range(non_tx_freq):
-            if r.process_msg_and_check(new_peers_message, rl_v2, rl_v2) is None:
-                passed += 1
-            else:
-                blocked += 1
+    saw_disconnect = False
+    for i in range(500):
+        response = r.process_msg_and_check(message_3, rl_v2, rl_v2)
+        if response is not None:
+            saw_disconnect = True
+    assert saw_disconnect
 
-        assert passed == 10
-        assert blocked == non_tx_freq - passed
+    # Size limits
+    r = RateLimiter(incoming=True, get_time=timer.monotonic)
+    message_4 = make_msg(ProtocolMessageTypes.respond_proof_of_weight, bytes([1] * 49 * 1024 * 1024))
+    message_5 = make_msg(ProtocolMessageTypes.request_blocks, bytes([1] * 49 * 1024 * 1024))
 
-        # ensure that other message types *are* blocked because of this
+    for i in range(2):
+        assert r.process_msg_and_check(message_4, rl_v2, rl_v2) is None
 
-        new_signatures_message = make_msg(ProtocolMessageTypes.respond_signatures, bytes([1]))
-        assert r.process_msg_and_check(new_signatures_message, rl_v2, rl_v2) is not None
+    saw_disconnect = False
+    for i in range(2):
+        response = r.process_msg_and_check(message_5, rl_v2, rl_v2)
+        if response is not None:
+            saw_disconnect = True
+    assert saw_disconnect
 
-    @pytest.mark.parametrize(
-        "node_with_params",
-        [
-            pytest.param(
-                dict(
-                    disable_capabilities=[Capability.BLOCK_HEADERS, Capability.RATE_LIMITS_V2],
-                ),
-                id="V1",
+
+@pytest.mark.anyio
+async def test_periodic_reset():
+    timer = SimClock()
+    r = RateLimiter(True, 5, get_time=timer.monotonic)
+    tx_message = make_msg(ProtocolMessageTypes.respond_transaction, bytes([1] * 500 * 1024))
+    for i in range(10):
+        assert r.process_msg_and_check(tx_message, rl_v2, rl_v2) is None
+
+    saw_disconnect = False
+    for i in range(300):
+        response = r.process_msg_and_check(tx_message, rl_v2, rl_v2)
+        if response is not None:
+            saw_disconnect = True
+    assert saw_disconnect
+    assert r.process_msg_and_check(tx_message, rl_v2, rl_v2) is not None
+    timer.sleep(6)
+    assert r.process_msg_and_check(tx_message, rl_v2, rl_v2) is None
+
+    # Counts reset also
+    r = RateLimiter(True, 5, get_time=timer.monotonic)
+    new_tx_message = make_msg(ProtocolMessageTypes.new_transaction, bytes([1] * 40))
+    for i in range(4999):
+        assert r.process_msg_and_check(new_tx_message, rl_v2, rl_v2) is None
+
+    saw_disconnect = False
+    for i in range(4999):
+        response = r.process_msg_and_check(new_tx_message, rl_v2, rl_v2)
+        if response is not None:
+            saw_disconnect = True
+    assert saw_disconnect
+    timer.sleep(6)
+    assert r.process_msg_and_check(new_tx_message, rl_v2, rl_v2) is None
+
+
+@pytest.mark.anyio
+async def test_percentage_limits():
+    timer = SimClock()
+    r = RateLimiter(True, 60, 40, get_time=timer.monotonic)
+    new_peak_message = make_msg(ProtocolMessageTypes.new_peak, bytes([1] * 40))
+    for i in range(50):
+        assert r.process_msg_and_check(new_peak_message, rl_v2, rl_v2) is None
+
+    saw_disconnect = False
+    for i in range(50):
+        response = r.process_msg_and_check(new_peak_message, rl_v2, rl_v2)
+        if response is not None:
+            saw_disconnect = True
+    assert saw_disconnect
+
+    r = RateLimiter(True, 60, 40, get_time=timer.monotonic)
+    block_message = make_msg(ProtocolMessageTypes.respond_unfinished_block, bytes([1] * 1024 * 1024))
+    for i in range(5):
+        assert r.process_msg_and_check(block_message, rl_v2, rl_v2) is None
+
+    saw_disconnect = False
+    for i in range(5):
+        response = r.process_msg_and_check(block_message, rl_v2, rl_v2)
+        if response is not None:
+            saw_disconnect = True
+    assert saw_disconnect
+
+    # Aggregate percentage limit count
+    r = RateLimiter(True, 60, 40, get_time=timer.monotonic)
+    message_1 = make_msg(ProtocolMessageTypes.coin_state_update, bytes([1] * 5))
+    message_2 = make_msg(ProtocolMessageTypes.request_blocks, bytes([1] * 32))
+    message_3 = make_msg(ProtocolMessageTypes.plot_sync_start, bytes([1] * 32))
+
+    for i in range(180):
+        assert r.process_msg_and_check(message_1, rl_v2, rl_v2) is None
+    for i in range(180):
+        assert r.process_msg_and_check(message_2, rl_v2, rl_v2) is None
+
+    saw_disconnect = False
+    for i in range(100):
+        response = r.process_msg_and_check(message_3, rl_v2, rl_v2)
+        if response is not None:
+            saw_disconnect = True
+    assert saw_disconnect
+
+    # Aggregate percentage limit max total size
+    r = RateLimiter(True, 60, 40, get_time=timer.monotonic)
+    message_4 = make_msg(ProtocolMessageTypes.respond_proof_of_weight, bytes([1] * 18 * 1024 * 1024))
+    message_5 = make_msg(ProtocolMessageTypes.respond_unfinished_block, bytes([1] * 24 * 1024 * 1024))
+
+    for i in range(2):
+        assert r.process_msg_and_check(message_4, rl_v2, rl_v2) is None
+
+    saw_disconnect = False
+    for i in range(2):
+        response = r.process_msg_and_check(message_5, rl_v2, rl_v2)
+        if response is not None:
+            saw_disconnect = True
+    assert saw_disconnect
+
+
+@pytest.mark.anyio
+async def test_too_many_outgoing_messages():
+    # Too many messages
+    timer = SimClock()
+    r = RateLimiter(incoming=False, get_time=timer.monotonic)
+    new_peers_message = make_msg(ProtocolMessageTypes.respond_peers, bytes([1]))
+    non_tx_freq = get_rate_limits_to_use(rl_v2, rl_v2)["non_tx_freq"]
+
+    passed = 0
+    blocked = 0
+    for i in range(non_tx_freq):
+        if r.process_msg_and_check(new_peers_message, rl_v2, rl_v2) is None:
+            passed += 1
+        else:
+            blocked += 1
+
+    assert passed == 10
+    assert blocked == non_tx_freq - passed
+
+    # ensure that *another* message type is not blocked because of this
+
+    new_signatures_message = make_msg(ProtocolMessageTypes.respond_signatures, bytes([1]))
+    assert r.process_msg_and_check(new_signatures_message, rl_v2, rl_v2) is None
+
+
+@pytest.mark.anyio
+async def test_too_many_incoming_messages():
+    # Too many messages
+    timer = SimClock()
+    r = RateLimiter(incoming=True, get_time=timer.monotonic)
+    new_peers_message = make_msg(ProtocolMessageTypes.respond_peers, bytes([1]))
+    non_tx_freq = get_rate_limits_to_use(rl_v2, rl_v2)["non_tx_freq"]
+
+    passed = 0
+    blocked = 0
+    for i in range(non_tx_freq):
+        if r.process_msg_and_check(new_peers_message, rl_v2, rl_v2) is None:
+            passed += 1
+        else:
+            blocked += 1
+
+    assert passed == 10
+    assert blocked == non_tx_freq - passed
+
+    # ensure that other message types *are* blocked because of this
+
+    new_signatures_message = make_msg(ProtocolMessageTypes.respond_signatures, bytes([1]))
+    assert r.process_msg_and_check(new_signatures_message, rl_v2, rl_v2) is not None
+
+
+@pytest.mark.parametrize(
+    "node_with_params",
+    [
+        pytest.param(
+            dict(
+                disable_capabilities=[Capability.BLOCK_HEADERS, Capability.RATE_LIMITS_V2],
             ),
-            pytest.param(
-                dict(
-                    disable_capabilities=[],
-                ),
-                id="V2",
+            id="V1",
+        ),
+        pytest.param(
+            dict(
+                disable_capabilities=[],
             ),
-        ],
-        indirect=True,
+            id="V2",
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "node_with_params_b",
+    [
+        pytest.param(
+            dict(
+                disable_capabilities=[Capability.BLOCK_HEADERS, Capability.RATE_LIMITS_V2],
+            ),
+            id="V1",
+        ),
+        pytest.param(
+            dict(
+                disable_capabilities=[],
+            ),
+            id="V2",
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(reason="save time")
+async def test_different_versions(node_with_params, node_with_params_b, self_hostname):
+    node_a = node_with_params
+    node_b = node_with_params_b
+
+    full_node_server_a: ChiaServer = node_a.full_node.server
+    full_node_server_b: ChiaServer = node_b.full_node.server
+
+    await full_node_server_b.start_client(PeerInfo(self_hostname, full_node_server_a.get_port()), None)
+
+    assert len(full_node_server_b.get_connections()) == 1
+    assert len(full_node_server_a.get_connections()) == 1
+
+    a_con: WSChiaConnection = full_node_server_a.get_connections()[0]
+    b_con: WSChiaConnection = full_node_server_b.get_connections()[0]
+
+    print(a_con.local_capabilities, a_con.peer_capabilities)
+    print(b_con.local_capabilities, b_con.peer_capabilities)
+
+    # The two nodes will use the same rate limits even if their versions are different
+    assert get_rate_limits_to_use(a_con.local_capabilities, a_con.peer_capabilities) == get_rate_limits_to_use(
+        b_con.local_capabilities, b_con.peer_capabilities
     )
-    @pytest.mark.parametrize(
-        "node_with_params_b",
-        [
-            pytest.param(
-                dict(
-                    disable_capabilities=[Capability.BLOCK_HEADERS, Capability.RATE_LIMITS_V2],
-                ),
-                id="V1",
-            ),
-            pytest.param(
-                dict(
-                    disable_capabilities=[],
-                ),
-                id="V2",
-            ),
-        ],
-        indirect=True,
+
+    # The following code checks whether all of the runs resulted in the same number of items in "rate_limits_tx",
+    # which would mean the same rate limits are always used. This should not happen, since two nodes with V2
+    # will use V2.
+    total_tx_msg_count = len(
+        get_rate_limits_to_use(a_con.local_capabilities, a_con.peer_capabilities)["rate_limits_tx"]
     )
-    @pytest.mark.anyio
-    @pytest.mark.limit_consensus_modes(reason="save time")
-    async def test_different_versions(self, node_with_params, node_with_params_b, self_hostname):
-        node_a = node_with_params
-        node_b = node_with_params_b
 
-        full_node_server_a: ChiaServer = node_a.full_node.server
-        full_node_server_b: ChiaServer = node_b.full_node.server
+    test_different_versions_results.append(total_tx_msg_count)
+    if len(test_different_versions_results) >= 4:
+        assert len(set(test_different_versions_results)) >= 2
 
-        await full_node_server_b.start_client(PeerInfo(self_hostname, full_node_server_a.get_port()), None)
 
-        assert len(full_node_server_b.get_connections()) == 1
-        assert len(full_node_server_a.get_connections()) == 1
+@pytest.mark.anyio
+async def test_compose():
+    rl_1 = rl_numbers[1]
+    rl_2 = rl_numbers[2]
+    assert ProtocolMessageTypes.respond_children in rl_1["rate_limits_other"]
+    assert ProtocolMessageTypes.respond_children not in rl_1["rate_limits_tx"]
+    assert ProtocolMessageTypes.respond_children not in rl_2["rate_limits_other"]
+    assert ProtocolMessageTypes.respond_children in rl_2["rate_limits_tx"]
 
-        a_con: WSChiaConnection = full_node_server_a.get_connections()[0]
-        b_con: WSChiaConnection = full_node_server_b.get_connections()[0]
+    assert ProtocolMessageTypes.request_block in rl_1["rate_limits_other"]
+    assert ProtocolMessageTypes.request_block not in rl_1["rate_limits_tx"]
+    assert ProtocolMessageTypes.request_block not in rl_2["rate_limits_other"]
+    assert ProtocolMessageTypes.request_block not in rl_2["rate_limits_tx"]
 
-        print(a_con.local_capabilities, a_con.peer_capabilities)
-        print(b_con.local_capabilities, b_con.peer_capabilities)
+    comps = compose_rate_limits(rl_1, rl_2)
+    # v2 limits are used if present
+    assert ProtocolMessageTypes.respond_children not in comps["rate_limits_other"]
+    assert ProtocolMessageTypes.respond_children in comps["rate_limits_tx"]
 
-        # The two nodes will use the same rate limits even if their versions are different
-        assert get_rate_limits_to_use(a_con.local_capabilities, a_con.peer_capabilities) == get_rate_limits_to_use(
-            b_con.local_capabilities, b_con.peer_capabilities
-        )
-
-        # The following code checks whether all of the runs resulted in the same number of items in "rate_limits_tx",
-        # which would mean the same rate limits are always used. This should not happen, since two nodes with V2
-        # will use V2.
-        total_tx_msg_count = len(
-            get_rate_limits_to_use(a_con.local_capabilities, a_con.peer_capabilities)["rate_limits_tx"]
-        )
-
-        test_different_versions_results.append(total_tx_msg_count)
-        if len(test_different_versions_results) >= 4:
-            assert len(set(test_different_versions_results)) >= 2
-
-    @pytest.mark.anyio
-    async def test_compose(self):
-        rl_1 = rl_numbers[1]
-        rl_2 = rl_numbers[2]
-        assert ProtocolMessageTypes.respond_children in rl_1["rate_limits_other"]
-        assert ProtocolMessageTypes.respond_children not in rl_1["rate_limits_tx"]
-        assert ProtocolMessageTypes.respond_children not in rl_2["rate_limits_other"]
-        assert ProtocolMessageTypes.respond_children in rl_2["rate_limits_tx"]
-
-        assert ProtocolMessageTypes.request_block in rl_1["rate_limits_other"]
-        assert ProtocolMessageTypes.request_block not in rl_1["rate_limits_tx"]
-        assert ProtocolMessageTypes.request_block not in rl_2["rate_limits_other"]
-        assert ProtocolMessageTypes.request_block not in rl_2["rate_limits_tx"]
-
-        comps = compose_rate_limits(rl_1, rl_2)
-        # v2 limits are used if present
-        assert ProtocolMessageTypes.respond_children not in comps["rate_limits_other"]
-        assert ProtocolMessageTypes.respond_children in comps["rate_limits_tx"]
-
-        # Otherwise, fall back to v1
-        assert ProtocolMessageTypes.request_block in rl_1["rate_limits_other"]
-        assert ProtocolMessageTypes.request_block not in rl_1["rate_limits_tx"]
+    # Otherwise, fall back to v1
+    assert ProtocolMessageTypes.request_block in rl_1["rate_limits_other"]
+    assert ProtocolMessageTypes.request_block not in rl_1["rate_limits_tx"]
 
 
 @pytest.mark.anyio

--- a/chia/_tests/core/server/test_rate_limits.py
+++ b/chia/_tests/core/server/test_rate_limits.py
@@ -71,25 +71,25 @@ async def test_limits_v2(
         limits.update(
             {
                 # this is the rate limit across all (non-tx) messages
-                "non_tx_freq": 2000,
+                "non_tx_freq": count * 2,
                 # this is the byte size limit across all (non-tx) messages
-                "non_tx_max_total_size": 1000 * 1024,
+                "non_tx_max_total_size": count * len(message_data),
             }
         )
     else:
         limits.update(
             {
                 # this is the rate limit across all (non-tx) messages
-                "non_tx_freq": 1000,
+                "non_tx_freq": count,
                 # this is the byte size limit across all (non-tx) messages
-                "non_tx_max_total_size": 100 * 1024 * 1024,
+                "non_tx_max_total_size": count * 2 * len(message_data),
             }
         )
 
     if limit_size:
-        rate_limit = {msg_type: RLSettings(2000, 1024, 1000 * 1024)}
+        rate_limit = {msg_type: RLSettings(count * 2, 1024, count * len(message_data))}
     else:
-        rate_limit = {msg_type: RLSettings(1000, 1024, 1000 * 1024 * 1024)}
+        rate_limit = {msg_type: RLSettings(count, 1024, count * 2 * len(message_data))}
 
     if exempt_from_aggregate:
         limits.update({"rate_limits_tx": rate_limit, "rate_limits_other": {}})

--- a/chia/server/rate_limit_numbers.py
+++ b/chia/server/rate_limit_numbers.py
@@ -24,6 +24,8 @@ class RLSettings:
 # this class is used to indicate that a message type is not subject to a rate
 # limit, but just a per-message size limit. This may be appropriate for response
 # messages that are implicitly limited by their corresponding request message
+# Unlimited message types are also not subject to the overall limit across all
+# messages (just like messages in the "tx" category)
 @dataclasses.dataclass(frozen=True)
 class Unlimited:
     max_size: int  # Max size of each request

--- a/chia/server/rate_limits.py
+++ b/chia/server/rate_limits.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-import time
 from collections import Counter
+from time import monotonic
 from typing import Optional
 
 from chia.protocols.outbound_message import Message
@@ -35,7 +35,7 @@ class RateLimiter:
         """
         self.incoming = incoming
         self.reset_seconds = reset_seconds
-        self.current_minute = int(time.time() // reset_seconds)
+        self.current_minute = int(monotonic() // reset_seconds)
         self.message_counts = Counter()
         self.message_cumulative_sizes = Counter()
         self.percentage_of_limit = percentage_of_limit
@@ -51,7 +51,7 @@ class RateLimiter:
         hit and the message is good to be sent or received.
         """
 
-        current_minute = int(time.time() // self.reset_seconds)
+        current_minute = int(monotonic() // self.reset_seconds)
         if current_minute != self.current_minute:
             self.current_minute = current_minute
             self.message_counts = Counter()

--- a/chia/server/rate_limits.py
+++ b/chia/server/rate_limits.py
@@ -83,7 +83,7 @@ class RateLimiter:
         rate_limits = get_rate_limits_to_use(our_capabilities, peer_capabilities)
 
         try:
-            limits: RLSettings = rate_limits["default_settings"]
+            limits: RLSettings
             if message_type in rate_limits["rate_limits_tx"]:
                 limits = rate_limits["rate_limits_tx"][message_type]
             elif message_type in rate_limits["rate_limits_other"]:
@@ -113,6 +113,7 @@ class RateLimiter:
                 log.warning(
                     f"Message type {message_type} not found in rate limits (scale factor: {proportion_of_limit})",
                 )
+                limits = rate_limits["default_settings"]
 
             if isinstance(limits, Unlimited):
                 # this message type is not rate limited. This is used for
@@ -130,9 +131,9 @@ class RateLimiter:
                 if new_message_counts > limits.frequency * proportion_of_limit:
                     return " ".join(
                         [
-                            f"message count: {new_message_counts}"
-                            f"> {limits.frequency * proportion_of_limit}"
-                            f"(scale factor: {proportion_of_limit})"
+                            f"message count: {new_message_counts}",
+                            f"> {limits.frequency * proportion_of_limit}",
+                            f"(scale factor: {proportion_of_limit})",
                         ]
                     )
                 if len(message.data) > limits.max_size:

--- a/chia/server/rate_limits.py
+++ b/chia/server/rate_limits.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class RateLimiter:
     incoming: bool
     reset_seconds: int
-    current_minute: int
+    current_slot: int
     message_counts: Counter[ProtocolMessageTypes]
     message_cumulative_sizes: Counter[ProtocolMessageTypes]
     percentage_of_limit: int
@@ -35,7 +35,7 @@ class RateLimiter:
         """
         self.incoming = incoming
         self.reset_seconds = reset_seconds
-        self.current_minute = int(monotonic() // reset_seconds)
+        self.current_slot = int(monotonic() // reset_seconds)
         self.message_counts = Counter()
         self.message_cumulative_sizes = Counter()
         self.percentage_of_limit = percentage_of_limit
@@ -51,9 +51,9 @@ class RateLimiter:
         hit and the message is good to be sent or received.
         """
 
-        current_minute = int(monotonic() // self.reset_seconds)
-        if current_minute != self.current_minute:
-            self.current_minute = current_minute
+        current_slot = int(monotonic() // self.reset_seconds)
+        if current_slot != self.current_slot:
+            self.current_slot = current_slot
             self.message_counts = Counter()
             self.message_cumulative_sizes = Counter()
             self.non_tx_message_counts = 0


### PR DESCRIPTION
This PR is best reviewed one commit at a time. In the one commit where the indentation level is reduced, it's best reviewed ignoring white space.

This is in preparation for further work on the rate limits system, which has a lot of potential to be simpler and more efficient (as in, not rate limiting messages as severely).

These are the changes, in order of commits:

* use `monotonic()` clock to avoid being affected by system clock changes
* in the rate limiter, the 1 minute window is configurable, so rename `current_minute` to `current_slot`
* override the clock in tests, to make tests fully deterministic
* remove (de-indent) the pytest class in `test_rate_limits.py`
* small improvement to a comment
* minor typo fixes in `rate_limits.py`. The log message would not have spaces as intended, and the `default_settings` (which doesn't appear to be used) can have its lookup deferred
* replace the `test_too_many_messages()` test with a parameterized test covering almost all rate limit cases.