### PR TITLE
[CHIA-3793] after the hard fork, disallow block references

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -200,7 +200,8 @@ class ConsensusMode(ComparableEnum):
 
 @pytest.fixture(
     scope="session",
-    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0, ConsensusMode.HARD_FORK_3_0],
+    # TODO: todo_v2_plots add HARD_FORK_3_0 mode as well as after phase-out
+    params=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0],
 )
 def consensus_mode(request):
     return request.param

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -341,10 +341,14 @@ async def validate_block_body(
     #     the generator ref list for this block (or 'one' bytes [0x01] if no generator)
     # 8b. The generator ref list length must be less than or equal to MAX_GENERATOR_REF_LIST_SIZE entries
     # 8c. The generator ref list must not point to a height >= this block's height
-    if block.transactions_generator_ref_list in (None, []):
+    if block.transactions_generator_ref_list == []:
         if block.transactions_info.generator_refs_root != bytes([1] * 32):
             return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
     else:
+        # With hard fork 2 we ban transactions_generator_ref_list.
+        if prev_transaction_block_height >= constants.HARD_FORK2_HEIGHT:
+            return Err.TOO_MANY_GENERATOR_REFS
+
         # If we have a generator reference list, we must have a generator
         if block.transactions_generator is None:
             return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -33,6 +33,7 @@ from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_dif
 from chia.consensus.find_fork_point import lookup_fork_chain
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.generator_tools import get_block_header
+from chia.consensus.get_block_challenge import prev_tx_block
 from chia.consensus.get_block_generator import get_block_generator
 from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.full_node.block_store import BlockStore
@@ -698,11 +699,15 @@ class Blockchain:
         if len(block.transactions_generator_ref_list) > self.constants.MAX_GENERATOR_REF_LIST_SIZE:
             return None, Err.TOO_MANY_GENERATOR_REFS
 
-        if (
-            self.try_block_record(block.prev_header_hash) is None
-            and block.prev_header_hash != self.constants.GENESIS_CHALLENGE
-        ):
+        prev_b = self.try_block_record(block.prev_header_hash)
+        if prev_b is None and block.prev_header_hash != self.constants.GENESIS_CHALLENGE:
             return None, Err.INVALID_PREV_BLOCK_HASH
+
+        prev_tx_height = prev_tx_block(self, prev_b)
+
+        # With hard fork 2 we ban transactions_generator_ref_list.
+        if prev_tx_height >= self.constants.HARD_FORK2_HEIGHT and block.transactions_generator_ref_list != []:
+            return None, Err.TOO_MANY_GENERATOR_REFS
 
         if block.transactions_info is not None:
             if block.transactions_generator is not None:

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -385,6 +385,10 @@ class BlockTools:
         transaction_data: Optional[SpendBundle],
         block_refs: list[uint32],
     ) -> Optional[NewBlockGenerator]:
+        if prev_tx_height >= self.constants.HARD_FORK2_HEIGHT:
+            assert block_refs == [], "block references are not allowed after hard fork 2"
+            dummy_block_references = False
+
         # we don't know if the new block will be a transaction
         # block or not, so even though we prepare a block
         # generator, we can't update our state (like,


### PR DESCRIPTION
### Purpose:

With hard fork 2, we want to disallow block references. We have not seen any benefit or use of them so far. We currently compress block generators using (internal) back references. Deduplicating structures.

Disallowing block generators has the following upsides:

* It's much simpler to validate a block, without needing access to the whole chain
* A node don't necessarily need to keep every block around to validate and be a part of the chain
* It's cheaper to validate blocks, without requiring additional DB lookups for previous blocks

There are two additional commits in this PR.
1. Disable simulations of har fork 2 activation, since the existing chains *do* contain block references, we can't use them in tests after the hard fork. These will be re-enabled once we have new test block chains specifically made with the new consensus rules
2. fix a flaky (and awkward) test related to rate limits