### PR TITLE
[CHIA-3811] fix measurement of harvester lookup times for logging

### DIFF
--- a/chia/harvester/harvester_api.py
+++ b/chia/harvester/harvester_api.py
@@ -425,7 +425,6 @@ class HarvesterAPI:
             self.harvester.log.debug(f"new_signage_point_harvester {passed} plots passed the plot filter")
 
         # Concurrently executes all lookups on disk, to take advantage of multiple disk parallelism
-        time_taken = time.monotonic() - start
         total_proofs_found = 0
         total_v2_partial_proofs_found = 0
 
@@ -446,6 +445,7 @@ class HarvesterAPI:
                 else:
                     total_v2_partial_proofs_found = results[0]
 
+        time_taken = time.monotonic() - start
         now = uint64(time.time())
 
         farming_info = FarmingInfo(


### PR DESCRIPTION
### Purpose:

Correct harvester timing log

### Current Behavior:

We take the end-timestamp _before_ all harvester lookup tasks had complted.

### New Behavior:

We take the end-timestamp _after_ all harvester lookup tasks had complted.