### PR TITLE
Minor pos2 updates

### DIFF
--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -112,25 +112,23 @@ def b32(key: str) -> bytes32:
         id="v2 plot size 0",
         pos_challenge=bytes32(b"1" * 32),
         plot_size=PlotSize.make_v2(0),
+        pool_contract_puzzle_hash=bytes32(b"1" * 32),
         plot_public_key=G1Element(),
-        pool_public_key=G1Element(),
         expected_error="Plot size (0) is lower than the minimum (28)",
     ),
     ProofOfSpaceCase(
         id="v2 plot size 34",
         pos_challenge=bytes32(b"1" * 32),
         plot_size=PlotSize.make_v2(34),
+        pool_contract_puzzle_hash=bytes32(b"1" * 32),
         plot_public_key=G1Element(),
-        pool_public_key=G1Element(),
         expected_error="Plot size (34) is higher than the maximum (32)",
     ),
     ProofOfSpaceCase(
         id="Not passing the plot filter v2",
-        pos_challenge=b32("3d29ea79d19b3f7e99ebf764ae53697cbe143603909873946af6ab1ece606861"),
+        pos_challenge=b32("2b76a5fe5d4ae062ba9e80b5bcb0e9c1301f3a2787b8f3141e3fb458d1c1864c"),
         plot_size=PlotSize.make_v2(32),
-        pool_public_key=g1(
-            "b6449c2c68df97c19e884427e42ee7350982d4020571ead08732615ff39bd216bfd630b6460784982bec98b49fea79d0"
-        ),
+        pool_contract_puzzle_hash=bytes32(b"1" * 32),
         plot_public_key=g1(
             "879526b4e7b616cfd64984d8ad140d0798b048392a6f11e2faf09054ef467ea44dc0dab5e5edb2afdfa850c5c8b629cc"
         ),
@@ -160,16 +158,15 @@ def test_verify_and_get_quality_string(caplog: pytest.LogCaptureFixture, case: P
 @datacases(
     ProofOfSpaceCase(
         id="v2 plot are not implemented",
-        plot_size=PlotSize.make_v2(30),
-        pos_challenge=b32("47deb938e145d25d7b3b3c85ca9e3972b76c01aeeb78a02fe5d3b040d282317e"),
+        plot_size=PlotSize.make_v2(28),
+        pos_challenge=b32("be7ac7436520a3fa259a618a2c54de4ca8b8d2319c1ec5b11a2ef4c025c2e0a6"),
         plot_public_key=g1(
             "afa3aaf09c03885154be49216ee7fb2e4581b9c4a4d7e9cc402e27280bf0cfdbdf1b9ba674e301fd1d1450234b3b1868"
         ),
-        pool_public_key=g1(
-            "b6449c2c68df97c19e884427e42ee7350982d4020571ead08732615ff39bd216bfd630b6460784982bec98b49fea79d0"
-        ),
-        expected_error="NotImplementedError",
+        pool_contract_puzzle_hash=bytes32(b"1" * 32),
+        expected_error="Did not pass the plot filter",
     ),
+    # TODO: todo_v2_plots add test case that passes the plot filter
 )
 def test_verify_and_get_quality_string_v2(caplog: pytest.LogCaptureFixture, case: ProofOfSpaceCase) -> None:
     pos = make_pos(

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -398,6 +398,11 @@ class HarvesterAPI:
                     )
                     passed += 1
                 else:
+                    constants = self.harvester.constants
+                    # after the phase-out, ignore v1 plots
+                    if new_challenge.last_tx_height >= constants.HARD_FORK2_HEIGHT + constants.PLOT_V1_PHASE_OUT:
+                        continue
+
                     passed += 1
                     awaitables.append(lookup_challenge(try_plot_filename, try_plot_info))
             self.harvester.log.debug(f"new_signage_point_harvester {passed} plots passed the plot filter")

--- a/chia/plot_sync/receiver.py
+++ b/chia/plot_sync/receiver.py
@@ -113,8 +113,8 @@ class Receiver:
     async def trigger_callback(self, update: Optional[Delta] = None) -> None:
         try:
             await self._update_callback(self._connection.peer_node_id, update)
-        except Exception as e:
-            log.error(f"_update_callback: node_id {self.connection().peer_node_id}, raised {e}")
+        except Exception:
+            log.exception(f"_update_callback: node_id {self.connection().peer_node_id}")
 
     def reset(self) -> None:
         log.info(f"reset: node_id {self.connection().peer_node_id}, current_sync: {self._current_sync}")
@@ -181,13 +181,13 @@ class Receiver:
             await method(message)
             await send_response()
         except InvalidIdentifierError as e:
-            log.warning(f"_process: node_id {self.connection().peer_node_id}, InvalidIdentifierError {e}")
+            log.exception(f"_process: node_id {self.connection().peer_node_id}")
             await send_response(PlotSyncError(int16(e.error_code), f"{e}", e.expected_identifier))
         except PlotSyncException as e:
-            log.warning(f"_process: node_id {self.connection().peer_node_id}, Error {e}")
+            log.exception(f"_process: node_id {self.connection().peer_node_id}")
             await send_response(PlotSyncError(int16(e.error_code), f"{e}", None))
         except Exception as e:
-            log.warning(f"_process: node_id {self.connection().peer_node_id}, Exception {e}")
+            log.exception(f"_process: node_id {self.connection().peer_node_id}")
             await send_response(PlotSyncError(int16(ErrorCodes.unknown), f"{e}", None))
 
     def _validate_identifier(self, identifier: PlotSyncIdentifier, start: bool = False) -> None:

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -278,8 +278,8 @@ class PlotManager:
                     f"total_result.removed {len(total_result.removed)}, "
                     f"total_duration {total_result.duration:.2f} seconds"
                 )
-            except Exception as e:
-                log.error(f"_refresh_callback raised: {e} with the traceback: {traceback.format_exc()}")
+            except Exception:
+                log.exception("_refresh_callback raised")
                 self.reset()
 
     def refresh_batch(self, plot_paths: list[Path], plot_directories: set[Path]) -> PlotRefreshResult:

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -1553,6 +1553,8 @@ class BlockTools:
                         f"cannot be used for farming: {plot_info.prover.get_filename()}"
                     )
                     continue
+            elif prev_transaction_b_height >= constants.HARD_FORK2_HEIGHT + constants.PLOT_V1_PHASE_OUT:
+                continue
 
             new_challenge: bytes32 = calculate_pos_challenge(plot_id, challenge_hash, signage_point)
 


### PR DESCRIPTION
### Purpose:

This PR collects a few minor changes, shaved off of my larger PR to integrate v2 plots.

These 3 commits are best reviewed one at a time, and are somewhat independent.

### Current Behavior:

* We still have some stub functions for the new chiapos2 API.
* We use `log.warning()` and `log.error()` to log exceptions.
* When farming v1 plots we always get the qualities, adjust them based on phase-out and check against difficulty.

### New Behavior:

* The last chiapos2 stub APIs have been removed.
* We use `log.exception()` to log exceptions.
* When farming v1 plots we short cut and ignore them if the block height is past the end of the phase-out. This is an optimization to avoid scanning the plots for proofs that will never pass the difficulty.