### PR TITLE
Ensure config and certs are setup on upgrade for new solver service

### DIFF
--- a/build_scripts/pyinstaller.spec
+++ b/build_scripts/pyinstaller.spec
@@ -33,6 +33,7 @@ SERVERS = [
     "farmer",
     "introducer",
     "timelord",
+    "solver"
 ]
 
 if THIS_IS_WINDOWS:


### PR DESCRIPTION
When upgrading from previous installs, the solver config and certificates won't be present
This change will create the correct items as needed following the pattern used in data_layer when we added that service
This allows the solver to run on upgrade without any errors.

Also make sure to add the new solver service to the pyinstaller spec so that it is included in the packaged installers