### PR TITLE
Change default limit for transactions to 65536 (uint16)

### DIFF
--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -94,7 +94,7 @@ def get_transaction_cmd(
     "--limit",
     help="Max number of transactions to return",
     type=int,
-    default=(2**32 - 1),
+    default=(2**16 - 1),
     show_default=True,
     required=False,
 )


### PR DESCRIPTION
Make sure default transaction limit (`--limit`) fits into uint16