### PR TITLE
Remove macos-intel from coverage job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,7 +189,6 @@ jobs:
     name: ${{ matrix.os.emoji }} Coverage - ${{ matrix.python.name }}
     runs-on: ${{ matrix.os.runs-on }}
     needs:
-      - macos-intel
       - macos-arm
       - ubuntu
       - windows


### PR DESCRIPTION
`macos-intel` doesn't run except in a few scenarios now that we're on self-hosted mac intel. `needs` can't be dynamically defined, so remove macos-intel as a requirement for coverage to run for now