### PR TITLE
[CHIA-3795] change v1 plot phase-out

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -200,7 +200,8 @@ class ConsensusMode(ComparableEnum):
 
 @pytest.fixture(
     scope="session",
-    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.HARD_FORK_3_0],
+    # TODO: todo_v2_plots add HARD_FORK_3_0 mode as well as after phase-out
+    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0],
 )
 def consensus_mode(request):
     return request.param

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3224,12 +3224,15 @@ async def declare_pos_unfinished_block(
         include_signature_source_data=True,
     )
     await full_node_api.declare_proof_of_space(pospace, dummy_peer)
+    tx_peak = blockchain.get_tx_peak()
+    assert tx_peak is not None
     q_str: Optional[bytes32] = verify_and_get_quality_string(
         block.reward_chain_block.proof_of_space,
         blockchain.constants,
         challenge,
         challenge_chain_sp,
         height=block.reward_chain_block.height,
+        prev_transaction_block_height=tx_peak.height,
     )
     assert q_str is not None
     unfinised_block = None

--- a/chia/_tests/farmer_harvester/test_farmer.py
+++ b/chia/_tests/farmer_harvester/test_farmer.py
@@ -626,7 +626,14 @@ async def test_farmer_new_proof_of_space_for_pool_stats(
     }
 
     assert (
-        verify_and_get_quality_string(pos, DEFAULT_CONSTANTS, case.challenge_hash, case.sp_hash, height=uint32(1))
+        verify_and_get_quality_string(
+            pos,
+            DEFAULT_CONSTANTS,
+            case.challenge_hash,
+            case.sp_hash,
+            height=uint32(1),
+            prev_transaction_block_height=uint32(1),
+        )
         is not None
     )
 
@@ -883,7 +890,12 @@ async def test_farmer_pool_response(
 
     assert (
         verify_and_get_quality_string(
-            pos, DEFAULT_CONSTANTS, sp.challenge_hash, sp.challenge_chain_sp, height=uint32(1)
+            pos,
+            DEFAULT_CONSTANTS,
+            sp.challenge_hash,
+            sp.challenge_chain_sp,
+            height=uint32(1),
+            prev_transaction_block_height=uint32(1),
         )
         is not None
     )
@@ -1251,7 +1263,12 @@ async def test_farmer_additional_headers_on_partial_submit(
 
     assert (
         verify_and_get_quality_string(
-            pos, DEFAULT_CONSTANTS, sp.challenge_hash, sp.challenge_chain_sp, height=uint32(1)
+            pos,
+            DEFAULT_CONSTANTS,
+            sp.challenge_hash,
+            sp.challenge_chain_sp,
+            height=uint32(1),
+            prev_transaction_block_height=uint32(1),
         )
         is not None
     )

--- a/chia/_tests/weight_proof/test_weight_proof.py
+++ b/chia/_tests/weight_proof/test_weight_proof.py
@@ -47,7 +47,6 @@ async def load_blocks_dont_validate(
             cc_sp,
             block.height,
             difficulty,
-            sub_slot_iters,
             uint32(0),  # prev_tx_block(blocks, prev_b), todo need to get height of prev tx block somehow here
         )
         assert required_iters is not None

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -502,7 +502,6 @@ def validate_unfinished_header_block(
         cc_sp_hash,
         height,
         expected_vs.difficulty,
-        expected_vs.ssi,
         prev_tx_block(blocks, prev_b),
     )
     if required_iters is None:

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -84,7 +84,7 @@ DEFAULT_CONSTANTS = ConsensusConstants(
     HARD_FORK2_HEIGHT=uint32(0xFFFFFFFA),
     # starting at the hard fork 2 height, v1 plots will gradually be phased out,
     # and stop working entirely after this many blocks
-    PLOT_V1_PHASE_OUT=uint32(1179648),
+    PLOT_V1_PHASE_OUT=uint32(255 * 4608),
     # June 2027
     PLOT_FILTER_128_HEIGHT=uint32(10542000),
     # June 2030

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -220,7 +220,6 @@ async def pre_validate_block(
         cc_sp_hash,
         block.height,
         vs.difficulty,
-        vs.ssi,
         prev_tx_block(blockchain, prev_b),
     )
     if required_iters is None:

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -111,6 +111,7 @@ class FarmerAPI:
                 new_proof_of_space.challenge_hash,
                 new_proof_of_space.sp_hash,
                 height=sp.peak_height,
+                prev_transaction_block_height=sp.last_tx_height,
             )
             if computed_quality_string is None:
                 plotid: bytes32 = get_plot_id(new_proof_of_space.proof)
@@ -125,8 +126,6 @@ class FarmerAPI:
                 new_proof_of_space.proof.size(),
                 sp.difficulty,
                 new_proof_of_space.sp_hash,
-                sp.sub_slot_iters,
-                sp.last_tx_height,
             )
 
             # If the iters are good enough to make a block, proceed with the block making flow
@@ -234,8 +233,6 @@ class FarmerAPI:
                     new_proof_of_space.proof.size(),
                     pool_state_dict["current_difficulty"],
                     new_proof_of_space.sp_hash,
-                    sp.sub_slot_iters,
-                    sp.last_tx_height,
                 )
                 if required_iters >= calculate_sp_interval_iters(
                     self.farmer.constants, self.farmer.constants.POOL_SUB_SLOT_ITERS
@@ -813,6 +810,7 @@ class FarmerAPI:
         is_sp_signatures: bool = False
         sps = self.farmer.sps[response.sp_hash]
         peak_height = sps[0].peak_height
+        last_tx_height = sps[0].last_tx_height
         signage_point_index = sps[0].signage_point_index
         found_sp_hash_debug = False
         for sp_candidate in sps:
@@ -831,7 +829,12 @@ class FarmerAPI:
         include_taproot: bool = pospace.pool_contract_puzzle_hash is not None
 
         computed_quality_string = verify_and_get_quality_string(
-            pospace, self.farmer.constants, response.challenge_hash, response.sp_hash, height=peak_height
+            pospace,
+            self.farmer.constants,
+            response.challenge_hash,
+            response.sp_hash,
+            height=peak_height,
+            prev_transaction_block_height=last_tx_height,
         )
         if computed_quality_string is None:
             self.farmer.log.warning(f"Have invalid PoSpace {pospace}")

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1000,7 +1000,7 @@ def _validate_segment(
         if sampled and sub_slot_data.is_challenge():
             after_challenge = True
             required_iters = __validate_pospace(
-                constants, segment, idx, curr_difficulty, curr_ssi, ses, first_segment_in_se, height
+                constants, segment, idx, curr_difficulty, ses, first_segment_in_se, height
             )
             if required_iters is None:
                 return False, uint64(0), uint64(0), uint64(0), []
@@ -1267,7 +1267,7 @@ def validate_recent_blocks(
                 required_iters = caluclated_required_iters
             else:
                 ret = _validate_pospace_recent_chain(
-                    constants, sub_blocks, block, challenge, diff, ssi, overflow, prev_challenge
+                    constants, sub_blocks, block, challenge, diff, overflow, prev_challenge
                 )
                 if ret is None:
                     return False, []
@@ -1310,7 +1310,6 @@ def _validate_pospace_recent_chain(
     block: HeaderBlock,
     challenge: bytes32,
     diff: uint64,
-    ssi: uint64,
     overflow: bool,
     prev_challenge: bytes32,
 ) -> Optional[uint64]:
@@ -1328,7 +1327,6 @@ def _validate_pospace_recent_chain(
         cc_sp_hash,
         block.height,
         diff,
-        ssi,
         prev_tx_block(blocks, blocks.block_record(block.prev_header_hash)),
     )
     if required_iters is None:
@@ -1343,7 +1341,6 @@ def __validate_pospace(
     segment: SubEpochChallengeSegment,
     idx: int,
     curr_diff: uint64,
-    curr_sub_slot_iters: uint64,
     ses: Optional[SubEpochSummary],
     first_in_sub_epoch: bool,
     height: uint32,
@@ -1377,7 +1374,6 @@ def __validate_pospace(
         cc_sp_hash,
         height,
         curr_diff,
-        curr_sub_slot_iters,
         uint32(0),  # prev_tx_block(blocks, prev_b), todo need to get height of prev tx block somehow here
     )
     if required_iters is None:

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1367,6 +1367,9 @@ def __validate_pospace(
     # validate proof of space
     assert sub_slot_data.proof_of_space is not None
 
+    # when sampling blocks as part of weight proof validation, the previous
+    # transaction height is a conservative estimate, since we don't have direct
+    # access to it.
     required_iters = validate_pospace_and_get_required_iters(
         constants,
         sub_slot_data.proof_of_space,
@@ -1374,7 +1377,7 @@ def __validate_pospace(
         cc_sp_hash,
         height,
         curr_diff,
-        uint32(0),  # prev_tx_block(blocks, prev_b), todo need to get height of prev tx block somehow here
+        uint32(max(0, height - constants.MAX_SUB_SLOT_BLOCKS)),
     )
     if required_iters is None:
         log.error("could not verify proof of space")

--- a/chia/timelord/iters_from_block.py
+++ b/chia/timelord/iters_from_block.py
@@ -34,7 +34,6 @@ def iters_from_block(
         cc_sp,
         height,
         difficulty,
-        sub_slot_iters,
         prev_transaction_block_height,
     )
     assert required_iters is not None

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -75,6 +75,42 @@ def check_plot_size(constants: ConsensusConstants, ps: PlotSize) -> bool:
     return True
 
 
+def is_v1_phased_out(
+    proof: bytes,
+    prev_transaction_block_height: uint32,  # this is the height of the last tx block before the current block SP
+    constants: ConsensusConstants,
+) -> bool:
+    if prev_transaction_block_height < constants.HARD_FORK2_HEIGHT:
+        return False
+
+    # This is a v1 plot and the phase-out period has started
+    # The probability of having been phased out is proportional on the
+    # number of epochs since hard fork activation
+
+    # TODO: todo_v2_plots change the existing PLOT_V1_PHASE_OUT constant to
+    # direclty specify the power-of-two epochs to phase-out over
+    phase_out_epoch_bits = (constants.PLOT_V1_PHASE_OUT // constants.EPOCH_BLOCKS).bit_length()
+
+    phase_out_epoch_mask = (1 << phase_out_epoch_bits) - 1
+
+    # we just look at one byte so the mask can't be bigger than that
+    assert phase_out_epoch_mask < 256
+
+    # this counter is counting down to zero
+    epoch_counter = (1 << phase_out_epoch_bits) - (
+        prev_transaction_block_height - constants.HARD_FORK2_HEIGHT
+    ) // constants.EPOCH_BLOCKS
+
+    # if we're past the phase-out, v1 plots are unconditionally invalid
+    if epoch_counter <= 0:
+        return True
+
+    proof_value = std_hash(proof + b"chia proof-of-space v1 phase-out")[0] & phase_out_epoch_mask
+    return proof_value > epoch_counter
+
+
+# TODO: the "height" parameter is a bit suspect. It can probably be removed in
+# favor of prev_transaction_block_height
 def verify_and_get_quality_string(
     pos: ProofOfSpace,
     constants: ConsensusConstants,
@@ -82,7 +118,13 @@ def verify_and_get_quality_string(
     signage_point: bytes32,
     *,
     height: uint32,
+    prev_transaction_block_height: uint32,  # this is the height of the last tx block before the current block SP
 ) -> Optional[bytes32]:
+    plot_size = pos.size()
+
+    if plot_size.size_v1 is not None and is_v1_phased_out(pos.proof, prev_transaction_block_height, constants):
+        return None
+
     # Exactly one of (pool_public_key, pool_contract_puzzle_hash) must not be None
     if (pos.pool_public_key is None) and (pos.pool_contract_puzzle_hash is None):
         log.error("Expected pool public key or pool contract puzzle hash but got neither")
@@ -91,7 +133,6 @@ def verify_and_get_quality_string(
         log.error("Expected pool public key or pool contract puzzle hash but got both")
         return None
 
-    plot_size = pos.size()
     if not check_plot_size(constants, plot_size):
         return None
 

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -109,8 +109,6 @@ def is_v1_phased_out(
     return proof_value > epoch_counter
 
 
-# TODO: the "height" parameter is a bit suspect. It can probably be removed in
-# favor of prev_transaction_block_height
 def verify_and_get_quality_string(
     pos: ProofOfSpace,
     constants: ConsensusConstants,
@@ -123,6 +121,7 @@ def verify_and_get_quality_string(
     plot_size = pos.size()
 
     if plot_size.size_v1 is not None and is_v1_phased_out(pos.proof, prev_transaction_block_height, constants):
+        log.info("v1 proof has been phased-out and is no longer valid")
         return None
 
     # Exactly one of (pool_public_key, pool_contract_puzzle_hash) must not be None


### PR DESCRIPTION

to not affect required_iters which will change block infusion distribution in the slot and to be quantized to epoch blocksץ

The phase-out check is implemented in `is_v1_phased_out()`.

The proof-of-space, when validated (as opposed to farmed) uses `verify_and_get_quality_string()`, which now needs to take the previous transaction block height, to check the phase-out.

When farming, we need to check the phase-out independently now. There are new calls to `is_v1_phased_out()` in `harvester_api.py` as well as `block_tools.py`.

`calculate_iterations_quality()` no longer needs to take sub slot iterators nor height, since it doesn't implement the phase-out anymore. The phase-out is now separate from computing quality.