### PR TITLE
prev-tx-height for plot-filter

### DIFF
--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -149,7 +149,7 @@ def test_verify_and_get_quality_string(caplog: pytest.LogCaptureFixture, case: P
         constants=DEFAULT_CONSTANTS,
         original_challenge_hash=b32("0x73490e166d0b88347c37d921660b216c27316aae9a3450933d3ff3b854e5831a"),
         signage_point=b32("0x7b3e23dbd438f9aceefa9827e2c5538898189987f49b06eceb7a43067e77b531"),
-        height=case.height,
+        prev_tx_height=case.height,
     )
     assert quality_string is None
     assert len(caplog.text) == 0 if case.expected_error is None else case.expected_error in caplog.text
@@ -186,7 +186,7 @@ def test_verify_and_get_quality_string_v2(caplog: pytest.LogCaptureFixture, case
             constants=DEFAULT_CONSTANTS,
             original_challenge_hash=b32("0x73490e166d0b88347c37d921660b216c27316aae9a3450933d3ff3b854e5831a"),
             signage_point=b32("0x7b3e23dbd438f9aceefa9827e2c5538898189987f49b06eceb7a43067e77b531"),
-            height=case.height,
+            prev_tx_height=case.height,
         )
     except NotImplementedError as e:
         assert case.expected_error is not None

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3224,12 +3224,14 @@ async def declare_pos_unfinished_block(
         include_signature_source_data=True,
     )
     await full_node_api.declare_proof_of_space(pospace, dummy_peer)
+    tx_peak = blockchain.get_tx_peak()
+    assert tx_peak is not None
     q_str: Optional[bytes32] = verify_and_get_quality_string(
         block.reward_chain_block.proof_of_space,
         blockchain.constants,
         challenge,
         challenge_chain_sp,
-        height=block.reward_chain_block.height,
+        prev_tx_height=tx_peak.height,
     )
     assert q_str is not None
     unfinised_block = None

--- a/chia/_tests/farmer_harvester/test_farmer.py
+++ b/chia/_tests/farmer_harvester/test_farmer.py
@@ -626,7 +626,9 @@ async def test_farmer_new_proof_of_space_for_pool_stats(
     }
 
     assert (
-        verify_and_get_quality_string(pos, DEFAULT_CONSTANTS, case.challenge_hash, case.sp_hash, height=uint32(1))
+        verify_and_get_quality_string(
+            pos, DEFAULT_CONSTANTS, case.challenge_hash, case.sp_hash, prev_tx_height=uint32(1)
+        )
         is not None
     )
 
@@ -883,7 +885,7 @@ async def test_farmer_pool_response(
 
     assert (
         verify_and_get_quality_string(
-            pos, DEFAULT_CONSTANTS, sp.challenge_hash, sp.challenge_chain_sp, height=uint32(1)
+            pos, DEFAULT_CONSTANTS, sp.challenge_hash, sp.challenge_chain_sp, prev_tx_height=uint32(1)
         )
         is not None
     )
@@ -1251,7 +1253,7 @@ async def test_farmer_additional_headers_on_partial_submit(
 
     assert (
         verify_and_get_quality_string(
-            pos, DEFAULT_CONSTANTS, sp.challenge_hash, sp.challenge_chain_sp, height=uint32(1)
+            pos, DEFAULT_CONSTANTS, sp.challenge_hash, sp.challenge_chain_sp, prev_tx_height=uint32(1)
         )
         is not None
     )

--- a/chia/_tests/weight_proof/test_weight_proof.py
+++ b/chia/_tests/weight_proof/test_weight_proof.py
@@ -40,12 +40,12 @@ async def load_blocks_dont_validate(
         else:
             cc_sp = block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
 
+        # TODO: todo_v2_plots fix passing in the correct prev_tx_block height to this call
         required_iters = validate_pospace_and_get_required_iters(
             constants,
             block.reward_chain_block.proof_of_space,
             block.reward_chain_block.pos_ss_cc_challenge_hash,
             cc_sp,
-            block.height,
             difficulty,
             sub_slot_iters,
             uint32(0),  # prev_tx_block(blocks, prev_b), todo need to get height of prev tx block somehow here

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -500,7 +500,6 @@ def validate_unfinished_header_block(
         header_block.reward_chain_block.proof_of_space,
         challenge,
         cc_sp_hash,
-        height,
         expected_vs.difficulty,
         expected_vs.ssi,
         prev_tx_block(blocks, prev_b),

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -218,7 +218,6 @@ async def pre_validate_block(
         block.reward_chain_block.proof_of_space,
         challenge,
         cc_sp_hash,
-        block.height,
         vs.difficulty,
         vs.ssi,
         prev_tx_block(blockchain, prev_b),

--- a/chia/consensus/pot_iterations.py
+++ b/chia/consensus/pot_iterations.py
@@ -73,13 +73,12 @@ def validate_pospace_and_get_required_iters(
     proof_of_space: ProofOfSpace,
     challenge: bytes32,
     cc_sp_hash: bytes32,
-    height: uint32,
     difficulty: uint64,
     sub_slot_iters: uint64,
-    prev_transaction_block_height: uint32,  # this is the height of the last tx block before the current block SP
+    prev_tx_height: uint32,  # this is the height of the last tx block before the current block SP
 ) -> Optional[uint64]:
     q_str: Optional[bytes32] = verify_and_get_quality_string(
-        proof_of_space, constants, challenge, cc_sp_hash, height=height
+        proof_of_space, constants, challenge, cc_sp_hash, prev_tx_height=prev_tx_height
     )
     if q_str is None:
         return None
@@ -91,7 +90,7 @@ def validate_pospace_and_get_required_iters(
         difficulty,
         cc_sp_hash,
         sub_slot_iters,
-        prev_transaction_block_height,
+        prev_tx_height,
     )
 
 

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -110,7 +110,7 @@ class FarmerAPI:
                 self.farmer.constants,
                 new_proof_of_space.challenge_hash,
                 new_proof_of_space.sp_hash,
-                height=sp.peak_height,
+                prev_tx_height=sp.last_tx_height,
             )
             if computed_quality_string is None:
                 plotid: bytes32 = get_plot_id(new_proof_of_space.proof)
@@ -812,7 +812,7 @@ class FarmerAPI:
             return None
         is_sp_signatures: bool = False
         sps = self.farmer.sps[response.sp_hash]
-        peak_height = sps[0].peak_height
+        prev_tx_height = sps[0].last_tx_height
         signage_point_index = sps[0].signage_point_index
         found_sp_hash_debug = False
         for sp_candidate in sps:
@@ -831,7 +831,7 @@ class FarmerAPI:
         include_taproot: bool = pospace.pool_contract_puzzle_hash is not None
 
         computed_quality_string = verify_and_get_quality_string(
-            pospace, self.farmer.constants, response.challenge_hash, response.sp_hash, height=peak_height
+            pospace, self.farmer.constants, response.challenge_hash, response.sp_hash, prev_tx_height=prev_tx_height
         )
         if computed_quality_string is None:
             self.farmer.log.warning(f"Have invalid PoSpace {pospace}")

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -889,7 +889,7 @@ class FullNodeAPI:
                     self.full_node.constants,
                     cc_challenge_hash,
                     request.challenge_chain_sp,
-                    height=height,
+                    prev_tx_height=height,
                 )
                 assert quality_string is not None and len(quality_string) == 32
 

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -927,7 +927,7 @@ def _validate_sub_epoch_segments(
     rng: random.Random,
     weight_proof_bytes: bytes,
     summaries_bytes: list[bytes],
-    height: uint32,
+    prev_tx_height: uint32,
     validate_from: int = 0,
 ) -> Optional[list[tuple[VDFProof, ClassgroupElement, VDFInfo]]]:
     summaries = summaries_from_bytes(summaries_bytes)
@@ -968,7 +968,7 @@ def _validate_sub_epoch_segments(
                 prev_ses,
                 idx == 0,
                 sampled_seg_index == idx,
-                height,
+                prev_tx_height,
             )
             vdfs_to_validate.extend(vdf_list)
             if not valid_segment:
@@ -991,7 +991,7 @@ def _validate_segment(
     ses: Optional[SubEpochSummary],
     first_segment_in_se: bool,
     sampled: bool,
-    height: uint32,
+    prev_tx_height: uint32,
 ) -> tuple[bool, int, int, int, list[tuple[VDFProof, ClassgroupElement, VDFInfo]]]:
     ip_iters, slot_iters, slots = 0, 0, 0
     after_challenge = False
@@ -1000,7 +1000,7 @@ def _validate_segment(
         if sampled and sub_slot_data.is_challenge():
             after_challenge = True
             required_iters = __validate_pospace(
-                constants, segment, idx, curr_difficulty, curr_ssi, ses, first_segment_in_se, height
+                constants, segment, idx, curr_difficulty, curr_ssi, ses, first_segment_in_se, prev_tx_height
             )
             if required_iters is None:
                 return False, uint64(0), uint64(0), uint64(0), []
@@ -1326,7 +1326,6 @@ def _validate_pospace_recent_chain(
         block.reward_chain_block.proof_of_space,
         challenge if not overflow else prev_challenge,
         cc_sp_hash,
-        block.height,
         diff,
         ssi,
         prev_tx_block(blocks, blocks.block_record(block.prev_header_hash)),
@@ -1346,7 +1345,7 @@ def __validate_pospace(
     curr_sub_slot_iters: uint64,
     ses: Optional[SubEpochSummary],
     first_in_sub_epoch: bool,
-    height: uint32,
+    prev_tx_height: uint32,
 ) -> Optional[uint64]:
     if first_in_sub_epoch and segment.sub_epoch_n == 0 and idx == 0:
         cc_sub_slot_hash = constants.GENESIS_CHALLENGE
@@ -1375,10 +1374,9 @@ def __validate_pospace(
         sub_slot_data.proof_of_space,
         challenge,
         cc_sp_hash,
-        height,
         curr_diff,
         curr_sub_slot_iters,
-        uint32(0),  # prev_tx_block(blocks, prev_b), todo need to get height of prev tx block somehow here
+        prev_tx_height,
     )
     if required_iters is None:
         log.error("could not verify proof of space")

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -1850,7 +1850,6 @@ def load_block_list(
             full_block.reward_chain_block.proof_of_space,
             challenge,
             sp_hash,
-            full_block.height,
             uint64(difficulty),
             sub_slot_iters,
             prev_transaction_b_height,

--- a/chia/timelord/iters_from_block.py
+++ b/chia/timelord/iters_from_block.py
@@ -32,7 +32,6 @@ def iters_from_block(
         reward_chain_block.proof_of_space,
         reward_chain_block.pos_ss_cc_challenge_hash,
         cc_sp,
-        height,
         difficulty,
         sub_slot_iters,
         prev_transaction_block_height,

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -81,7 +81,7 @@ def verify_and_get_quality_string(
     original_challenge_hash: bytes32,
     signage_point: bytes32,
     *,
-    height: uint32,
+    prev_tx_height: uint32,
 ) -> Optional[bytes32]:
     # Exactly one of (pool_public_key, pool_contract_puzzle_hash) must not be None
     if (pos.pool_public_key is None) and (pos.pool_contract_puzzle_hash is None):
@@ -103,7 +103,7 @@ def verify_and_get_quality_string(
         return None
 
     # we use different plot filter prefix sizes depending on v1 or v2 plots
-    prefix_bits = calculate_prefix_bits(constants, height, plot_size)
+    prefix_bits = calculate_prefix_bits(constants, prev_tx_height, plot_size)
     if not passes_plot_filter(prefix_bits, plot_id, original_challenge_hash, signage_point):
         log.error("Did not pass the plot filter")
         return None
@@ -147,24 +147,24 @@ def passes_plot_filter(
     return cast(bool, plot_filter[:prefix_bits].uint == 0)
 
 
-def calculate_prefix_bits(constants: ConsensusConstants, height: uint32, plot_size: PlotSize) -> int:
+def calculate_prefix_bits(constants: ConsensusConstants, prev_tx_height: uint32, plot_size: PlotSize) -> int:
     if plot_size.size_v2 is not None:
-        if height >= constants.PLOT_FILTER_V2_THIRD_ADJUSTMENT_HEIGHT:
+        if prev_tx_height >= constants.PLOT_FILTER_V2_THIRD_ADJUSTMENT_HEIGHT:
             return constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2 + 3
-        if height >= constants.PLOT_FILTER_V2_SECOND_ADJUSTMENT_HEIGHT:
+        if prev_tx_height >= constants.PLOT_FILTER_V2_SECOND_ADJUSTMENT_HEIGHT:
             return constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2 + 2
-        if height >= constants.PLOT_FILTER_V2_FIRST_ADJUSTMENT_HEIGHT:
+        if prev_tx_height >= constants.PLOT_FILTER_V2_FIRST_ADJUSTMENT_HEIGHT:
             return constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2 + 1
         return constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2
 
     prefix_bits = int(constants.NUMBER_ZERO_BITS_PLOT_FILTER_V1)
-    if height >= constants.PLOT_FILTER_32_HEIGHT:
+    if prev_tx_height >= constants.PLOT_FILTER_32_HEIGHT:
         prefix_bits -= 4
-    elif height >= constants.PLOT_FILTER_64_HEIGHT:
+    elif prev_tx_height >= constants.PLOT_FILTER_64_HEIGHT:
         prefix_bits -= 3
-    elif height >= constants.PLOT_FILTER_128_HEIGHT:
+    elif prev_tx_height >= constants.PLOT_FILTER_128_HEIGHT:
         prefix_bits -= 2
-    elif height >= constants.HARD_FORK_HEIGHT:
+    elif prev_tx_height >= constants.HARD_FORK_HEIGHT:
         prefix_bits -= 1
 
     return max(0, prefix_bits)


### PR DESCRIPTION
use previous transaction block height for determining plot filter adjustments, instesad of direct block height.

If this works, it simplifies the logic a bit.