### PR TITLE
CHIA-3737 Simplify BundleCoinSpend's tracking of fast forward spends

### DIFF
--- a/chia/full_node/eligible_coin_spends.py
+++ b/chia/full_node/eligible_coin_spends.py
@@ -196,7 +196,7 @@ class SingletonFastForward:
         new_bundle_coin_spends = {}
         fast_forwarded_spends = 0
         for coin_id, spend_data in mempool_item.bundle_coin_spends.items():
-            if not spend_data.eligible_for_fast_forward:
+            if not spend_data.supports_fast_forward:
                 # Nothing to do for this spend, moving on
                 new_coin_spends.append(spend_data.coin_spend)
                 new_bundle_coin_spends[coin_id] = spend_data
@@ -210,8 +210,7 @@ class SingletonFastForward:
             unspent_lineage_info = self.fast_forward_spends.get(spend_data.coin_spend.coin.puzzle_hash)
             if unspent_lineage_info is None:
                 # We didn't, so let's check the item's latest lineage info
-                if spend_data.latest_singleton_lineage is None:
-                    raise ValueError("Cannot proceed with singleton spend fast forward.")
+                assert spend_data.latest_singleton_lineage is not None
                 unspent_lineage_info = spend_data.latest_singleton_lineage
                 # See if we're the most recent version
                 if unspent_lineage_info.coin_id == coin_id:
@@ -235,9 +234,9 @@ class SingletonFastForward:
                 new_bundle_coin_spends[new_coin_spend.coin.name()] = BundleCoinSpend(
                     coin_spend=new_coin_spend,
                     eligible_for_dedup=spend_data.eligible_for_dedup,
-                    eligible_for_fast_forward=spend_data.eligible_for_fast_forward,
                     additions=patched_additions,
                     cost=spend_data.cost,
+                    latest_singleton_lineage=self.fast_forward_spends.get(spend_data.coin_spend.coin.puzzle_hash),
                 )
                 # Update the list of coins spends that will make the new fast
                 # forward spend bundle
@@ -258,9 +257,9 @@ class SingletonFastForward:
             new_bundle_coin_spends[new_coin_spend.coin.name()] = BundleCoinSpend(
                 coin_spend=new_coin_spend,
                 eligible_for_dedup=spend_data.eligible_for_dedup,
-                eligible_for_fast_forward=spend_data.eligible_for_fast_forward,
                 additions=patched_additions,
                 cost=spend_data.cost,
+                latest_singleton_lineage=self.fast_forward_spends.get(spend_data.coin_spend.coin.puzzle_hash),
             )
             # Update the list of coins spends that make the new fast forward bundle
             new_coin_spends.append(new_coin_spend)

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -611,7 +611,7 @@ class Mempool:
                     # might fit, but we also want to avoid spending too much
                     # time on potentially expensive ones, hence this shortcut.
                     if any(
-                        sd.eligible_for_dedup or sd.eligible_for_fast_forward for sd in item.bundle_coin_spends.values()
+                        sd.eligible_for_dedup or sd.supports_fast_forward for sd in item.bundle_coin_spends.values()
                     ):
                         log.info(f"Skipping transaction with dedup or FF spends {name}")
                         continue

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -243,7 +243,7 @@ def check_removals(
     conflicts = set()
     for coin_id, coin_bcs in bundle_coin_spends.items():
         # 1. Checks if it's been spent already
-        if removals[coin_id].spent and not coin_bcs.eligible_for_fast_forward:
+        if removals[coin_id].spent and not coin_bcs.supports_fast_forward:
             return Err.DOUBLE_SPEND, []
 
         # 2. Checks if there's a mempool conflict
@@ -269,12 +269,12 @@ def check_removals(
                     return Err.INVALID_SPEND_BUNDLE, []
             # if the spend we're adding to the mempool is not DEDUP nor FF, it's
             # just a regular conflict
-            if not coin_bcs.eligible_for_fast_forward and not coin_bcs.eligible_for_dedup:
+            if not coin_bcs.supports_fast_forward and not coin_bcs.eligible_for_dedup:
                 conflicts.add(item)
 
             # if the spend we're adding is FF, but there's a conflicting spend
             # that isn't FF, they can't be chained, so that's a conflict
-            elif coin_bcs.eligible_for_fast_forward and not conflict_bcs.eligible_for_fast_forward:
+            elif coin_bcs.supports_fast_forward and not conflict_bcs.supports_fast_forward:
                 conflicts.add(item)
 
             # if the spend we're adding is DEDUP, but there's a conflicting spend
@@ -611,8 +611,7 @@ class MempoolManager:
                 return Err.INVALID_COIN_SOLUTION, None, []
 
             lineage_info = None
-            eligible_for_ff = bool(spend_conds.flags & ELIGIBLE_FOR_FF) and supports_fast_forward(coin_spend)
-            if eligible_for_ff:
+            if bool(spend_conds.flags & ELIGIBLE_FOR_FF) and supports_fast_forward(coin_spend):
                 # Make sure the fast forward spend still has a version that is
                 # still unspent, because if the singleton has been spent in a
                 # non-FF spend, this fast forward spend will never become valid.
@@ -622,8 +621,6 @@ class MempoolManager:
                 # spent_index will also fail this test, and such spends will
                 # fall back to be treated as non-FF spends.
                 lineage_info = await get_unspent_lineage_info_for_puzzle_hash(spend_conds.puzzle_hash)
-                if lineage_info is None:
-                    eligible_for_ff = False
 
             spend_additions = []
             for puzzle_hash, amount, _ in spend_conds.create_coin:
@@ -635,7 +632,6 @@ class MempoolManager:
             bundle_coin_spends[coin_id] = BundleCoinSpend(
                 coin_spend=coin_spend,
                 eligible_for_dedup=bool(spend_conds.flags & ELIGIBLE_FOR_DEDUP),
-                eligible_for_fast_forward=eligible_for_ff,
                 additions=spend_additions,
                 cost=uint64(spend_conds.condition_cost + spend_conds.execution_cost),
                 latest_singleton_lineage=lineage_info,
@@ -644,7 +640,7 @@ class MempoolManager:
         # fast forward spends are only allowed when bundled with other, non-FF, spends
         # in order to evict an FF spend, it must be associated with a normal
         # spend that can be included in a block or invalidated some other way
-        if all([s.eligible_for_fast_forward for s in bundle_coin_spends.values()]):
+        if all([s.supports_fast_forward for s in bundle_coin_spends.values()]):
             return Err.INVALID_SPEND_BUNDLE, None, []
 
         removal_record_dict: dict[bytes32, CoinRecord] = {}
@@ -1062,7 +1058,7 @@ def can_replace(
             if coin_id not in removal_names:
                 log.debug("Rejecting conflicting tx as it does not spend conflicting coin %s", coin_id)
                 return False
-            if bcs.eligible_for_fast_forward:
+            if bcs.supports_fast_forward:
                 existing_ff_spends.add(bytes32(coin_id))
             if bcs.eligible_for_dedup:
                 existing_dedup_spends.add(bytes32(coin_id))
@@ -1113,7 +1109,7 @@ def can_replace(
 
     if len(existing_ff_spends) > 0 or len(existing_dedup_spends) > 0:
         for coin_id, bcs in new_item.bundle_coin_spends.items():
-            if not bcs.eligible_for_fast_forward and coin_id in existing_ff_spends:
+            if not bcs.supports_fast_forward and coin_id in existing_ff_spends:
                 log.debug("Rejecting conflicting tx due to changing ELIGIBLE_FOR_FF of coin spend %s", coin_id)
                 return False
 

--- a/chia/types/mempool_item.py
+++ b/chia/types/mempool_item.py
@@ -22,7 +22,6 @@ class UnspentLineageInfo:
 class BundleCoinSpend:
     coin_spend: CoinSpend
     eligible_for_dedup: bool
-    eligible_for_fast_forward: bool
     additions: list[Coin]
     # cost on the specific solution in this item. The cost includes execution
     # cost and conditions cost, not byte-cost.
@@ -32,7 +31,11 @@ class BundleCoinSpend:
     # current unspent lineage belonging to this singleton, that we would rebase
     # this spend on top of if we were to make a block now
     # When finding MempoolItems by coin ID, we use Coin ID from it if it's set
-    latest_singleton_lineage: Optional[UnspentLineageInfo] = None
+    latest_singleton_lineage: Optional[UnspentLineageInfo]
+
+    @property
+    def supports_fast_forward(self) -> bool:
+        return self.latest_singleton_lineage is not None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
### Purpose:

Instead of tracking `eligible_for_fast_forward` introduce a `supports_fast_forward` property that is true when a spend has fast forward unspent lineage information.

This simplifies determining when a spend supports fast forward without data duplication, and it renders the state where `eligible_for_fast_forward` is true without lineage information, impossible.

### Current Behavior:

We track fast forward spends information through both `eligible_for_fast_forward` and `latest_singleton_lineage`.

### New Behavior:

We determine `supports_fast_forward` based on `latest_singleton_lineage`.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
