### PR TITLE
CHIA-3768 Optimize constructing removal names in new_peak's slow path

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -934,8 +934,7 @@ class MempoolManager:
 
             removals: set[bytes32] = set()
             for item in old_pool.all_items():
-                for s in item.spend_bundle.coin_spends:
-                    removals.add(s.coin.name())
+                removals.update(item.bundle_coin_spends)
 
             for record in await self.get_coin_records(removals):
                 name = record.coin.name()


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

Avoid recomputing coin names out of spend bundle coin spends when constructing removals in `new_peak`'s slow path.

### Current Behavior:

We recompute coin names out of spend bundle coin spends when constructing removals in `new_peak`'s slow path.

### New Behavior:

We use the item's bundle coin spends map keys as removal names.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
