### PR TITLE
Update the macos-13 GH hosted runner to macos-15-intel, due to EOL of…

### DIFF
--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         python-version: ["3.12"]
         os:
-          - runs-on: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-13' }}
+          - runs-on: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-15-intel' }}
             name: intel
             bladebit-suffix: macos-x86-64.tar.gz
             arch-artifact-name: intel
@@ -296,7 +296,7 @@ jobs:
           - name: 13
             matrix: 13
             runs-on:
-              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-13' }}
+              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-15-intel' }}
           - name: 14
             matrix: 14
             runs-on:

--- a/.github/workflows/check_wheel_availability.yaml
+++ b/.github/workflows/check_wheel_availability.yaml
@@ -32,7 +32,7 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-13' }}
+              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-15-intel' }}
               arm: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-arm64' || 'macos-15' }}
           - name: Windows
             matrix: windows

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,7 +29,7 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-13' }}
+              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-15-intel' }}
               arm: macos-latest
           - name: Windows
             matrix: windows

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -44,7 +44,7 @@ jobs:
             emoji: 🍎
             runs-on:
               arm: macos-15
-              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-13' }}
+              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-15-intel' }}
             matrix: macos
           - name: Windows
             emoji: 🪟


### PR DESCRIPTION
… macos-13

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

The macos-13 GitHub hosted runner (intel) is being retired on December 4th, 2025. The next image available is macos-15-intel.

### Current Behavior:

### New Behavior:

No changes in behavior

### Testing Notes:
The macos-15-intel image is already being used in various locations in the chia-blockchain repository.
