### PR TITLE
Install latest boost instead of boost@1.85 on macos in `install-timelord.sh`

### DIFF
--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -117,11 +117,7 @@ else
       brew install --formula --quiet cmake
     fi
     # The most recent boost version causes compile errors.
-    brew install --formula --quiet boost@1.85 gmp
-    # boost@1.85 is keg-only, which means it was not symlinked into /usr/local,
-    # because this is an alternate version of another formula.
-    export LDFLAGS="-L/usr/local/opt/boost@1.85/lib"
-    export CPPFLAGS="-I/usr/local/opt/boost@1.85/include"
+    brew install --formula --quiet boost gmp
     echo "Installing chiavdf from source."
     # User needs to provide required packages
     echo venv/bin/python -m pip install --force --no-binary chiavdf "$CHIAVDF_VERSION"


### PR DESCRIPTION
Replaced specific boost version installation with the latest boost.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
