### PR TITLE
Change GetTransactions to use uint32 to support wallets with very large numbers of transactions

### DIFF
--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -234,8 +234,8 @@ def test_get_transactions(capsys: object, get_test_cli_clients: tuple[TestRpcCli
     expected_calls: logType = {
         "get_wallets": [(GetWallets(type=None, include_data=True),)] * 2,
         "get_transactions": [
-            (GetTransactions(uint32(1), uint16(2), uint16(4), SortKey.RELEVANCE.name, True, None, None, None),),
-            (GetTransactions(uint32(1), uint16(2), uint16(4), SortKey.RELEVANCE.name, True, None, None, None),),
+            (GetTransactions(uint32(1), uint32(2), uint32(4), SortKey.RELEVANCE.name, True, None, None, None),),
+            (GetTransactions(uint32(1), uint32(2), uint32(4), SortKey.RELEVANCE.name, True, None, None, None),),
         ],
         "get_coin_records": [
             (GetCoinRecords(coin_id_filter=HashFilter.include([expected_coin_id])),),

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -945,9 +945,9 @@ async def test_get_transactions(wallet_environments: WalletTestFramework) -> Non
     unconfirmed_txs_count = 0
     assert len(all_transactions) == expected_initial_txs_count
     # Test transaction pagination
-    some_transactions = (await client.get_transactions(GetTransactions(uint32(1), uint16(0), uint16(5)))).transactions
+    some_transactions = (await client.get_transactions(GetTransactions(uint32(1), uint32(0), uint32(5)))).transactions
     some_transactions_2 = (
-        await client.get_transactions(GetTransactions(uint32(1), uint16(5), uint16(10)))
+        await client.get_transactions(GetTransactions(uint32(1), uint32(5), uint32(10)))
     ).transactions
     assert some_transactions == all_transactions[0:5]
     assert some_transactions_2 == all_transactions[5:10]

--- a/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
@@ -462,8 +462,8 @@ async def test_vc_lifecycle(wallet_environments: WalletTestFramework) -> None:
         await client_1.get_transactions(
             GetTransactions(
                 uint32(env_1.dealias_wallet_id("crcat")),
-                uint16(0),
-                uint16(1),
+                uint32(0),
+                uint32(1),
                 reverse=True,
                 type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CRCAT_PENDING]),
             )

--- a/chia/cmds/wallet.py
+++ b/chia/cmds/wallet.py
@@ -93,7 +93,7 @@ def get_transaction_cmd(
     "--limit",
     help="Max number of transactions to return",
     type=int,
-    default=(2**16 - 1),
+    default=(2**32 - 1),
     show_default=True,
     required=False,
 )

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -258,8 +258,8 @@ async def get_transactions(
             await wallet_client.get_transactions(
                 GetTransactions(
                     uint32(wallet_id),
-                    start=uint16(offset),
-                    end=uint16(offset + limit),
+                    start=uint32(offset),
+                    end=uint32(offset + limit),
                     sort_key=sort_key.name,
                     reverse=reverse,
                     type_filter=type_filter,

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -272,8 +272,8 @@ class GetTransactionResponse(Streamable):
 @dataclass(frozen=True)
 class GetTransactions(Streamable):
     wallet_id: uint32
-    start: uint16 | None = None
-    end: uint16 | None = None
+    start: uint32 | None = None
+    end: uint32 | None = None
     sort_key: str | None = None
     reverse: bool = False
     to_address: str | None = None


### PR DESCRIPTION
In `2.5.7` we limited the number of transactions one can view to a uint16 (65535) - if you have more transactions there wasn't a way to retrieve them using the `get_transactions` RPC or CLI.

This was introduced here: https://github.com/Chia-Network/chia-blockchain/pull/19775 and first released in `2.5.7`

There are apparently users with large numbers of transactions in their wallet where this causes problems. See https://github.com/Chia-Network/chia-blockchain/issues/20256

This PR changes the type value to a uint32.

