### PR TITLE
[LABS-296] Merge `get_cat_spendable_coins` into `get_spendable_coins_for_wallet`

### DIFF
--- a/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
@@ -1089,7 +1089,9 @@ async def test_cat_max_amount_send(wallet_environments: WalletTestFramework, wal
         for i in range(1, 50):
             amounts.append(uint64(i))
             puzzle_hashes.append(cat_2_hash)
-        spent_coin = (await cat_wallet.get_cat_spendable_coins())[0].coin
+        spent_coin = next(
+            iter(await cat_wallet.wallet_state_manager.get_spendable_coins_for_wallet(cat_wallet.id()))
+        ).coin
         await cat_wallet.generate_signed_transaction(amounts, puzzle_hashes, action_scope, coins={spent_coin})
 
     await wallet_environments.process_pending_states(
@@ -1120,7 +1122,7 @@ async def test_cat_max_amount_send(wallet_environments: WalletTestFramework, wal
     )
 
     async def check_all_there() -> bool:
-        spendable = await cat_wallet.get_cat_spendable_coins()
+        spendable = await cat_wallet.wallet_state_manager.get_spendable_coins_for_wallet(cat_wallet.id())
         spendable_name_set = set()
         for record in spendable:
             spendable_name_set.add(record.coin.name())
@@ -1649,7 +1651,9 @@ async def test_cat_melt_balance(wallet_environments: WalletTestFramework) -> Non
     # Let's test that continuing to melt this CAT results in the correct balance changes
     for _ in range(5):
         tx_amount -= 1
-        new_coin = (await cat_wallet.get_cat_spendable_coins())[0].coin
+        new_coin = next(
+            iter(await cat_wallet.wallet_state_manager.get_spendable_coins_for_wallet(cat_wallet.id()))
+        ).coin
         new_spend = unsigned_spend_bundle_for_spendable_cats(
             CAT_MOD,
             [

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -342,7 +342,9 @@ class CATWallet:
         return uint128(
             sum(
                 cr.coin.amount
-                for cr in await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), records)
+                for cr in await self.wallet_state_manager.get_spendable_coins_for_wallet(
+                    self.id(), records, in_one_block=True
+                )
             )
         )
 
@@ -488,7 +490,7 @@ class CATWallet:
         """
         spendable_amount: uint128 = await self.get_spendable_balance()
         spendable_coins: list[WalletCoinRecord] = list(
-            await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id())
+            await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), in_one_block=True)
         )
 
         # Try to use coins from the store, if there isn't enough of "unused"

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -338,15 +338,13 @@ class CATWallet:
         # avoid full block TXs
         return int(self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM / 2 / self.cost_of_single_tx)
 
-    async def get_max_spendable_coins(self, records: Optional[set[WalletCoinRecord]] = None) -> set[WalletCoinRecord]:
-        spendable: list[WalletCoinRecord] = list(
-            await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), records)
-        )
-        spendable.sort(reverse=True, key=lambda record: record.coin.amount)
-        return set(spendable[0 : min(len(spendable), self.max_send_quantity)])
-
     async def get_max_send_amount(self, records: Optional[set[WalletCoinRecord]] = None) -> uint128:
-        return uint128(sum(cr.coin.amount for cr in await self.get_max_spendable_coins()))
+        return uint128(
+            sum(
+                cr.coin.amount
+                for cr in await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), records)
+            )
+        )
 
     def get_name(self) -> str:
         return self.wallet_info.name

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -442,7 +442,7 @@ class CATWallet:
             return derivation_record.puzzle_hash
 
     async def get_spendable_balance(self, records: Optional[set[WalletCoinRecord]] = None) -> uint128:
-        coins = await self.get_cat_spendable_coins(records)
+        coins = await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), records)
         amount = 0
         for record in coins:
             amount += record.coin.amount
@@ -475,19 +475,9 @@ class CATWallet:
 
         return uint64(addition_amount)
 
-    async def get_cat_spendable_coins(self, records: Optional[set[WalletCoinRecord]] = None) -> list[WalletCoinRecord]:
-        result: list[WalletCoinRecord] = []
-
-        record_list: set[WalletCoinRecord] = await self.wallet_state_manager.get_spendable_coins_for_wallet(
-            self.id(), records
-        )
-
-        for record in record_list:
-            lineage = await self.get_lineage_proof_for_coin(record.coin)
-            if lineage is not None and not lineage.is_none():
-                result.append(record)
-
-        return list(await self.get_max_spendable_coins(set(result)))
+    async def is_coin_spendable(self, record: WalletCoinRecord) -> bool:
+        lineage = await self.get_lineage_proof_for_coin(record.coin)
+        return lineage is not None and not lineage.is_none()
 
     async def select_coins(
         self,
@@ -499,7 +489,9 @@ class CATWallet:
         Note: Must be called under wallet state manager lock
         """
         spendable_amount: uint128 = await self.get_spendable_balance()
-        spendable_coins: list[WalletCoinRecord] = await self.get_cat_spendable_coins()
+        spendable_coins: list[WalletCoinRecord] = list(
+            await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id())
+        )
 
         # Try to use coins from the store, if there isn't enough of "unused"
         # coins use change coins that are not confirmed yet

--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -322,19 +322,11 @@ class CRCATWallet(CATWallet):
             "inner_puzzle_for_cat_puzhash is a legacy method and is not available on CR-CAT wallets"
         )
 
-    async def get_cat_spendable_coins(self, records: Optional[set[WalletCoinRecord]] = None) -> list[WalletCoinRecord]:
-        result: list[WalletCoinRecord] = []
-
-        record_list: set[WalletCoinRecord] = await self.wallet_state_manager.get_spendable_coins_for_wallet(
-            self.id(), records
-        )
-
-        for record in record_list:
-            crcat: CRCAT = self.coin_record_to_crcat(record)
-            if crcat.lineage_proof is not None and not crcat.lineage_proof.is_none():
-                result.append(record)
-
-        return result
+    async def is_coin_spendable(self, record: WalletCoinRecord) -> bool:
+        crcat: CRCAT = self.coin_record_to_crcat(record)
+        if crcat.lineage_proof is not None and not crcat.lineage_proof.is_none():
+            return True
+        return False
 
     async def get_confirmed_balance(self, record_list: Optional[set[WalletCoinRecord]] = None) -> uint128:
         if record_list is None:

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -100,7 +100,9 @@ class Wallet:
         return uint128(
             sum(
                 cr.coin.amount
-                for cr in await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), records)
+                for cr in await self.wallet_state_manager.get_spendable_coins_for_wallet(
+                    self.id(), records, in_one_block=True
+                )
             )
         )
 
@@ -204,7 +206,7 @@ class Wallet:
         """
         spendable_amount: uint128 = await self.get_spendable_balance()
         spendable_coins: list[WalletCoinRecord] = list(
-            await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id())
+            await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), in_one_block=True)
         )
 
         # Try to use coins from the store, if there isn't enough of "unused"

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -96,15 +96,13 @@ class Wallet:
         # avoid full block TXs
         return int(self.wallet_state_manager.constants.MAX_BLOCK_COST_CLVM / 5 / self.cost_of_single_tx)
 
-    async def get_max_spendable_coins(self, records: Optional[set[WalletCoinRecord]] = None) -> set[WalletCoinRecord]:
-        spendable: list[WalletCoinRecord] = list(
-            await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), records)
-        )
-        spendable.sort(reverse=True, key=lambda record: record.coin.amount)
-        return set(spendable[0 : min(len(spendable), self.max_send_quantity)])
-
     async def get_max_send_amount(self, records: Optional[set[WalletCoinRecord]] = None) -> uint128:
-        return uint128(sum(cr.coin.amount for cr in await self.get_max_spendable_coins()))
+        return uint128(
+            sum(
+                cr.coin.amount
+                for cr in await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), records)
+            )
+        )
 
     @classmethod
     def type(cls) -> WalletType:
@@ -205,7 +203,9 @@ class Wallet:
         Note: Must be called under wallet state manager lock
         """
         spendable_amount: uint128 = await self.get_spendable_balance()
-        spendable_coins: list[WalletCoinRecord] = list(await self.get_max_spendable_coins())
+        spendable_coins: list[WalletCoinRecord] = list(
+            await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id())
+        )
 
         # Try to use coins from the store, if there isn't enough of "unused"
         # coins use change coins that are not confirmed yet

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -1803,16 +1803,9 @@ class WalletRpcApi:
             raise ValueError("Wallet needs to be fully synced before getting all coins")
 
         state_mgr = self.service.wallet_state_manager
-        wallet = state_mgr.wallets[request.wallet_id]
         async with state_mgr.lock:
             all_coin_records = await state_mgr.coin_store.get_unspent_coins_for_wallet(request.wallet_id)
-            if wallet.type() in {WalletType.CAT, WalletType.CRCAT, WalletType.RCAT}:
-                assert isinstance(wallet, CATWallet)
-                spendable_coins: list[WalletCoinRecord] = await wallet.get_cat_spendable_coins(all_coin_records)
-            else:
-                spendable_coins = list(
-                    await state_mgr.get_spendable_coins_for_wallet(request.wallet_id, all_coin_records)
-                )
+            spendable_coins = list(await state_mgr.get_spendable_coins_for_wallet(request.wallet_id, all_coin_records))
 
             # Now we get the unconfirmed transactions and manually derive the additions and removals.
             unconfirmed_transactions: list[TransactionRecord] = await state_mgr.tx_store.get_unconfirmed_for_wallet(

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -2528,8 +2528,10 @@ class WalletStateManager:
                 continue
             filtered.add(record)
 
-        if hasattr(wallet, "get_max_spendable_coins"):
-            return await wallet.get_max_spendable_coins(filtered)  # type: ignore[no-any-return]
+        if hasattr(wallet, "max_send_quantity"):
+            filtered_as_list = list(filtered)
+            filtered_as_list.sort(reverse=True, key=lambda rec: rec.coin.amount)
+            return set(filtered_as_list[0 : min(len(filtered_as_list), wallet.max_send_quantity)])
 
         return filtered
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -2496,7 +2496,7 @@ class WalletStateManager:
         self.state_changed("wallet_created")
 
     async def get_spendable_coins_for_wallet(
-        self, wallet_id: int, records: Optional[set[WalletCoinRecord]] = None
+        self, wallet_id: int, records: Optional[set[WalletCoinRecord]] = None, in_one_block: bool = False
     ) -> set[WalletCoinRecord]:
         wallet = self.wallets[uint32(wallet_id)]
         wallet_type = wallet.type()
@@ -2528,7 +2528,7 @@ class WalletStateManager:
                 continue
             filtered.add(record)
 
-        if hasattr(wallet, "max_send_quantity"):
+        if hasattr(wallet, "max_send_quantity") and in_one_block:
             filtered_as_list = list(filtered)
             filtered_as_list.sort(reverse=True, key=lambda rec: rec.coin.amount)
             return set(filtered_as_list[0 : min(len(filtered_as_list), wallet.max_send_quantity)])

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -2498,7 +2498,8 @@ class WalletStateManager:
     async def get_spendable_coins_for_wallet(
         self, wallet_id: int, records: Optional[set[WalletCoinRecord]] = None
     ) -> set[WalletCoinRecord]:
-        wallet_type = self.wallets[uint32(wallet_id)].type()
+        wallet = self.wallets[uint32(wallet_id)]
+        wallet_type = wallet.type()
         if records is None:
             if wallet_type == WalletType.CRCAT:
                 records = await self.coin_store.get_unspent_coins_for_wallet(wallet_id, CoinType.CRCAT)
@@ -2523,7 +2524,12 @@ class WalletStateManager:
                 continue
             if record.coin.name() in removal_dict:
                 continue
+            if hasattr(wallet, "is_coin_spendable") and not await wallet.is_coin_spendable(record):
+                continue
             filtered.add(record)
+
+        if hasattr(wallet, "get_max_spendable_coins"):
+            return await wallet.get_max_spendable_coins(filtered)  # type: ignore[no-any-return]
 
         return filtered
 


### PR DESCRIPTION
This PR removes a special method from the CAT-type wallets and rolls it into the general purpose wallet state manager.  I'm not thrilled with `hasattr` here but to keep the scope relatively small I think it's the right way forward.