### PR TITLE
fix tx block refrences in blocktools

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -155,9 +155,9 @@ class TestGenesisBlock:
     async def test_genesis_validate_1(
         self, empty_blockchain: Blockchain, bt: BlockTools, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Monkey patch prev_tx_block so we dont throw there
+        # Monkey patch pre_sp_tx_block so we dont throw there
         monkeypatch.setattr(
-            "chia.consensus.multiprocess_validation.prev_tx_block",
+            "chia.consensus.multiprocess_validation.pre_sp_tx_block_height",
             lambda *args, **kwargs: uint32(0),
         )
         genesis = bt.get_consecutive_blocks(1, force_overflow=False)[0]

--- a/chia/_tests/core/full_node/test_prev_tx_block.py
+++ b/chia/_tests/core/full_node/test_prev_tx_block.py
@@ -5,21 +5,21 @@ from typing import Optional
 from chia_rs import FullBlock
 from chia_rs.sized_ints import uint8, uint32
 
-from chia.consensus.get_block_challenge import prev_tx_block
+from chia.consensus.get_block_challenge import pre_sp_block_height
 from chia.simulator.block_tools import BlockTools, load_block_list, test_constants
 from chia.util.block_cache import BlockCache
 
 
 def test_prev_tx_block_none() -> None:
     # If prev_b is None, should return 0
-    assert prev_tx_block(
+    assert pre_sp_block_height(
         constants=test_constants,
         blocks=BlockCache({}),
         prev_b_hash=test_constants.GENESIS_CHALLENGE,
         sp_index=uint8(0),
         first_in_sub_slot=False,
     ) == uint32(0)
-    assert prev_tx_block(
+    assert pre_sp_block_height(
         constants=test_constants,
         blocks=BlockCache({}),
         prev_b_hash=test_constants.GENESIS_CHALLENGE,
@@ -40,7 +40,7 @@ def test_prev_tx_block_blockrecord_tx(bt: BlockTools) -> None:
     latest_tx_before_sp = find_tx_before_sp(block_list)
     assert latest_tx_before_sp is not None
     assert (
-        prev_tx_block(
+        pre_sp_block_height(
             constants=test_constants,
             blocks=BlockCache(blocks),
             prev_b_hash=block.prev_header_hash,
@@ -53,7 +53,7 @@ def test_prev_tx_block_blockrecord_tx(bt: BlockTools) -> None:
     latest_tx_before_sp = find_tx_before_sp(block_list[:-1])
     assert latest_tx_before_sp is not None
     assert (
-        prev_tx_block(
+        pre_sp_block_height(
             constants=test_constants,
             blocks=BlockCache(blocks),
             prev_b_hash=block.prev_header_hash,
@@ -66,7 +66,7 @@ def test_prev_tx_block_blockrecord_tx(bt: BlockTools) -> None:
     latest_tx_before_sp = find_tx_before_sp(block_list[:-2])
     assert latest_tx_before_sp is not None
     assert (
-        prev_tx_block(
+        pre_sp_block_height(
             constants=test_constants,
             blocks=BlockCache(blocks),
             prev_b_hash=block.prev_header_hash,
@@ -92,7 +92,7 @@ def test_prev_tx_block_blockrecord_not_tx(bt: BlockTools) -> None:
     block = block_list[-1]
     latest_tx_before_sp = find_tx_before_sp(block_list)
     assert latest_tx_before_sp is not None
-    assert prev_tx_block(
+    assert pre_sp_block_height(
         constants=test_constants,
         blocks=BlockCache(blocks),
         prev_b_hash=block.prev_header_hash,

--- a/chia/_tests/core/full_node/test_prev_tx_block.py
+++ b/chia/_tests/core/full_node/test_prev_tx_block.py
@@ -5,21 +5,21 @@ from typing import Optional
 from chia_rs import FullBlock
 from chia_rs.sized_ints import uint8, uint32
 
-from chia.consensus.get_block_challenge import pre_sp_block_height
+from chia.consensus.get_block_challenge import pre_sp_tx_block_height
 from chia.simulator.block_tools import BlockTools, load_block_list, test_constants
 from chia.util.block_cache import BlockCache
 
 
 def test_prev_tx_block_none() -> None:
     # If prev_b is None, should return 0
-    assert pre_sp_block_height(
+    assert pre_sp_tx_block_height(
         constants=test_constants,
         blocks=BlockCache({}),
         prev_b_hash=test_constants.GENESIS_CHALLENGE,
         sp_index=uint8(0),
         first_in_sub_slot=False,
     ) == uint32(0)
-    assert pre_sp_block_height(
+    assert pre_sp_tx_block_height(
         constants=test_constants,
         blocks=BlockCache({}),
         prev_b_hash=test_constants.GENESIS_CHALLENGE,
@@ -40,7 +40,7 @@ def test_prev_tx_block_blockrecord_tx(bt: BlockTools) -> None:
     latest_tx_before_sp = find_tx_before_sp(block_list)
     assert latest_tx_before_sp is not None
     assert (
-        pre_sp_block_height(
+        pre_sp_tx_block_height(
             constants=test_constants,
             blocks=BlockCache(blocks),
             prev_b_hash=block.prev_header_hash,
@@ -53,7 +53,7 @@ def test_prev_tx_block_blockrecord_tx(bt: BlockTools) -> None:
     latest_tx_before_sp = find_tx_before_sp(block_list[:-1])
     assert latest_tx_before_sp is not None
     assert (
-        pre_sp_block_height(
+        pre_sp_tx_block_height(
             constants=test_constants,
             blocks=BlockCache(blocks),
             prev_b_hash=block.prev_header_hash,
@@ -66,7 +66,7 @@ def test_prev_tx_block_blockrecord_tx(bt: BlockTools) -> None:
     latest_tx_before_sp = find_tx_before_sp(block_list[:-2])
     assert latest_tx_before_sp is not None
     assert (
-        pre_sp_block_height(
+        pre_sp_tx_block_height(
             constants=test_constants,
             blocks=BlockCache(blocks),
             prev_b_hash=block.prev_header_hash,
@@ -92,7 +92,7 @@ def test_prev_tx_block_blockrecord_not_tx(bt: BlockTools) -> None:
     block = block_list[-1]
     latest_tx_before_sp = find_tx_before_sp(block_list)
     assert latest_tx_before_sp is not None
-    assert pre_sp_block_height(
+    assert pre_sp_tx_block_height(
         constants=test_constants,
         blocks=BlockCache(blocks),
         prev_b_hash=block.prev_header_hash,

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -20,7 +20,7 @@ from chia_rs.sized_ints import uint8, uint32, uint64, uint128
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.deficit import calculate_deficit
 from chia.consensus.difficulty_adjustment import can_finish_sub_and_full_epoch
-from chia.consensus.get_block_challenge import final_eos_is_already_included, get_block_challenge, prev_tx_block
+from chia.consensus.get_block_challenge import final_eos_is_already_included, get_block_challenge, pre_sp_block_height
 from chia.consensus.make_sub_epoch_summary import make_sub_epoch_summary
 from chia.consensus.pot_iterations import (
     calculate_ip_iters,
@@ -502,7 +502,7 @@ def validate_unfinished_header_block(
         cc_sp_hash,
         height,
         expected_vs.difficulty,
-        prev_tx_block(
+        pre_sp_block_height(
             constants=constants,
             blocks=blocks,
             prev_b_hash=header_block.prev_header_hash,

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -20,7 +20,11 @@ from chia_rs.sized_ints import uint8, uint32, uint64, uint128
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.deficit import calculate_deficit
 from chia.consensus.difficulty_adjustment import can_finish_sub_and_full_epoch
-from chia.consensus.get_block_challenge import final_eos_is_already_included, get_block_challenge, pre_sp_block_height
+from chia.consensus.get_block_challenge import (
+    final_eos_is_already_included,
+    get_block_challenge,
+    pre_sp_tx_block_height,
+)
 from chia.consensus.make_sub_epoch_summary import make_sub_epoch_summary
 from chia.consensus.pot_iterations import (
     calculate_ip_iters,
@@ -502,7 +506,7 @@ def validate_unfinished_header_block(
         cc_sp_hash,
         height,
         expected_vs.difficulty,
-        pre_sp_block_height(
+        pre_sp_tx_block_height(
             constants=constants,
             blocks=blocks,
             prev_b_hash=header_block.prev_header_hash,

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -33,7 +33,7 @@ from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_dif
 from chia.consensus.find_fork_point import lookup_fork_chain
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.generator_tools import get_block_header
-from chia.consensus.get_block_challenge import pre_sp_block_height
+from chia.consensus.get_block_challenge import pre_sp_tx_block_height
 from chia.consensus.get_block_generator import get_block_generator
 from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.full_node.block_store import BlockStore
@@ -703,7 +703,7 @@ class Blockchain:
         if prev_b is None and block.prev_header_hash != self.constants.GENESIS_CHALLENGE:
             return None, Err.INVALID_PREV_BLOCK_HASH
 
-        prev_tx_height = pre_sp_block_height(
+        prev_tx_height = pre_sp_tx_block_height(
             constants=self.constants,
             blocks=self,
             prev_b_hash=block.prev_header_hash,

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -33,7 +33,7 @@ from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_dif
 from chia.consensus.find_fork_point import lookup_fork_chain
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.generator_tools import get_block_header
-from chia.consensus.get_block_challenge import prev_tx_block
+from chia.consensus.get_block_challenge import pre_sp_block_height
 from chia.consensus.get_block_generator import get_block_generator
 from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.full_node.block_store import BlockStore
@@ -703,7 +703,7 @@ class Blockchain:
         if prev_b is None and block.prev_header_hash != self.constants.GENESIS_CHALLENGE:
             return None, Err.INVALID_PREV_BLOCK_HASH
 
-        prev_tx_height = prev_tx_block(
+        prev_tx_height = pre_sp_block_height(
             constants=self.constants,
             blocks=self,
             prev_b_hash=block.prev_header_hash,

--- a/chia/consensus/get_block_challenge.py
+++ b/chia/consensus/get_block_challenge.py
@@ -126,7 +126,7 @@ def pre_sp_tx_block(
     return curr
 
 
-def pre_sp_block_height(
+def pre_sp_tx_block_height(
     constants: ConsensusConstants,
     blocks: BlockRecordsProtocol,
     *,

--- a/chia/consensus/get_block_challenge.py
+++ b/chia/consensus/get_block_challenge.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Union
+from typing import Optional, Union
 
 from chia_rs import BlockRecord, ConsensusConstants, FullBlock, HeaderBlock, UnfinishedBlock
 from chia_rs.sized_bytes import bytes32
@@ -105,16 +105,16 @@ def get_block_challenge(
 # Returns the height of the previous transaction block up to the blocks signage point
 # we use this for block validation since when the block is farmed we do not know the latest transaction block
 # since a new one might be infused by the time the block is infused
-def prev_tx_block(
+def pre_sp_tx_block(
     constants: ConsensusConstants,
     blocks: BlockRecordsProtocol,
     *,
     prev_b_hash: bytes32,
     sp_index: uint8,
     first_in_sub_slot: bool,
-) -> uint32:
+) -> Optional[BlockRecord]:
     if prev_b_hash == constants.GENESIS_CHALLENGE:
-        return uint32(0)
+        return None
     curr = blocks.block_record(prev_b_hash)
     before_slot = first_in_sub_slot
     while curr.height > 0:
@@ -123,4 +123,24 @@ def prev_tx_block(
         if curr.first_in_sub_slot:
             before_slot = True
         curr = blocks.block_record(curr.prev_hash)
-    return curr.height
+    return curr
+
+
+def pre_sp_block_height(
+    constants: ConsensusConstants,
+    blocks: BlockRecordsProtocol,
+    *,
+    prev_b_hash: bytes32,
+    sp_index: uint8,
+    first_in_sub_slot: bool,
+) -> uint32:
+    latest_tx_block = pre_sp_tx_block(
+        constants=constants,
+        blocks=blocks,
+        prev_b_hash=prev_b_hash,
+        sp_index=sp_index,
+        first_in_sub_slot=first_in_sub_slot,
+    )
+    if latest_tx_block is None:
+        return uint32(0)
+    return latest_tx_block.height

--- a/chia/consensus/get_block_challenge.py
+++ b/chia/consensus/get_block_challenge.py
@@ -102,7 +102,7 @@ def get_block_challenge(
     return challenge
 
 
-# Returns the height of the previous transaction block up to the blocks signage point
+# Returns the previous transaction block up to the blocks signage point
 # we use this for block validation since when the block is farmed we do not know the latest transaction block
 # since a new one might be infused by the time the block is infused
 def pre_sp_tx_block(

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -28,7 +28,7 @@ from chia.consensus.block_header_validation import validate_finished_header_bloc
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.generator_tools import get_block_header, tx_removals_and_additions
-from chia.consensus.get_block_challenge import get_block_challenge, pre_sp_block_height
+from chia.consensus.get_block_challenge import get_block_challenge, pre_sp_tx_block_height
 from chia.consensus.get_block_generator import get_block_generator
 from chia.consensus.pot_iterations import (
     is_overflow_block,
@@ -220,7 +220,7 @@ async def pre_validate_block(
         cc_sp_hash,
         block.height,
         vs.difficulty,
-        pre_sp_block_height(
+        pre_sp_tx_block_height(
             constants=constants,
             blocks=blockchain,
             prev_b_hash=block.prev_header_hash,

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -28,7 +28,7 @@ from chia.consensus.block_header_validation import validate_finished_header_bloc
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.generator_tools import get_block_header, tx_removals_and_additions
-from chia.consensus.get_block_challenge import get_block_challenge, prev_tx_block
+from chia.consensus.get_block_challenge import get_block_challenge, pre_sp_block_height
 from chia.consensus.get_block_generator import get_block_generator
 from chia.consensus.pot_iterations import (
     is_overflow_block,
@@ -220,7 +220,7 @@ async def pre_validate_block(
         cc_sp_hash,
         block.height,
         vs.difficulty,
-        prev_tx_block(
+        pre_sp_block_height(
             constants=constants,
             blocks=blockchain,
             prev_b_hash=block.prev_header_hash,

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -30,7 +30,7 @@ from chia.consensus.block_header_validation import validate_finished_header_bloc
 from chia.consensus.blockchain_interface import BlockchainInterface
 from chia.consensus.deficit import calculate_deficit
 from chia.consensus.full_block_to_block_record import header_block_to_sub_block_record
-from chia.consensus.get_block_challenge import pre_sp_block_height
+from chia.consensus.get_block_challenge import pre_sp_tx_block_height
 from chia.consensus.pot_iterations import (
     calculate_ip_iters,
     calculate_sp_iters,
@@ -1329,7 +1329,7 @@ def _validate_pospace_recent_chain(
         cc_sp_hash,
         block.height,
         diff,
-        pre_sp_block_height(
+        pre_sp_tx_block_height(
             constants=constants,
             blocks=blocks,
             prev_b_hash=block.prev_header_hash,

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -30,7 +30,7 @@ from chia.consensus.block_header_validation import validate_finished_header_bloc
 from chia.consensus.blockchain_interface import BlockchainInterface
 from chia.consensus.deficit import calculate_deficit
 from chia.consensus.full_block_to_block_record import header_block_to_sub_block_record
-from chia.consensus.get_block_challenge import prev_tx_block
+from chia.consensus.get_block_challenge import pre_sp_block_height
 from chia.consensus.pot_iterations import (
     calculate_ip_iters,
     calculate_sp_iters,
@@ -1329,7 +1329,7 @@ def _validate_pospace_recent_chain(
         cc_sp_hash,
         block.height,
         diff,
-        prev_tx_block(
+        pre_sp_block_height(
             constants=constants,
             blocks=blocks,
             prev_b_hash=block.prev_header_hash,

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -51,7 +51,7 @@ from chia.consensus.constants import replace_str_to_bytes
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.deficit import calculate_deficit
 from chia.consensus.full_block_to_block_record import block_to_block_record
-from chia.consensus.get_block_challenge import pre_sp_tx_block
+from chia.consensus.get_block_challenge import pre_sp_block_height
 from chia.consensus.make_sub_epoch_summary import next_sub_epoch_summary
 from chia.consensus.pot_iterations import (
     calculate_ip_iters,
@@ -912,15 +912,13 @@ class BlockTools:
                         assert signage_point.cc_vdf is not None
                         cc_sp_output_hash = signage_point.cc_vdf.output.get_hash()
 
-                    prev_tx = pre_sp_tx_block(
+                    prev_tx_height = pre_sp_block_height(
                         constants=constants,
                         blocks=BlockCache(blocks),
                         prev_b_hash=latest_block.prev_hash,
                         sp_index=latest_block.signage_point_index,
                         first_in_sub_slot=latest_block.first_in_sub_slot,
                     )
-                    if prev_tx is not None:
-                        prev_tx_height = prev_tx.height
 
                     qualified_proofs: list[tuple[uint64, ProofOfSpace]] = self.get_pospaces_for_challenge(
                         constants,
@@ -1224,15 +1222,14 @@ class BlockTools:
                         cc_sp_output_hash = signage_point.cc_vdf.output.get_hash()
 
                     # If did not reach the target slots to skip, don't make any proofs for this sub-slot
-                    prev_tx = pre_sp_tx_block(
+                    prev_tx_height = pre_sp_block_height(
                         constants=constants,
                         blocks=BlockCache(blocks),
                         prev_b_hash=latest_block.prev_hash,
                         sp_index=latest_block.signage_point_index,
                         first_in_sub_slot=latest_block.first_in_sub_slot,
                     )
-                    if prev_tx is not None:
-                        prev_tx_height = prev_tx.height
+
                     qualified_proofs = self.get_pospaces_for_challenge(
                         constants,
                         slot_cc_challenge,
@@ -1870,7 +1867,13 @@ def load_block_list(
             sp_hash = full_block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
 
         cache = BlockCache(blocks)
-
+        prev_transaction_b_height = pre_sp_block_height(
+            constants=constants,
+            blocks=BlockCache(blocks),
+            prev_b_hash=full_block.prev_header_hash,
+            sp_index=full_block.reward_chain_block.signage_point_index,
+            first_in_sub_slot=len(full_block.finished_sub_slots) > 0,
+        )
         required_iters = validate_pospace_and_get_required_iters(
             constants,
             full_block.reward_chain_block.proof_of_space,
@@ -1881,9 +1884,6 @@ def load_block_list(
             prev_transaction_b_height,
         )
         assert required_iters is not None
-
-        if full_block.is_transaction_block():
-            prev_transaction_b_height = full_block.height
 
         blocks[full_block.header_hash] = block_to_block_record(
             constants,

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -51,7 +51,7 @@ from chia.consensus.constants import replace_str_to_bytes
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.deficit import calculate_deficit
 from chia.consensus.full_block_to_block_record import block_to_block_record
-from chia.consensus.get_block_challenge import pre_sp_block_height
+from chia.consensus.get_block_challenge import pre_sp_tx_block_height
 from chia.consensus.make_sub_epoch_summary import next_sub_epoch_summary
 from chia.consensus.pot_iterations import (
     calculate_ip_iters,
@@ -912,7 +912,7 @@ class BlockTools:
                         assert signage_point.cc_vdf is not None
                         cc_sp_output_hash = signage_point.cc_vdf.output.get_hash()
 
-                    prev_tx_height = pre_sp_block_height(
+                    prev_tx_height = pre_sp_tx_block_height(
                         constants=constants,
                         blocks=BlockCache(blocks),
                         prev_b_hash=latest_block.prev_hash,
@@ -1222,7 +1222,7 @@ class BlockTools:
                         cc_sp_output_hash = signage_point.cc_vdf.output.get_hash()
 
                     # If did not reach the target slots to skip, don't make any proofs for this sub-slot
-                    prev_tx_height = pre_sp_block_height(
+                    prev_tx_height = pre_sp_tx_block_height(
                         constants=constants,
                         blocks=BlockCache(blocks),
                         prev_b_hash=latest_block.prev_hash,
@@ -1867,7 +1867,7 @@ def load_block_list(
             sp_hash = full_block.reward_chain_block.challenge_chain_sp_vdf.output.get_hash()
 
         cache = BlockCache(blocks)
-        prev_transaction_b_height = pre_sp_block_height(
+        prev_transaction_b_height = pre_sp_tx_block_height(
             constants=constants,
             blocks=BlockCache(blocks),
             prev_b_hash=full_block.prev_header_hash,

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -1850,7 +1850,6 @@ def load_block_list(
     sub_slot_iters = uint64(constants.SUB_SLOT_ITERS_STARTING)
     height_to_hash: dict[uint32, bytes32] = {}
     blocks: dict[bytes32, BlockRecord] = {}
-    prev_transaction_b_height = uint32(0)
     for full_block in block_list:
         if full_block.height != 0:
             if len(full_block.finished_sub_slots) > 0:

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -915,9 +915,9 @@ class BlockTools:
                     prev_tx_height = pre_sp_tx_block_height(
                         constants=constants,
                         blocks=BlockCache(blocks),
-                        prev_b_hash=latest_block.prev_hash,
-                        sp_index=latest_block.signage_point_index,
-                        first_in_sub_slot=latest_block.first_in_sub_slot,
+                        prev_b_hash=latest_block.header_hash,
+                        sp_index=uint8(signage_point_index),
+                        first_in_sub_slot=len(finished_sub_slots_at_ip) > 0,
                     )
 
                     qualified_proofs: list[tuple[uint64, ProofOfSpace]] = self.get_pospaces_for_challenge(
@@ -1225,9 +1225,9 @@ class BlockTools:
                     prev_tx_height = pre_sp_tx_block_height(
                         constants=constants,
                         blocks=BlockCache(blocks),
-                        prev_b_hash=latest_block.prev_hash,
-                        sp_index=latest_block.signage_point_index,
-                        first_in_sub_slot=latest_block.first_in_sub_slot,
+                        prev_b_hash=latest_block.header_hash,
+                        sp_index=uint8(signage_point_index),
+                        first_in_sub_slot=len(finished_sub_slots_at_ip) > 0,
                     )
 
                     qualified_proofs = self.get_pospaces_for_challenge(
@@ -1869,7 +1869,7 @@ def load_block_list(
         cache = BlockCache(blocks)
         prev_transaction_b_height = pre_sp_tx_block_height(
             constants=constants,
-            blocks=BlockCache(blocks),
+            blocks=cache,
             prev_b_hash=full_block.prev_header_hash,
             sp_index=full_block.reward_chain_block.signage_point_index,
             first_in_sub_slot=len(full_block.finished_sub_slots) > 0,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
fixing the latest transaction block ref in block tools to point to the latest transaction block before the block SP
<!-- Does this PR introduce a breaking change? -->

### Current Behavior:
we use the latest transaction block, this is wrong since while producing the block before infusion we dont know what blocks will be infused before our block, the correct way is to use the latest transaction block up to the block sp
### New Behavior:
use the same method used in validation to find the latest transaction block before the sp
<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
