### PR TITLE
make timelord/test_new_peak.py a bit more robust

### DIFF
--- a/chia/_tests/timelord/test_new_peak.py
+++ b/chia/_tests/timelord/test_new_peak.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Optional
 
 import pytest
-from chia_rs import BlockRecord, FullBlock, SubEpochSummary, UnfinishedBlock
+from chia_rs import BlockRecord, FullBlock, SubEpochSummary, UnfinishedBlock, is_overflow_block
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint64, uint128
 
@@ -22,11 +22,11 @@ from chia.simulator.wallet_tools import WalletTool
 from chia.timelord.timelord_api import TimelordAPI
 
 
-def last_unfinished(tl: TimelordAPI) -> timelord_protocol.NewUnfinishedBlockTimelord:
-    if len(tl.timelord.unfinished_blocks) > 0:
-        return tl.timelord.unfinished_blocks[-1]
-    else:
+def last_unfinished(tl: TimelordAPI, *, overflow: bool) -> timelord_protocol.NewUnfinishedBlockTimelord:
+    if overflow:
         return tl.timelord.overflow_blocks[-1]
+    else:
+        return tl.timelord.unfinished_blocks[-1]
 
 
 class TestNewPeak:
@@ -134,7 +134,8 @@ class TestNewPeak:
             )
             await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
 
-            assert last_unfinished(timelord_api).get_hash() == timelord_unf_block.get_hash()
+            overflow = is_overflow_block(bt.constants, timelord_unf_block.reward_chain_block.signage_point_index)
+            assert last_unfinished(timelord_api, overflow=overflow).get_hash() == timelord_unf_block.get_hash()
             new_peak = timelord_peak_from_block(b1, block_2)
             assert timelord_unf_block.reward_chain_block.total_iters <= new_peak.reward_chain_block.total_iters
             await timelord_api.new_peak_timelord(new_peak)
@@ -200,7 +201,9 @@ class TestNewPeak:
                     await get_rc_prev(b1, block_1),
                 )
                 await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
-                assert last_unfinished(timelord_api).get_hash() == timelord_unf_block.get_hash()
+
+                overflow = is_overflow_block(bt.constants, timelord_unf_block.reward_chain_block.signage_point_index)
+                assert last_unfinished(timelord_api, overflow=overflow).get_hash() == timelord_unf_block.get_hash()
                 new_peak = timelord_peak_from_block(b2, block_2)
 
                 # timelord knows unfinished block_1 that has lower iterations,
@@ -215,7 +218,8 @@ class TestNewPeak:
                     == peak.reward_chain_block.get_hash()
                 )
                 # check unfinished block_1 is still in cache
-                assert last_unfinished(timelord_api).get_hash() == timelord_unf_block.get_hash()
+                overflow = is_overflow_block(bt.constants, timelord_unf_block.reward_chain_block.signage_point_index)
+                assert last_unfinished(timelord_api, overflow=overflow).get_hash() == timelord_unf_block.get_hash()
 
                 # full node gets block_1 unfinished
                 block_1_unf = UnfinishedBlock(
@@ -378,7 +382,8 @@ class TestNewPeak:
 
                 # add unfinished and make sure we cache it
                 await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
-                assert last_unfinished(timelord_api).get_hash() == timelord_unf_block.get_hash()
+                overflow = is_overflow_block(bt.constants, timelord_unf_block.reward_chain_block.signage_point_index)
+                assert last_unfinished(timelord_api, overflow=overflow).get_hash() == timelord_unf_block.get_hash()
                 new_peak = timelord_peak_from_block(b1, block_1)
                 assert timelord_unf_block.reward_chain_block.total_iters >= new_peak.reward_chain_block.total_iters
                 await timelord_api.new_peak_timelord(new_peak)
@@ -538,9 +543,10 @@ class TestNewPeak:
                 )
 
             await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
-            assert last_unfinished(timelord_api).get_hash() == timelord_unf_block.get_hash()
+            overflow = is_overflow_block(bt.constants, timelord_unf_block.reward_chain_block.signage_point_index)
+            assert last_unfinished(timelord_api, overflow=overflow).get_hash() == timelord_unf_block.get_hash()
             assert (
-                last_unfinished(timelord_api).reward_chain_block.get_hash()
+                last_unfinished(timelord_api, overflow=overflow).reward_chain_block.get_hash()
                 == timelord_unf_block.reward_chain_block.get_hash()
             )
 

--- a/chia/_tests/timelord/test_new_peak.py
+++ b/chia/_tests/timelord/test_new_peak.py
@@ -22,6 +22,13 @@ from chia.simulator.wallet_tools import WalletTool
 from chia.timelord.timelord_api import TimelordAPI
 
 
+def last_unfinished(tl: TimelordAPI) -> timelord_protocol.NewUnfinishedBlockTimelord:
+    if len(tl.timelord.unfinished_blocks) > 0:
+        return tl.timelord.unfinished_blocks[-1]
+    else:
+        return tl.timelord.overflow_blocks[-1]
+
+
 class TestNewPeak:
     @pytest.mark.anyio
     async def test_timelord_new_peak_basic(
@@ -127,7 +134,7 @@ class TestNewPeak:
             )
             await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
 
-            assert timelord_api.timelord.unfinished_blocks[-1].get_hash() == timelord_unf_block.get_hash()
+            assert last_unfinished(timelord_api).get_hash() == timelord_unf_block.get_hash()
             new_peak = timelord_peak_from_block(b1, block_2)
             assert timelord_unf_block.reward_chain_block.total_iters <= new_peak.reward_chain_block.total_iters
             await timelord_api.new_peak_timelord(new_peak)
@@ -193,7 +200,7 @@ class TestNewPeak:
                     await get_rc_prev(b1, block_1),
                 )
                 await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
-                assert timelord_api.timelord.unfinished_blocks[-1].get_hash() == timelord_unf_block.get_hash()
+                assert last_unfinished(timelord_api).get_hash() == timelord_unf_block.get_hash()
                 new_peak = timelord_peak_from_block(b2, block_2)
 
                 # timelord knows unfinished block_1 that has lower iterations,
@@ -208,7 +215,7 @@ class TestNewPeak:
                     == peak.reward_chain_block.get_hash()
                 )
                 # check unfinished block_1 is still in cache
-                assert timelord_api.timelord.unfinished_blocks[-1].get_hash() == timelord_unf_block.get_hash()
+                assert last_unfinished(timelord_api).get_hash() == timelord_unf_block.get_hash()
 
                 # full node gets block_1 unfinished
                 block_1_unf = UnfinishedBlock(
@@ -371,7 +378,7 @@ class TestNewPeak:
 
                 # add unfinished and make sure we cache it
                 await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
-                assert timelord_api.timelord.unfinished_blocks[-1].get_hash() == timelord_unf_block.get_hash()
+                assert last_unfinished(timelord_api).get_hash() == timelord_unf_block.get_hash()
                 new_peak = timelord_peak_from_block(b1, block_1)
                 assert timelord_unf_block.reward_chain_block.total_iters >= new_peak.reward_chain_block.total_iters
                 await timelord_api.new_peak_timelord(new_peak)
@@ -531,9 +538,9 @@ class TestNewPeak:
                 )
 
             await timelord_api.new_unfinished_block_timelord(timelord_unf_block)
-            assert timelord_api.timelord.unfinished_blocks[-1].get_hash() == timelord_unf_block.get_hash()
+            assert last_unfinished(timelord_api).get_hash() == timelord_unf_block.get_hash()
             assert (
-                timelord_api.timelord.unfinished_blocks[-1].reward_chain_block.get_hash()
+                last_unfinished(timelord_api).reward_chain_block.get_hash()
                 == timelord_unf_block.reward_chain_block.get_hash()
             )
 

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -80,6 +80,9 @@ class Timelord:
 
         _protocol_check: ClassVar[RpcServiceProtocol] = cast("Timelord", None)
 
+    unfinished_blocks: list[timelord_protocol.NewUnfinishedBlockTimelord]
+    overflow_blocks: list[timelord_protocol.NewUnfinishedBlockTimelord]
+
     @property
     def server(self) -> ChiaServer:
         # This is a stop gap until the class usage is refactored such the values of


### PR DESCRIPTION
### Purpose:

This test is ensuring unfinished blocks ended up accepted by the timelord. However, the timelord sometimes record unfinished blocks in the `overflows` list.

This makes the test pick either of the lists, and therefore makes it more robust as we add new test chains. We'll add additional test chains for the 3.0 hard fork.