### PR TITLE
fix sp lookup at genesis

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1882,7 +1882,9 @@ async def test_new_signage_point_caching(
 ) -> None:
     full_node_1, _full_node_2, server_1, server_2, _wallet_a, _wallet_receiver, bt = wallet_nodes
     blocks = await full_node_1.get_all_full_blocks()
-
+    assert full_node_1.full_node.full_node_store.get_signage_point_by_index_and_cc_output(
+        bytes32.zeros, full_node_1.full_node.constants.GENESIS_CHALLENGE, uint8(0)
+    ) == SignagePoint(None, None, None, None)
     peer = await connect_and_get_peer(server_1, server_2, self_hostname)
     blocks = bt.get_consecutive_blocks(3, block_list_input=blocks, skip_slots=2)
     await full_node_1.full_node.add_block(blocks[-3])
@@ -1950,10 +1952,6 @@ async def test_new_signage_point_caching(
         )
         is not None
     )
-
-    assert full_node_1.full_node.full_node_store.get_signage_point_by_index_and_cc_output(
-        full_node_1.full_node.constants.GENESIS_CHALLENGE, bytes32.zeros, uint8(0)
-    ) == SignagePoint(None, None, None, None)
 
 
 @pytest.mark.anyio

--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -832,8 +832,8 @@ class FullNodeStore:
     def get_signage_point_by_index_and_cc_output(
         self, cc_signage_point: bytes32, challenge: bytes32, index: uint8
     ) -> Optional[SignagePoint]:
-        assert len(self.finished_sub_slots) >= 1        
-        for sub_slot, sps, _ in self.finished_sub_slots:            
+        assert len(self.finished_sub_slots) >= 1
+        for sub_slot, sps, _ in self.finished_sub_slots:
             if sub_slot is not None:
                 cc_hash = sub_slot.challenge_chain.get_hash()
             else:

--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -832,11 +832,13 @@ class FullNodeStore:
     def get_signage_point_by_index_and_cc_output(
         self, cc_signage_point: bytes32, challenge: bytes32, index: uint8
     ) -> Optional[SignagePoint]:
-        assert len(self.finished_sub_slots) >= 1
-        if cc_signage_point == self.constants.GENESIS_CHALLENGE:
-            return SignagePoint(None, None, None, None)
-        for sub_slot, sps, _ in self.finished_sub_slots:
-            if sub_slot is not None and sub_slot.challenge_chain.get_hash() == challenge:
+        assert len(self.finished_sub_slots) >= 1        
+        for sub_slot, sps, _ in self.finished_sub_slots:            
+            if sub_slot is not None:
+                cc_hash = sub_slot.challenge_chain.get_hash()
+            else:
+                cc_hash = self.constants.GENESIS_CHALLENGE
+            if cc_hash == challenge:
                 if index == 0:
                     # first SP in the sub slot
                     return SignagePoint(None, None, None, None)


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

fix edge case looking up sps in genesis, we had a bug which mage us miss sps in the first slot
for the first slot we use None when looking up instead of looking for the slot to get the challenge we should use Genesis challenge, slot None only happens for the first slot in the chain

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
