### PR TITLE
fix incorrect assert in create_block_generator2()

### DIFF
--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -590,7 +590,9 @@ def make_bundle_spends_map_and_fee(
 
 
 def mempool_item_from_spendbundle(spend_bundle: SpendBundle) -> MempoolItem:
-    conds = get_conditions_from_spendbundle(spend_bundle, INFINITE_COST, DEFAULT_CONSTANTS, uint32(0))
+    conds = get_conditions_from_spendbundle(
+        spend_bundle, INFINITE_COST, DEFAULT_CONSTANTS, DEFAULT_CONSTANTS.HARD_FORK2_HEIGHT
+    )
     bundle_coin_spends, fee = make_bundle_spends_map_and_fee(spend_bundle, conds)
     return MempoolItem(
         spend_bundle=spend_bundle,

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -750,6 +750,7 @@ class Mempool:
                             f"cost: {batch_cost} total cost: {block_cost}"
                         )
                     else:
+                        log.info(f"Skipping transaction batch cumulative cost: {block_cost} batch cost: {batch_cost}")
                         skipped_items += 1
 
                     batch_cost = 0
@@ -775,12 +776,12 @@ class Mempool:
 
         if len(batch_transactions) > 0:
             added, _ = builder.add_spend_bundles(batch_transactions, uint64(batch_cost), constants)
+            log.info(f"trying to add residual batch: {len(batch_transactions)} batch cost: {batch_cost} added: {added}")
 
             if added:
                 added_spends += batch_spends
                 additions.extend(batch_additions)
                 removals.extend([cs.coin for sb in batch_transactions for cs in sb.coin_spends])
-                block_cost = builder.cost()
                 log.info(
                     f"adding TX batch, additions: {len(batch_additions)} removals: {batch_spends} "
                     f"cost: {batch_cost} total cost: {block_cost}"
@@ -797,7 +798,6 @@ class Mempool:
             f"create_block_generator2() took {duration:0.4f} seconds. "
             f"block cost: {cost} spends: {added_spends} additions: {len(additions)}",
         )
-        assert block_cost == cost
 
         return NewBlockGenerator(
             SerializedProgram.from_bytes(block_program),
@@ -806,5 +806,5 @@ class Mempool:
             signature,
             additions,
             removals,
-            uint64(block_cost),
+            uint64(cost),
         )


### PR DESCRIPTION
### Purpose:

correct the block cost accounting in `create_block_generator2()`. This function is still disabled by default.

The variable `block_cost` is an *estimate* of the current cost of the block + the cost of the current *batch* of transactions that haven't been added yet.

### Current Behavior:

The `block_cost` estimate is assumed to match the final cost returned by the BlockBuilder. This is not a safe assumption.

### New Behavior:

Disregard `block_cost` once the block is built, and just look at `cost` instead, which is the cost returned by the `BlockBuilder` object.

### Testing Notes:

The new test exercises the path where the last batch is attempted to be added to the block, but fails. In this scenario, the estimated block cost is still incremented with the next transaction, even though it's never added. This case would cause the assertion to fail (before this PR removes it).