### PR TITLE
Remove `max_generator_size` from `default_constants` as it was unused

### DIFF
--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -76,7 +76,6 @@ DEFAULT_CONSTANTS = ConsensusConstants(
     # inclusive, so the max allowed range of 32 is a request for 33 blocks
     # (which is allowed)
     MAX_BLOCK_COUNT_PER_REQUESTS=uint32(32),
-    MAX_GENERATOR_SIZE=uint32(1000000),
     MAX_GENERATOR_REF_LIST_SIZE=uint32(512),  # Number of references allowed in the block generator ref list
     POOL_SUB_SLOT_ITERS=uint64(37600000000),  # iters limit * NUM_SPS
     # June 2024


### PR DESCRIPTION
### Purpose:
This is a corresponding PR to [this PR in chia_rs](https://github.com/Chia-Network/chia_rs/pull/1249) which removes an unused constant.
This will need to go in when the next version of chia_rs lands.

In 2021 we added a check that the length of the bytes of the generator wasn't over a maximum limit - https://github.com/Chia-Network/chia-blockchain/commit/73d5577bec3272e6cb64008736d6091589ab97ac
but it seems like this was reverted in a following merge
https://github.com/Chia-Network/chia-blockchain/commit/a6874bd2fe395b5b7c2569afbd1896bb111087d5
