### PR TITLE
Remove macOS intel keychain setup from test workflow

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -148,14 +148,6 @@ jobs:
         with:
           python-version: ${{ matrix.python.action }}
 
-      - name: Create keychain for CI use (macOS)
-        if: matrix.os.matrix == 'macos'
-        run: |
-          security create-keychain -p foo chiachain
-          security default-keychain -s chiachain
-          security unlock-keychain -p foo chiachain
-          security set-keychain-settings -t 7200 -u chiachain
-
       - name: Cache npm (Ubuntu)
         if: matrix.os.matrix == 'ubuntu'
         uses: actions/cache@v4


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

macos-arm isn't having it run so maybe intel doesn't need it either.

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

### Draft For:
- [x] https://github.com/Chia-Network/chia-blockchain/pull/20026