### PR TITLE
[CHIA-3606] Port `create_offer_for_ids` to `@marshal`

### DIFF
--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -294,6 +294,8 @@ def recurse_jsonify(
     """
     if next_recursion_step is None:
         next_recursion_step = recurse_jsonify
+    if getattr(d, "json_serialization_override", None) is not None:
+        return d.json_serialization_override(d)
     if dataclasses.is_dataclass(d):
         new_dict = {}
         for field in dataclasses.fields(d):

--- a/chia/wallet/puzzle_drivers.py
+++ b/chia/wallet/puzzle_drivers.py
@@ -129,7 +129,7 @@ def decode_info_value(cls: Any, value: Any) -> Any:
     elif isinstance(value, Program) and value.atom is None:
         return value
     else:
-        if value == "()":  # special case
+        if value in {"()", ""}:  # special case
             return Program.to([])
         expression: SExp = assemble(value)
         if expression.atom is None:

--- a/chia/wallet/puzzle_drivers.py
+++ b/chia/wallet/puzzle_drivers.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Self
+from typing import Any, Optional
 
 from clvm.SExp import SExp
 from clvm_tools.binutils import assemble, type_for_atom
 from ir.Type import Type
+from typing_extensions import Self
 
 from chia.types.blockchain_format.program import Program
 from chia.util.casts import int_from_bytes

--- a/chia/wallet/puzzle_drivers.py
+++ b/chia/wallet/puzzle_drivers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, Self
 
 from clvm.SExp import SExp
 from clvm_tools.binutils import assemble, type_for_atom
@@ -17,7 +16,6 @@ When you access a value in the dictionary, it will be deserialized to a str, int
 """
 
 
-@dataclass(frozen=True)
 class PuzzleInfo:
     """
     There are two 'magic' keys in a PuzzleInfo object:
@@ -26,6 +24,10 @@ class PuzzleInfo:
     """
 
     info: dict[str, Any]
+
+    def __init__(self, info: dict[str, Any]) -> None:
+        self.info = info
+        self.__post_init__()
 
     def __post_init__(self) -> None:
         if "type" not in self.info:
@@ -74,10 +76,24 @@ class PuzzleInfo:
         else:
             return False
 
+    # Methods to make this a valid Streamable member
+    # Should not be being serialized as bytes
+    stream = None
+    parse = None
 
-@dataclass(frozen=True)
+    def to_json_dict(self) -> dict[str, Any]:
+        return self.info
+
+    @classmethod
+    def from_json_dict(cls, json_dict: dict[str, Any]) -> Self:
+        return cls(json_dict)
+
+
 class Solver:
     info: dict[str, Any]
+
+    def __init__(self, info: dict[str, Any]) -> None:
+        self.info = info
 
     def __getitem__(self, item: str) -> Any:
         value = self.info[item]
@@ -91,6 +107,17 @@ class Solver:
             except Exception:
                 return False
         return True
+
+    # Methods to make this a valid Streamable member
+    stream = None
+    parse = None
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return self.info
+
+    @classmethod
+    def from_json_dict(cls, json_dict: dict[str, Any]) -> Self:
+        return cls(json_dict)
 
 
 def decode_info_value(cls: Any, value: Any) -> Any:

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -429,7 +429,7 @@ class TradeManager:
         validate_only: bool = False,
         extra_conditions: tuple[Condition, ...] = tuple(),
         taking: bool = False,
-    ) -> Union[tuple[Literal[True], TradeRecord, None], tuple[Literal[False], None, str]]:
+    ) -> tuple[Literal[True], TradeRecord, None]:
         if driver_dict is None:
             driver_dict = {}
         if solver is None:


### PR DESCRIPTION
Another PR following https://github.com/Chia-Network/chia-blockchain/pull/18593

There's some changes to the serialization of the pre-existing `_OfferEndpointResponse` because we hadn't actually returned any of those responses yet, only used the classes as a vehicle to deserialize some free-form responses.  The main thing is that I needed to a hack a way in streamable for using a specific serialization of `Offer` that was not the default dataclass serialization.