### PR TITLE
Increase job timeout from 60 to 90 seconds

### DIFF
--- a/chia/_tests/util/config.py
+++ b/chia/_tests/util/config.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-job_timeout = 60
+job_timeout = 90


### PR DESCRIPTION
Slower macos Intel runners can take up to 70+ mins - increase timeout to 90 mins to cover these slower runners