### PR TITLE
 filelock for test- plots and blocks

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -230,9 +230,11 @@ def blockchain_constants(consensus_mode: ConsensusMode) -> ConsensusConstants:
 
 
 @pytest.fixture(scope="session", name="bt")
-async def block_tools_fixture(get_keychain, blockchain_constants, anyio_backend) -> BlockTools:
+async def block_tools_fixture(get_keychain, blockchain_constants, anyio_backend, testrun_uid: str) -> BlockTools:
     # Note that this causes a lot of CPU and disk traffic - disk, DB, ports, process creation ...
-    shared_block_tools = await create_block_tools_async(constants=blockchain_constants, keychain=get_keychain)
+    shared_block_tools = await create_block_tools_async(
+        constants=blockchain_constants, keychain=get_keychain, testrun_uid=testrun_uid
+    )
     return shared_block_tools
 
 
@@ -950,13 +952,17 @@ def get_temp_keyring():
 
 
 @pytest.fixture(scope="function")
-async def get_b_tools_1(get_temp_keyring):
-    return await create_block_tools_async(constants=test_constants_modified, keychain=get_temp_keyring)
+async def get_b_tools_1(get_temp_keyring, testrun_uid: str):
+    return await create_block_tools_async(
+        constants=test_constants_modified, keychain=get_temp_keyring, testrun_uid=testrun_uid
+    )
 
 
 @pytest.fixture(scope="function")
-async def get_b_tools(get_temp_keyring):
-    local_b_tools = await create_block_tools_async(constants=test_constants_modified, keychain=get_temp_keyring)
+async def get_b_tools(get_temp_keyring, testrun_uid):
+    local_b_tools = await create_block_tools_async(
+        constants=test_constants_modified, keychain=get_temp_keyring, testrun_uid=testrun_uid
+    )
     new_config = local_b_tools._config
     local_b_tools.change_config(new_config)
     return local_b_tools
@@ -1258,7 +1264,9 @@ def populated_temp_file_keyring_fixture() -> Iterator[TempKeyring]:
 
 @pytest.fixture(scope="function")
 async def farmer_harvester_2_simulators_zero_bits_plot_filter(
-    tmp_path: Path, get_temp_keyring: Keychain
+    tmp_path: Path,
+    get_temp_keyring: Keychain,
+    testrun_uid,
 ) -> AsyncIterator[
     tuple[
         FarmerService,
@@ -1277,6 +1285,7 @@ async def farmer_harvester_2_simulators_zero_bits_plot_filter(
         bt = await create_block_tools_async(
             zero_bit_plot_filter_consts,
             keychain=get_temp_keyring,
+            testrun_uid=testrun_uid,
         )
 
         config_overrides: dict[str, int] = {"full_node.max_sync_wait": 0}
@@ -1289,6 +1298,7 @@ async def farmer_harvester_2_simulators_zero_bits_plot_filter(
                 num_pool_plots=0,
                 num_non_keychain_plots=0,
                 config_overrides=config_overrides,
+                testrun_uid=testrun_uid,
             )
             for _ in range(2)
         ]

--- a/chia/_tests/util/blockchain.py
+++ b/chia/_tests/util/blockchain.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import os
 import pickle  # noqa: S403  # TODO: use explicit serialization instead of pickle
+import time
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Optional
@@ -59,6 +60,7 @@ def persistent_blocks(
         block_list_input = []
     block_path_dir = DEFAULT_ROOT_PATH.parent.joinpath("blocks")
     file_path = block_path_dir.joinpath(db_name)
+    lock_file_path = block_path_dir / (db_name + ".lockfile")
 
     ci = os.environ.get("CI")
     if ci is not None and not file_path.exists():
@@ -66,40 +68,54 @@ def persistent_blocks(
 
     block_path_dir.mkdir(parents=True, exist_ok=True)
 
-    if file_path.exists():
-        print(f"File found at: {file_path}")
+    # first acquire the lock
+    while True:
         try:
-            bytes_list = file_path.read_bytes()
-            # TODO: use explicit serialization instead of pickle
-            block_bytes_list: list[bytes] = pickle.loads(bytes_list)  # noqa: S301
-            blocks: list[FullBlock] = []
-            for block_bytes in block_bytes_list:
-                blocks.append(FullBlock.from_bytes_unchecked(block_bytes))
-            if len(blocks) == num_of_blocks + len(block_list_input):
-                print(f"\n loaded {file_path} with {len(blocks)} blocks")
+            lockfile = open(lock_file_path, "x")
+            break
+        except OSError:
+            # some other process is already holding the lock, wait for the file
+            # to appear
+            time.sleep(1)
 
-                return blocks
-        except EOFError:
-            print("\n error reading db file")
-    else:
-        print(f"File not found at: {file_path}")
+    try:
+        if file_path.exists():
+            print(f"File found at: {file_path}")
+            try:
+                bytes_list = file_path.read_bytes()
+                # TODO: use explicit serialization instead of pickle
+                block_bytes_list: list[bytes] = pickle.loads(bytes_list)  # noqa: S301
+                blocks: list[FullBlock] = []
+                for block_bytes in block_bytes_list:
+                    blocks.append(FullBlock.from_bytes_unchecked(block_bytes))
+                if len(blocks) == num_of_blocks + len(block_list_input):
+                    print(f"\n loaded {file_path} with {len(blocks)} blocks")
 
-    print("Creating a new test db")
-    return new_test_db(
-        file_path,
-        num_of_blocks,
-        seed,
-        empty_sub_slots,
-        bt,
-        block_list_input,
-        time_per_block,
-        normalized_to_identity_cc_eos=normalized_to_identity_cc_eos,
-        normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
-        normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
-        normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
-        dummy_block_references=dummy_block_references,
-        include_transactions=include_transactions,
-    )
+                    return blocks
+            except EOFError:
+                print("\n error reading db file")
+        else:
+            print(f"File not found at: {file_path}")
+
+        print("Creating a new test db")
+        return new_test_db(
+            file_path,
+            num_of_blocks,
+            seed,
+            empty_sub_slots,
+            bt,
+            block_list_input,
+            time_per_block,
+            normalized_to_identity_cc_eos=normalized_to_identity_cc_eos,
+            normalized_to_identity_icc_eos=normalized_to_identity_icc_eos,
+            normalized_to_identity_cc_sp=normalized_to_identity_cc_sp,
+            normalized_to_identity_cc_ip=normalized_to_identity_cc_ip,
+            dummy_block_references=dummy_block_references,
+            include_transactions=include_transactions,
+        )
+    finally:
+        lockfile.close()
+        lock_file_path.unlink()
 
 
 def new_test_db(

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -338,6 +338,29 @@ class BlockTools:
                 assert self.total_result.processed == update_result.processed
                 assert self.total_result.duration == update_result.duration
                 assert update_result.remaining == 0
+
+                expected_plots: set[str] = set()
+                found_plots: set[str] = set()
+                if len(self.plot_manager.plots) != len(self.expected_plots):  # pragma: no cover
+                    for pid, filename in self.expected_plots.items():
+                        expected_plots.add(filename.name)
+                    for filename, _ in self.plot_manager.plots.items():
+                        found_plots.add(filename.name)
+                    print(f"directory: {self.plot_dir}")
+                    print(f"expected: {len(expected_plots)}")
+                    for f in expected_plots:
+                        print(f)
+                    print(f"plot manager: {len(found_plots)}")
+                    for f in found_plots:
+                        print(f)
+                    diff = found_plots.difference(expected_plots)
+                    print(f"found unexpected: {len(diff)}")
+                    for f in diff:
+                        print(f)
+                    diff = expected_plots.difference(found_plots)
+                    print(f"not found: {len(diff)}")
+                    for f in diff:
+                        print(f)
                 assert len(self.plot_manager.plots) == len(self.expected_plots)
 
         self.plot_manager: PlotManager = PlotManager(


### PR DESCRIPTION
### Purpose:

The test fixtures that create test plots and test blockchains are currently not aware of `pytest-xdist`, and perform the same (expensive) work multiple times, in parallel. This patch introduces a lockfile for creating the plots, as well as a lock file for each individual test chain being created.

The chains are primarily CPU bound, so they benefit from being created in parallel.

This also mitigates a bug in `chiapos` where creating the exact same plot in the same temp directory and the same target directory causes it to segfault.

### Current Behavior:

```
rm -rf ~/.chia/test-plots
pytest -n 10
```

Causes a segfault because multiple processes start making the same test plots

### New Behavior:

```
rm -rf ~/.chia/test-plots
pytest -n 10
```

Creates the test plots only once, in a single process. The other processes will wait for it to complete before resuming.