### PR TITLE
Skip slow test for FullBlock parser

### DIFF
--- a/chia/_tests/util/test_full_block_utils.py
+++ b/chia/_tests/util/test_full_block_utils.py
@@ -255,6 +255,7 @@ def get_full_blocks() -> Iterator[FullBlock]:
 
 
 @pytest.mark.anyio
+@pytest.mark.skip("Very slow test with limited usefulness: was used to ensure the cheap parser for FullBlock matched the regular (slow) one")
 async def test_parser():
     # loop over every combination of Optionals being set and not set
     # along with random values for the FullBlock fields. Ensure

--- a/chia/_tests/util/test_full_block_utils.py
+++ b/chia/_tests/util/test_full_block_utils.py
@@ -255,7 +255,9 @@ def get_full_blocks() -> Iterator[FullBlock]:
 
 
 @pytest.mark.anyio
-@pytest.mark.skip("Very slow test with limited usefulness: was used to ensure the cheap parser for FullBlock matched the regular one")
+@pytest.mark.skip(
+    "Very slow test with limited usefulness: was used to ensure the cheap parser for FullBlock matched the regular one"
+)
 async def test_parser():
     # loop over every combination of Optionals being set and not set
     # along with random values for the FullBlock fields. Ensure

--- a/chia/_tests/util/test_full_block_utils.py
+++ b/chia/_tests/util/test_full_block_utils.py
@@ -255,7 +255,7 @@ def get_full_blocks() -> Iterator[FullBlock]:
 
 
 @pytest.mark.anyio
-@pytest.mark.skip("Very slow test with limited usefulness: was used to ensure the cheap parser for FullBlock matched the regular (slow) one")
+@pytest.mark.skip("Very slow test with limited usefulness: was used to ensure the cheap parser for FullBlock matched the regular one")
 async def test_parser():
     # loop over every combination of Optionals being set and not set
     # along with random values for the FullBlock fields. Ensure


### PR DESCRIPTION
Skip slow test for FullBlock parser due to limited usefulness.

per Arvid: 
"I don't think this test is very useful anymore. It was primarily there to ensure our cheap parser for FullBlock matched the regular (slow) one exactly and it's run successfully quite a few times now"