### PR TITLE
[LABS-310] Improve `WalletStateManager.get_wallet` error handling

### DIFF
--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -660,7 +660,7 @@ async def test_nft_wallet_rpc_creation_and_list(wallet_environments: WalletTestF
     # test counts
     assert (await env.rpc_client.count_nfts(NFTCountNFTs(uint32(env.wallet_aliases["nft"])))).count == 2
     assert (await env.rpc_client.count_nfts(NFTCountNFTs())).count == 2
-    with pytest.raises(ResponseFailureError, match="Wallet 50 not found"):
+    with pytest.raises(ResponseFailureError, match="Wallet with id 50 does not exist"):
         await env.rpc_client.count_nfts(NFTCountNFTs(uint32(50)))
 
 

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -2928,12 +2928,9 @@ class WalletRpcApi:
     async def nft_count_nfts(self, request: NFTCountNFTs) -> NFTCountNFTsResponse:
         count = 0
         if request.wallet_id is not None:
-            try:
-                nft_wallet = self.service.wallet_state_manager.get_wallet(id=request.wallet_id, required_type=NFTWallet)
-            except KeyError:
-                # wallet not found
-                raise ValueError(f"Wallet {request.wallet_id} not found.")
-            count = await nft_wallet.get_nft_count()
+            count = await self.service.wallet_state_manager.get_wallet(
+                id=request.wallet_id, required_type=NFTWallet
+            ).get_nft_count()
         else:
             count = await self.service.wallet_state_manager.nft_store.count()
         return NFTCountNFTsResponse(request.wallet_id, uint64(count))

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -367,9 +367,13 @@ class WalletStateManager:
         return self.private_key
 
     def get_wallet(self, id: uint32, required_type: type[TWalletType]) -> TWalletType:
+        if id not in self.wallets:
+            raise ValueError(f"Wallet with id {id} does not exist")
+
         wallet = self.wallets[id]
+
         if not isinstance(wallet, required_type):
-            raise Exception(
+            raise ValueError(
                 f"wallet id {id} is of type {type(wallet).__name__} but type {required_type.__name__} is required",
             )
 


### PR DESCRIPTION
This method used to raise a `KeyError` when the wallet didn't exist, which is a very unhelpful error.  So unhelpful in fact that an RPC endpoint caught this error in order to make it more helpful.  This PR moves that logic into the method itself.