### PR TITLE
Add HARD_FORK_HEIGHT to initial-config.yaml for testneta

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -55,6 +55,7 @@ network_overrides: &network_overrides
       MIN_PLOT_SIZE_V2: 20
       NETWORK_TYPE: 1
       SUB_SLOT_ITERS_STARTING: 67108864
+      HARD_FORK_HEIGHT: 3695110
   config:
     mainnet:
       address_prefix: "xch"

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -55,7 +55,7 @@ network_overrides: &network_overrides
       MIN_PLOT_SIZE_V2: 20
       NETWORK_TYPE: 1
       SUB_SLOT_ITERS_STARTING: 67108864
-      HARD_FORK_HEIGHT: 3695110
+      HARD_FORK_HEIGHT: 3693395
   config:
     mainnet:
       address_prefix: "xch"


### PR DESCRIPTION
### Purpose:

TestnetA does not have a hard-fork height specified and can therefore not successfully farm plots with the latest version of Chia.  This adds a hard fork height to the default config, which is also being applied on any existing testneta infrastructure.  
