### PR TITLE
Add a `wait_for_wallet_synced` to some flaky tests

### DIFF
--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -779,9 +779,8 @@ async def test_get_owned_stores(
             expected_store_ids.append(launcher_id)
 
         await time_out_assert(4, check_mempool_spend_count, True, full_node_api, 3)
-        for i in range(num_blocks):
-            await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-            await asyncio.sleep(0.5)
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+        await full_node_api.wait_for_wallet_synced(wallet_node)
 
         response = await data_rpc_api.get_owned_stores(request={})
         store_ids = sorted(bytes32.from_hexstr(id) for id in response["store_ids"])

--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -1873,6 +1873,8 @@ async def test_make_and_cancel_offer(offer_setup: OfferSetup, reference: MakeAnd
     else:  # pragma: no cover
         assert False, "offer was not cancelled"
 
+    await offer_setup.wait_for_wallets_synced()
+
     taker_request = {
         "offer": maker_response["offer"],
         "fee": 0,


### PR DESCRIPTION
https://github.com/Chia-Network/chia-blockchain/actions/runs/19111222387/job/54608534079?pr=20227#step:17:1003

https://github.com/Chia-Network/chia-blockchain/actions/runs/19112449009/job/54612819580?pr=20229#step:17:1079