### PR TITLE
CHIA-3736 Avoid recomputing skipped transaction ID in create_bundle_from_mempool_items

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -613,7 +613,7 @@ class Mempool:
                     if any(
                         sd.eligible_for_dedup or sd.eligible_for_fast_forward for sd in item.bundle_coin_spends.values()
                     ):
-                        log.info(f"Skipping transaction with dedup or FF spends {item.spend_bundle.name()}")
+                        log.info(f"Skipping transaction with dedup or FF spends {name}")
                         continue
 
                     unique_coin_spends = []


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

We already fetch the transaction ID as part of iterating through transactions. There is no need to recompute it again out of the item's spend bundle.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
