### PR TITLE
[LABS-297] Merge `get/delete_(all_)notifications`

### DIFF
--- a/chia/_tests/wallet/test_notifications.py
+++ b/chia/_tests/wallet/test_notifications.py
@@ -187,12 +187,12 @@ async def test_notifications(
     sent_notifications = await notification_manager_1.notification_store.get_notifications()
     assert len(sent_notifications) == 0
 
-    await notification_manager_2.notification_store.delete_all_notifications()
+    await notification_manager_2.notification_store.delete_notifications()
     assert len(await notification_manager_2.notification_store.get_notifications()) == 0
     await notification_manager_2.notification_store.add_notification(notifications[0])
-    await notification_manager_2.notification_store.delete_notifications([n.id for n in notifications])
+    await notification_manager_2.notification_store.delete_notifications(coin_ids=[n.id for n in notifications])
     assert len(await notification_manager_2.notification_store.get_notifications()) == 0
 
     assert not await func(*notification_manager_2.most_recent_args)
-    await notification_manager_2.notification_store.delete_all_notifications()
+    await notification_manager_2.notification_store.delete_notifications()
     assert not await func(*notification_manager_2.most_recent_args)

--- a/chia/_tests/wallet/test_notifications.py
+++ b/chia/_tests/wallet/test_notifications.py
@@ -165,33 +165,33 @@ async def test_notifications(
     assert allow_larger_height is not None
     assert allow_height is not None
 
-    notifications = await notification_manager_2.notification_store.get_all_notifications(pagination=(0, 2))
+    notifications = await notification_manager_2.notification_store.get_notifications(pagination=(0, 2))
     assert len(notifications) == 2
     assert notifications[0].message == b"allow_larger"
     assert notifications[0].height == allow_larger_height
-    notifications = await notification_manager_2.notification_store.get_all_notifications(pagination=(1, None))
+    notifications = await notification_manager_2.notification_store.get_notifications(pagination=(1, None))
     assert len(notifications) == 1
     assert notifications[0].message == b"allow"
     assert notifications[0].height == allow_height
-    notifications = await notification_manager_2.notification_store.get_all_notifications(pagination=(0, 1))
+    notifications = await notification_manager_2.notification_store.get_notifications(pagination=(0, 1))
     assert len(notifications) == 1
     assert notifications[0].message == b"allow_larger"
-    notifications = await notification_manager_2.notification_store.get_all_notifications(pagination=(None, 1))
+    notifications = await notification_manager_2.notification_store.get_notifications(pagination=(None, 1))
     assert len(notifications) == 1
     assert notifications[0].message == b"allow_larger"
     assert (
-        await notification_manager_2.notification_store.get_notifications([n.id for n in notifications])
+        await notification_manager_2.notification_store.get_notifications(coin_ids=[n.id for n in notifications])
         == notifications
     )
 
-    sent_notifications = await notification_manager_1.notification_store.get_all_notifications()
+    sent_notifications = await notification_manager_1.notification_store.get_notifications()
     assert len(sent_notifications) == 0
 
     await notification_manager_2.notification_store.delete_all_notifications()
-    assert len(await notification_manager_2.notification_store.get_all_notifications()) == 0
+    assert len(await notification_manager_2.notification_store.get_notifications()) == 0
     await notification_manager_2.notification_store.add_notification(notifications[0])
     await notification_manager_2.notification_store.delete_notifications([n.id for n in notifications])
-    assert len(await notification_manager_2.notification_store.get_all_notifications()) == 0
+    assert len(await notification_manager_2.notification_store.get_notifications()) == 0
 
     assert not await func(*notification_manager_2.most_recent_args)
     await notification_manager_2.notification_store.delete_all_notifications()

--- a/chia/wallet/notification_store.py
+++ b/chia/wallet/notification_store.py
@@ -104,19 +104,15 @@ class NotificationStore:
             coin_id_filter = ""
             coin_id_params = list()
 
-        if pagination is not None:
-            if pagination[1] is not None and pagination[0] is not None:
-                pagination_str = " LIMIT ?, ?"
-                pagination_params: tuple[int, ...] = (pagination[0], pagination[1] - pagination[0])
-            elif pagination[1] is None and pagination[0] is not None:
-                pagination_str = " LIMIT ?, (SELECT COUNT(*) from notifications)"
-                pagination_params = (pagination[0],)
-            elif pagination[1] is not None and pagination[0] is None:
-                pagination_str = " LIMIT ?"
-                pagination_params = (pagination[1],)
-            else:
-                pagination_str = ""
-                pagination_params = tuple()
+        if pagination[1] is not None and pagination[0] is not None:
+            pagination_str = " LIMIT ?, ?"
+            pagination_params: tuple[int, ...] = (pagination[0], pagination[1] - pagination[0])
+        elif pagination[1] is None and pagination[0] is not None:
+            pagination_str = " LIMIT ?, (SELECT COUNT(*) from notifications)"
+            pagination_params = (pagination[0],)
+        elif pagination[1] is not None and pagination[0] is None:
+            pagination_str = " LIMIT ?"
+            pagination_params = (pagination[1],)
         else:
             pagination_str = ""
             pagination_params = tuple()

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -1935,12 +1935,9 @@ class WalletRpcApi:
 
     @marshal
     async def delete_notifications(self, request: DeleteNotifications) -> Empty:
-        if request.ids is None:
-            await self.service.wallet_state_manager.notification_manager.notification_store.delete_all_notifications()
-        else:
-            await self.service.wallet_state_manager.notification_manager.notification_store.delete_notifications(
-                request.ids
-            )
+        await self.service.wallet_state_manager.notification_manager.notification_store.delete_notifications(
+            coin_ids=request.ids
+        )
 
         return Empty()
 

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -68,7 +68,6 @@ from chia.wallet.nft_wallet.nft_info import NFTCoinInfo, NFTInfo
 from chia.wallet.nft_wallet.nft_puzzle_utils import get_metadata_and_phs
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.nft_wallet.uncurry_nft import UncurriedNFT
-from chia.wallet.notification_store import Notification
 from chia.wallet.outer_puzzles import AssetType
 from chia.wallet.puzzle_drivers import PuzzleInfo
 from chia.wallet.puzzles import p2_delegated_conditions
@@ -1928,20 +1927,11 @@ class WalletRpcApi:
 
     @marshal
     async def get_notifications(self, request: GetNotifications) -> GetNotificationsResponse:
-        if request.ids is None:
-            notifications: list[
-                Notification
-            ] = await self.service.wallet_state_manager.notification_manager.notification_store.get_all_notifications(
-                pagination=(request.start, request.end)
+        return GetNotificationsResponse(
+            await self.service.wallet_state_manager.notification_manager.notification_store.get_notifications(
+                coin_ids=request.ids, pagination=(request.start, request.end)
             )
-        else:
-            notifications = (
-                await self.service.wallet_state_manager.notification_manager.notification_store.get_notifications(
-                    request.ids
-                )
-            )
-
-        return GetNotificationsResponse(notifications)
+        )
 
     @marshal
     async def delete_notifications(self, request: DeleteNotifications) -> Empty:


### PR DESCRIPTION
These endpoints are a little redundant and easily combined into a single endpoint.  This decreases duplication.