### PR TITLE
Increase timeout for check_nodes_in_sync

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2713,7 +2713,7 @@ async def test_long_reorg_nodes(
         p2 = full_node_1.full_node.blockchain.get_peak()
         return p1 == p2
 
-    await time_out_assert(300, check_nodes_in_sync)
+    await time_out_assert(600, check_nodes_in_sync)
     peak = full_node_2.full_node.blockchain.get_peak()
     assert peak is not None
     print(f"peak: {str(peak.header_hash)[:6]}")


### PR DESCRIPTION
macOS Intel often hits this 300s timeout - try increasing to 600s

Testing passed 40/40 with this change