### PR TITLE
[LABS-161] Add a method for creating outgoing transactions

### DIFF
--- a/chia/_tests/wallet/test_wallet.py
+++ b/chia/_tests/wallet/test_wallet.py
@@ -21,11 +21,9 @@ from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.errors import Err
-from chia.wallet.conditions import ConditionValidTimes
 from chia.wallet.derive_keys import master_sk_to_wallet_sk
 from chia.wallet.estimate_fees import estimate_fees
 from chia.wallet.puzzles.clawback.metadata import AutoClaimSettings
-from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.compute_additions import compute_additions
 from chia.wallet.util.query_filter import TransactionTypeFilter
 from chia.wallet.util.transaction_type import TransactionType
@@ -1706,26 +1704,15 @@ class TestWalletSimulator:
 
         # get a legit signature
         stolen_sb, _ = await wallet.wallet_state_manager.sign_bundle([stolen_cs])
-        name = stolen_sb.name()
-        stolen_tx = TransactionRecord(
-            confirmed_at_height=uint32(0),
-            created_at_time=uint64(0),
-            to_puzzle_hash=bytes32(32 * b"0"),
-            to_address=encode_puzzle_hash(bytes32(32 * b"0"), "txch"),
+        stolen_tx = wallet.wallet_state_manager.new_outgoing_transaction(
+            wallet_id=wallet.id(),
+            puzzle_hash=bytes32.zeros,
             amount=uint64(0),
-            fee_amount=uint64(0),
-            confirmed=False,
-            sent=uint32(0),
+            fee=uint64(0),
             spend_bundle=stolen_sb,
             additions=[],
             removals=[],
-            wallet_id=wallet.id(),
-            sent_to=[],
-            trade_id=None,
-            type=uint32(TransactionType.OUTGOING_TX.value),
-            name=name,
-            memos={},
-            valid_times=ConditionValidTimes(),
+            name=stolen_sb.name(),
         )
         [stolen_tx] = await wallet.wallet_state_manager.add_pending_transactions([stolen_tx])
 

--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-import time
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
 
 from chia_rs import BlockRecord, CoinSpend, CoinState, G1Element, G2Element
@@ -29,7 +28,6 @@ from chia.wallet.conditions import (
     CreateCoin,
     CreateCoinAnnouncement,
     UnknownCondition,
-    parse_timelock_info,
 )
 from chia.wallet.db_wallet.db_wallet_puzzles import (
     ACS_MU,
@@ -52,9 +50,7 @@ from chia.wallet.singleton import SINGLETON_LAUNCHER_PUZZLE, SINGLETON_LAUNCHER_
 from chia.wallet.trading.offer import NotarizedPayment, Offer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.compute_additions import compute_additions
-from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.merkle_utils import _simplify_merkle_proof
-from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend, fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
@@ -535,25 +531,16 @@ class DataLayerWallet:
         if announce_new_state:
             spend_bundle = WalletSpendBundle([coin_spend, second_coin_spend], spend_bundle.aggregated_signature)
 
-        dl_tx = TransactionRecord(
-            confirmed_at_height=uint32(0),
-            created_at_time=uint64(time.time()),
-            to_puzzle_hash=new_puz_hash,
-            to_address=self.wallet_state_manager.encode_puzzle_hash(new_puz_hash),
+        dl_tx = self.wallet_state_manager.new_outgoing_transaction(
+            wallet_id=self.id(),
+            puzzle_hash=new_puz_hash,
             amount=uint64(singleton_record.lineage_proof.amount),
-            fee_amount=fee,
-            confirmed=False,
-            sent=uint32(10),
+            fee=fee,
             spend_bundle=spend_bundle,
             additions=spend_bundle.additions(),
             removals=spend_bundle.removals(),
-            memos=compute_memos(spend_bundle),
-            wallet_id=self.id(),
-            sent_to=[],
-            trade_id=None,
-            type=uint32(TransactionType.OUTGOING_TX.value),
             name=singleton_record.coin_id,
-            valid_times=parse_timelock_info(extra_conditions),
+            extra_conditions=extra_conditions,
         )
         assert dl_tx.spend_bundle is not None
         if fee > 0:
@@ -730,25 +717,16 @@ class DataLayerWallet:
 
         async with action_scope.use() as interface:
             interface.side_effects.transactions.append(
-                TransactionRecord(
-                    confirmed_at_height=uint32(0),
-                    created_at_time=uint64(time.time()),
-                    to_puzzle_hash=new_puzhash,
-                    to_address=self.wallet_state_manager.encode_puzzle_hash(new_puzhash),
+                self.wallet_state_manager.new_outgoing_transaction(
+                    wallet_id=self.id(),
+                    puzzle_hash=new_puzhash,
                     amount=uint64(mirror_coin.amount),
-                    fee_amount=fee,
-                    confirmed=False,
-                    sent=uint32(10),
+                    fee=fee,
                     spend_bundle=mirror_bundle,
                     additions=mirror_bundle.additions(),
                     removals=mirror_bundle.removals(),
-                    memos=compute_memos(mirror_bundle),
-                    wallet_id=self.id(),  # This is being called before the wallet is created so we're using a ID of 0
-                    sent_to=[],
-                    trade_id=None,
-                    type=uint32(TransactionType.OUTGOING_TX.value),
                     name=mirror_bundle.name(),
-                    valid_times=parse_timelock_info(extra_conditions),
+                    extra_conditions=extra_conditions,
                 )
             )
 

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -39,7 +39,6 @@ from chia.wallet.conditions import (
     CreateCoin,
     CreateCoinAnnouncement,
     UnknownCondition,
-    parse_timelock_info,
 )
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.lineage_proof import LineageProof
@@ -49,7 +48,6 @@ from chia.wallet.puzzles.tails import ALL_LIMITATIONS_PROGRAMS
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.compute_additions import compute_additions_with_cost
-from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.curry_and_treehash import curry_and_treehash
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend_for_coin_state
@@ -794,25 +792,16 @@ class CATWallet:
                 removal for tx in interface.side_effects.transactions for removal in tx.additions
             }
             interface.side_effects.transactions.append(
-                TransactionRecord(
-                    confirmed_at_height=uint32(0),
-                    created_at_time=uint64(time.time()),
-                    to_puzzle_hash=puzzle_hashes[0],
-                    to_address=self.wallet_state_manager.encode_puzzle_hash(puzzle_hashes[0]),
+                self.wallet_state_manager.new_outgoing_transaction(
+                    wallet_id=self.id(),
+                    puzzle_hash=puzzle_hashes[0],
                     amount=uint64(payment_sum),
-                    fee_amount=fee,
-                    confirmed=False,
-                    sent=uint32(0),
+                    fee=fee,
                     spend_bundle=spend_bundle,
                     additions=list(set(spend_bundle.additions()) - other_tx_additions),
                     removals=list(set(spend_bundle.removals()) - other_tx_removals),
-                    wallet_id=self.id(),
-                    sent_to=[],
-                    trade_id=None,
-                    type=uint32(TransactionType.OUTGOING_TX.value),
                     name=spend_bundle.name(),
-                    memos=compute_memos(spend_bundle),
-                    valid_times=parse_timelock_info(extra_conditions),
+                    extra_conditions=extra_conditions,
                 )
             )
 

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -23,7 +23,6 @@ from chia.wallet.conditions import (
     ConditionValidTimes,
     CreateCoin,
     CreateCoinAnnouncement,
-    parse_timelock_info,
 )
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.did_wallet import did_wallet_puzzles
@@ -44,7 +43,6 @@ from chia.wallet.singleton import (
 )
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
-from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.curry_and_treehash import NIL_TREEHASH, shatree_int, shatree_pair
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
@@ -649,25 +647,16 @@ class DIDWallet:
                 extra_conditions=(AssertCoinAnnouncement(asserted_id=coin_name, asserted_msg=coin_name),),
             )
         to_ph = await action_scope.get_puzzle_hash(self.wallet_state_manager, override_reuse_puzhash_with=True)
-        did_record = TransactionRecord(
-            confirmed_at_height=uint32(0),
-            created_at_time=uint64(time.time()),
-            to_puzzle_hash=to_ph,
-            to_address=self.wallet_state_manager.encode_puzzle_hash(to_ph),
+        did_record = self.wallet_state_manager.new_outgoing_transaction(
+            wallet_id=self.id(),
+            puzzle_hash=to_ph,
             amount=uint64(coin.amount),
-            fee_amount=uint64(0),
-            confirmed=False,
-            sent=uint32(0),
+            fee=uint64(0),
             spend_bundle=spend_bundle,
             additions=spend_bundle.additions(),
             removals=spend_bundle.removals(),
-            wallet_id=self.wallet_info.id,
-            sent_to=[],
-            trade_id=None,
-            type=uint32(TransactionType.OUTGOING_TX.value),
-            name=bytes32.secret(),
-            memos=compute_memos(spend_bundle),
-            valid_times=parse_timelock_info(extra_conditions),
+            name=spend_bundle.name(),
+            extra_conditions=extra_conditions,
         )
 
         async with action_scope.use() as interface:
@@ -735,25 +724,16 @@ class DIDWallet:
                 extra_conditions=(AssertCoinAnnouncement(asserted_id=coin_name, asserted_msg=coin_name),),
             )
         to_ph = await action_scope.get_puzzle_hash(self.wallet_state_manager, override_reuse_puzhash_with=True)
-        did_record = TransactionRecord(
-            confirmed_at_height=uint32(0),
-            created_at_time=uint64(time.time()),
-            to_puzzle_hash=to_ph,
-            to_address=self.wallet_state_manager.encode_puzzle_hash(to_ph),
+        did_record = self.wallet_state_manager.new_outgoing_transaction(
+            wallet_id=self.id(),
+            puzzle_hash=to_ph,
             amount=uint64(coin.amount),
-            fee_amount=fee,
-            confirmed=False,
-            sent=uint32(0),
+            fee=fee,
             spend_bundle=spend_bundle,
             additions=spend_bundle.additions(),
             removals=spend_bundle.removals(),
-            wallet_id=self.wallet_info.id,
-            sent_to=[],
-            trade_id=None,
-            type=uint32(TransactionType.OUTGOING_TX.value),
             name=spend_bundle.name(),
-            memos=compute_memos(spend_bundle),
-            valid_times=parse_timelock_info(extra_conditions),
+            extra_conditions=extra_conditions,
         )
 
         async with action_scope.use() as interface:
@@ -815,25 +795,16 @@ class DIDWallet:
         )
         list_of_coinspends = [make_spend(coin, full_puzzle, fullsol)]
         unsigned_spend_bundle = WalletSpendBundle(list_of_coinspends, G2Element())
-        tx = TransactionRecord(
-            confirmed_at_height=uint32(0),
-            created_at_time=uint64(time.time()),
-            to_puzzle_hash=p2_ph,
-            to_address=self.wallet_state_manager.encode_puzzle_hash(p2_ph),
+        tx = self.wallet_state_manager.new_outgoing_transaction(
+            wallet_id=self.id(),
+            puzzle_hash=p2_ph,
             amount=uint64(coin.amount),
-            fee_amount=uint64(0),
-            confirmed=False,
-            sent=uint32(0),
+            fee=uint64(0),
             spend_bundle=unsigned_spend_bundle,
             additions=unsigned_spend_bundle.additions(),
             removals=[coin],
-            wallet_id=self.id(),
-            sent_to=[],
-            trade_id=None,
-            type=uint32(TransactionType.OUTGOING_TX.value),
             name=unsigned_spend_bundle.name(),
-            memos=compute_memos(unsigned_spend_bundle),
-            valid_times=parse_timelock_info(extra_conditions),
+            extra_conditions=extra_conditions,
         )
         async with action_scope.use() as interface:
             interface.side_effects.transactions.append(tx)

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -1391,7 +1391,7 @@ class NFTWallet:
         async with action_scope.use() as interface:
             interface.side_effects.transactions.append(
                 self.wallet_state_manager.new_outgoing_transaction(
-                    wallet_id=self.id(),
+                    wallet_id=did_wallet.id(),
                     puzzle_hash=innerpuz.get_tree_hash(),
                     amount=uint64(1),
                     fee=fee,

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import math
-import time
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar, cast
 
 from chia_rs import AugSchemeMPL, CoinSpend, CoinState, G1Element, G2Element
@@ -26,7 +25,6 @@ from chia.wallet.conditions import (
     CreateCoinAnnouncement,
     CreatePuzzleAnnouncement,
     UnknownCondition,
-    parse_timelock_info,
 )
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.did_wallet import did_wallet_puzzles
@@ -49,8 +47,6 @@ from chia.wallet.trading.offer import OFFER_MOD, OFFER_MOD_HASH, NotarizedPaymen
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
 from chia.wallet.util.compute_additions import compute_additions
-from chia.wallet.util.compute_memos import compute_memos
-from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_action_scope import WalletActionScope
@@ -613,25 +609,16 @@ class NFTWallet:
             other_tx_additions: set[Coin] = {
                 addition for tx in interface.side_effects.transactions for addition in tx.additions
             }
-            tx = TransactionRecord(
-                confirmed_at_height=uint32(0),
-                created_at_time=uint64(time.time()),
-                to_puzzle_hash=puzzle_hashes[0],
-                to_address=self.wallet_state_manager.encode_puzzle_hash(puzzle_hashes[0]),
+            tx = self.wallet_state_manager.new_outgoing_transaction(
+                wallet_id=self.id(),
+                puzzle_hash=puzzle_hashes[0],
                 amount=uint64(payment_sum),
-                fee_amount=fee,
-                confirmed=False,
-                sent=uint32(0),
+                fee=fee,
                 spend_bundle=spend_bundle,
                 additions=list(set(spend_bundle.additions()) - other_tx_additions),
                 removals=list(set(spend_bundle.removals()) - other_tx_removals),
-                wallet_id=self.id(),
-                sent_to=[],
-                trade_id=None,
-                type=uint32(TransactionType.OUTGOING_TX.value),
                 name=spend_bundle.name(),
-                memos=compute_memos(spend_bundle),
-                valid_times=parse_timelock_info(extra_conditions),
+                extra_conditions=extra_conditions,
             )
 
             interface.side_effects.transactions.append(tx)
@@ -1403,25 +1390,16 @@ class NFTWallet:
 
         async with action_scope.use() as interface:
             interface.side_effects.transactions.append(
-                TransactionRecord(
-                    confirmed_at_height=uint32(0),
-                    created_at_time=uint64(time.time()),
-                    to_puzzle_hash=innerpuz.get_tree_hash(),
-                    to_address=self.wallet_state_manager.encode_puzzle_hash(innerpuz.get_tree_hash()),
+                self.wallet_state_manager.new_outgoing_transaction(
+                    wallet_id=self.id(),
+                    puzzle_hash=innerpuz.get_tree_hash(),
                     amount=uint64(1),
-                    fee_amount=fee,
-                    confirmed=False,
-                    sent=uint32(0),
+                    fee=fee,
                     spend_bundle=unsigned_spend_bundle,
-                    additions=list(unsigned_spend_bundle.additions()),
-                    removals=list(unsigned_spend_bundle.removals()),
-                    wallet_id=did_wallet.id(),
-                    sent_to=[],
-                    trade_id=None,
-                    type=uint32(TransactionType.OUTGOING_TX.value),
+                    additions=unsigned_spend_bundle.additions(),
+                    removals=unsigned_spend_bundle.removals(),
                     name=unsigned_spend_bundle.name(),
-                    memos=compute_memos(unsigned_spend_bundle),
-                    valid_times=parse_timelock_info(extra_conditions),
+                    extra_conditions=extra_conditions,
                 )
             )
 

--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -659,25 +659,17 @@ class CRCATWallet(CATWallet):
                 addition for tx in interface.side_effects.transactions for addition in tx.additions
             }
             tx_list = [
-                TransactionRecord(
-                    confirmed_at_height=uint32(0),
-                    created_at_time=uint64(time.time()),
-                    to_puzzle_hash=payment.puzzle_hash,
-                    to_address=self.wallet_state_manager.encode_puzzle_hash(payment.puzzle_hash),
-                    amount=payment.amount,
-                    fee_amount=fee,
-                    confirmed=False,
-                    sent=uint32(0),
-                    spend_bundle=spend_bundle if i == 0 else None,
+                self.wallet_state_manager.new_outgoing_transaction(
+                    wallet_id=self.id(),
+                    puzzle_hash=payment.puzzle_hash,
+                    amount=uint64(payment.amount),
+                    fee=fee,
+                    # semantics guarantee not None here
+                    spend_bundle=spend_bundle if i == 0 else None,  # type: ignore[arg-type]
                     additions=list(set(spend_bundle.additions()) - other_tx_additions) if i == 0 else [],
                     removals=list(set(spend_bundle.removals()) - other_tx_removals) if i == 0 else [],
-                    wallet_id=self.id(),
-                    sent_to=[],
-                    trade_id=None,
-                    type=uint32(TransactionType.OUTGOING_TX.value),
                     name=spend_bundle.name() if i == 0 else payment.to_program().get_tree_hash(),
-                    memos=compute_memos(spend_bundle),
-                    valid_times=parse_timelock_info(extra_conditions),
+                    extra_conditions=extra_conditions,
                 )
                 for i, payment in enumerate(payments)
             ]

--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -201,7 +201,7 @@ class VCWallet:
         async with action_scope.use() as interface:
             interface.side_effects.transactions.append(
                 self.wallet_state_manager.new_outgoing_transaction(
-                    wallet_id=self.id(),
+                    wallet_id=uint32(1),
                     puzzle_hash=inner_puzzle_hash,
                     amount=uint64(1),
                     fee=fee,

--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import time
 import traceback
 from typing import TYPE_CHECKING, Optional, TypeVar, Union
 
@@ -25,16 +24,12 @@ from chia.wallet.conditions import (
     CreateCoinAnnouncement,
     CreatePuzzleAnnouncement,
     UnknownCondition,
-    parse_timelock_info,
 )
 from chia.wallet.did_wallet.did_wallet import DIDWallet
 from chia.wallet.puzzle_drivers import Solver
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import solution_for_delegated_puzzle
 from chia.wallet.trading.offer import Offer
-from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.uncurried_puzzle import uncurry_puzzle
-from chia.wallet.util.compute_memos import compute_memos
-from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import WalletType
 from chia.wallet.vc_wallet.cr_cat_drivers import CRCAT, CRCATSpend, ProofsChecker, construct_pending_approval_state
@@ -200,31 +195,21 @@ class VCWallet:
             puzzle = await self.standard_wallet.puzzle_for_puzzle_hash(coin.puzzle_hash)
             coin_spends.append(make_spend(coin, puzzle, solution))
         spend_bundle = WalletSpendBundle(coin_spends, G2Element())
-        now = uint64(time.time())
         add_list: list[Coin] = list(spend_bundle.additions())
         rem_list: list[Coin] = list(spend_bundle.removals())
         vc_record: VCRecord = VCRecord(vc, uint32(0))
         async with action_scope.use() as interface:
             interface.side_effects.transactions.append(
-                TransactionRecord(
-                    confirmed_at_height=uint32(0),
-                    created_at_time=now,
-                    to_puzzle_hash=inner_puzzle_hash,
-                    to_address=self.wallet_state_manager.encode_puzzle_hash(inner_puzzle_hash),
+                self.wallet_state_manager.new_outgoing_transaction(
+                    wallet_id=self.id(),
+                    puzzle_hash=inner_puzzle_hash,
                     amount=uint64(1),
-                    fee_amount=uint64(fee),
-                    confirmed=False,
-                    sent=uint32(0),
+                    fee=fee,
                     spend_bundle=spend_bundle,
                     additions=add_list,
                     removals=rem_list,
-                    wallet_id=uint32(1),
-                    sent_to=[],
-                    trade_id=None,
-                    type=uint32(TransactionType.OUTGOING_TX.value),
                     name=spend_bundle.name(),
-                    memos=compute_memos(spend_bundle),
-                    valid_times=parse_timelock_info(extra_conditions),
+                    extra_conditions=extra_conditions,
                 )
             )
 
@@ -340,29 +325,19 @@ class VCWallet:
                 )  # pragma: no cover
         add_list: list[Coin] = list(spend_bundle.additions())
         rem_list: list[Coin] = list(spend_bundle.removals())
-        now = uint64(time.time())
 
         async with action_scope.use() as interface:
             interface.side_effects.transactions.append(
-                TransactionRecord(
-                    confirmed_at_height=uint32(0),
-                    created_at_time=now,
-                    to_puzzle_hash=puzzle_hashes[0],
-                    to_address=self.wallet_state_manager.encode_puzzle_hash(puzzle_hashes[0]),
+                self.wallet_state_manager.new_outgoing_transaction(
+                    wallet_id=self.id(),
+                    puzzle_hash=puzzle_hashes[0],
                     amount=uint64(1),
-                    fee_amount=uint64(fee),
-                    confirmed=False,
-                    sent=uint32(0),
+                    fee=fee,
                     spend_bundle=spend_bundle,
                     additions=add_list,
                     removals=rem_list,
-                    wallet_id=self.id(),
-                    sent_to=[],
-                    trade_id=None,
-                    type=uint32(TransactionType.OUTGOING_TX.value),
                     name=spend_bundle.name(),
-                    memos=compute_memos(spend_bundle),
-                    valid_times=parse_timelock_info(extra_conditions),
+                    extra_conditions=extra_conditions,
                 )
             )
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -2780,3 +2780,38 @@ class WalletStateManager:
 
     def encode_puzzle_hash(self, puzzle_hash: bytes32) -> str:
         return encode_puzzle_hash(puzzle_hash, AddressType.XCH.hrp(self.config))
+
+    def new_outgoing_transaction(
+        self,
+        *,
+        wallet_id: uint32,
+        puzzle_hash: bytes32,
+        amount: uint64,
+        fee: uint64,
+        spend_bundle: WalletSpendBundle,
+        additions: list[Coin],
+        removals: list[Coin],
+        name: bytes32,
+        extra_conditions: tuple[Condition, ...] = tuple(),
+        trade_id: bytes32 | None = None,
+    ) -> TransactionRecord:
+        return TransactionRecord(
+            confirmed_at_height=uint32(0),
+            created_at_time=uint64(time.time()),
+            to_puzzle_hash=puzzle_hash,
+            to_address=self.encode_puzzle_hash(puzzle_hash),
+            amount=amount,
+            fee_amount=fee,
+            confirmed=False,
+            sent=uint32(0),
+            spend_bundle=spend_bundle,
+            additions=additions,
+            removals=removals,
+            wallet_id=wallet_id,
+            sent_to=[],
+            trade_id=trade_id,
+            type=uint32(TransactionType.OUTGOING_TX.value),
+            name=name,
+            memos=compute_memos(spend_bundle),
+            valid_times=parse_timelock_info(extra_conditions),
+        )


### PR DESCRIPTION
This PR creates a convenience method for creating transactions of type `OUTGOING`.  This is our most common transaction type and the type that developers are most likely to write in the future.

The purpose of creating this method is for more than just convenience, but also for consistency across wallets.  Right now, there's a lot of copy/pasting going on, but it's possible to set certain default values to that which they should not default to. This method makes sure to only ask for the values that actually need to be thought about by the developer, rather than the stuff that is the same for every new initialization of an `OUTGOING` tx.