### PR TITLE
Use setup-node action and .nvmrc specified version for all installers

### DIFF
--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -92,6 +92,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Node 22.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22.x"
+
       - name: Get latest madmax plotter
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -92,10 +92,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node 22.x
+      - name: Setup Node per .nvmrc in GUI
         uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version-file: chia-blockchain-gui/.nvmrc
 
       - name: Get latest madmax plotter
         env:

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -82,6 +82,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Node 22.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22.x"
+
       - name: Get latest madmax plotter
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -82,10 +82,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node 22.x
+      - name: Setup Node per .nvmrc in GUI
         uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version-file: chia-blockchain-gui/.nvmrc
 
       - name: Get latest madmax plotter
         env:

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -176,10 +176,10 @@ jobs:
 
       - uses: chia-network/actions/activate-venv@main
 
-      - name: Setup Node 20.x
-        uses: actions/setup-node@v4
+      - name: Setup Node 22.x
+        uses: actions/setup-node@v5
         with:
-          node-version: "20.x"
+          node-version: "22.x"
 
       - name: Prepare GUI cache
         id: gui-ref

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -176,10 +176,10 @@ jobs:
 
       - uses: chia-network/actions/activate-venv@main
 
-      - name: Setup Node 22.x
+      - name: Setup Node per .nvmrc in GUI
         uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version-file: chia-blockchain-gui/.nvmrc
 
       - name: Prepare GUI cache
         id: gui-ref

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -95,10 +95,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Setup Node 20.x
-        uses: actions/setup-node@v4
+      - name: Setup Node 22.x
+        uses: actions/setup-node@v5
         with:
-          node-version: "20.x"
+          node-version: "22.x"
 
       - name: Test for secrets access
         id: check_secrets

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -95,10 +95,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Setup Node 22.x
+      - name: Setup Node per .nvmrc in GUI
         uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version-file: chia-blockchain-gui/.nvmrc
 
       - name: Test for secrets access
         id: check_secrets


### PR DESCRIPTION
- Update all installer builds to use the version of node specified in chia-blockchain-gui `.nvmrc`
- Update the workflows that didn't previously use the setup-node action to use it, to make future updates easier (this action now works with all the currently supported platforms we build on)