### PR TITLE
[LABS-290] Port `test_wallet_rpc.py` to `WalletTestFramework`

### DIFF
--- a/chia/_tests/environments/wallet.py
+++ b/chia/_tests/environments/wallet.py
@@ -228,7 +228,7 @@ class WalletEnvironment:
                 )
             else:
                 for key, change in kwargs.items():
-                    if key in "set_remainder":
+                    if key in {"set_remainder", "init"}:
                         continue
                     if "#" in key:
                         opp: str = key[0 : key.index("#")]

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -3359,13 +3359,16 @@ async def test_set_wallet_resync_on_startup_disable(wallet_environments: WalletT
     await wallet_node_2._await_closed()
 
 
-@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [{"num_environments": 1, "blocks_needed": [0]}],
+    indirect=True,
+)
 @pytest.mark.limit_consensus_modes(reason="irrelevant")
-async def test_set_wallet_resync_schema(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
-    env: WalletRpcTestEnvironment = wallet_rpc_environment
-    full_node_api: FullNodeSimulator = env.full_node.api
-    await generate_funds(full_node_api, env.wallet_1)
-    wallet_node: WalletNode = env.wallet_1.node
+@pytest.mark.anyio
+async def test_set_wallet_resync_schema(wallet_environments: WalletTestFramework) -> None:
+    env = wallet_environments.environments[0]
+    wallet_node: WalletNode = env.node
     fingerprint = wallet_node.logged_in_fingerprint
     assert fingerprint is not None
     db_path = wallet_node.wallet_state_manager.db_path

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -3315,14 +3315,19 @@ async def test_set_wallet_resync_on_startup(wallet_environments: WalletTestFrame
     await wallet_node_2._await_closed()
 
 
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [{"num_environments": 2, "blocks_needed": [1, 0]}],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
 @pytest.mark.anyio
-async def test_set_wallet_resync_on_startup_disable(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
-    env: WalletRpcTestEnvironment = wallet_rpc_environment
-    full_node_api: FullNodeSimulator = env.full_node.api
-    client: WalletRpcClient = env.wallet_1.rpc_client
-    await generate_funds(full_node_api, env.wallet_1)
-    wallet_node: WalletNode = env.wallet_1.node
-    wallet_node_2: WalletNode = env.wallet_2.node
+async def test_set_wallet_resync_on_startup_disable(wallet_environments: WalletTestFramework) -> None:
+    env = wallet_environments.environments[0]
+    env_2 = wallet_environments.environments[1]
+    client: WalletRpcClient = env.rpc_client
+    wallet_node: WalletNode = env.node
+    wallet_node_2: WalletNode = env_2.node
     wallet_node_2._close()
     await wallet_node_2._await_closed()
     # set flag to reset wallet sync data on start

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -634,14 +634,16 @@ async def test_get_farmed_amount_with_fee(wallet_environments: WalletTestFramewo
     assert result["fee_amount"] == fee_amount
 
 
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [{"num_environments": 1, "blocks_needed": [1], "reuse_puzhash": True, "trusted": True}],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
 @pytest.mark.anyio
-async def test_get_timestamp_for_height(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
-    env: WalletRpcTestEnvironment = wallet_rpc_environment
-
-    full_node_api: FullNodeSimulator = env.full_node.api
-    client: WalletRpcClient = env.wallet_1.rpc_client
-
-    await generate_funds(full_node_api, env.wallet_1)
+async def test_get_timestamp_for_height(wallet_environments: WalletTestFramework) -> None:
+    env = wallet_environments.environments[0]
+    client: WalletRpcClient = env.rpc_client
 
     # This tests that the client returns successfully, rather than raising or returning something unexpected
     await client.get_timestamp_for_height(GetTimestampForHeight(uint32(1)))

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -2718,11 +2718,17 @@ async def test_select_coins_rpc(wallet_environments: WalletTestFramework) -> Non
         )
 
 
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [{"num_environments": 1, "blocks_needed": [0], "reuse_puzhash": True, "trusted": True}],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
 @pytest.mark.anyio
-async def test_get_coin_records_rpc(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
-    env: WalletRpcTestEnvironment = wallet_rpc_environment
-    wallet_node: WalletNode = env.wallet_1.node
-    client: WalletRpcClient = env.wallet_1.rpc_client
+async def test_get_coin_records_rpc(wallet_environments: WalletTestFramework) -> None:
+    env = wallet_environments.environments[0]
+    wallet_node: WalletNode = env.node
+    client: WalletRpcClient = env.rpc_client
     store = wallet_node.wallet_state_manager.coin_store
 
     for record in [record_1, record_2, record_3, record_4, record_5, record_6, record_7, record_8, record_9]:

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -531,15 +531,25 @@ async def test_push_transactions(wallet_environments: WalletTestFramework) -> No
     assert resp["success"]
 
 
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [
+        {
+            "num_environments": 1,
+            "blocks_needed": [1],
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
 @pytest.mark.anyio
-async def test_get_balance(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
-    env = wallet_rpc_environment
-    wallet: Wallet = env.wallet_1.wallet
-    wallet_node: WalletNode = env.wallet_1.node
-    full_node_api: FullNodeSimulator = env.full_node.api
-    wallet_rpc_client = env.wallet_1.rpc_client
-    await full_node_api.farm_blocks_to_wallet(2, wallet)
-    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+async def test_get_balance(wallet_environments: WalletTestFramework) -> None:
+    env = wallet_environments.environments[0]
+    wallet: Wallet = env.xch_wallet
+    wallet_node: WalletNode = env.node
+    full_node_api: FullNodeSimulator = wallet_environments.full_node
+    wallet_rpc_client = env.rpc_client
+    async with wallet.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         cat_wallet = await CATWallet.create_new_cat_wallet(
             wallet_node.wallet_state_manager,
             wallet,

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -563,13 +563,21 @@ async def test_get_balance(wallet_environments: WalletTestFramework) -> None:
     await assert_get_balance(wallet_rpc_client, wallet_node, cat_wallet)
 
 
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [
+        {
+            "num_environments": 1,
+            "blocks_needed": [2],
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
 @pytest.mark.anyio
-async def test_get_farmed_amount(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
-    env = wallet_rpc_environment
-    wallet: Wallet = env.wallet_1.wallet
-    full_node_api: FullNodeSimulator = env.full_node.api
-    wallet_rpc_client = env.wallet_1.rpc_client
-    await full_node_api.farm_blocks_to_wallet(2, wallet)
+async def test_get_farmed_amount(wallet_environments: WalletTestFramework) -> None:
+    env = wallet_environments.environments[0]
+    wallet_rpc_client = env.rpc_client
 
     get_farmed_amount_result = await wallet_rpc_client.get_farmed_amount()
     get_timestamp_for_height_result = await wallet_rpc_client.get_timestamp_for_height(

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -3105,20 +3105,30 @@ async def test_notification_rpcs(wallet_environments: WalletTestFramework) -> No
     ],
 )
 @pytest.mark.parametrize("prefix_hex_strings", [True, False], ids=["with 0x", "no 0x"])
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [
+        {
+            "num_environments": 1,
+            "blocks_needed": [1],
+            "reuse_puzhash": True,
+            "trusted": True,
+        }
+    ],
+    indirect=True,
+)
 @pytest.mark.anyio
 @pytest.mark.limit_consensus_modes(reason="irrelevant")
 async def test_verify_signature(
-    wallet_rpc_environment: WalletRpcTestEnvironment,
+    wallet_environments: WalletTestFramework,
     rpc_request: dict[str, Any],
     rpc_response: VerifySignatureResponse,
     prefix_hex_strings: bool,
 ) -> None:
-    rpc_server = wallet_rpc_environment.wallet_1.service.rpc_server
-    assert rpc_server is not None
     updated_request = rpc_request.copy()
     updated_request["pubkey"] = ("0x" if prefix_hex_strings else "") + updated_request["pubkey"]
     updated_request["signature"] = ("0x" if prefix_hex_strings else "") + updated_request["signature"]
-    res = await wallet_rpc_environment.wallet_1.rpc_client.verify_signature(
+    res = await wallet_environments.environments[0].rpc_client.verify_signature(
         VerifySignature.from_json_dict(updated_request)
     )
     assert res == rpc_response

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -597,18 +597,27 @@ async def test_get_farmed_amount(wallet_environments: WalletTestFramework) -> No
     assert get_farmed_amount_result == expected_result
 
 
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [
+        {
+            "num_environments": 1,
+            "blocks_needed": [2],
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
 @pytest.mark.anyio
-async def test_get_farmed_amount_with_fee(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
-    env = wallet_rpc_environment
-    wallet: Wallet = env.wallet_1.wallet
-    full_node_api: FullNodeSimulator = env.full_node.api
-    wallet_rpc_client = env.wallet_1.rpc_client
-    wallet_node: WalletNode = env.wallet_1.node
-
-    await generate_funds(full_node_api, env.wallet_1)
+async def test_get_farmed_amount_with_fee(wallet_environments: WalletTestFramework) -> None:
+    env = wallet_environments.environments[0]
+    wallet: Wallet = env.xch_wallet
+    full_node_api: FullNodeSimulator = wallet_environments.full_node
+    wallet_rpc_client = env.rpc_client
+    wallet_node: WalletNode = env.node
 
     fee_amount = 100
-    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+    async with wallet.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         await wallet.generate_signed_transaction(
             amounts=[uint64(5)],
             puzzle_hashes=[bytes32.zeros],

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -1149,14 +1149,16 @@ async def test_get_transactions(wallet_environments: WalletTestFramework) -> Non
     assert len(all_transactions) == 1
 
 
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [{"num_environments": 1, "blocks_needed": [1]}],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
 @pytest.mark.anyio
-async def test_get_transaction_count(wallet_rpc_environment: WalletRpcTestEnvironment) -> None:
-    env: WalletRpcTestEnvironment = wallet_rpc_environment
-
-    full_node_api: FullNodeSimulator = env.full_node.api
-    client: WalletRpcClient = env.wallet_1.rpc_client
-
-    await generate_funds(full_node_api, env.wallet_1)
+async def test_get_transaction_count(wallet_environments: WalletTestFramework) -> None:
+    env = wallet_environments.environments[0]
+    client: WalletRpcClient = env.rpc_client
 
     all_transactions = (await client.get_transactions(GetTransactions(uint32(1)))).transactions
     assert len(all_transactions) > 0

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -183,9 +183,7 @@ async def create_tx_outputs(
         for args in output_args:
             output = {
                 "amount": uint64(args[0]),
-                "puzzle_hash": await action_scope.get_puzzle_hash(
-                    wallet.wallet_state_manager, override_reuse_puzhash_with=False
-                ),
+                "puzzle_hash": await action_scope.get_puzzle_hash(wallet.wallet_state_manager),
             }
             if args[1] is not None:
                 assert len(args[1]) > 0
@@ -546,6 +544,11 @@ async def test_create_signed_transaction(
     select_coin: bool,
     is_cat: bool,
 ) -> None:
+    if (
+        len(list(set(amount for amount, _ in output_args))) != len(output_args)
+        and wallet_environments.tx_config.reuse_puzhash
+    ):
+        pytest.skip("Skipping reuse_puzhash + identical amounts for simplicity sake")
     env = wallet_environments.environments[0]
     env_2 = wallet_environments.environments[1]
 

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -565,12 +565,7 @@ async def test_get_balance(wallet_environments: WalletTestFramework) -> None:
 
 @pytest.mark.parametrize(
     "wallet_environments",
-    [
-        {
-            "num_environments": 1,
-            "blocks_needed": [2],
-        }
-    ],
+    [{"num_environments": 1, "blocks_needed": [2], "reuse_puzhash": True, "trusted": True}],
     indirect=True,
 )
 @pytest.mark.limit_consensus_modes(reason="irrelevant")
@@ -599,12 +594,7 @@ async def test_get_farmed_amount(wallet_environments: WalletTestFramework) -> No
 
 @pytest.mark.parametrize(
     "wallet_environments",
-    [
-        {
-            "num_environments": 1,
-            "blocks_needed": [2],
-        }
-    ],
+    [{"num_environments": 1, "blocks_needed": [2], "reuse_puzhash": True, "trusted": True}],
     indirect=True,
 )
 @pytest.mark.limit_consensus_modes(reason="irrelevant")


### PR DESCRIPTION
This PR ports the entire `test_wallet_rpc.py` file to the currently paradigmatic `WalletTestFramework`.  This should have benefits for test run speed as well as flakiness. It will also add coverage for `reuse_puzhash` parametrization and provide more cross compatibility porting code between these and other tests.

There is one change that needed to be made to the `WalletTestFramework` that was discovered as a result of this port.  The concept of explicitly specifying `"init": False` was not covered and led to an error in the test where it had to be used.