### PR TITLE
CHIA-2515 Simplify MempoolItem by constructing SpendBundle on demand from its components

### DIFF
--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -117,7 +117,7 @@ def make_item(
 ) -> MempoolItem:
     spend_bundle_name = bytes32([idx] * 32)
     return MempoolItem(
-        SpendBundle([], G2Element()),
+        G2Element(),
         fee,
         SpendBundleConditions([], 0, 0, 0, None, None, [], cost, 0, 0, False, 0, 0, 0, 0, 0),
         spend_bundle_name,
@@ -2922,8 +2922,8 @@ def test_items_by_feerate(items: list[MempoolItem], expected: list[Coin]) -> Non
 
     last_fpc: Optional[float] = None
     for mi, expected_coin in zip(ordered_items, expected):
-        assert len(mi.spend_bundle.coin_spends) == 1
-        assert mi.spend_bundle.coin_spends[0].coin == expected_coin
+        assert len(mi.bundle_coin_spends) == 1
+        assert next(iter(mi.bundle_coin_spends.values())).coin_spend.coin == expected_coin
         assert last_fpc is None or last_fpc >= mi.fee_per_cost
         last_fpc = mi.fee_per_cost
 

--- a/chia/_tests/core/mempool/test_mempool_item_queries.py
+++ b/chia/_tests/core/mempool/test_mempool_item_queries.py
@@ -48,7 +48,7 @@ def make_item(coin_spends: list[CoinSpend]) -> MempoolItem:
     assert npc_result.conds is not None
     bundle_coin_spends, fee = make_bundle_spends_map_and_fee(spend_bundle, npc_result.conds)
     return MempoolItem(
-        spend_bundle=spend_bundle,
+        aggregated_signature=spend_bundle.aggregated_signature,
         fee=fee,
         conds=npc_result.conds,
         spend_bundle_name=spend_bundle.name(),

--- a/chia/_tests/core/mempool/test_singleton_fast_forward.py
+++ b/chia/_tests/core/mempool/test_singleton_fast_forward.py
@@ -53,7 +53,9 @@ def test_process_fast_forward_spends_nothing_to_do() -> None:
     item = mempool_item_from_spendbundle(sb)
     # This coin is not eligible for fast forward
     assert not item.bundle_coin_spends[TEST_COIN_ID].supports_fast_forward
-    internal_mempool_item = InternalMempoolItem(sb, item.conds, item.height_added_to_mempool, item.bundle_coin_spends)
+    internal_mempool_item = InternalMempoolItem(
+        sb.aggregated_signature, item.conds, item.height_added_to_mempool, item.bundle_coin_spends
+    )
     original_version = dataclasses.replace(internal_mempool_item)
     singleton_ff = SingletonFastForward()
     bundle_coin_spends = singleton_ff.process_fast_forward_spends(
@@ -83,7 +85,9 @@ def test_process_fast_forward_spends_latest_unspent() -> None:
     item = mempool_item_from_spendbundle(sb)
     assert item.bundle_coin_spends[test_coin.name()].supports_fast_forward
     item.bundle_coin_spends[test_coin.name()].latest_singleton_lineage = test_unspent_lineage_info
-    internal_mempool_item = InternalMempoolItem(sb, item.conds, item.height_added_to_mempool, item.bundle_coin_spends)
+    internal_mempool_item = InternalMempoolItem(
+        sb.aggregated_signature, item.conds, item.height_added_to_mempool, item.bundle_coin_spends
+    )
     original_version = dataclasses.replace(internal_mempool_item)
     singleton_ff = SingletonFastForward()
     bundle_coin_spends = singleton_ff.process_fast_forward_spends(

--- a/chia/_tests/fee_estimation/test_fee_estimation_integration.py
+++ b/chia/_tests/fee_estimation/test_fee_estimation_integration.py
@@ -42,7 +42,7 @@ def make_mempoolitem() -> MempoolItem:
     spends: list[SpendConditions] = []
     conds = SpendBundleConditions(spends, 0, 0, 0, None, None, [], cost, 0, 0, False, 0, 0, 0, 0, 0)
     mempool_item = MempoolItem(
-        spend_bundle,
+        spend_bundle.aggregated_signature,
         fee,
         conds,
         spend_bundle.name(),

--- a/chia/full_node/eligible_coin_spends.py
+++ b/chia/full_node/eligible_coin_spends.py
@@ -268,9 +268,7 @@ class SingletonFastForward:
             # This item doesn't have any fast forward coins, nothing to do here
             return new_bundle_coin_spends
         # Update the mempool item after validating the new spend bundle
-        new_sb = SpendBundle(
-            coin_spends=new_coin_spends, aggregated_signature=mempool_item.spend_bundle.aggregated_signature
-        )
+        new_sb = SpendBundle(coin_spends=new_coin_spends, aggregated_signature=mempool_item.aggregated_signature)
         assert mempool_item.conds is not None
         try:
             # Run the new spend bundle to make sure it remains valid. What we

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -158,7 +158,7 @@ class Mempool:
         item = self._items[name]
 
         return MempoolItem(
-            item.spend_bundle,
+            item.aggregated_signature,
             uint64(fee),
             item.conds,
             name,
@@ -481,7 +481,7 @@ class Mempool:
             conn.executemany("INSERT OR IGNORE INTO spends VALUES(?, ?)", all_coin_spends)
 
         self._items[item_name] = InternalMempoolItem(
-            item.spend_bundle, item.conds, item.height_added_to_mempool, item.bundle_coin_spends
+            item.aggregated_signature, item.conds, item.height_added_to_mempool, item.bundle_coin_spends
         )
         self._total_cost += item.cost
         self._total_fee += item.fee
@@ -653,7 +653,7 @@ class Mempool:
                     break
                 coin_spends.extend(unique_coin_spends)
                 additions.extend(unique_additions)
-                sigs.append(item.spend_bundle.aggregated_signature)
+                sigs.append(item.aggregated_signature)
                 cost_sum = new_cost_sum
                 fee_sum = new_fee_sum
                 processed_spend_bundles += 1
@@ -761,7 +761,7 @@ class Mempool:
                         break
 
                 batch_cost += cost - cost_saving
-                batch_transactions.append(SpendBundle(unique_coin_spends, item.spend_bundle.aggregated_signature))
+                batch_transactions.append(SpendBundle(unique_coin_spends, item.aggregated_signature))
                 batch_spends += len(unique_coin_spends)
                 batch_additions.extend(unique_additions)
                 fee_sum = new_fee_sum

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -741,7 +741,7 @@ class MempoolManager:
             return Err.IMPOSSIBLE_SECONDS_ABSOLUTE_CONSTRAINTS, None, []  # MempoolInclusionStatus.FAILED
 
         potential = MempoolItem(
-            new_spend,
+            new_spend.aggregated_signature,
             uint64(fees),
             conds,
             spend_name,
@@ -781,7 +781,7 @@ class MempoolManager:
         """Returns a full SpendBundle if it's inside one the mempools"""
         item: Optional[MempoolItem] = self.mempool.get_item_by_id(bundle_hash)
         if item is not None:
-            return item.spend_bundle
+            return item.to_spend_bundle()
         return None
 
     def get_mempool_item(self, bundle_hash: bytes32, include_pending: bool = False) -> Optional[MempoolItem]:
@@ -950,7 +950,7 @@ class MempoolManager:
 
             for item in old_pool.all_items():
                 info = await self.add_spend_bundle(
-                    item.spend_bundle,
+                    item.to_spend_bundle(),
                     item.conds,
                     item.spend_bundle_name,
                     item.height_added_to_mempool,
@@ -972,7 +972,7 @@ class MempoolManager:
         txs_added = []
         for item in potential_txs.values():
             info = await self.add_spend_bundle(
-                item.spend_bundle,
+                item.to_spend_bundle(),
                 item.conds,
                 item.spend_bundle_name,
                 item.height_added_to_mempool,
@@ -1003,7 +1003,7 @@ class MempoolManager:
                 return items
             if mempool_filter.Match(bytearray(item.spend_bundle_name)):
                 continue
-            items.append(item.spend_bundle)
+            items.append(item.to_spend_bundle())
 
         return items
 

--- a/chia/types/internal_mempool_item.py
+++ b/chia/types/internal_mempool_item.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from chia_rs import SpendBundle, SpendBundleConditions
+from chia_rs import G2Element, SpendBundleConditions
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32
 
@@ -11,7 +11,7 @@ from chia.types.mempool_item import BundleCoinSpend
 
 @dataclass(frozen=True)
 class InternalMempoolItem:
-    spend_bundle: SpendBundle
+    aggregated_signature: G2Element
     conds: SpendBundleConditions
     height_added_to_mempool: uint32
     # Map of coin ID to coin spend data between the bundle and its SpendBundleConditions


### PR DESCRIPTION
### Purpose:

Instead of holding a `SpendBundle` in a `MempoolItem`, just construct it on-demand from the coin spends and the aggregate signature.

### Current Behavior:

We hold coin spends in both `spend_bundle` and `bundle_coin_spends`. 

### New Behavior:

We hold coin spends in `bundle_coin_spends` and we construct the spend bundle from that and the aggregate signature.

