### PR TITLE
[CHIA-3805] reduce use of pool_reward_puzzle_hash feature of BlockTools

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -38,6 +38,7 @@ from chia._tests.blockchain.blockchain_test_utils import (
     check_block_store_invariant,
 )
 from chia._tests.conftest import ConsensusMode
+from chia._tests.core.full_node.test_full_node import find_reward_coin
 from chia._tests.util.blockchain import create_blockchain
 from chia._tests.util.get_name_puzzle_conditions import get_name_puzzle_conditions
 from chia.consensus.augmented_chain import AugmentedBlockchain
@@ -1895,7 +1896,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
             genesis_timestamp=uint64(10_000),
             time_per_block=10,
         )
@@ -1905,9 +1905,8 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx1 = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx1 = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
         coin1: Coin = tx1.additions()[0]
 
         if opcode == ConditionOpcode.ASSERT_MY_AMOUNT:
@@ -2044,7 +2043,6 @@ class TestBodyValidation:
                 3,
                 guarantee_transaction_block=True,
                 farmer_reward_puzzle_hash=bt.pool_ph,
-                pool_reward_puzzle_hash=bt.pool_ph,
                 genesis_timestamp=uint64(10_000),
                 time_per_block=10,
             )
@@ -2055,7 +2053,7 @@ class TestBodyValidation:
 
             conditions = {opcode: [ConditionWithArgs(opcode, [int_to_bytes(lock_value)])]}
 
-            coin = blocks[-1].get_included_reward_coins()[0]
+            coin = find_reward_coin(blocks[-1], bt.pool_ph)
             tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin, condition_dic=conditions)
 
             blocks = bt.get_consecutive_blocks(
@@ -2115,7 +2113,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
             genesis_timestamp=uint64(10_000),
             time_per_block=10,
         )
@@ -2125,9 +2122,8 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx1 = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx1 = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
         coin1: Coin = tx1.additions()[0]
         secret_key = wt.get_private_key_for_puzzle_hash(coin1.puzzle_hash)
         synthetic_secret_key = calculate_synthetic_secret_key(secret_key, DEFAULT_HIDDEN_PUZZLE_HASH)
@@ -2245,7 +2241,6 @@ class TestBodyValidation:
                 3,
                 guarantee_transaction_block=True,
                 farmer_reward_puzzle_hash=bt.pool_ph,
-                pool_reward_puzzle_hash=bt.pool_ph,
                 genesis_timestamp=uint64(10_000),
                 time_per_block=10,
             )
@@ -2259,9 +2254,8 @@ class TestBodyValidation:
                 opcode: [ConditionWithArgs(opcode, [int_to_bytes(lock_value)] + ([b"garbage"] if with_garbage else []))]
             }
 
-            tx1 = wt.generate_signed_transaction(
-                uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-            )
+            coin = find_reward_coin(blocks[-1], bt.pool_ph)
+            tx1 = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
             coin1: Coin = tx1.additions()[0]
             tx2 = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin1, condition_dic=conditions)
             assert coin1 in tx2.removals()
@@ -2495,15 +2489,13 @@ class TestBodyValidation:
             block_list_input=blocks,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[2])
         await _validate_and_add_block(b, blocks[3])
 
         wt: WalletTool = bt.get_pool_wallet_tool()
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
         )
@@ -2533,7 +2525,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[0])
         await _validate_and_add_block(b, blocks[1])
@@ -2565,9 +2556,8 @@ class TestBodyValidation:
         # Hash should be correct when there is a ref list
         await _validate_and_add_block(b, blocks[-1])
         wt: WalletTool = bt.get_pool_wallet_tool()
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
         blocks = bt.get_consecutive_blocks(5, block_list_input=blocks, guarantee_transaction_block=False)
         for block in blocks[-5:]:
             await _validate_and_add_block(b, block)
@@ -2600,7 +2590,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[0])
         await _validate_and_add_block(b, blocks[1])
@@ -2613,9 +2602,8 @@ class TestBodyValidation:
             output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bt.pool_ph, int_to_bytes(i)])
             condition_dict[ConditionOpcode.CREATE_COIN].append(output)
 
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0], condition_dic=condition_dict
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin, condition_dic=condition_dict)
 
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
@@ -2671,7 +2659,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[0])
         await _validate_and_add_block(b, blocks[1])
@@ -2679,9 +2666,8 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
 
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
@@ -2821,7 +2807,6 @@ class TestBodyValidation:
         #         3,
         #         guarantee_transaction_block=True,
         #         farmer_reward_puzzle_hash=bt.pool_ph,
-        #         pool_reward_puzzle_hash=bt.pool_ph,
         #     )
         #     assert (await b.add_block(blocks[0]))[0] == AddBlockResult.NEW_PEAK
         #     assert (await b.add_block(blocks[1]))[0] == AddBlockResult.NEW_PEAK
@@ -2833,10 +2818,11 @@ class TestBodyValidation:
         #     output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bt_2.pool_ph, int_to_bytes(2 ** 64)])
         #     condition_dict[ConditionOpcode.CREATE_COIN].append(output)
 
+        #     coin = find_reward_coin(blocks[1], bt.pool_ph)
         #     tx = wt.generate_signed_transaction_multiple_coins(
         #         uint64(10),
         #         wt.get_new_puzzlehash(),
-        #         blocks[1].get_included_reward_coins(),
+        #         coin,
         #         condition_dic=condition_dict,
         #     )
         #     with pytest.raises(Exception):
@@ -2853,7 +2839,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(empty_blockchain, blocks[0])
         await _validate_and_add_block(empty_blockchain, blocks[1])
@@ -2861,9 +2846,8 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
 
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
@@ -2904,7 +2888,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[0])
         await _validate_and_add_block(b, blocks[1])
@@ -2912,9 +2895,8 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
 
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
@@ -2939,7 +2921,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[0])
         await _validate_and_add_block(b, blocks[1])
@@ -2952,9 +2933,8 @@ class TestBodyValidation:
             output = ConditionWithArgs(ConditionOpcode.CREATE_COIN, [bt.pool_ph, int_to_bytes(1)])
             condition_dict[ConditionOpcode.CREATE_COIN].append(output)
 
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0], condition_dic=condition_dict
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin, condition_dic=condition_dict)
 
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
@@ -2969,7 +2949,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[0])
         await _validate_and_add_block(b, blocks[1])
@@ -2977,12 +2956,9 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
-        tx_2 = wt.generate_signed_transaction(
-            uint64(11), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
+        tx_2 = wt.generate_signed_transaction(uint64(11), wt.get_new_puzzlehash(), coin)
         agg = SpendBundle.aggregate([tx, tx_2])
 
         blocks = bt.get_consecutive_blocks(
@@ -2998,7 +2974,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[0])
         await _validate_and_add_block(b, blocks[1])
@@ -3006,9 +2981,8 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
 
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
@@ -3032,7 +3006,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[0])
         await _validate_and_add_block(b, blocks[1])
@@ -3040,9 +3013,8 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
         )
@@ -3140,7 +3112,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[0])
         await _validate_and_add_block(b, blocks[1])
@@ -3148,7 +3119,7 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        spend = blocks[-1].get_included_reward_coins()[0]
+        spend = find_reward_coin(blocks[-1], bt.pool_ph)
         print("spend=", spend)
         # this create coin will spend all of the coin, so the 10 mojos below
         # will be "minted".
@@ -3176,7 +3147,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[0])
         await _validate_and_add_block(b, blocks[1])
@@ -3184,9 +3154,8 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
 
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
@@ -3218,7 +3187,6 @@ class TestBodyValidation:
             3,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=bt.pool_ph,
-            pool_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[0])
         await _validate_and_add_block(b, blocks[1])
@@ -3226,9 +3194,8 @@ class TestBodyValidation:
 
         wt: WalletTool = bt.get_pool_wallet_tool()
 
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
         blocks = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
         )
@@ -3621,16 +3588,14 @@ class TestReorgs:
         blocks = bt.get_consecutive_blocks(
             3,
             guarantee_transaction_block=True,
-            pool_reward_puzzle_hash=bt.pool_ph,
             farmer_reward_puzzle_hash=bt.pool_ph,
         )
         await _validate_and_add_block(b, blocks[0])
         await _validate_and_add_block(b, blocks[1])
         await _validate_and_add_block(b, blocks[2])
         wt: WalletTool = bt.get_pool_wallet_tool()
-        tx = wt.generate_signed_transaction(
-            uint64(10), wt.get_new_puzzlehash(), blocks[2].get_included_reward_coins()[0]
-        )
+        coin = find_reward_coin(blocks[2], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
         blocks = bt.get_consecutive_blocks(
             1,
             block_list_input=blocks,

--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -812,7 +812,6 @@ async def one_node_one_block(
             1,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=reward_ph,
-            pool_reward_puzzle_hash=reward_ph,
             genesis_timestamp=uint64(10000),
             time_per_block=10,
         )
@@ -841,7 +840,6 @@ async def two_nodes_one_block(blockchain_constants: ConsensusConstants):
             1,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=reward_ph,
-            pool_reward_puzzle_hash=reward_ph,
             genesis_timestamp=uint64(10000),
             time_per_block=10,
         )

--- a/chia/_tests/core/full_node/stores/test_block_store.py
+++ b/chia/_tests/core/full_node/stores/test_block_store.py
@@ -16,6 +16,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
 
 from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
+from chia._tests.core.full_node.test_full_node import find_reward_coin
 from chia._tests.util.db_connection import DBConnection, PathDBConnection
 from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.block_height_map import BlockHeightMap
@@ -57,11 +58,11 @@ async def test_block_store(tmp_dir: Path, db_version: int, bt: BlockTools, use_c
         3,
         guarantee_transaction_block=True,
         farmer_reward_puzzle_hash=bt.pool_ph,
-        pool_reward_puzzle_hash=bt.pool_ph,
         time_per_block=10,
     )
     wt: WalletTool = bt.get_pool_wallet_tool()
-    tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0])
+    coin = find_reward_coin(blocks[-1], bt.pool_ph)
+    tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
     blocks = bt.get_consecutive_blocks(
         10,
         block_list_input=blocks,

--- a/chia/_tests/core/full_node/stores/test_coin_store.py
+++ b/chia/_tests/core/full_node/stores/test_coin_store.py
@@ -67,7 +67,6 @@ async def test_basic_coin_store(db_version: int, softfork_height: uint32, bt: Bl
         10,
         [],
         farmer_reward_puzzle_hash=reward_ph,
-        pool_reward_puzzle_hash=reward_ph,
     )
 
     coins_to_spend: list[Coin] = []
@@ -86,7 +85,6 @@ async def test_basic_coin_store(db_version: int, softfork_height: uint32, bt: Bl
             10,
             blocks,
             farmer_reward_puzzle_hash=reward_ph,
-            pool_reward_puzzle_hash=reward_ph,
             transaction_data=spend_bundle,
         )
 
@@ -374,11 +372,9 @@ async def test_get_puzzle_hash(tmp_dir: Path, db_version: int, bt: BlockTools) -
     async with DBConnection(db_version) as db_wrapper:
         num_blocks = 20
         farmer_ph = bytes32(32 * b"0")
-        pool_ph = bytes32(32 * b"1")
         blocks = bt.get_consecutive_blocks(
             num_blocks,
             farmer_reward_puzzle_hash=farmer_ph,
-            pool_reward_puzzle_hash=pool_ph,
             guarantee_transaction_block=True,
         )
         coin_store = await CoinStore.create(db_wrapper)
@@ -391,7 +387,7 @@ async def test_get_puzzle_hash(tmp_dir: Path, db_version: int, bt: BlockTools) -
         assert peak is not None
         assert peak.height == num_blocks - 1
 
-        coins_farmer = await coin_store.get_coin_records_by_puzzle_hash(True, pool_ph)
+        coins_farmer = await coin_store.get_coin_records_by_puzzle_hash(True, bt.pool_ph)
         coins_pool = await coin_store.get_coin_records_by_puzzle_hash(True, farmer_ph)
 
         assert len(coins_farmer) == num_blocks - 2

--- a/chia/_tests/core/full_node/stores/test_hint_store.py
+++ b/chia/_tests/core/full_node/stores/test_hint_store.py
@@ -6,6 +6,7 @@ import pytest
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint64
 
+from chia._tests.core.full_node.test_full_node import find_reward_coin
 from chia._tests.util.db_connection import DBConnection
 from chia.full_node.hint_store import HintStore
 from chia.server.server import ChiaServer
@@ -151,7 +152,6 @@ async def test_hints_in_blockchain(
         block_list_input=[],
         guarantee_transaction_block=True,
         farmer_reward_puzzle_hash=bt.pool_ph,
-        pool_reward_puzzle_hash=bt.pool_ph,
     )
     for block in blocks:
         await full_node_1.full_node.add_block(block, None)
@@ -160,7 +160,7 @@ async def test_hints_in_blockchain(
     puzzle_hash = bytes32(32 * b"\0")
     amount = int_to_bytes(1)
     hint = bytes32(32 * b"\5")
-    coin_spent = blocks[-1].get_included_reward_coins()[0]
+    coin_spent = find_reward_coin(blocks[-1], bt.pool_ph)
     condition_dict = {
         ConditionOpcode.CREATE_COIN: [ConditionWithArgs(ConditionOpcode.CREATE_COIN, [puzzle_hash, amount, hint])]
     }

--- a/chia/_tests/core/full_node/test_performance.py
+++ b/chia/_tests/core/full_node/test_performance.py
@@ -36,7 +36,6 @@ class TestPerformance:
             block_list_input=blocks,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=wallet_ph,
-            pool_reward_puzzle_hash=wallet_ph,
         )
         for block in blocks:
             await full_node_1.full_node.add_block(block)

--- a/chia/_tests/core/mempool/test_mempool_fee_protocol.py
+++ b/chia/_tests/core/mempool/test_mempool_fee_protocol.py
@@ -28,7 +28,6 @@ async def test_protocol_messages(
         35,
         guarantee_transaction_block=True,
         farmer_reward_puzzle_hash=reward_ph,
-        pool_reward_puzzle_hash=reward_ph,
     )
 
     full_node_sim: FullNodeAPI | FullNodeSimulator = full_nodes[0]

--- a/chia/_tests/core/test_cost_calculation.py
+++ b/chia/_tests/core/test_cost_calculation.py
@@ -58,9 +58,7 @@ async def test_basics(softfork_height: int, bt: BlockTools) -> None:
     wallet_tool = bt.get_pool_wallet_tool()
     ph = wallet_tool.get_new_puzzlehash()
     num_blocks = 3
-    blocks = bt.get_consecutive_blocks(
-        num_blocks, [], guarantee_transaction_block=True, pool_reward_puzzle_hash=ph, farmer_reward_puzzle_hash=ph
-    )
+    blocks = bt.get_consecutive_blocks(num_blocks, [], guarantee_transaction_block=True, farmer_reward_puzzle_hash=ph)
     coinbase = None
     for coin in blocks[2].get_included_reward_coins():
         if coin.puzzle_hash == ph and coin.amount == 250000000000:
@@ -124,9 +122,7 @@ async def test_mempool_mode(softfork_height: int, bt: BlockTools) -> None:
     ph = wallet_tool.get_new_puzzlehash()
 
     num_blocks = 3
-    blocks = bt.get_consecutive_blocks(
-        num_blocks, [], guarantee_transaction_block=True, pool_reward_puzzle_hash=ph, farmer_reward_puzzle_hash=ph
-    )
+    blocks = bt.get_consecutive_blocks(num_blocks, [], guarantee_transaction_block=True, farmer_reward_puzzle_hash=ph)
 
     coinbase = None
     for coin in blocks[2].get_included_reward_coins():

--- a/chia/_tests/core/test_filter.py
+++ b/chia/_tests/core/test_filter.py
@@ -19,7 +19,6 @@ async def test_basic_filter_test(simulator_and_wallet):
         10,
         guarantee_transaction_block=True,
         farmer_reward_puzzle_hash=ph,
-        pool_reward_puzzle_hash=ph,
     )
     for i in range(1, num_blocks):
         byte_array_tx: list[bytes] = []

--- a/chia/_tests/core/test_full_node_rpc.py
+++ b/chia/_tests/core/test_full_node_rpc.py
@@ -9,6 +9,7 @@ from chia import __version__
 from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from chia._tests.conftest import ConsensusMode
 from chia._tests.connection_utils import connect_and_get_peer
+from chia._tests.core.full_node.test_full_node import find_reward_coin
 from chia._tests.util.rpc import validate_get_routes
 from chia._tests.util.setup_nodes import SimulatorsAndWalletsServices
 from chia._tests.util.time_out_assert import time_out_assert
@@ -763,7 +764,6 @@ async def test_coin_name_found_in_mempool(one_node: SimulatorsAndWalletsServices
             block_list_input=blocks,
             guarantee_transaction_block=True,
             farmer_reward_puzzle_hash=ph,
-            pool_reward_puzzle_hash=ph,
         )
         for block in blocks[-2:]:
             await full_node_api.full_node.add_block(block)
@@ -771,7 +771,7 @@ async def test_coin_name_found_in_mempool(one_node: SimulatorsAndWalletsServices
         # empty mempool
         assert len(await client.get_all_mempool_items()) == 0
 
-        coin_to_spend = blocks[-1].get_included_reward_coins()[0]
+        coin_to_spend = find_reward_coin(blocks[-1], ph)
         spend_bundle = wallet.generate_signed_transaction(coin_to_spend.amount, ph_receiver, coin_to_spend)
         await client.push_tx(spend_bundle)
 

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -110,7 +110,9 @@ async def test_request_block_headers(
     assert [x.transactions_filter for x in bh] == [b"\x00"] * 6
 
     num_blocks = 20
-    new_blocks = bt.get_consecutive_blocks(num_blocks, block_list_input=default_400_blocks, pool_reward_puzzle_hash=ph)
+    new_blocks = bt.get_consecutive_blocks(
+        num_blocks, block_list_input=default_400_blocks, farmer_reward_puzzle_hash=ph
+    )
     await add_blocks_in_batches(new_blocks, full_node_api.full_node)
     msg = await full_node_api.request_block_headers(wallet_protocol.RequestBlockHeaders(uint32(110), uint32(115), True))
     assert msg is not None

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -345,6 +345,10 @@ def create_unfinished_block(
 
     cc_sp_hash: bytes32 = slot_cc_challenge
 
+    if proof_of_space.param().strength_v2 is not None:
+        # v2 plots don't support pool public key
+        assert proof_of_space.pool_public_key is None
+
     # Only enters this if statement if we are in testing mode (making VDF proofs here)
     if signage_point.cc_vdf is not None:
         assert signage_point.rc_vdf is not None

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -829,6 +829,12 @@ class BlockTools:
         if num_blocks == 0:
             return block_list
 
+        if block_list[-1].height >= constants.HARD_FORK2_HEIGHT and pool_reward_puzzle_hash is not None:
+            raise ValueError(
+                "block height is past hard fork 2 activation. v2 plots don't "
+                "support pool puzzle hashes, only contract hashes"
+            )
+
         blocks: dict[bytes32, BlockRecord]
         if block_list[-1].header_hash == self._block_cache_header:
             height_to_hash = self._block_cache_height_to_hash


### PR DESCRIPTION
since it's not supported by v2 plots

### Purpose:

v1 plots can have pool rewards either paid to a pool_reward_puzzle_hash (specified in the plot header) or any puzzle hash signed by a pool key (the public key of which is also specified in the plot header).

v2 plot are a bit simpler by only supporting the pool reward puzzle hash. To have the flexibility of diverting the reward, the pool rewards can be paid to a plot nft puzzle, for example.

Many of our tests make use of the pool public key feature, by farming test plots and have rewards paid to the test's wallet. These tests won't work with v2 plots. This PR updates some of the tests to no longer rely on this feature. Instead they rely only on the farmer reward.

### Current Behavior:

Many tests use the `pool_reward_puzzle_hash` feature in `BlockTools`.

### New Behavior:

Fewer tests use the `pool_reward_puzzle_hash` feature in `BlockTools`.