### PR TITLE
Update error message for invalid IP and port format to clarify ipv6

### DIFF
--- a/chia/cmds/peer_funcs.py
+++ b/chia/cmds/peer_funcs.py
@@ -20,7 +20,7 @@ async def add_node_connection(rpc_client: RpcClient, add_connection: str) -> Non
         except Exception:
             print(f"Failed to connect to {host}:{port}")
     except ValueError:
-        print("Enter a valid IP and port in the following format: 10.5.4.3:8000")
+        print("Enter a valid IP and port in the following format: 10.5.4.3:8444 or [2606:f6c0:80:5::a]:8444")
 
 
 async def remove_node_connection(rpc_client: RpcClient, remove_connection: str) -> None:


### PR DESCRIPTION
Hint how to format the ipv6 address on the command line

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

It is not entirely clear what the proper method of handing an ipv6:port is on the command line. Extending this error message gives the user a solid hint on how to do it appropriately. Also updated the v4 example to hint the correct port of 8444 since that's what most nodes are on.

### Current Behavior:

Everything works as expected, but it's hard to find documentation re ipv6

### New Behavior:

Error message explains both ipv4 and ipv6

### Testing Notes:

Manually tested that the ipv6 address is being correctly parsed by urlsplit(). The example v6 address is currently node.chia.net. Also manually confirmed that my ipv6 farm could add my other ipv6 farm in [ipv6]:8444 form.