### PR TITLE
[CHIA-3729] Fix clvm streamable type analysis

### DIFF
--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import functools
 import io
 import os
 import pprint
@@ -210,39 +211,33 @@ def streamable_from_dict(klass: type[_T_Streamable], item: Any) -> _T_Streamable
 
 
 def function_to_convert_one_item(
-    f_type: type[Any], json_parsers: Optional[list[Callable[[object], Streamable]]] = None
+    f_type: type[Any], json_parser: Optional[Callable[[object, type[object]], Streamable]] = None
 ) -> ConvertFunctionType:
     if is_type_SpecificOptional(f_type):
-        convert_inner_func = function_to_convert_one_item(get_args(f_type)[0], json_parsers)
+        convert_inner_func = function_to_convert_one_item(get_args(f_type)[0], json_parser)
         return lambda item: convert_optional(convert_inner_func, item)
     elif is_type_Tuple(f_type):
         args = get_args(f_type)
         convert_inner_tuple_funcs = []
         for arg in args:
-            convert_inner_tuple_funcs.append(function_to_convert_one_item(arg, json_parsers))
+            convert_inner_tuple_funcs.append(function_to_convert_one_item(arg, json_parser))
         # Ignoring for now as the proper solution isn't obvious
         return lambda items: convert_tuple(convert_inner_tuple_funcs, items)  # type: ignore[arg-type]
     elif is_type_List(f_type):
         inner_type = get_args(f_type)[0]
-        convert_inner_func = function_to_convert_one_item(inner_type, json_parsers)
+        convert_inner_func = function_to_convert_one_item(inner_type, json_parser)
         # Ignoring for now as the proper solution isn't obvious
         return lambda items: convert_list(convert_inner_func, items)  # type: ignore[arg-type]
     elif is_type_Dict(f_type):
         inner_types = get_args(f_type)
-        if json_parsers is None:
-            key_parsers = None
-            value_parsers = None
-        else:
-            key_parsers = [json_parsers[0]]
-            value_parsers = [json_parsers[1]]
-        key_converter = function_to_convert_one_item(inner_types[0], key_parsers)
-        value_converter = function_to_convert_one_item(inner_types[1], value_parsers)
+        key_converter = function_to_convert_one_item(inner_types[0], json_parser)
+        value_converter = function_to_convert_one_item(inner_types[1], json_parser)
         return lambda mapping: convert_dict(key_converter, value_converter, mapping)  # type: ignore[arg-type]
     elif hasattr(f_type, "from_json_dict"):
-        if json_parsers is None:
+        if json_parser is None:
             return f_type.from_json_dict  # type: ignore[no-any-return]
         else:
-            return json_parsers[0]
+            return functools.partial(json_parser, streamable_type=f_type)  # type: ignore[call-arg]
     elif issubclass(f_type, bytes):
         # Type is bytes, data is a hex string or bytes
         return lambda item: convert_byte_type(f_type, item)

--- a/chia/wallet/util/clvm_streamable.py
+++ b/chia/wallet/util/clvm_streamable.py
@@ -125,22 +125,19 @@ def json_deserialize_with_clvm_streamable(
         for old_field in old_streamable_fields:
             if is_compound_type(old_field.type):
                 inner_type = get_args(old_field.type)[0]
-                if is_clvm_streamable_type(inner_type):
-                    new_streamable_fields.append(
-                        dataclasses.replace(
-                            old_field,
-                            convert_function=function_to_convert_one_item(
-                                old_field.type,
-                                functools.partial(
-                                    json_deserialize_with_clvm_streamable,
-                                    streamable_type=inner_type,
-                                    translation_layer=translation_layer,
-                                ),
+                new_streamable_fields.append(
+                    dataclasses.replace(
+                        old_field,
+                        convert_function=function_to_convert_one_item(
+                            old_field.type,
+                            functools.partial(
+                                json_deserialize_with_clvm_streamable,
+                                streamable_type=inner_type,
+                                translation_layer=translation_layer,
                             ),
-                        )
+                        ),
                     )
-                else:
-                    new_streamable_fields.append(old_field)
+                )
             elif is_clvm_streamable_type(old_field.type):
                 new_streamable_fields.append(
                     dataclasses.replace(

--- a/chia/wallet/util/clvm_streamable.py
+++ b/chia/wallet/util/clvm_streamable.py
@@ -140,7 +140,7 @@ def json_deserialize_with_clvm_streamable(
         old_streamable_fields = streamable_type.streamable_fields()
         new_streamable_fields = []
         for old_field in old_streamable_fields:
-            if is_compound_type(old_field):
+            if is_compound_type(old_field.type):
                 inner_types = get_args(old_field.type)
                 new_streamable_fields.append(
                     dataclasses.replace(

--- a/chia/wallet/util/clvm_streamable.py
+++ b/chia/wallet/util/clvm_streamable.py
@@ -120,6 +120,9 @@ def json_deserialize_with_clvm_streamable(
             bytes.fromhex(json_dict), streamable_type, translation_layer=translation_layer
         )
     else:
+        if not hasattr(streamable_type, "streamable_fields"):
+            # This is a rust streamable and therefore cannot be a clvm_streamable
+            return streamable_type.from_json_dict(json_dict)
         old_streamable_fields = streamable_type.streamable_fields()
         new_streamable_fields = []
         for old_field in old_streamable_fields:

--- a/chia/wallet/util/clvm_streamable.py
+++ b/chia/wallet/util/clvm_streamable.py
@@ -176,58 +176,6 @@ def json_deserialize_with_clvm_streamable(
         return streamable_type.from_json_dict(json_dict)
 
 
-# def json_deserialize_with_clvm_streamable(
-#     json_dict: Union[str, dict[str, Any]],
-#     streamable_type: type[_T_Streamable],
-#     translation_layer: Optional[TranslationLayer] = None,
-# ) -> _T_Streamable:
-#     if isinstance(json_dict, str):
-#         return byte_deserialize_clvm_streamable(
-#             bytes.fromhex(json_dict), streamable_type, translation_layer=translation_layer
-#         )
-#     else:
-#         if not hasattr(streamable_type, "streamable_fields"):
-#             # This is a rust streamable and therefore cannot be a clvm_streamable
-#             return streamable_type.from_json_dict(json_dict)
-#         old_streamable_fields = streamable_type.streamable_fields()
-#         new_streamable_fields = []
-#         for old_field in old_streamable_fields:
-#             if is_compound_type(old_field.type):
-#                 inner_types = get_args(old_field.type)
-#                 new_streamable_fields.append(
-#                     dataclasses.replace(
-#                         old_field,
-#                         convert_function=function_to_convert_one_item(
-#                             old_field.type,
-#                             [
-#                                 functools.partial(
-#                                     json_deserialize_with_clvm_streamable,
-#                                     streamable_type=inner_type,
-#                                     translation_layer=translation_layer,
-#                                 )
-#                                 for inner_type in inner_types
-#                             ],
-#                         ),
-#                     )
-#                 )
-#             elif is_clvm_streamable_type(old_field.type):
-#                 new_streamable_fields.append(
-#                     dataclasses.replace(
-#                         old_field,
-#                         convert_function=functools.partial(
-#                             json_deserialize_with_clvm_streamable,
-#                             streamable_type=old_field.type,
-#                             translation_layer=translation_layer,
-#                         ),
-#                     )
-#                 )
-#             else:
-#                 new_streamable_fields.append(old_field)
-
-#         setattr(streamable_type, "_streamable_fields", tuple(new_streamable_fields))
-#         return streamable_type.from_json_dict(json_dict)
-
-
 _T_ClvmStreamable = TypeVar("_T_ClvmStreamable", bound="Streamable")
 _T_TLClvmStreamable = TypeVar("_T_TLClvmStreamable", bound="Streamable")
 

--- a/chia/wallet/util/clvm_streamable.py
+++ b/chia/wallet/util/clvm_streamable.py
@@ -12,9 +12,6 @@ from chia.types.blockchain_format.program import Program
 from chia.util.streamable import (
     Streamable,
     function_to_convert_one_item,
-    is_type_Dict,
-    is_type_List,
-    is_type_SpecificOptional,
     is_type_Tuple,
     recurse_jsonify,
     streamable,
@@ -93,16 +90,6 @@ def byte_deserialize_clvm_streamable(
     return program_deserialize_clvm_streamable(
         Program.from_bytes(blob), clvm_streamable_type, translation_layer=translation_layer
     )
-
-
-def is_compound_type(typ: Any) -> bool:
-    return is_type_SpecificOptional(typ) or is_type_Tuple(typ) or is_type_List(typ) or is_type_Dict(typ)
-
-
-# TODO: this is more than _just_ a Streamable, but it is also a Streamable and that's
-#       useful for now
-def is_clvm_streamable_type(v: type[object]) -> TypeGuard[type[Streamable]]:
-    return issubclass(v, Streamable) and hasattr(v, "_clvm_streamable")
 
 
 # TODO: this is more than _just_ a Streamable, but it is also a Streamable and that's


### PR DESCRIPTION
An alternative for #20020

3.13 raised an issue with using `issubclass` on generic type hints.  This PR does fix that issue, but the investigation revealed a problem with the recursive functionality of the `clvm_streamable` deserialization from JSON.

After a few iterations, I realized the problem was primarily that by hacking _some_ mutual recursive-ness into `function_to_convert_one_item` I hadn't fully supported crossing the barrier more than once.  This has been fine but was bugged for things like dicts and sufficiently recursive stuff.  By re-hacking the streamable portion a little bit, I was able to simplify the overall code and have it support more stuff more gracefully.