### PR TITLE
[LABS-289] Add `kw_only=True` to `TransactionRecord`

### DIFF
--- a/chia/_tests/wallet/test_transaction_store.py
+++ b/chia/_tests/wallet/test_transaction_store.py
@@ -31,24 +31,24 @@ coin_2 = Coin(bytes32.random(module_seeded_random), bytes32.random(module_seeded
 coin_3 = Coin(bytes32.random(module_seeded_random), bytes32.random(module_seeded_random), uint64(12312 - 1234))
 
 tr1 = TransactionRecord(
-    uint32(0),  # confirmed height
-    uint64(1000),  # created_at_time
-    bytes32(bytes32.zeros),  # to_puzzle_hash
-    uint64(1234),  # amount
-    uint64(12),  # fee_amount
-    False,  # confirmed
-    uint32(0),  # sent
-    None,  # Optional[SpendBundle] spend_bundle
-    [coin_2, coin_3],  # additions
-    [coin_1],  # removals
-    uint32(1),  # wallet_id
-    [],  # list[tuple[str, uint8, Optional[str]]] sent_to
-    bytes32(bytes32.random(module_seeded_random)),  # trade_id
-    uint32(TransactionType.OUTGOING_TX),  # type
-    bytes32(bytes32.random(module_seeded_random)),  # name
-    {},  # memos
-    ConditionValidTimes(),
-    encode_puzzle_hash(bytes32(bytes32.zeros), "txch"),
+    confirmed_at_height=uint32(0),
+    created_at_time=uint64(1000),
+    to_puzzle_hash=bytes32(bytes32.zeros),
+    to_address=encode_puzzle_hash(bytes32(bytes32.zeros), "txch"),
+    amount=uint64(1234),
+    fee_amount=uint64(12),
+    confirmed=False,
+    sent=uint32(0),
+    spend_bundle=None,
+    additions=[coin_2, coin_3],
+    removals=[coin_1],
+    wallet_id=uint32(1),
+    sent_to=[],
+    trade_id=bytes32(bytes32.random(module_seeded_random)),
+    type=uint32(TransactionType.OUTGOING_TX),
+    name=bytes32(bytes32.random(module_seeded_random)),
+    memos={},
+    valid_times=ConditionValidTimes(),
 )
 
 MINIMUM_CONFIG = {

--- a/chia/wallet/transaction_record.py
+++ b/chia/wallet/transaction_record.py
@@ -29,7 +29,7 @@ class ItemAndTransactionRecords(Generic[T]):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class TransactionRecordOld(Streamable):
     """
     Used for storing transaction data and status in wallets.
@@ -100,7 +100,7 @@ class TransactionRecordOld(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class TransactionRecord(TransactionRecordOld):
     valid_times: ConditionValidTimes
     to_address: str


### PR DESCRIPTION
This object would be quite a pain to read if initialized positionally and is almost always initialized with kwargs already, so it's a good candidate to be ported to this decorator.