### PR TITLE
CHIA-3758 Avoid recomputing mempool removals' transaction IDs in FullNode's broadcast_removed_tx

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2903,7 +2903,7 @@ class FullNode:
         removals_to_send: dict[bytes32, list[RemovedMempoolItem]] = dict()
 
         for removal_info in mempool_removals:
-            for internal_mempool_item in removal_info.items:
+            for transaction_id, internal_mempool_item in removal_info.items.items():
                 conds = internal_mempool_item.conds
                 assert conds is not None
 
@@ -2914,8 +2914,6 @@ class FullNode:
 
                 if len(peer_ids) == 0:
                     continue
-
-                transaction_id = internal_mempool_item.spend_bundle.name()
 
                 self.log.debug(f"Broadcasting removed transaction {transaction_id} to wallet peers {peer_ids}")
 

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -67,7 +67,7 @@ MEMPOOL_ITEM_FEE_LIMIT = 2**50
 
 @dataclass
 class MempoolRemoveInfo:
-    items: list[InternalMempoolItem]
+    items: dict[bytes32, InternalMempoolItem]
     reason: MempoolRemoveReason
 
 
@@ -340,7 +340,7 @@ class Mempool:
         Removes an item from the mempool.
         """
         if items == []:
-            return MempoolRemoveInfo([], reason)
+            return MempoolRemoveInfo({}, reason)
 
         removed_items: list[MempoolItemInfo] = []
         if reason != MempoolRemoveReason.BLOCK_INCLUSION:
@@ -356,7 +356,7 @@ class Mempool:
                         item = MempoolItemInfo(int(row[1]), int(row[2]), internal_item.height_added_to_mempool)
                         removed_items.append(item)
 
-        removed_internal_items = [self._items.pop(name) for name in items]
+        removed_internal_items = {name: self._items.pop(name) for name in items}
 
         for batch in to_batches(items, SQLITE_MAX_VARIABLE_NUMBER):
             args = ",".join(["?"] * len(batch.entries))


### PR DESCRIPTION
### Purpose:

We have access to it already when we construct `removed_internal_items` so just pass it as part of `MempoolRemoveInfo`'s `items`.

### Current Behavior:

We recompute mempool removals' transaction IDs in `FullNode`'s `broadcast_removed_tx`.

### New Behavior:

We access transaction IDs directly without recomputing them.

### Testing Notes:
