### PR TITLE
[LABS-288] Less `asset_id: str`

### DIFF
--- a/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
@@ -121,7 +121,7 @@ async def mint_cat(
             )
 
     cat_wallet = await wallet_type.get_or_create_wallet_for_cat(
-        environment.wallet_state_manager, environment.xch_wallet, tail_hash.hex(), *extra_args
+        environment.wallet_state_manager, environment.xch_wallet, tail_hash, *extra_args
     )
 
     await wallet_environments.process_pending_states(
@@ -577,7 +577,7 @@ async def test_get_wallet_for_asset_id(wallet_environments: WalletTestFramework,
 
     # Test that the a default CAT will initialize correctly
     asset = DEFAULT_CATS[next(iter(DEFAULT_CATS))]
-    asset_id = asset["asset_id"]
+    asset_id = bytes32.from_hexstr(asset["asset_id"])
     if wallet_type is RCATWallet:
         extra_args: Any = (bytes32.zeros,)
     else:

--- a/chia/_tests/wallet/cat_wallet/test_trades.py
+++ b/chia/_tests/wallet/cat_wallet/test_trades.py
@@ -173,7 +173,7 @@ async def test_cat_trades(
         cat_wallet_maker: CATWallet = await CRCATWallet.get_or_create_wallet_for_cat(
             wallet_node_maker.wallet_state_manager,
             wallet_maker,
-            tail_maker.get_tree_hash().hex(),
+            tail_maker.get_tree_hash(),
             None,
             authorized_providers,
             proofs_checker_maker,
@@ -181,7 +181,7 @@ async def test_cat_trades(
         new_cat_wallet_taker: CATWallet = await CRCATWallet.get_or_create_wallet_for_cat(
             wallet_node_taker.wallet_state_manager,
             wallet_taker,
-            tail_taker.get_tree_hash().hex(),
+            tail_taker.get_tree_hash(),
             None,
             authorized_providers,
             proofs_checker_taker,
@@ -417,14 +417,14 @@ async def test_cat_trades(
     # Create the trade parameters
     chia_for_cat: OfferSpecification = {
         wallet_maker.id(): -1,
-        bytes32.from_hexstr(new_cat_wallet_maker.get_asset_id()): 2,  # This is the CAT that the taker made
+        new_cat_wallet_maker.get_asset_id(): 2,  # This is the CAT that the taker made
     }
     cat_for_chia: OfferSpecification = {
         wallet_maker.id(): 3,
         cat_wallet_maker.id(): -4,  # The taker has no knowledge of this CAT yet
     }
     cat_for_cat: OfferSpecification = {
-        bytes32.from_hexstr(cat_wallet_maker.get_asset_id()): -5,
+        cat_wallet_maker.get_asset_id(): -5,
         new_cat_wallet_maker.id(): 6,
     }
     chia_for_multiple_cat: OfferSpecification = {
@@ -445,10 +445,10 @@ async def test_cat_trades(
 
     driver_dict: dict[bytes32, PuzzleInfo] = {}
     for wallet in (cat_wallet_maker, new_cat_wallet_maker):
-        asset_id: str = wallet.get_asset_id()
+        asset_id = wallet.get_asset_id()
         driver_item: dict[str, Any] = {
             "type": AssetType.CAT.value,
-            "tail": "0x" + asset_id,
+            "tail": "0x" + asset_id.hex(),
         }
         if credential_restricted:
             driver_item["also"] = {
@@ -460,7 +460,7 @@ async def test_cat_trades(
                     else proofs_checker_taker.as_program()
                 ),
             }
-        driver_dict[bytes32.from_hexstr(asset_id)] = PuzzleInfo(driver_item)
+        driver_dict[asset_id] = PuzzleInfo(driver_item)
 
     trade_manager_maker = env_maker.wallet_state_manager.trade_manager
     trade_manager_taker = env_taker.wallet_state_manager.trade_manager
@@ -1805,7 +1805,7 @@ async def test_trade_cancellation(wallet_environments: WalletTestFramework, wall
     # This take should fail since we have no CATs to fulfill it with
     with pytest.raises(
         ValueError,
-        match=f"Do not have a wallet for asset ID: {cat_wallet_maker.get_asset_id()} to fulfill offer",
+        match=f"Do not have a wallet for asset ID: {cat_wallet_maker.get_asset_id().hex()} to fulfill offer",
     ):
         async with env_taker.wallet_state_manager.new_action_scope(
             wallet_environments.tx_config, push=False

--- a/chia/_tests/wallet/nft_wallet/test_nft_1_offers.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_1_offers.py
@@ -1982,7 +1982,7 @@ async def test_complex_nft_offer(
         1: XCH_REQUESTED,
         nft_to_offer_asset_id_taker_1: 1,
         nft_to_offer_asset_id_taker_2: 1,
-        bytes32.from_hexstr(cat_wallet_taker.get_asset_id()): CAT_REQUESTED,
+        cat_wallet_taker.get_asset_id(): CAT_REQUESTED,
     }
 
     nft_taker_1_info = match_puzzle(uncurry_puzzle(taker_nfts[0].full_puzzle))
@@ -1992,10 +1992,10 @@ async def test_complex_nft_offer(
     driver_dict = {
         nft_to_offer_asset_id_taker_1: nft_taker_1_info,
         nft_to_offer_asset_id_taker_2: nft_taker_2_info,
-        bytes32.from_hexstr(cat_wallet_taker.get_asset_id()): PuzzleInfo(
+        cat_wallet_taker.get_asset_id(): PuzzleInfo(
             {
                 "type": "CAT",
-                "tail": "0x" + cat_wallet_taker.get_asset_id(),
+                "tail": "0x" + cat_wallet_taker.get_asset_id().hex(),
                 **(
                     {}
                     if wallet_type is CATWallet
@@ -2047,7 +2047,7 @@ async def test_complex_nft_offer(
         },
         {
             None: uint64(XCH_REQUESTED),
-            bytes32.from_hexstr(cat_wallet_taker.get_asset_id()): uint64(CAT_REQUESTED),
+            cat_wallet_taker.get_asset_id(): uint64(CAT_REQUESTED),
         },
     )
     taker_royalty_summary = NFTWallet.royalty_calculation(
@@ -2056,7 +2056,7 @@ async def test_complex_nft_offer(
             nft_to_offer_asset_id_taker_2: (royalty_puzhash_taker, royalty_basis_pts_taker_2),
         },
         {
-            bytes32.from_hexstr(cat_wallet_maker.get_asset_id()): uint64(CAT_REQUESTED),
+            cat_wallet_maker.get_asset_id(): uint64(CAT_REQUESTED),
         },
     )
     maker_xch_royalties_expected = maker_royalty_summary[nft_to_offer_asset_id_maker][0]["amount"]
@@ -2198,7 +2198,7 @@ async def test_complex_nft_offer(
     complex_nft_offer = {
         cat_wallet_maker.id(): CAT_REQUESTED * -1,
         1: HALF_XCH_REQUESTED,
-        bytes32.from_hexstr(cat_wallet_taker.get_asset_id()): CAT_REQUESTED,
+        cat_wallet_taker.get_asset_id(): CAT_REQUESTED,
         nft_to_offer_asset_id_maker: 1,
     }
 
@@ -2206,10 +2206,10 @@ async def test_complex_nft_offer(
     assert maker_nft_info is not None
     driver_dict = {
         nft_to_offer_asset_id_maker: maker_nft_info,
-        bytes32.from_hexstr(cat_wallet_taker.get_asset_id()): PuzzleInfo(
+        cat_wallet_taker.get_asset_id(): PuzzleInfo(
             {
                 "type": "CAT",
-                "tail": "0x" + cat_wallet_taker.get_asset_id(),
+                "tail": "0x" + cat_wallet_taker.get_asset_id().hex(),
             }
         ),
     }

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -235,7 +235,7 @@ async def assert_get_balance(rpc_client: WalletRpcClient, wallet_node: WalletNod
     expected_balance_dict["fingerprint"] = wallet_node.logged_in_fingerprint
     if wallet.type() in {WalletType.CAT, WalletType.CRCAT}:
         assert isinstance(wallet, CATWallet)
-        expected_balance_dict["asset_id"] = "0x" + wallet.get_asset_id()
+        expected_balance_dict["asset_id"] = "0x" + wallet.get_asset_id().hex()
     else:
         expected_balance_dict["asset_id"] = None
     assert (
@@ -1133,7 +1133,7 @@ async def test_cat_endpoints(wallet_environments: WalletTestFramework, wallet_ty
     asset_id = (await env_0.rpc_client.get_cat_asset_id(CATGetAssetID(cat_0_id))).asset_id
     assert (
         await env_0.rpc_client.get_cat_name(CATGetName(cat_0_id))
-    ).name == wallet_type.default_wallet_name_for_unknown_cat(asset_id.hex())
+    ).name == wallet_type.default_wallet_name_for_unknown_cat(asset_id)
     await env_0.rpc_client.set_cat_name(CATSetName(cat_0_id, "My cat"))
     assert (await env_0.rpc_client.get_cat_name(CATGetName(cat_0_id))).name == "My cat"
     asset_to_name_response = await env_0.rpc_client.cat_asset_id_to_name(CATAssetIDToName(asset_id))

--- a/chia/_tests/wallet/test_wallet_test_framework.py
+++ b/chia/_tests/wallet/test_wallet_test_framework.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 from chia_rs import BlockRecord
+from chia_rs.sized_bytes import bytes32
 
 from chia._tests.environments.wallet import (
     BalanceCheckingError,
@@ -145,7 +146,7 @@ async def test_balance_checking(
             )
         ]
     )
-    await CATWallet.get_or_create_wallet_for_cat(env_0.wallet_state_manager, env_0.xch_wallet, "00" * 32)
+    await CATWallet.get_or_create_wallet_for_cat(env_0.wallet_state_manager, env_0.xch_wallet, bytes32.zeros)
     with pytest.raises(KeyError, match="No wallet state for wallet id 2"):
         await env_0.check_balances()
 

--- a/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
@@ -848,7 +848,7 @@ async def test_cat_wallet_conversion(
 
     # Key point of test: create a normal CAT wallet first, and see if it gets converted to CR-CAT wallet
     await CATWallet.get_or_create_wallet_for_cat(
-        wallet_node_0.wallet_state_manager, wallet_0, Program.NIL.get_tree_hash().hex()
+        wallet_node_0.wallet_state_manager, wallet_0, Program.NIL.get_tree_hash()
     )
 
     did_id = bytes32.zeros

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -271,7 +271,7 @@ class CATWallet:
         return await cls.get_or_create_wallet_for_cat(
             wallet_state_manager,
             wallet,
-            puzzle_driver["tail"].hex(),
+            puzzle_driver["tail"],
             name,
         )
 

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -95,8 +95,8 @@ class CATWallet:
     wallet_info_type: ClassVar[type[CATInfo]] = CATInfo
 
     @staticmethod
-    def default_wallet_name_for_unknown_cat(limitations_program_hash_hex: str) -> str:
-        return f"CAT {limitations_program_hash_hex[:16]}..."
+    def default_wallet_name_for_unknown_cat(limitations_program_hash: bytes32) -> str:
+        return f"CAT {limitations_program_hash.hex()[:16]}..."
 
     @staticmethod
     async def create_new_cat_wallet(
@@ -152,7 +152,7 @@ class CATWallet:
         # since we didn't yet know the TAIL. Now we know the TAIL, we can update the name
         # according to the template name for unknown/new CATs.
         if original_name is None:
-            name = self.default_wallet_name_for_unknown_cat(self.cat_info.limitations_program_hash.hex())
+            name = self.default_wallet_name_for_unknown_cat(self.cat_info.limitations_program_hash)
             await self.set_name(name)
 
         # Change and actual CAT coin
@@ -200,30 +200,27 @@ class CATWallet:
         cls,
         wallet_state_manager: WalletStateManager,
         wallet: Wallet,
-        limitations_program_hash_hex: str,
+        limitations_program_hash: bytes32,
         name: str | None = None,
     ) -> Self:
         self = cls()
         self.standard_wallet = wallet
         self.log = logging.getLogger(__name__)
 
-        limitations_program_hash_hex = bytes32.from_hexstr(limitations_program_hash_hex).hex()  # Normalize the format
-
         for id, w in wallet_state_manager.wallets.items():
             if w.type() == cls.type():
                 assert isinstance(w, cls)
-                if w.get_asset_id() == limitations_program_hash_hex:
+                if w.get_asset_id() == limitations_program_hash:
                     self.log.warning("Not creating wallet for already existing CAT wallet")
                     return w
 
         self.wallet_state_manager = wallet_state_manager
-        if limitations_program_hash_hex in DEFAULT_CATS:
-            cat_info = DEFAULT_CATS[limitations_program_hash_hex]
+        if limitations_program_hash.hex() in DEFAULT_CATS:
+            cat_info = DEFAULT_CATS[limitations_program_hash.hex()]
             name = cat_info["name"]
         elif name is None:
-            name = self.default_wallet_name_for_unknown_cat(limitations_program_hash_hex)
+            name = self.default_wallet_name_for_unknown_cat(limitations_program_hash)
 
-        limitations_program_hash = bytes32.from_hexstr(limitations_program_hash_hex)
         self.cat_info = cls.wallet_info_type(limitations_program_hash, None)
         info_as_string = bytes(self.cat_info).hex()
         self.wallet_info = await wallet_state_manager.user_store.create_wallet(name, self.wallet_type, info_as_string)
@@ -356,8 +353,8 @@ class CATWallet:
         self.wallet_info = new_info
         await self.wallet_state_manager.user_store.update_wallet(self.wallet_info)
 
-    def get_asset_id(self) -> str:
-        return bytes(self.cat_info.limitations_program_hash).hex()
+    def get_asset_id(self) -> bytes32:
+        return self.cat_info.limitations_program_hash
 
     async def coin_added(
         self, coin: Coin, height: uint32, peer: WSChiaConnection, parent_coin_data: CATCoinData | None
@@ -821,12 +818,12 @@ class CATWallet:
     async def match_puzzle_info(self, puzzle_driver: PuzzleInfo) -> bool:
         return (
             AssetType(puzzle_driver.type()) == AssetType.CAT
-            and puzzle_driver["tail"] == bytes.fromhex(self.get_asset_id())
+            and puzzle_driver["tail"] == self.get_asset_id()
             and puzzle_driver.also() is None
         )
 
     async def get_puzzle_info(self, asset_id: bytes32) -> PuzzleInfo:
-        return PuzzleInfo({"type": AssetType.CAT.value, "tail": "0x" + self.get_asset_id()})
+        return PuzzleInfo({"type": AssetType.CAT.value, "tail": "0x" + self.get_asset_id().hex()})
 
     async def get_coins_to_offer(
         self,

--- a/chia/wallet/cat_wallet/lineage_store.py
+++ b/chia/wallet/cat_wallet/lineage_store.py
@@ -21,9 +21,9 @@ class CATLineageStore:
     table_name: str
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper2, asset_id: str) -> CATLineageStore:
+    async def create(cls, db_wrapper: DBWrapper2, asset_id: bytes32) -> CATLineageStore:
         self = cls()
-        self.table_name = f"lineage_proofs_{asset_id}"
+        self.table_name = f"lineage_proofs_{asset_id.hex()}"
         self.db_wrapper = db_wrapper
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             await conn.execute(f"CREATE TABLE IF NOT EXISTS {self.table_name}(coin_id text PRIMARY KEY, lineage blob)")

--- a/chia/wallet/cat_wallet/r_cat_wallet.py
+++ b/chia/wallet/cat_wallet/r_cat_wallet.py
@@ -147,7 +147,7 @@ class RCATWallet(CATWallet):
         return await cls.get_or_create_wallet_for_cat(
             wallet_state_manager,
             wallet,
-            puzzle_driver["tail"].hex(),
+            puzzle_driver["tail"],
             bytes32(rev_layer["hidden_puzzle_hash"]),
             name,
         )

--- a/chia/wallet/cat_wallet/r_cat_wallet.py
+++ b/chia/wallet/cat_wallet/r_cat_wallet.py
@@ -71,8 +71,8 @@ class RCATWallet(CATWallet):
     create_new_cat_wallet = None  # type: ignore[assignment]
 
     @staticmethod
-    def default_wallet_name_for_unknown_cat(limitations_program_hash_hex: str) -> str:
-        return f"Revocable-CAT {limitations_program_hash_hex[:16]}..."
+    def default_wallet_name_for_unknown_cat(limitations_program_hash: bytes32) -> str:
+        return f"Revocable-CAT {limitations_program_hash.hex()[:16]}..."
 
     # We need to override this with a different signature.
     # It's not immediately clear what is proper here, likely needs a bit of a refactor.
@@ -81,7 +81,7 @@ class RCATWallet(CATWallet):
         cls,
         wallet_state_manager: WalletStateManager,
         wallet: Wallet,
-        limitations_program_hash_hex: str,
+        limitations_program_hash: bytes32,
         hidden_puzzle_hash: bytes32,
         name: str | None = None,
     ) -> Self:
@@ -89,23 +89,20 @@ class RCATWallet(CATWallet):
         self.standard_wallet = wallet
         self.log = logging.getLogger(__name__)
 
-        limitations_program_hash_hex = bytes32.from_hexstr(limitations_program_hash_hex).hex()  # Normalize the format
-
         for id, w in wallet_state_manager.wallets.items():
             if w.type() == cls.type():
                 assert isinstance(w, cls)
-                if w.get_asset_id() == limitations_program_hash_hex:
+                if w.get_asset_id() == limitations_program_hash:
                     self.log.warning("Not creating wallet for already existing CAT wallet")
                     return w
 
         self.wallet_state_manager = wallet_state_manager
-        if limitations_program_hash_hex in DEFAULT_CATS:
-            cat_info = DEFAULT_CATS[limitations_program_hash_hex]
+        if limitations_program_hash.hex() in DEFAULT_CATS:
+            cat_info = DEFAULT_CATS[limitations_program_hash.hex()]
             name = cat_info["name"]
         elif name is None:
-            name = self.default_wallet_name_for_unknown_cat(limitations_program_hash_hex)
+            name = self.default_wallet_name_for_unknown_cat(limitations_program_hash)
 
-        limitations_program_hash = bytes32.from_hexstr(limitations_program_hash_hex)
         self.cat_info = cls.wallet_info_type(limitations_program_hash, None, hidden_puzzle_hash)
         info_as_string = bytes(self.cat_info).hex()
         self.wallet_info = await wallet_state_manager.user_store.create_wallet(name, cls.wallet_type, info_as_string)
@@ -247,7 +244,7 @@ class RCATWallet(CATWallet):
         return PuzzleInfo(
             {
                 "type": AssetType.CAT.value,
-                "tail": "0x" + self.get_asset_id(),
+                "tail": "0x" + self.get_asset_id().hex(),
                 "also": {
                     "type": AssetType.REVOCATION_LAYER.value,
                     "hidden_puzzle_hash": "0x" + self.cat_info.hidden_puzzle_hash.hex(),

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -821,7 +821,7 @@ class NFTWallet:
                 if asset is None:
                     wallet = wallet_state_manager.main_wallet
                 else:
-                    wallet = await wallet_state_manager.get_wallet_for_asset_id(asset.hex())
+                    wallet = await wallet_state_manager.get_wallet_for_asset_id(asset)
                 if asset in royalty_payments:
                     royalty_amount: int = sum(p.amount for _, p in royalty_payments[asset])
                 else:
@@ -872,7 +872,7 @@ class NFTWallet:
                 if asset is None:
                     wallet = wallet_state_manager.main_wallet
                 else:
-                    wallet = await wallet_state_manager.get_wallet_for_asset_id(asset.hex())
+                    wallet = await wallet_state_manager.get_wallet_for_asset_id(asset)
 
                 # First, sending all the coins to the OFFER_MOD
                 async with wallet_state_manager.new_action_scope(

--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -98,7 +98,7 @@ class GenesisById(LimitationsProgram):
         tail: Program = cls.construct([Program.to(origin_id)])
 
         wallet.lineage_store = await CATLineageStore.create(
-            wallet.wallet_state_manager.db_wrapper, tail.get_tree_hash().hex()
+            wallet.wallet_state_manager.db_wrapper, tail.get_tree_hash()
         )
         await wallet.add_lineage(origin_id, LineageProof())
 

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -504,7 +504,7 @@ class TradeManager:
                         if wallet.type() != WalletType.STANDARD_WALLET:
                             if callable(getattr(wallet, "get_asset_id", None)):  # ATTENTION: new wallets
                                 assert isinstance(wallet, CATWallet)
-                                asset_id = bytes32(bytes.fromhex(wallet.get_asset_id()))
+                                asset_id = wallet.get_asset_id()
                                 memos = [p2_ph]
                             else:
                                 raise ValueError(
@@ -512,7 +512,7 @@ class TradeManager:
                                 )
                     else:
                         asset_id = id
-                        wallet = await self.wallet_state_manager.get_wallet_for_asset_id(asset_id.hex())
+                        wallet = await self.wallet_state_manager.get_wallet_for_asset_id(asset_id)
                         memos = [p2_ph]
                     requested_payments[asset_id] = [CreateCoin(p2_ph, uint64(amount), memos)]
                 elif amount < 0:
@@ -523,14 +523,14 @@ class TradeManager:
                         if wallet.type() != WalletType.STANDARD_WALLET:
                             if callable(getattr(wallet, "get_asset_id", None)):  # ATTENTION: new wallets
                                 assert isinstance(wallet, CATWallet)
-                                asset_id = bytes32(bytes.fromhex(wallet.get_asset_id()))
+                                asset_id = wallet.get_asset_id()
                             else:
                                 raise ValueError(
                                     f"Cannot offer assets from wallet id {wallet.id()} without more information"
                                 )
                     else:
                         asset_id = id
-                        wallet = await self.wallet_state_manager.get_wallet_for_asset_id(asset_id.hex())
+                        wallet = await self.wallet_state_manager.get_wallet_for_asset_id(asset_id)
                     assert wallet is not None
                     if not callable(getattr(wallet, "get_coins_to_offer", None)):  # ATTENTION: new wallets
                         raise ValueError(f"Cannot offer coins from wallet id {wallet.id()}")
@@ -605,7 +605,7 @@ class TradeManager:
                 if isinstance(id, int):
                     wallet = self.wallet_state_manager.wallets.get(uint32(id))
                 else:
-                    wallet = await self.wallet_state_manager.get_wallet_for_asset_id(id.hex())
+                    wallet = await self.wallet_state_manager.get_wallet_for_asset_id(id)
                 async with self.wallet_state_manager.new_action_scope(
                     action_scope.config.tx_config, push=False
                 ) as inner_action_scope:
@@ -830,7 +830,7 @@ class TradeManager:
                 key: bytes32 | int = int(wallet.id())
             else:
                 # ATTENTION: new wallets
-                wallet = await self.wallet_state_manager.get_wallet_for_asset_id(asset_id.hex())
+                wallet = await self.wallet_state_manager.get_wallet_for_asset_id(asset_id)
                 if wallet is None and amount < 0:
                     raise ValueError(f"Do not have a wallet for asset ID: {asset_id} to fulfill offer")
                 elif wallet is None or wallet.type() in {WalletType.NFT, WalletType.DATA_LAYER}:

--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -72,8 +72,8 @@ class CRCATWallet(CATWallet):
     wallet_info_type: ClassVar[type[CRCATInfo]] = CRCATInfo
 
     @staticmethod
-    def default_wallet_name_for_unknown_cat(limitations_program_hash_hex: str) -> str:
-        return f"CAT {limitations_program_hash_hex[:16]}..."
+    def default_wallet_name_for_unknown_cat(limitations_program_hash: bytes32) -> str:
+        return f"CAT {limitations_program_hash.hex()[:16]}..."
 
     @property
     def cost_of_single_tx(self) -> int:
@@ -97,7 +97,7 @@ class CRCATWallet(CATWallet):
         cls,
         wallet_state_manager: WalletStateManager,
         wallet: Wallet,
-        limitations_program_hash_hex: str,
+        limitations_program_hash: bytes32,
         name: str | None = None,
         authorized_providers: list[bytes32] | None = None,
         proofs_checker: ProofsChecker | None = None,
@@ -107,21 +107,19 @@ class CRCATWallet(CATWallet):
         self = cls()
         self.standard_wallet = wallet
         if name is None:
-            name = self.default_wallet_name_for_unknown_cat(limitations_program_hash_hex)
+            name = self.default_wallet_name_for_unknown_cat(limitations_program_hash)
         self.log = logging.getLogger(name)
-
-        tail_hash = bytes32.from_hexstr(limitations_program_hash_hex)
 
         for id, w in wallet_state_manager.wallets.items():
             if w.type() == cls.type():
                 assert isinstance(w, cls)
-                if w.get_asset_id() == limitations_program_hash_hex:
+                if w.get_asset_id() == limitations_program_hash:
                     self.log.warning("Not creating wallet for already existing CR-CAT wallet")
                     return w
 
         self.wallet_state_manager = wallet_state_manager
 
-        self.info = cls.wallet_info_type(tail_hash, None, authorized_providers, proofs_checker)
+        self.info = cls.wallet_info_type(limitations_program_hash, None, authorized_providers, proofs_checker)
         info_as_string = bytes(self.info).hex()
         self.wallet_info = await wallet_state_manager.user_store.create_wallet(name, WalletType.CRCAT, info_as_string)
 
@@ -201,8 +199,8 @@ class CRCATWallet(CATWallet):
     def id(self) -> uint32:
         return self.wallet_info.id
 
-    def get_asset_id(self) -> str:
-        return bytes(self.info.limitations_program_hash).hex()
+    def get_asset_id(self) -> bytes32:
+        return self.info.limitations_program_hash
 
     async def set_tail_program(self, tail_program: str) -> None:  # pragma: no cover
         raise NotImplementedError("set_tail_program is a legacy method and is not available on CR-CAT wallets")

--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -145,7 +145,7 @@ class CRCATWallet(CATWallet):
         return await cls.get_or_create_wallet_for_cat(
             wallet_state_manager,
             wallet,
-            puzzle_driver["tail"].hex(),
+            puzzle_driver["tail"],
             name,
             [bytes32(provider) for provider in cr_layer["authorized_providers"]],
             ProofsChecker.from_program(uncurry_puzzle(cr_layer["proofs_checker"])),

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -1142,7 +1142,7 @@ class WalletRpcApi:
                     self.service.wallet_state_manager.state_changed("wallet_created")
                     return {
                         "type": cat_wallet.type(),
-                        "asset_id": asset_id,
+                        "asset_id": asset_id.hex(),
                         "wallet_id": cat_wallet.id(),
                         "transactions": None,  # tx_endpoint wrapper will take care of this
                     }
@@ -1338,7 +1338,7 @@ class WalletRpcApi:
             wallet_balance["fingerprint"] = self.service.logged_in_fingerprint
         if wallet.type() in {WalletType.CAT, WalletType.CRCAT, WalletType.RCAT}:
             assert isinstance(wallet, CATWallet)
-            wallet_balance["asset_id"] = wallet.get_asset_id()
+            wallet_balance["asset_id"] = wallet.get_asset_id().hex()
             if wallet.type() == WalletType.CRCAT:
                 assert isinstance(wallet, CRCATWallet)
                 wallet_balance["pending_approval_balance"] = await wallet.get_pending_approval_balance()
@@ -2185,12 +2185,12 @@ class WalletRpcApi:
     @marshal
     async def cat_get_asset_id(self, request: CATGetAssetID) -> CATGetAssetIDResponse:
         wallet = self.service.wallet_state_manager.get_wallet(id=request.wallet_id, required_type=CATWallet)
-        asset_id: str = wallet.get_asset_id()
-        return CATGetAssetIDResponse(asset_id=bytes32.from_hexstr(asset_id), wallet_id=request.wallet_id)
+        asset_id = wallet.get_asset_id()
+        return CATGetAssetIDResponse(asset_id=asset_id, wallet_id=request.wallet_id)
 
     @marshal
     async def cat_asset_id_to_name(self, request: CATAssetIDToName) -> CATAssetIDToNameResponse:
-        wallet = await self.service.wallet_state_manager.get_wallet_for_asset_id(request.asset_id.hex())
+        wallet = await self.service.wallet_state_manager.get_wallet_for_asset_id(request.asset_id)
         if wallet is None:
             if request.asset_id.hex() in DEFAULT_CATS:
                 return CATAssetIDToNameResponse(wallet_id=None, name=DEFAULT_CATS[request.asset_id.hex()]["name"])

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -1155,7 +1155,7 @@ class WalletRpcApi:
             elif request["mode"] == "existing":
                 async with self.service.wallet_state_manager.lock:
                     cat_wallet = await CATWallet.get_or_create_wallet_for_cat(
-                        wallet_state_manager, main_wallet, request["asset_id"], name
+                        wallet_state_manager, main_wallet, bytes32.from_hexstr(request["asset_id"]), name
                     )
                 return {"type": cat_wallet.type(), "asset_id": request["asset_id"], "wallet_id": cat_wallet.id()}
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1210,7 +1210,7 @@ class WalletStateManager:
                     cat_wallet: CATWallet = await CRCATWallet.get_or_create_wallet_for_cat(
                         self,
                         self.main_wallet,
-                        crcat.tail_hash.hex(),
+                        crcat.tail_hash,
                         authorized_providers=crcat.authorized_providers,
                         proofs_checker=ProofsChecker.from_program(uncurry_puzzle(crcat.proofs_checker)),
                     )
@@ -1218,20 +1218,20 @@ class WalletStateManager:
                     cat_wallet = await RCATWallet.get_or_create_wallet_for_cat(
                         self,
                         self.main_wallet,
-                        parent_data.tail_program_hash.hex(),
+                        parent_data.tail_program_hash,
                         # too complicated for mypy but semantics guarantee this not to be None
                         hidden_puzzle_hash=revocation_layer_match[0],  # type: ignore[index]
                     )
                 else:
                     cat_wallet = await CATWallet.get_or_create_wallet_for_cat(
-                        self, self.main_wallet, parent_data.tail_program_hash.hex()
+                        self, self.main_wallet, parent_data.tail_program_hash
                     )
                 return WalletIdentifier.create(cat_wallet)
             else:
                 # Found unacknowledged CAT, save it in the database.
                 await self.interested_store.add_unacknowledged_token(
                     asset_id,
-                    CATWallet.default_wallet_name_for_unknown_cat(asset_id.hex()),
+                    CATWallet.default_wallet_name_for_unknown_cat(asset_id),
                     None if parent_coin_state.spent_height is None else uint32(parent_coin_state.spent_height),
                     parent_coin_state.coin.puzzle_hash,
                 )
@@ -2451,7 +2451,7 @@ class WalletStateManager:
     async def get_all_wallet_info_entries(self, wallet_type: WalletType | None = None) -> list[WalletInfo]:
         return await self.user_store.get_all_wallet_info_entries(wallet_type)
 
-    async def get_wallet_for_asset_id(self, asset_id: str) -> WalletProtocol[Any] | None:
+    async def get_wallet_for_asset_id(self, asset_id: bytes32) -> WalletProtocol[Any] | None:
         for wallet_id, wallet in self.wallets.items():
             if wallet.type() in {WalletType.CAT, WalletType.CRCAT, WalletType.RCAT}:
                 assert isinstance(wallet, CATWallet)
@@ -2459,11 +2459,11 @@ class WalletStateManager:
                     return wallet
             elif wallet.type() == WalletType.DATA_LAYER:
                 assert isinstance(wallet, DataLayerWallet)
-                if await wallet.get_latest_singleton(bytes32.from_hexstr(asset_id)) is not None:
+                if await wallet.get_latest_singleton(asset_id) is not None:
                     return wallet
             elif wallet.type() == WalletType.NFT:
                 assert isinstance(wallet, NFTWallet)
-                nft_coin = await self.nft_store.get_nft_by_id(bytes32.from_hexstr(asset_id), wallet_id)
+                nft_coin = await self.nft_store.get_nft_by_id(asset_id, wallet_id)
                 if nft_coin:
                     return wallet
         return None


### PR DESCRIPTION
This has been a chronic headache for a while.  We would willy-nilly use `asset_id` as a `str` or as a `bytes32`.  This PR makes sure to use it as a bytes32 everywhere and explicitly convert it to hex where needed.