### PR TITLE
CHIA-3718 Handle building chiavdf for MacOS when CMake is already installed (#20018)

### DIFF
--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -113,8 +113,11 @@ else
     symlink_vdf_bench "$PYTHON_VERSION"
   elif [ -e venv/bin/python ] && test "$MACOS"; then
     echo "Installing chiavdf dependencies for MacOS."
+    if ! cmake --version >/dev/null 2>&1; then
+      brew install --formula --quiet cmake
+    fi
     # The most recent boost version causes compile errors.
-    brew install --formula --quiet boost@1.85 cmake gmp
+    brew install --formula --quiet boost@1.85 gmp
     # boost@1.85 is keg-only, which means it was not symlinked into /usr/local,
     # because this is an alternate version of another formula.
     export LDFLAGS="-L/usr/local/opt/boost@1.85/lib"


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

fixes https://github.com/Chia-Network/chia-blockchain/actions/runs/17475547684/job/49647564413

(cherry picked from commit 061d588bcaed3a20ab00fa440d528de50ee1b2db)

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
