### PR TITLE
Unskip Windows condition for harvester plots test

### DIFF
--- a/chia/_tests/core/test_farmer_harvester_rpc.py
+++ b/chia/_tests/core/test_farmer_harvester_rpc.py
@@ -360,7 +360,6 @@ def test_plot_matches_filter(filter_item: FilterItem, match: bool) -> None:
     ],
 )
 @pytest.mark.anyio
-# @pytest.mark.skipif(sys.platform == "win32", reason="avoiding crashes on windows until we fix this (crashing workers)")
 async def test_farmer_get_harvester_plots_endpoints(
     harvester_farmer_environment: HarvesterFarmerEnvironment,
     endpoint: Callable[[FarmerRpcClient, PaginatedRequestData], Awaitable[dict[str, Any]]],

--- a/chia/_tests/core/test_farmer_harvester_rpc.py
+++ b/chia/_tests/core/test_farmer_harvester_rpc.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import dataclasses
 import logging
 import operator
-import sys
 import time
 from collections.abc import Awaitable
 from math import ceil

--- a/chia/_tests/core/test_farmer_harvester_rpc.py
+++ b/chia/_tests/core/test_farmer_harvester_rpc.py
@@ -360,7 +360,7 @@ def test_plot_matches_filter(filter_item: FilterItem, match: bool) -> None:
     ],
 )
 @pytest.mark.anyio
-@pytest.mark.skipif(sys.platform == "win32", reason="avoiding crashes on windows until we fix this (crashing workers)")
+# @pytest.mark.skipif(sys.platform == "win32", reason="avoiding crashes on windows until we fix this (crashing workers)")
 async def test_farmer_get_harvester_plots_endpoints(
     harvester_farmer_environment: HarvesterFarmerEnvironment,
     endpoint: Callable[[FarmerRpcClient, PaginatedRequestData], Awaitable[dict[str, Any]]],


### PR DESCRIPTION
Removed skip condition for Windows from test_farmer_get_harvester_plots_endpoints.

Testing confirms this completed 25/25 on Windows on 3.10, 3.11 and 3.12
