### PR TITLE
[LABS-293] Ensure wallet is synced for RPC TX endpoints

### DIFF
--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -73,7 +73,6 @@ from chia.util.timing import adjusted_timeout, backoff_times
 from chia.wallet.trading.offer import Offer as TradingOffer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
-from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_request_types import CheckOfferValidity, DLLatestSingleton
 from chia.wallet.wallet_rpc_api import WalletRpcApi
@@ -763,6 +762,7 @@ async def test_get_owned_stores(
         ph = await action_scope.get_puzzle_hash(wallet_node.wallet_state_manager)
     for i in range(num_blocks):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+    await full_node_api.wait_for_wallet_synced(wallet_node, timeout=30)
     funds = sum(
         calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)
     )
@@ -845,6 +845,11 @@ class OfferSetup:
     maker: StoreSetup
     taker: StoreSetup
     full_node_api: FullNodeSimulator
+    wallet_nodes: list[WalletNode]
+
+    async def wait_for_wallets_synced(self, timeout: int = 30) -> None:
+        for node in self.wallet_nodes:
+            await self.full_node_api.wait_for_wallet_synced(wallet_node=node, timeout=timeout)
 
 
 @pytest.fixture(name="offer_setup")
@@ -857,14 +862,14 @@ async def offer_setup_fixture(
     [full_node_service], wallet_services, bt = two_wallet_nodes_services
     enable_batch_autoinsertion_settings = getattr(request, "param", (True, True))
     full_node_api = full_node_service._api
-    wallets: list[Wallet] = []
+    wallets: list[WalletNode] = []
     for wallet_service in wallet_services:
         wallet_node = wallet_service._node
         assert wallet_node.server is not None
         await wallet_node.server.start_client(PeerInfo(self_hostname, full_node_api.server.get_port()), None)
         assert wallet_node.wallet_state_manager is not None
         wallet = wallet_node.wallet_state_manager.main_wallet
-        wallets.append(wallet)
+        wallets.append(wallet_node)
 
         await full_node_api.farm_blocks_to_wallet(count=1, wallet=wallet, timeout=60)
         await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=30)
@@ -952,6 +957,7 @@ async def offer_setup_fixture(
                 data_rpc_client=taker.data_rpc_client,
             ),
             full_node_api=full_node_api,
+            wallet_nodes=wallets,
         )
 
         maker.data_rpc_client.close()
@@ -1019,6 +1025,7 @@ async def populate_offer_setup(offer_setup: OfferSetup, count: int) -> OfferSetu
             data_rpc_client=offer_setup.taker.data_rpc_client,
         ),
         full_node_api=offer_setup.full_node_api,
+        wallet_nodes=offer_setup.wallet_nodes,
     )
 
 
@@ -1844,6 +1851,7 @@ async def test_make_and_cancel_offer(offer_setup: OfferSetup, reference: MakeAnd
     # due to differences in chain progression, the exact offer and trade id may differ from the reference
     # assert maker_response == {"success": True, "offer": reference.make_offer_response}
     assert maker_response["success"] is True
+    await offer_setup.wait_for_wallets_synced()
 
     cancel_request = {
         "trade_id": maker_response["offer"]["trade_id"],
@@ -1927,6 +1935,7 @@ async def test_make_and_cancel_offer_then_update(
     # due to differences in chain progression, the exact offer and trade id may differ from the reference
     # assert maker_response == {"success": True, "offer": reference.make_offer_response}
     assert maker_response["success"] is True
+    await offer_setup.wait_for_wallets_synced()
 
     cancel_request = {
         "trade_id": maker_response["offer"]["trade_id"],
@@ -2016,6 +2025,7 @@ async def test_make_and_cancel_offer_not_secure_clears_pending_roots(
     # due to differences in chain progression, the exact offer and trade id may differ from the reference
     # assert maker_response == {"success": True, "offer": reference.make_offer_response}
     assert maker_response["success"] is True
+    await offer_setup.wait_for_wallets_synced()
 
     cancel_request = {
         "trade_id": maker_response["offer"]["trade_id"],
@@ -2569,6 +2579,7 @@ async def populate_proof_setup(offer_setup: OfferSetup, count: int) -> OfferSetu
             data_rpc_client=offer_setup.taker.data_rpc_client,
         ),
         full_node_api=offer_setup.full_node_api,
+        wallet_nodes=offer_setup.wallet_nodes,
     )
 
 

--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -867,6 +867,7 @@ async def offer_setup_fixture(
         wallets.append(wallet)
 
         await full_node_api.farm_blocks_to_wallet(count=1, wallet=wallet, timeout=60)
+        await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=30)
 
     async with contextlib.AsyncExitStack() as exit_stack:
         store_setups: list[StoreSetup] = []

--- a/chia/_tests/pools/test_pool_rpc.py
+++ b/chia/_tests/pools/test_pool_rpc.py
@@ -839,6 +839,7 @@ class TestPoolWalletRpc:
             our_ph, "", uint32(0), f"{self_hostname}:5000", "new", "SELF_POOLING", fee
         )
         await full_node_api.wait_transaction_records_entered_mempool(records=[creation_tx])
+        await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
         creation_tx_2: TransactionRecord = await client.create_new_pool_wallet(
             our_ph, "", uint32(0), f"{self_hostname}:5001", "new", "SELF_POOLING", fee
         )

--- a/chia/_tests/wallet/rpc/test_dl_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_dl_wallet_rpc.py
@@ -74,6 +74,7 @@ class TestWalletRpc:
             calculate_pool_reward(uint32(i)) + calculate_base_farmer_reward(uint32(i)) for i in range(1, num_blocks)
         )
 
+        await full_node_api.wait_for_wallet_synced(wallet_node)
         await time_out_assert(15, wallet.get_confirmed_balance, initial_funds)
         await time_out_assert(15, wallet.get_unconfirmed_balance, initial_funds)
 
@@ -108,6 +109,7 @@ class TestWalletRpc:
             for i in range(5):
                 await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32.zeros))
                 await asyncio.sleep(0.5)
+            await full_node_api.wait_for_wallet_synced(wallet_node)
 
             async def is_singleton_confirmed(rpc_client: WalletRpcClient, lid: bytes32) -> bool:
                 rec = (await rpc_client.dl_latest_singleton(DLLatestSingleton(lid))).singleton
@@ -128,6 +130,7 @@ class TestWalletRpc:
             for i in range(5):
                 await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32.zeros))
                 await asyncio.sleep(0.5)
+            await full_node_api.wait_for_wallet_synced(wallet_node)
 
             new_singleton_record = (await client.dl_latest_singleton(DLLatestSingleton(launcher_id))).singleton
             assert new_singleton_record is not None
@@ -216,6 +219,7 @@ class TestWalletRpc:
             launcher_id_2 = (
                 await client.create_new_dl(CreateNewDL(root=merkle_root, fee=uint64(50), push=True), DEFAULT_TX_CONFIG)
             ).launcher_id
+            await full_node_api.wait_for_wallet_synced(wallet_node)
             launcher_id_3 = (
                 await client.create_new_dl(CreateNewDL(root=merkle_root, fee=uint64(50), push=True), DEFAULT_TX_CONFIG)
             ).launcher_id
@@ -223,6 +227,7 @@ class TestWalletRpc:
             for i in range(5):
                 await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32.zeros))
                 await asyncio.sleep(0.5)
+            await full_node_api.wait_for_wallet_synced(wallet_node)
 
             await time_out_assert(15, is_singleton_confirmed, True, client, launcher_id_2)
             await time_out_assert(15, is_singleton_confirmed, True, client, launcher_id_3)
@@ -245,6 +250,7 @@ class TestWalletRpc:
             for i in range(5):
                 await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32.zeros))
                 await asyncio.sleep(0.5)
+            await full_node_api.wait_for_wallet_synced(wallet_node)
 
             await time_out_assert(15, is_singleton_confirmed, True, client, launcher_id)
             await time_out_assert(15, is_singleton_confirmed, True, client, launcher_id_2)
@@ -280,6 +286,7 @@ class TestWalletRpc:
             for i in range(5):
                 await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32.zeros))
                 await asyncio.sleep(0.5)
+            await full_node_api.wait_for_wallet_synced(wallet_node)
             additions = []
             for tx in txs:
                 if tx.spend_bundle is not None:

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -2004,6 +2004,7 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment) -
 
     await time_out_assert(5, check_mempool_spend_count, True, full_node_api, 1)
     await farm_transaction_block(full_node_api, wallet_1_node)
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_1_node, timeout=20)
 
     # Update metadata
     with pytest.raises(ValueError, match="wallet id 1 is of type Wallet but type DIDWallet is required"):
@@ -2019,6 +2020,7 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment) -
 
     await time_out_assert(5, check_mempool_spend_count, True, full_node_api, 1)
     await farm_transaction_block(full_node_api, wallet_1_node)
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_1_node, timeout=20)
 
     # Transfer DID
     async with wallet_2.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
@@ -2032,6 +2034,8 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment) -
 
     await time_out_assert(5, check_mempool_spend_count, True, full_node_api, 1)
     await farm_transaction_block(full_node_api, wallet_1_node)
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_1_node, timeout=20)
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_2_node, timeout=20)
 
     async def num_wallets() -> int:
         return len(await wallet_2_node.wallet_state_manager.get_all_wallet_info_entries())
@@ -2059,6 +2063,8 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment) -
 
     await time_out_assert(5, check_mempool_spend_count, True, full_node_api, 1)
     await farm_transaction_block(full_node_api, wallet_2_node)
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_1_node, timeout=20)
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_2_node, timeout=20)
 
     next_did_coin = await did_wallet_2.get_coin()
     assert next_did_coin.parent_coin_info == last_did_coin.name()
@@ -2071,6 +2077,8 @@ async def test_did_endpoints(wallet_rpc_environment: WalletRpcTestEnvironment) -
 
     await time_out_assert(5, check_mempool_spend_count, True, full_node_api, 1)
     await farm_transaction_block(full_node_api, wallet_2_node)
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_1_node, timeout=20)
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_2_node, timeout=20)
 
     next_did_coin = await did_wallet_2.get_coin()
     assert next_did_coin.parent_coin_info == last_did_coin.name()


### PR DESCRIPTION
Many `@tx_endpoint`s implement this logic but not consistently.  It makes sense to make sure the wallet is synced before proposing a potential change to a state you don't know the current state of.  This change makes the check universal across transaction endpoints.

There are some test changes as a result of this change that became necessary because this made poor state checking fail more consistently and thus caused many flakes.  This is a good thing because it exposed areas that were probably slightly flaky before and locked them down to non-flaky behavior.