### PR TITLE
[LABS-291] Port `get_farmed_amount` to `@marshal`

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -130,6 +130,8 @@ from chia.wallet.wallet_request_types import (
     FungibleAsset,
     GetAllOffers,
     GetCoinRecordsByNames,
+    GetFarmedAmount,
+    GetFarmedAmountResponse,
     GetNextAddress,
     GetNotifications,
     GetOffer,
@@ -468,21 +470,20 @@ async def test_get_farmed_amount(wallet_environments: WalletTestFramework) -> No
     env = wallet_environments.environments[0]
     wallet_rpc_client = env.rpc_client
 
-    get_farmed_amount_result = await wallet_rpc_client.get_farmed_amount()
+    get_farmed_amount_result = await wallet_rpc_client.get_farmed_amount(GetFarmedAmount())
     get_timestamp_for_height_result = await wallet_rpc_client.get_timestamp_for_height(
         GetTimestampForHeight(uint32(3))
     )  # genesis + 2
 
-    expected_result = {
-        "blocks_won": 2,
-        "farmed_amount": 4_000_000_000_000,
-        "farmer_reward_amount": 500_000_000_000,
-        "fee_amount": 0,
-        "last_height_farmed": 3,
-        "last_time_farmed": get_timestamp_for_height_result.timestamp,
-        "pool_reward_amount": 3_500_000_000_000,
-        "success": True,
-    }
+    expected_result = GetFarmedAmountResponse(
+        blocks_won=uint32(2),
+        farmed_amount=uint64(4_000_000_000_000),
+        farmer_reward_amount=uint64(500_000_000_000),
+        fee_amount=uint64(0),
+        last_height_farmed=uint32(3),
+        last_time_farmed=uint64(get_timestamp_for_height_result.timestamp),
+        pool_reward_amount=uint64(3_500_000_000_000),
+    )
     assert get_farmed_amount_result == expected_result
 
 
@@ -514,8 +515,8 @@ async def test_get_farmed_amount_with_fee(wallet_environments: WalletTestFramewo
     await full_node_api.farm_blocks_to_puzzlehash(count=2, farm_to=our_ph, guarantee_transaction_blocks=True)
     await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
-    result = await wallet_rpc_client.get_farmed_amount()
-    assert result["fee_amount"] == fee_amount
+    result = await wallet_rpc_client.get_farmed_amount(GetFarmedAmount())
+    assert result.fee_amount == fee_amount
 
 
 @pytest.mark.parametrize(

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -2514,3 +2514,21 @@ class CRCATApprovePending(TransactionEndpointRequest):
 @dataclass(frozen=True)
 class CRCATApprovePendingResponse(TransactionEndpointResponse):
     pass
+
+
+@streamable
+@dataclass(frozen=True)
+class GetFarmedAmount(Streamable):
+    include_pool_rewards: bool = False
+
+
+@streamable
+@dataclass(frozen=True)
+class GetFarmedAmountResponse(Streamable):
+    farmed_amount: uint64
+    pool_reward_amount: uint64
+    farmer_reward_amount: uint64
+    fee_amount: uint64
+    last_height_farmed: uint32
+    last_time_farmed: uint64
+    blocks_won: uint32

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -197,6 +197,8 @@ from chia.wallet.wallet_request_types import (
     GetCoinRecordsByNames,
     GetCoinRecordsByNamesResponse,
     GetCurrentDerivationIndexResponse,
+    GetFarmedAmount,
+    GetFarmedAmountResponse,
     GetHeightInfoResponse,
     GetLoggedInFingerprintResponse,
     GetNextAddress,
@@ -3200,7 +3202,8 @@ class WalletRpcApi:
             "total_count": result.total_count,
         }
 
-    async def get_farmed_amount(self, request: dict[str, Any]) -> EndpointResult:
+    @marshal
+    async def get_farmed_amount(self, request: GetFarmedAmount) -> GetFarmedAmountResponse:
         tx_records: list[TransactionRecord] = await self.service.wallet_state_manager.tx_store.get_farming_rewards()
         amount = 0
         pool_reward_amount = 0
@@ -3209,14 +3212,12 @@ class WalletRpcApi:
         blocks_won = 0
         last_height_farmed = uint32(0)
 
-        include_pool_rewards = request.get("include_pool_rewards", False)
-
         for record in tx_records:
             if record.wallet_id not in self.service.wallet_state_manager.wallets:
                 continue
             if record.type == TransactionType.COINBASE_REWARD.value:
                 if (
-                    not include_pool_rewards
+                    not request.include_pool_rewards
                     and self.service.wallet_state_manager.wallets[record.wallet_id].type() == WalletType.POOLING_WALLET
                 ):
                     # Don't add pool rewards for pool wallets unless explicitly requested
@@ -3236,19 +3237,19 @@ class WalletRpcApi:
             last_height_farmed = max(last_height_farmed, height)
             amount += record.amount
 
-        last_time_farmed = uint64(
+        last_time_farmed = (
             await self.service.get_timestamp_for_height(last_height_farmed) if last_height_farmed > 0 else 0
         )
         assert amount == pool_reward_amount + farmer_reward_amount + fee_amount
-        return {
-            "farmed_amount": amount,
-            "pool_reward_amount": pool_reward_amount,
-            "farmer_reward_amount": farmer_reward_amount,
-            "fee_amount": fee_amount,
-            "last_height_farmed": last_height_farmed,
-            "last_time_farmed": last_time_farmed,
-            "blocks_won": blocks_won,
-        }
+        return GetFarmedAmountResponse(
+            farmed_amount=uint64(amount),
+            pool_reward_amount=uint64(pool_reward_amount),
+            farmer_reward_amount=uint64(farmer_reward_amount),
+            fee_amount=uint64(fee_amount),
+            last_height_farmed=uint32(last_height_farmed),
+            last_time_farmed=uint64(last_time_farmed),
+            blocks_won=uint32(blocks_won),
+        )
 
     @tx_endpoint(push=False)
     @marshal

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -104,6 +104,8 @@ from chia.wallet.wallet_request_types import (
     GetCoinRecordsByNames,
     GetCoinRecordsByNamesResponse,
     GetCurrentDerivationIndexResponse,
+    GetFarmedAmount,
+    GetFarmedAmountResponse,
     GetHeightInfoResponse,
     GetLoggedInFingerprintResponse,
     GetNextAddress,
@@ -391,8 +393,8 @@ class WalletRpcClient(RpcClient):
             await self.fetch("extend_derivation_index", request.to_json_dict())
         )
 
-    async def get_farmed_amount(self, include_pool_rewards: bool = False) -> dict[str, Any]:
-        return await self.fetch("get_farmed_amount", {"include_pool_rewards": include_pool_rewards})
+    async def get_farmed_amount(self, request: GetFarmedAmount) -> GetFarmedAmountResponse:
+        return GetFarmedAmountResponse.from_json_dict(await self.fetch("get_farmed_amount", request.to_json_dict()))
 
     async def create_signed_transactions(
         self,


### PR DESCRIPTION
Another PR following #18593

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates `get_farmed_amount` to a marshaled, typed RPC using `GetFarmedAmount` and `GetFarmedAmountResponse`, updating client/CLI usage and tests.
> 
> - **RPC/API**:
>   - Convert `wallet_rpc_api.get_farmed_amount` to `@marshal` with typed `GetFarmedAmount -> GetFarmedAmountResponse`.
>   - Add new streamables: `GetFarmedAmount` and `GetFarmedAmountResponse` in `wallet_request_types.py`.
>   - Update `WalletRpcClient.get_farmed_amount` to accept request object and return typed response.
> - **CLI** (`chia/cmds/farm_funcs.py`):
>   - Update `get_wallets_stats` to use `GetFarmedAmount` and return `GetFarmedAmountResponse`.
>   - Adjust summary output to use attributes instead of dict keys.
> - **Tests**:
>   - Update wallet RPC tests to call `get_farmed_amount(GetFarmedAmount())` and assert against `GetFarmedAmountResponse` and attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 824cbe6ac89312ee2e02353de71ed4ede626f112. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->