### PR TITLE
[CHIA-3608] Port `take_offer` to `@marshal`

### DIFF
--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -75,6 +75,7 @@ from chia.wallet.wallet_request_types import (
     SendTransactionResponse,
     SpendClawbackCoins,
     SpendClawbackCoinsResponse,
+    TakeOffer,
     TakeOfferResponse,
     TransactionRecordWithMetadata,
     WalletInfoResponse,
@@ -1055,18 +1056,19 @@ def test_take_offer(capsys: object, get_test_cli_clients: tuple[TestRpcClients, 
     class TakeOfferRpcClient(TestWalletRpcClient):
         async def take_offer(
             self,
-            offer: Offer,
+            request: TakeOffer,
             tx_config: TXConfig,
-            solver: Optional[dict[str, Any]] = None,
-            fee: uint64 = uint64(0),
-            push: bool = True,
+            extra_conditions: tuple[Condition, ...] = tuple(),
             timelock_info: ConditionValidTimes = ConditionValidTimes(),
         ) -> TakeOfferResponse:
-            self.add_to_log("take_offer", (offer, tx_config, solver, fee, push, timelock_info))
+            self.add_to_log(
+                "take_offer",
+                (request.parsed_offer, tx_config, request.solver, request.fee, request.push, timelock_info),
+            )
             return TakeOfferResponse(
                 [STD_UTX],
                 [STD_TX],
-                offer,
+                request.parsed_offer,
                 TradeRecord(
                     confirmed_at_index=uint32(0),
                     accepted_at_time=uint64(123456789),
@@ -1074,10 +1076,10 @@ def test_take_offer(capsys: object, get_test_cli_clients: tuple[TestRpcClients, 
                     is_my_offer=False,
                     sent=uint32(1),
                     sent_to=[("aaaaa", uint8(1), None)],
-                    offer=bytes(offer),
+                    offer=bytes(request.parsed_offer),
                     taken_offer=None,
-                    coins_of_interest=offer.get_involved_coins(),
-                    trade_id=offer.name(),
+                    coins_of_interest=request.parsed_offer.get_involved_coins(),
+                    trade_id=request.parsed_offer.name(),
                     status=uint32(TradeStatus.PENDING_ACCEPT.value),
                     valid_times=ConditionValidTimes(),
                 ),

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -160,6 +160,7 @@ from chia.wallet.wallet_request_types import (
     SetWalletResyncOnStartup,
     SpendClawbackCoins,
     SplitCoins,
+    TakeOffer,
     VerifySignature,
     VerifySignatureResponse,
 )
@@ -1647,7 +1648,16 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
     assert offer_count.my_offers_count == 1
     assert offer_count.taken_offers_count == 0
 
-    trade_record = (await env_2.rpc_client.take_offer(offer, wallet_environments.tx_config, fee=uint64(1))).trade_record
+    trade_record = (
+        await env_2.rpc_client.take_offer(
+            TakeOffer(
+                offer=offer.to_bech32(),
+                fee=uint64(1),
+                push=True,
+            ),
+            wallet_environments.tx_config,
+        )
+    ).trade_record
     assert TradeStatus(trade_record.status) == TradeStatus.PENDING_CONFIRM
 
     await env_1.rpc_client.cancel_offer(offer.name(), wallet_environments.tx_config, secure=False)

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -88,6 +88,7 @@ from chia.wallet.wallet_request_types import (
     SignMessageByID,
     SignMessageByIDResponse,
     SpendClawbackCoins,
+    TakeOffer,
     VCAddProofs,
     VCGet,
     VCGetList,
@@ -892,11 +893,9 @@ async def take_offer(
             print()
             cli_confirm("Would you like to take this offer? (y/n): ")
             res = await wallet_client.take_offer(
-                offer,
-                fee=fee,
-                tx_config=CMDTXConfigLoader().to_tx_config(units["chia"], config, fingerprint),
-                push=push,
+                TakeOffer(offer.to_bech32(), fee=fee, push=push),
                 timelock_info=condition_valid_times,
+                tx_config=CMDTXConfigLoader().to_tx_config(units["chia"], config, fingerprint),
             )
             if push:
                 print(f"Accepted offer with ID {res.trade_record.trade_id}")

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -893,7 +893,7 @@ async def take_offer(
             print()
             cli_confirm("Would you like to take this offer? (y/n): ")
             res = await wallet_client.take_offer(
-                TakeOffer(offer.to_bech32(), fee=fee, push=push),
+                TakeOffer(offer=offer.to_bech32(), fee=fee, push=push),
                 timelock_info=condition_valid_times,
                 tx_config=CMDTXConfigLoader().to_tx_config(units["chia"], config, fingerprint),
             )

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -1932,6 +1932,17 @@ class CreateOfferForIDsResponse(_OfferEndpointResponse):
 
 @streamable
 @dataclass(frozen=True)
+class TakeOffer(TransactionEndpointRequest):
+    offer: str
+    solver: Optional[Solver] = None
+
+    @cached_property
+    def parsed_offer(self) -> Offer:
+        return Offer.from_bech32(self.offer)
+
+
+@streamable
+@dataclass(frozen=True)
 class TakeOfferResponse(_OfferEndpointResponse):  # Inheriting for de-dup sake
     pass
 

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -1933,7 +1933,7 @@ class CreateOfferForIDsResponse(_OfferEndpointResponse):
 @streamable
 @dataclass(frozen=True)
 class TakeOffer(TransactionEndpointRequest):
-    offer: str
+    offer: str = field(default_factory=default_raise)
     solver: Optional[Solver] = None
 
     @cached_property

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -70,7 +70,7 @@ from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.nft_wallet.uncurry_nft import UncurriedNFT
 from chia.wallet.notification_store import Notification
 from chia.wallet.outer_puzzles import AssetType
-from chia.wallet.puzzle_drivers import PuzzleInfo, Solver
+from chia.wallet.puzzle_drivers import PuzzleInfo
 from chia.wallet.puzzles import p2_delegated_conditions
 from chia.wallet.puzzles.clawback.metadata import AutoClaimSettings, ClawbackMetadata
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import puzzle_hash_for_synthetic_public_key
@@ -283,6 +283,8 @@ from chia.wallet.wallet_request_types import (
     StrayCAT,
     SubmitTransactions,
     SubmitTransactionsResponse,
+    TakeOffer,
+    TakeOfferResponse,
     TransactionRecordWithMetadata,
     VCAddProofs,
     VCGet,
@@ -2327,44 +2329,34 @@ class WalletRpcApi:
         )
 
     @tx_endpoint(push=True)
+    @marshal
     async def take_offer(
         self,
-        request: dict[str, Any],
+        request: TakeOffer,
         action_scope: WalletActionScope,
         extra_conditions: tuple[Condition, ...] = tuple(),
-    ) -> EndpointResult:
-        offer_hex: str = request["offer"]
-
-        offer = Offer.from_bech32(offer_hex)
-        fee: uint64 = uint64(request.get("fee", 0))
-        maybe_marshalled_solver: Optional[dict[str, Any]] = request.get("solver")
-        solver: Optional[Solver]
-        if maybe_marshalled_solver is None:
-            solver = None
-        else:
-            solver = Solver(info=maybe_marshalled_solver)
-
+    ) -> TakeOfferResponse:
         peer = self.service.get_full_node_peer()
         trade_record = await self.service.wallet_state_manager.trade_manager.respond_to_offer(
-            offer,
+            request.parsed_offer,
             peer,
             action_scope,
-            fee=fee,
-            solver=solver,
+            fee=request.fee,
+            solver=request.solver,
             extra_conditions=extra_conditions,
         )
 
         async with action_scope.use() as interface:
             interface.side_effects.signing_responses.append(
-                SigningResponse(bytes(offer._bundle.aggregated_signature), trade_record.trade_id)
+                SigningResponse(bytes(request.parsed_offer._bundle.aggregated_signature), trade_record.trade_id)
             )
 
-        return {
-            "trade_record": trade_record.to_json_dict_convenience(),
-            "offer": Offer.from_bytes(trade_record.offer).to_bech32(),
-            "transactions": None,  # tx_endpoint wrapper will take care of this
-            "signing_responses": None,  # tx_endpoint wrapper will take care of this
-        }
+        return TakeOfferResponse(
+            [],  # tx_endpoint will fill in this default value
+            [],  # tx_endpoint will fill in this default value
+            Offer.from_bytes(trade_record.offer),
+            trade_record,
+        )
 
     async def get_offer(self, request: dict[str, Any]) -> EndpointResult:
         trade_mgr = self.service.wallet_state_manager.trade_manager


### PR DESCRIPTION
Another PR following https://github.com/Chia-Network/chia-blockchain/pull/18593

Worth noting: I removed `"signing_responses"` from the response of this RPC.  It would also have the value of `None` and is either a bad autofill or legacy property that I cannot fathom the purpose of at this juncture.  Since it statically returned the same thing, I think it's impossible to miss.  Can always be re-added in the future if the purpose is rediscovered.