### PR TITLE
Tweak phase out

### DIFF
--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -16,6 +16,7 @@ from chia.types.blockchain_format.proof_of_space import (
     check_plot_param,
     is_v1_phased_out,
     make_pos,
+    num_phase_out_epochs,
     passes_plot_filter,
     verify_and_get_quality_string,
 )
@@ -286,7 +287,7 @@ def test_v1_phase_out() -> None:
     constants = DEFAULT_CONSTANTS.replace(HARD_FORK2_HEIGHT=uint32(500000))
     rng = random.Random()
 
-    phase_out_epochs = (1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS) - 1
+    phase_out_epochs = num_phase_out_epochs(constants)
     print(f"phase-out epochs: {phase_out_epochs}")
 
     for epoch in range(-5, phase_out_epochs + 5):

--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -286,7 +286,7 @@ def test_v1_phase_out() -> None:
     constants = DEFAULT_CONSTANTS.replace(HARD_FORK2_HEIGHT=uint32(500000))
     rng = random.Random()
 
-    phase_out_epochs = 1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS
+    phase_out_epochs = (1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS) - 1
     print(f"phase-out epochs: {phase_out_epochs}")
 
     for epoch in range(-5, phase_out_epochs + 5):

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -31,8 +31,8 @@ from chia.types.blockchain_format.proof_of_space import (
     generate_plot_public_key,
     is_v1_phased_out,
     make_pos,
-    num_phase_out_epochs,
     passes_plot_filter,
+    v1_cut_off_height,
 )
 from chia.wallet.derive_keys import master_sk_to_local_sk
 
@@ -298,7 +298,7 @@ class HarvesterAPI:
                                     sp_challenge_hash, index, self.harvester.parallel_read
                                 )
 
-                                if is_v1_phased_out(proof_xs, new_challenge.last_tx_height, constants):
+                                if is_v1_phased_out(proof_xs, new_challenge.last_tx_height, self.harvester.constants):
                                     self.harvester.log.info(
                                         f"Proof dropped due to hard fork phase-out of v1 plots: {filename}"
                                     )
@@ -407,13 +407,8 @@ class HarvesterAPI:
                     )
                     passed += 1
                 else:
-                    constants = self.harvester.constants
                     # after the phase-out, ignore v1 plots
-                    phase_out_epochs = num_phase_out_epochs(constants)
-                    if (
-                        new_challenge.last_tx_height
-                        >= constants.HARD_FORK2_HEIGHT + phase_out_epochs * constants.EPOCH_BLOCKS
-                    ):
+                    if new_challenge.last_tx_height >= v1_cut_off_height(self.harvester.constants):
                         continue
 
                     passed += 1

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -408,10 +408,10 @@ class HarvesterAPI:
                 else:
                     constants = self.harvester.constants
                     # after the phase-out, ignore v1 plots
+                    phase_out_epochs = (1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS) - 1
                     if (
                         new_challenge.last_tx_height
-                        >= constants.HARD_FORK2_HEIGHT
-                        + (1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS) * constants.EPOCH_BLOCKS
+                        >= constants.HARD_FORK2_HEIGHT + phase_out_epochs * constants.EPOCH_BLOCKS
                     ):
                         continue
 

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -31,6 +31,7 @@ from chia.types.blockchain_format.proof_of_space import (
     generate_plot_public_key,
     is_v1_phased_out,
     make_pos,
+    num_phase_out_epochs,
     passes_plot_filter,
 )
 from chia.wallet.derive_keys import master_sk_to_local_sk
@@ -408,7 +409,7 @@ class HarvesterAPI:
                 else:
                     constants = self.harvester.constants
                     # after the phase-out, ignore v1 plots
-                    phase_out_epochs = (1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS) - 1
+                    phase_out_epochs = num_phase_out_epochs(constants)
                     if (
                         new_challenge.last_tx_height
                         >= constants.HARD_FORK2_HEIGHT + phase_out_epochs * constants.EPOCH_BLOCKS

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -1560,7 +1560,7 @@ class BlockTools:
         rng.seed(seed)
 
         sp_interval_iters = calculate_sp_interval_iters(constants, sub_slot_iters)
-        phase_out_epochs = 1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS
+        phase_out_epochs = (1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS) - 1
 
         for plot_info in self.plot_manager.plots.values():
             plot_id: bytes32 = plot_info.prover.get_id()

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -1559,6 +1559,9 @@ class BlockTools:
         rng = random.Random()
         rng.seed(seed)
 
+        sp_interval_iters = calculate_sp_interval_iters(constants, sub_slot_iters)
+        phase_out_epochs = 1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS
+
         for plot_info in self.plot_manager.plots.values():
             plot_id: bytes32 = plot_info.prover.get_id()
             if force_plot_id is not None and plot_id != force_plot_id:
@@ -1566,8 +1569,6 @@ class BlockTools:
             prefix_bits = calculate_prefix_bits(constants, height, plot_info.prover.get_param())
             if not passes_plot_filter(prefix_bits, plot_id, challenge_hash, signage_point):
                 continue
-
-            phase_out_epochs = 1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS
 
             if plot_info.prover.get_version() == PlotVersion.V2:
                 # v2 plots aren't valid until after the hard fork
@@ -1603,7 +1604,7 @@ class BlockTools:
                     difficulty,
                     signage_point,
                 )
-                if required_iters >= calculate_sp_interval_iters(constants, sub_slot_iters):
+                if required_iters >= sp_interval_iters:
                     continue
 
                 proof = b""

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -99,6 +99,7 @@ from chia.types.blockchain_format.proof_of_space import (
     generate_taproot_sk,
     is_v1_phased_out,
     make_pos,
+    num_phase_out_epochs,
     passes_plot_filter,
 )
 from chia.types.blockchain_format.serialized_program import SerializedProgram
@@ -1560,7 +1561,7 @@ class BlockTools:
         rng.seed(seed)
 
         sp_interval_iters = calculate_sp_interval_iters(constants, sub_slot_iters)
-        phase_out_epochs = (1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS) - 1
+        phase_out_epochs = num_phase_out_epochs(constants)
 
         for plot_info in self.plot_manager.plots.values():
             plot_id: bytes32 = plot_info.prover.get_id()

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -72,6 +72,16 @@ def check_plot_param(constants: ConsensusConstants, ps: PlotParam) -> bool:
     return True
 
 
+def num_phase_out_epochs(constants: ConsensusConstants) -> int:
+    """
+    The number of phase-out epochs is always a power-of-two minus 1. i.e. it
+    will also be a mask for the hash of the proof we're checking for phase-out.
+    Since the hash of the proof are random bits, the simplest check is just to
+    mask and compare the resulting value against the phase-out count down.
+    """
+    return (1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS) - 1
+
+
 def is_v1_phased_out(
     proof: bytes,
     prev_transaction_block_height: uint32,  # this is the height of the last tx block before the current block SP
@@ -83,11 +93,7 @@ def is_v1_phased_out(
     # This is a v1 plot and the phase-out period has started
     # The probability of having been phased out is proportional on the
     # number of epochs since hard fork activation
-    phase_out_epoch_bits = constants.PLOT_V1_PHASE_OUT_EPOCH_BITS
-    if phase_out_epoch_bits == 0:
-        return True
-
-    phase_out_epoch_mask = (1 << phase_out_epoch_bits) - 1
+    phase_out_epoch_mask = num_phase_out_epochs(constants)
 
     # we just look at one byte so the mask can't be bigger than that
     assert phase_out_epoch_mask < 256

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -104,7 +104,7 @@ def is_v1_phased_out(
     )
 
     # if we're past the phase-out, v1 plots are unconditionally invalid
-    if epoch_counter <= 0:
+    if epoch_counter < 0:
         return True
 
     proof_value = std_hash(proof + b"chia proof-of-space v1 phase-out")[0] & phase_out_epoch_mask

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -84,22 +84,25 @@ def is_v1_phased_out(
     # The probability of having been phased out is proportional on the
     # number of epochs since hard fork activation
     phase_out_epoch_bits = constants.PLOT_V1_PHASE_OUT_EPOCH_BITS
+    if phase_out_epoch_bits == 0:
+        return True
+
     phase_out_epoch_mask = (1 << phase_out_epoch_bits) - 1
 
     # we just look at one byte so the mask can't be bigger than that
     assert phase_out_epoch_mask < 256
 
     # this counter is counting down to zero
-    epoch_counter = (1 << phase_out_epoch_bits) - (
-        prev_transaction_block_height - constants.HARD_FORK2_HEIGHT
-    ) // constants.EPOCH_BLOCKS
+    epoch_counter = (
+        phase_out_epoch_mask - (prev_transaction_block_height - constants.HARD_FORK2_HEIGHT) // constants.EPOCH_BLOCKS
+    )
 
     # if we're past the phase-out, v1 plots are unconditionally invalid
     if epoch_counter <= 0:
         return True
 
     proof_value = std_hash(proof + b"chia proof-of-space v1 phase-out")[0] & phase_out_epoch_mask
-    return proof_value > epoch_counter
+    return proof_value >= epoch_counter
 
 
 def verify_and_get_quality_string(

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -82,6 +82,15 @@ def num_phase_out_epochs(constants: ConsensusConstants) -> int:
     return (1 << constants.PLOT_V1_PHASE_OUT_EPOCH_BITS) - 1
 
 
+def v1_cut_off_height(constants: ConsensusConstants) -> int:
+    """
+    returns the height where v1 proofs-of-space are no longer valid. Blocks
+    whose previous transaction block is equal to or higher than this may not have a
+    v1 proof.
+    """
+    return constants.HARD_FORK2_HEIGHT + num_phase_out_epochs(constants) * constants.EPOCH_BLOCKS
+
+
 def is_v1_phased_out(
     proof: bytes,
     prev_transaction_block_height: uint32,  # this is the height of the last tx block before the current block SP
@@ -99,9 +108,7 @@ def is_v1_phased_out(
     assert phase_out_epoch_mask < 256
 
     # this counter is counting down to zero
-    epoch_counter = (
-        phase_out_epoch_mask - (prev_transaction_block_height - constants.HARD_FORK2_HEIGHT) // constants.EPOCH_BLOCKS
-    )
+    epoch_counter = (v1_cut_off_height(constants) - prev_transaction_block_height) // constants.EPOCH_BLOCKS
 
     # if we're past the phase-out, v1 plots are unconditionally invalid
     if epoch_counter < 0:


### PR DESCRIPTION
This PR is best reviewed one commit at a time.

### Purpose:

Make it so `PLOT_V1_PHASE_OUT_EPOCH_BITS = 0` means there is no phase-out period. This is useful for tests where we want v2-only proofs from block 0.

The first commit is a minor refactor to hoist calculations out of the loop over all test plots, in `BlockTools`.

### Current Behavior:

There's always 1 epoch of phase-out, when `PLOT_V1_PHASE_OUT_EPOCH_BITS` is 0.

### New Behavior:

The number of phase-out epochs is `(1 << PLOT_V1_PHASE_OUT_EPOCH_BITS) - 1`, allowing 0 epochs phase-out (i.e. no phase-out).

The new phase-out behavior is this, if `PLOT_V1_PHASE_OUT_EPOCH_BITS` is `3`:

| epoch after activation | fraction of plots phased-out |
| --- | --- |
| 0 | 1/7 |
| 1 | 2/7 |
| 2 | 3/7 |
| 3 | 4/7 |
| 4 | 5/7 |
| 5 | 6/7 |
| 6 | 7/7 |

### Testing Notes:

There are existing tests for the phase-out. I also confirmed correct behavior when generating test chains in the debugger.