### PR TITLE
Capture dependabot dependency updates into release notes and changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,13 +6,11 @@ changelog:
       - CI
       - Tests
       - Cleanup
-      - dependencies
       - checkpoint_merge
       - Exclude_Notes
       - GUI-Pin
     authors:
       - octocat
-      - dependabot
       - snyk-bot
       - github-actions
   categories:
@@ -22,6 +20,7 @@ changelog:
     - title: Changed
       labels:
         - Changed
+        - dependencies
     - title: Fixed
       labels:
         - Fixed

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           mode: exactly
           count: 1
-          labels: "Added, Changed, Fixed"
+          labels: "Added, Changed, Fixed, dependencies"
           exit_type: success
       - run: echo SUCCESS
         if: steps.check-labels.outputs.status == 'success'


### PR DESCRIPTION
This should allow the automated release notes generation to capture all the Dependabot PRs which is helpful for listing all dependency updates in the changelog