### PR TITLE
improve v2-plot support in plot-sync

### DIFF
--- a/chia/_tests/plot_sync/test_delta.py
+++ b/chia/_tests/plot_sync/test_delta.py
@@ -17,6 +17,7 @@ def dummy_plot(path: str) -> Plot:
     return Plot(
         filename=path,
         size=uint8(32),
+        strength=uint8(0),
         plot_id=bytes32(b"\00" * 32),
         pool_public_key=G1Element(),
         pool_contract_puzzle_hash=None,

--- a/chia/_tests/plot_sync/test_plot_sync.py
+++ b/chia/_tests/plot_sync/test_plot_sync.py
@@ -68,6 +68,7 @@ class ExpectedResult:
             return Plot(
                 info.prover.get_filename(),
                 uint8(0),
+                uint8(0),
                 bytes32.zeros,
                 None,
                 None,

--- a/chia/_tests/plot_sync/test_receiver.py
+++ b/chia/_tests/plot_sync/test_receiver.py
@@ -171,6 +171,7 @@ def plot_sync_setup(seeded_random: random.Random) -> tuple[Receiver, list[SyncSt
         Plot(
             filename=str(x),
             size=uint8(0),
+            strength=uint8(0),
             plot_id=bytes32.random(seeded_random),
             pool_contract_puzzle_hash=None,
             pool_public_key=None,

--- a/chia/_tests/util/network_protocol_data.py
+++ b/chia/_tests/util/network_protocol_data.py
@@ -916,6 +916,7 @@ respond_signatures = harvester_protocol.RespondSignatures(
 plot = harvester_protocol.Plot(
     "plot_1",
     uint8(124),
+    uint8(0),
     bytes32(bytes.fromhex("b2eb7e5c5239e8610a9dd0e137e185966ebb430faf31ae4a0e55d86251065b98")),
     G1Element.from_bytes(
         bytes.fromhex(

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -201,6 +201,7 @@ class Harvester:
                     {
                         "filename": str(path),
                         "size": k,
+                        "strength": prover.get_strength(),
                         "plot_id": prover.get_id(),
                         "pool_public_key": plot_info.pool_public_key,
                         "pool_contract_puzzle_hash": plot_info.pool_contract_puzzle_hash,

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -511,6 +511,7 @@ class HarvesterAPI:
                 Plot(
                     plot["filename"],
                     plot["size"],
+                    plot["strength"],
                     plot["plot_id"],
                     plot["pool_public_key"],
                     plot["pool_contract_puzzle_hash"],

--- a/chia/plot_sync/sender.py
+++ b/chia/plot_sync/sender.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Generic, Optional, TypeVar
 
-from chia_rs.sized_ints import int16, uint32, uint64
+from chia_rs.sized_ints import int16, uint8, uint32, uint64
 from typing_extensions import Protocol
 
 from chia.plot_sync.exceptions import AlreadyStartedError, InvalidConnectionTypeError
@@ -37,13 +37,23 @@ log = logging.getLogger(__name__)
 def _convert_plot_info_list(plot_infos: list[PlotInfo]) -> list[Plot]:
     converted: list[Plot] = []
     for plot_info in plot_infos:
-        # TODO: todo_v2_plots support v2 plots
-        k = plot_info.prover.get_size().size_v1
-        assert k is not None
+        plot_size = plot_info.prover.get_size()
+        if plot_size.size_v1 is not None:
+            k = plot_size.size_v1
+            strength = 0
+        else:
+            # todo_v2_plots the k-size should probably be set to the constant,
+            # fixed k-size for v2 plots. Then we would need access to
+            # ConsensusConstants in here
+            assert plot_size.size_v2 is not None
+            k = plot_size.size_v2
+            strength = plot_size.size_v2
+
         converted.append(
             Plot(
                 filename=plot_info.prover.get_filename(),
-                size=k,
+                size=uint8(k),
+                strength=uint8(strength),
                 plot_id=plot_info.prover.get_id(),
                 pool_public_key=plot_info.pool_public_key,
                 pool_contract_puzzle_hash=plot_info.pool_contract_puzzle_hash,

--- a/chia/protocols/harvester_protocol.py
+++ b/chia/protocols/harvester_protocol.py
@@ -141,6 +141,7 @@ class RespondSignatures(Streamable):
 class Plot(Streamable):
     filename: str
     size: uint8
+    strength: uint8  # This is 0 for v1 plots
     plot_id: bytes32
     pool_public_key: Optional[G1Element]
     pool_contract_puzzle_hash: Optional[bytes32]


### PR DESCRIPTION
add support for v2-plots to the plot-sync protocol
This adds a new field, strength, to the `Plot` class. v1 plots have strength 0, v2 plots have a non-zero strength.