### PR TITLE
v2 plots only support pool contract puzzle hash

### DIFF
--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -127,7 +127,7 @@ def b32(key: str) -> bytes32:
     ),
     ProofOfSpaceCase(
         id="Not passing the plot filter v2",
-        pos_challenge=b32("2b76a5fe5d4ae062ba9e80b5bcb0e9c1301f3a2787b8f3141e3fb458d1c1864c"),
+        pos_challenge=b32("5706ae15c4a437399f464c64ef4f33c362d860ccd2945b76b3ebdb0505783817"),
         plot_size=PlotParam.make_v2(32),
         pool_contract_puzzle_hash=bytes32(b"1" * 32),
         plot_public_key=g1(
@@ -143,6 +143,14 @@ def b32(key: str) -> bytes32:
         plot_public_key=G1Element(),
         height=uint32(DEFAULT_CONSTANTS.HARD_FORK2_HEIGHT - 1),
         expected_error="v2 proof support has not yet activated",
+    ),
+    ProofOfSpaceCase(
+        id="v2 plot with pool pk",
+        pos_challenge=bytes32(b"1" * 32),
+        plot_size=PlotParam.make_v2(2),
+        plot_public_key=G1Element(),
+        pool_public_key=G1Element(),
+        expected_error="v2 plots require pool_contract_puzzle_hash, pool public key is not supported",
     ),
 )
 def test_verify_and_get_quality_string(caplog: pytest.LogCaptureFixture, case: ProofOfSpaceCase) -> None:
@@ -170,8 +178,8 @@ def test_verify_and_get_quality_string(caplog: pytest.LogCaptureFixture, case: P
 @datacases(
     ProofOfSpaceCase(
         id="not passing the plot filter v2",
-        plot_size=PlotParam.make_v2(28),
-        pos_challenge=b32("be7ac7436520a3fa259a618a2c54de4ca8b8d2319c1ec5b11a2ef4c025c2e0a6"),
+        plot_size=PlotParam.make_v2(2),
+        pos_challenge=b32("fb1d676f0e3ce173f4e6cfb06d7059886cbc3b91cf65be0af0fc2fbe569c6597"),
         plot_public_key=g1(
             "afa3aaf09c03885154be49216ee7fb2e4581b9c4a4d7e9cc402e27280bf0cfdbdf1b9ba674e301fd1d1450234b3b1868"
         ),
@@ -197,7 +205,7 @@ def test_verify_and_get_quality_string_v2(caplog: pytest.LogCaptureFixture, case
             pos=pos,
             constants=DEFAULT_CONSTANTS,
             original_challenge_hash=b32("0x73490e166d0b88347c37d921660b216c27316aae9a3450933d3ff3b854e5831a"),
-            signage_point=b32("0x7b3e23dbd438f9aceefa9827e2c5538898189987f49b06eceb7a43067e77b531"),
+            signage_point=b32("0xf7c1bd874da5e709d4713d60c8a70639eb1167b367a9c3787c65c1e582e2e662"),
             height=case.height,
             prev_transaction_block_height=case.height,
         )

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -764,10 +764,16 @@ def validate_unfinished_header_block(
             != constants.GENESIS_PRE_FARM_FARMER_PUZZLE_HASH
         ):
             return None, ValidationError(Err.INVALID_PREFARM)
-    # 20b. If pospace has a pool pk, heck pool target signature. Should not check this for genesis block.
+    # 20b. If pospace has a pool pk, check pool target signature. Should not check this for genesis block.
     elif header_block.reward_chain_block.proof_of_space.pool_public_key is not None:
         assert header_block.reward_chain_block.proof_of_space.pool_contract_puzzle_hash is None
         assert header_block.foliage.foliage_block_data.pool_signature is not None
+
+        # v2 plots require pool contract puzzle hash, not pool pk
+        # TODO: todo_v2_plots add test coverage of this check
+        if header_block.reward_chain_block.proof_of_space.param().strength_v2 is not None:
+            return None, ValidationError(Err.INVALID_POOL_TARGET)
+
         if not AugSchemeMPL.verify(
             header_block.reward_chain_block.proof_of_space.pool_public_key,
             bytes(header_block.foliage.foliage_block_data.pool_target),


### PR DESCRIPTION
### Purpose:

Make sure we only allow a pool contract puzzle hash for v2 proofs-of-space. Not a pool public key.


### Current Behavior:

We don't require PoS 2 to only have pool contract puzzle hash, but also allow a pool public key.

### New Behavior:

We require PoS 2 to only have pool contract puzzle hash, disallowing a pool public key.