### PR TITLE
move workaround arm64 ruby install to the build image

### DIFF
--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -86,7 +86,9 @@ jq --arg VER "$CHIA_INSTALLER_VERSION" '.version=$VER' package.json >temp.json &
 echo "Building Linux(deb) Electron app"
 PRODUCT_NAME="chia"
 if [ "$PLATFORM" = "arm64" ]; then
-  sudo gem install fpm
+  # https://github.com/jordansissel/fpm/issues/1801#issuecomment-919877499
+  # workaround for above now implemented in the image build at
+  # https://github.com/Chia-Network/build-images/blob/7c74d2f20739543c486c2522032cf09d96396d24/ubuntu-22.04/Dockerfile#L48-L61
   echo USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux deb --arm64 \
     --config.extraMetadata.name=chia-blockchain \
     --config.productName="$PRODUCT_NAME" --config.linux.desktop.Name="Chia Blockchain" \

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -86,11 +86,6 @@ jq --arg VER "$CHIA_INSTALLER_VERSION" '.version=$VER' package.json >temp.json &
 echo "Building Linux(deb) Electron app"
 PRODUCT_NAME="chia"
 if [ "$PLATFORM" = "arm64" ]; then
-  # electron-builder does not work for arm64 as of Aug 16, 2022.
-  # This is a temporary fix.
-  # https://github.com/jordansissel/fpm/issues/1801#issuecomment-919877499
-  # @TODO Consolidates the process to amd64 if the issue of electron-builder is resolved
-  sudo apt-get -y install ruby ruby-dev
   # ERROR:  Error installing fpm:
   #     The last version of dotenv (>= 0) to support your Ruby & RubyGems was 2.8.1. Try installing it with `gem install dotenv -v 2.8.1` and then running the current command again
   #     dotenv requires Ruby version >= 3.0. The current ruby version is 2.7.0.0.


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

### Draft For:
- [x] https://github.com/Chia-Network/build-images/pull/105
- [x] add comment linking to workaround provided in the build image
- [x] https://github.com/Chia-Network/chia-blockchain/pull/20036