### PR TITLE
Manual fixes for upcoming Ruff pyupgrade push

### DIFF
--- a/chia/_tests/core/data_layer/util.py
+++ b/chia/_tests/core/data_layer/util.py
@@ -17,7 +17,7 @@ from chia.data_layer.data_store import DataStore
 from chia.types.blockchain_format.program import Program
 
 # from subprocess.pyi
-_FILE = Union[int, IO[Any], None]
+_FILE = int | IO[Any] | None
 
 
 if TYPE_CHECKING:

--- a/chia/_tests/core/util/test_streamable.py
+++ b/chia/_tests/core/util/test_streamable.py
@@ -374,8 +374,8 @@ def test_not_lists() -> None:
 
 
 def test_basic_optional() -> None:
-    assert is_type_SpecificOptional(Optional[int])
-    assert is_type_SpecificOptional(Optional[int])
+    assert is_type_SpecificOptional(int | None)
+    assert is_type_SpecificOptional(int | None)
     assert not is_type_SpecificOptional(list[int])
 
 

--- a/chia/_tests/farmer_harvester/test_third_party_harvesters.py
+++ b/chia/_tests/farmer_harvester/test_third_party_harvesters.py
@@ -52,7 +52,7 @@ from chia.types.validation_state import ValidationState
 from chia.util.bech32m import decode_puzzle_hash
 from chia.util.hash import std_hash
 
-SPType = Union[timelord_protocol.NewEndOfSubSlotVDF, timelord_protocol.NewSignagePointVDF]
+SPType = timelord_protocol.NewEndOfSubSlotVDF | timelord_protocol.NewSignagePointVDF
 SPList = list[SPType]
 
 

--- a/chia/_tests/util/misc.py
+++ b/chia/_tests/util/misc.py
@@ -398,7 +398,7 @@ def closing_chia_root_popen(chia_root: ChiaRoot, args: list[str]) -> Iterator[su
 
 
 # https://github.com/pytest-dev/pytest/blob/7.3.1/src/_pytest/mark/__init__.py#L45
-Marks = Union[pytest.MarkDecorator, Collection[Union[pytest.MarkDecorator, pytest.Mark]]]
+Marks = pytest.MarkDecorator | Collection[pytest.MarkDecorator | pytest.Mark]
 
 
 class DataCase(Protocol):

--- a/chia/_tests/wallet/test_wallet_action_scope.py
+++ b/chia/_tests/wallet/test_wallet_action_scope.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 import pytest
 from chia_rs import G2Element, Program
@@ -36,7 +35,7 @@ def test_back_and_forth_serialization() -> None:
 
 @dataclass
 class MockWalletStateManager:
-    most_recent_call: Optional[
+    most_recent_call: (
         tuple[
             list[TransactionRecord],
             bool,
@@ -45,8 +44,9 @@ class MockWalletStateManager:
             list[SigningResponse],
             list[WalletSpendBundle],
             list[SingletonRecord],
-        ],
-    ] = None
+        ]
+        | None
+    ) = None
 
     async def add_pending_transactions(
         self,

--- a/chia/cmds/cmd_classes.py
+++ b/chia/cmds/cmd_classes.py
@@ -12,7 +12,6 @@ from typing import (
     ClassVar,
     Optional,
     Protocol,
-    Union,
     final,
     get_args,
     get_origin,
@@ -40,7 +39,7 @@ class AsyncChiaCommand(Protocol):
     async def run(self) -> None: ...
 
 
-ChiaCommand = Union[SyncChiaCommand, AsyncChiaCommand]
+ChiaCommand = SyncChiaCommand | AsyncChiaCommand
 
 
 def option(*param_decls: str, **kwargs: Any) -> Any:

--- a/chia/daemon/windows_signal.py
+++ b/chia/daemon/windows_signal.py
@@ -9,10 +9,10 @@ import os
 import signal
 import sys
 from types import FrameType
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional
 
 # https://github.com/python/typeshed/blob/fbddd2c4e2b746f1880399ed0cb31a44d6ede6ff/stdlib/signal.pyi
-_HANDLER = Union[Callable[[int, Optional[FrameType]], Any], int, signal.Handlers, None]
+_HANDLER = Callable[[int, FrameType | None], Any] | int | signal.Handlers | None
 
 if sys.platform != "win32" and sys.platform != "cygwin":
     kill = os.kill

--- a/chia/legacy/keyring.py
+++ b/chia/legacy/keyring.py
@@ -6,7 +6,7 @@ helper it's required to install the `legacy_keyring` extra dependency which can 
 from __future__ import annotations
 
 import sys
-from typing import Callable, Union, cast
+from typing import Callable, TypeAlias, cast
 
 import click
 from chia_rs import G1Element
@@ -19,13 +19,12 @@ try:
 except ImportError:
     if sys.platform == "linux":
         sys.exit("Use `install.sh -l` to install the legacy_keyring dependency.")
-    CryptFileKeyring = None
 
 
 from chia.util.errors import KeychainUserNotFound
 from chia.util.keychain import MAX_KEYS, KeyData, KeyDataSecrets, get_private_key_user
 
-LegacyKeyring = Union[MacKeyring, WinKeyring, CryptFileKeyring]
+LegacyKeyring: TypeAlias = MacKeyring | WinKeyring | CryptFileKeyring
 
 
 CURRENT_KEY_VERSION = "1.8"

--- a/chia/legacy/keyring.py
+++ b/chia/legacy/keyring.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     if sys.platform == "linux":
         sys.exit("Use `install.sh -l` to install the legacy_keyring dependency.")
-
+    CryptFileKeyring = None
 
 from chia.util.errors import KeychainUserNotFound
 from chia.util.keychain import MAX_KEYS, KeyData, KeyDataSecrets, get_private_key_user

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -7,7 +7,7 @@ import time
 import traceback
 from collections.abc import Awaitable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional
 
 from aiohttp import ClientSession, WebSocketError, WSCloseCode, WSMessage, WSMsgType
 from aiohttp.client import ClientWebSocketResponse
@@ -43,7 +43,7 @@ from chia.util.task_referencer import create_referenced_task
 # Max size 2^(8*4) which is around 4GiB
 LENGTH_BYTES: int = 4
 
-WebSocket = Union[WebSocketResponse, ClientWebSocketResponse]
+WebSocket = WebSocketResponse | ClientWebSocketResponse
 ConnectionCallback = Callable[["WSChiaConnection"], Awaitable[None]]
 
 error_response_version = Version("0.0.35")

--- a/chia/types/blockchain_format/tree_hash.py
+++ b/chia/types/blockchain_format/tree_hash.py
@@ -8,7 +8,7 @@ have to worry about blowing out the python stack.
 
 from __future__ import annotations
 
-from typing import Callable, Optional, Union
+from typing import Callable, Optional
 
 from chia_rs.sized_bytes import bytes32
 from clvm.CLVMObject import CLVMStorage
@@ -16,7 +16,7 @@ from clvm.SExp import SExp
 
 from chia.util.hash import std_hash
 
-ValueType = Union[bytes, CLVMStorage]
+ValueType = bytes | CLVMStorage
 ValueStackType = list[ValueType]
 Op = Callable[[ValueStackType, "OpStackType", set[bytes32]], None]
 OpStackType = list[Op]

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -254,7 +254,7 @@ def traverse_dict(d: dict[str, Any], key_path: str) -> Any:
 
 
 method_strings = Literal["default", "python_default", "fork", "forkserver", "spawn"]
-method_values = Optional[Literal["fork", "forkserver", "spawn"]]
+method_values = Literal["fork", "forkserver", "spawn"] | None
 start_methods: dict[method_strings, method_values] = {
     "default": None,
     "python_default": None,

--- a/chia/util/keyring_wrapper.py
+++ b/chia/util/keyring_wrapper.py
@@ -7,7 +7,7 @@ import time
 from getpass import getpass
 from pathlib import Path
 from sys import platform
-from typing import ClassVar, Optional, Union, overload
+from typing import ClassVar, Optional, overload
 
 import colorama
 from keyring.backends.macOS import Keyring as MacKeyring
@@ -30,7 +30,7 @@ MASTER_PASSPHRASE_SERVICE_NAME = "Chia Passphrase"  # noqa: S105
 MASTER_PASSPHRASE_USER_NAME = "Chia Passphrase"  # noqa: S105
 
 
-OSPassphraseStore = Union[MacKeyring, WinKeyring]
+OSPassphraseStore = MacKeyring | WinKeyring
 
 
 def get_os_passphrase_store() -> Optional[OSPassphraseStore]:

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -10,6 +10,7 @@ import pprint
 import traceback
 from collections.abc import Collection
 from enum import Enum, EnumMeta
+from types import UnionType
 from typing import TYPE_CHECKING, Any, BinaryIO, Callable, ClassVar, Optional, TypeVar, Union, get_type_hints
 
 from chia_rs.sized_bytes import bytes32
@@ -120,7 +121,7 @@ def is_type_SpecificOptional(f_type: object) -> bool:
     """
     Returns true for types such as Optional[T], but not Optional, or T.
     """
-    return get_origin(f_type) == Union and get_args(f_type)[1]() is None
+    return get_origin(f_type) in {Union, UnionType} and get_args(f_type)[1]() is None
 
 
 def is_type_Tuple(f_type: object) -> bool:

--- a/chia/util/virtual_project_analysis.py
+++ b/chia/util/virtual_project_analysis.py
@@ -288,7 +288,7 @@ class Package:
     is_file: Literal[False] = False
 
 
-FileOrPackage = Union[File, Package]
+FileOrPackage = File | Package
 
 
 def parse_file_or_package(identifier: str) -> FileOrPackage:

--- a/chia/wallet/conditions.py
+++ b/chia/wallet/conditions.py
@@ -1096,16 +1096,16 @@ class AssertAnnouncement(Condition):
         )
 
 
-TIMELOCK_TYPES = Union[
-    AssertSecondsRelative,
-    AssertHeightRelative,
-    AssertSecondsAbsolute,
-    AssertHeightAbsolute,
-    AssertBeforeSecondsRelative,
-    AssertBeforeHeightRelative,
-    AssertBeforeSecondsAbsolute,
-    AssertBeforeHeightAbsolute,
-]
+TIMELOCK_TYPES = (
+    AssertSecondsRelative
+    | AssertHeightRelative
+    | AssertSecondsAbsolute
+    | AssertHeightAbsolute
+    | AssertBeforeSecondsRelative
+    | AssertBeforeHeightRelative
+    | AssertBeforeSecondsAbsolute
+    | AssertBeforeHeightAbsolute
+)
 
 
 TIMELOCK_DRIVERS: tuple[

--- a/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
+++ b/chia/wallet/puzzles/p2_delegated_puzzle_or_hidden_puzzle.py
@@ -60,7 +60,6 @@ from __future__ import annotations
 
 import hashlib
 from functools import lru_cache
-from typing import Union
 
 from chia_puzzles_py.programs import P2_DELEGATED_PUZZLE_OR_HIDDEN_PUZZLE
 from chia_rs import G1Element, PrivateKey
@@ -79,7 +78,7 @@ MOD = Program.from_bytes(P2_DELEGATED_PUZZLE_OR_HIDDEN_PUZZLE)
 
 QUOTED_MOD_HASH = calculate_hash_of_quoted_mod_hash(MOD.get_tree_hash())
 
-PublicKeyProgram = Union[bytes, Program]
+PublicKeyProgram = bytes | Program
 
 GROUP_ORDER = 0x73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001
 

--- a/chia/wallet/wallet_coin_record.py
+++ b/chia/wallet/wallet_coin_record.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
@@ -13,7 +13,7 @@ from chia.wallet.puzzles.clawback.metadata import ClawbackMetadata, ClawbackVers
 from chia.wallet.util.wallet_types import CoinType, StreamableWalletIdentifier, WalletType
 from chia.wallet.vc_wallet.cr_cat_drivers import CRCATMetadata, CRCATVersion
 
-MetadataTypes = Union[ClawbackMetadata, CRCATMetadata]
+MetadataTypes = ClawbackMetadata | CRCATMetadata
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This is all of the manual fixes required by the process of removing the `UP*` ignores from `ruff.toml`