### PR TITLE
Increase weight-proof timeouts to 45m

### DIFF
--- a/chia/_tests/weight_proof/config.py
+++ b/chia/_tests/weight_proof/config.py
@@ -1,3 +1,4 @@
 from __future__ import annotations
 
 checkout_blocks_and_plots = True
+job_timeout = 45


### PR DESCRIPTION
In testing macOS Intel runners this test is taking longer than 30m at times - increase timeout to 45m

