### PR TITLE
[LABS-298] Simplify `push_transactions`

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -382,6 +382,13 @@ async def test_push_transactions(wallet_environments: WalletTestFramework) -> No
         )
     ).signed_tx
 
+    with pytest.raises(ValueError, match="Cannot add conditions to a transaction if no new fee spend is being added"):
+        await client.push_transactions(
+            PushTransactions(transactions=[tx]),
+            tx_config=wallet_environments.tx_config,
+            extra_conditions=(Remark(rest=Program.to("foo")),),
+        )
+
     resp_client = await client.push_transactions(
         PushTransactions(transactions=[tx], fee=uint64(10)),
         wallet_environments.tx_config,

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -393,10 +393,13 @@ async def test_push_transactions(wallet_environments: WalletTestFramework) -> No
         PushTransactions(transactions=[tx], fee=uint64(10)),
         wallet_environments.tx_config,
     )
+    await full_node_api.wait_for_wallet_synced(wallet_node)
     resp = await client.fetch("push_transactions", {"transactions": [tx.to_json_dict()], "fee": 10})
     assert resp["success"]
+    await full_node_api.wait_for_wallet_synced(wallet_node)
     resp = await client.fetch("push_transactions", {"transactions": [bytes(tx).hex()], "fee": 10})
     assert resp["success"]
+    await full_node_api.wait_for_wallet_synced(wallet_node)
 
     spend_bundle = WalletSpendBundle.aggregate(
         [tx.spend_bundle for tx in resp_client.transactions if tx.spend_bundle is not None]


### PR DESCRIPTION
This PR does three things:

1) Changes logic that hooks fee spends onto transactions from using announcement assertions to the new(ish) `ASSERT_CONCURRENT_SPEND` condition.  This drastically simplifies the endpoint.
2) Adds a check that a user didn't specify extra conditions when no fee spend is added, as those conditions then won't end up in the spend.
3) Removes an unnecessary extra sandbox with an `inner_action_scope`