### PR TITLE
Change pre-commit workflow macOS ARM runner to macos-latest

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,7 +30,7 @@ jobs:
             matrix: macos
             runs-on:
               intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-13' }}
-              arm: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-arm64' || 'macos-15' }}
+              arm: macos-latest
           - name: Windows
             matrix: windows
             runs-on:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

there are failures due to lack of wheel for macos 13 plus an issue with sdist:
https://github.com/Chia-Network/chia-blockchain/actions/runs/17922283319/job/50960403468?pr=20087
https://pypi.org/project/ruamel.yaml.clib/#files
https://sourceforge.net/p/ruamel-yaml-clib/tickets/47/

was changed from whatever macos arm (self-hosted i believe) to 13 specifically here
https://github.com/Chia-Network/chia-blockchain/commit/f2765229cd666a0dcbee7e74170bc15ab517121e#diff-ac5eead3f3ce4863c524fff031a87b7aecccb4a0493df087a4e1c704a1505036

i don't think we need to specifically use an old version here.  we could indeed add a matrix dimension for os oldest/newest etc, but so far we have not done that and so i think whatever intel and whatever arm we can get is fine.  we would generally prefer github-hosted so `macos-latest` or `macos-15` would be the choices to consider i think.

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
