### PR TITLE
don't allow, or harvest, v2 plots before hard fork activation

### DIFF
--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import random
 from dataclasses import dataclass
 from typing import Optional
@@ -29,7 +30,7 @@ class ProofOfSpaceCase:
     plot_public_key: G1Element
     pool_public_key: Optional[G1Element] = None
     pool_contract_puzzle_hash: Optional[bytes32] = None
-    height: uint32 = uint32(0)
+    height: uint32 = DEFAULT_CONSTANTS.HARD_FORK2_HEIGHT
     expected_error: Optional[str] = None
     marks: Marks = ()
 
@@ -135,8 +136,18 @@ def b32(key: str) -> bytes32:
         ),
         expected_error="Did not pass the plot filter",
     ),
+    ProofOfSpaceCase(
+        id="v2 not activated",
+        pos_challenge=bytes32(b"1" * 32),
+        plot_size=PlotParam.make_v2(2),
+        pool_contract_puzzle_hash=bytes32(b"1" * 32),
+        plot_public_key=G1Element(),
+        height=uint32(DEFAULT_CONSTANTS.HARD_FORK2_HEIGHT - 1),
+        expected_error="v2 proof support has not yet activated",
+    ),
 )
 def test_verify_and_get_quality_string(caplog: pytest.LogCaptureFixture, case: ProofOfSpaceCase) -> None:
+    caplog.set_level(logging.INFO)
     pos = make_pos(
         challenge=case.pos_challenge,
         pool_public_key=case.pool_public_key,

--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -396,6 +396,11 @@ class HarvesterAPI:
                 if not self._plot_passes_filter(try_plot_info, new_challenge):
                     continue
                 if try_plot_info.prover.get_version() == PlotVersion.V2:
+                    # before hard fork activation, we can't farm v2 plots
+                    constants = self.harvester.constants
+                    if new_challenge.last_tx_height < constants.HARD_FORK2_HEIGHT:
+                        continue
+
                     v2_awaitables.append(
                         loop.run_in_executor(
                             self.harvester.executor,

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -117,6 +117,10 @@ def verify_and_get_quality_string(
         log.info("v1 proof has been phased-out and is no longer valid")
         return None
 
+    if plot_param.strength_v2 is not None and prev_transaction_block_height < constants.HARD_FORK2_HEIGHT:
+        log.info("v2 proof support has not yet activated")
+        return None
+
     # Exactly one of (pool_public_key, pool_contract_puzzle_hash) must not be None
     if (pos.pool_public_key is None) and (pos.pool_contract_puzzle_hash is None):
         log.error("Expected pool public key or pool contract puzzle hash but got neither")


### PR DESCRIPTION
### Current Behavior:

There's no restriction on accepting v2 proofs-of-space.

### New Behavior:

We don't validate v2 proofs of space before hard fork 2 activation.
We don't _farm_ v2 plots before hard fork 2 activation.
