### PR TITLE
Test conditions pool reward

### DIFF
--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -128,7 +128,7 @@ def b32(key: str) -> bytes32:
     ),
     ProofOfSpaceCase(
         id="Not passing the plot filter v2",
-        pos_challenge=b32("5706ae15c4a437399f464c64ef4f33c362d860ccd2945b76b3ebdb0505783817"),
+        pos_challenge=b32("4cfaacbd2782db64d07cf490ca938534adb07dfbd2f92b0e479e2e5b196178db"),
         plot_size=PlotParam.make_v2(32),
         pool_contract_puzzle_hash=bytes32(b"1" * 32),
         plot_public_key=g1(
@@ -180,7 +180,7 @@ def test_verify_and_get_quality_string(caplog: pytest.LogCaptureFixture, case: P
     ProofOfSpaceCase(
         id="not passing the plot filter v2",
         plot_size=PlotParam.make_v2(2),
-        pos_challenge=b32("fb1d676f0e3ce173f4e6cfb06d7059886cbc3b91cf65be0af0fc2fbe569c6597"),
+        pos_challenge=b32("aefba5c94bc9bbfe2c538b7faaaf03384ac5a6170e40b024657df6b0a27c34a7"),
         plot_public_key=g1(
             "afa3aaf09c03885154be49216ee7fb2e4581b9c4a4d7e9cc402e27280bf0cfdbdf1b9ba674e301fd1d1450234b3b1868"
         ),

--- a/chia/_tests/core/full_node/test_conditions.py
+++ b/chia/_tests/core/full_node/test_conditions.py
@@ -15,6 +15,7 @@ from clvm_tools.binutils import assemble
 from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from chia._tests.conftest import ConsensusMode
 from chia._tests.core.full_node.ram_db import create_ram_blockchain
+from chia._tests.core.full_node.test_full_node import find_reward_coin
 from chia.consensus.condition_tools import agg_sig_additional_data
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.keyring import TempKeyring
@@ -47,7 +48,6 @@ async def initial_blocks(bt: BlockTools, block_count: int = 4) -> list[FullBlock
         block_count,
         guarantee_transaction_block=True,
         farmer_reward_puzzle_hash=EASY_PUZZLE_HASH,
-        pool_reward_puzzle_hash=EASY_PUZZLE_HASH,
         genesis_timestamp=uint64(10000),
         time_per_block=10,
     )
@@ -101,7 +101,7 @@ async def check_conditions(
     aggsig: G2Element = G2Element(),
 ) -> tuple[list[CoinRecord], list[CoinRecord], FullBlock]:
     blocks = await initial_blocks(bt)
-    coin = blocks[spend_reward_index].get_included_reward_coins()[0]
+    coin = find_reward_coin(blocks[spend_reward_index], EASY_PUZZLE_HASH)
 
     coin_spend = make_spend(coin, EASY_PUZZLE, condition_solution)
     spend_bundle = SpendBundle([coin_spend], aggsig)
@@ -143,9 +143,9 @@ class TestConditions:
         # once the hard fork activates, blocks no longer pay the cost of the ROM
         # generator (which includes hashing all puzzles).
         if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
-            block_base_cost = 756064
+            block_base_cost = 756064 - 12000
         else:
-            block_base_cost = 761056
+            block_base_cost = 761056 - 12000
         assert new_block.transactions_info is not None
         assert new_block.transactions_info.cost - block_base_cost == expected_cost
 
@@ -164,11 +164,11 @@ class TestConditions:
         _additions, _removals, new_block = await check_conditions(bt, conditions)
 
         if consensus_mode < ConsensusMode.HARD_FORK_2_0:
-            block_base_cost = 737056
+            block_base_cost = 737056 - 12000
         else:
             # once the hard fork activates, blocks no longer pay the cost of the ROM
             # generator (which includes hashing all puzzles).
-            block_base_cost = 732064
+            block_base_cost = 732064 - 12000
 
         # the block_base_cost includes the cost of the bytes for the condition
         # with 2 bytes argument. This test works as long as the conditions it's
@@ -267,7 +267,7 @@ class TestConditions:
     @pytest.mark.anyio
     async def test_invalid_my_id(self, bt: BlockTools) -> None:
         blocks = await initial_blocks(bt)
-        coin = blocks[-2].get_included_reward_coins()[0]
+        coin = find_reward_coin(blocks[-2], EASY_PUZZLE_HASH)
         wrong_name = bytearray(coin.name())
         wrong_name[-1] ^= 1
         conditions = Program.to(assemble(f"(({ConditionOpcode.ASSERT_MY_COIN_ID[0]} 0x{wrong_name.hex()}))"))
@@ -276,14 +276,14 @@ class TestConditions:
     @pytest.mark.anyio
     async def test_valid_my_id(self, bt: BlockTools) -> None:
         blocks = await initial_blocks(bt)
-        coin = blocks[-2].get_included_reward_coins()[0]
+        coin = find_reward_coin(blocks[-2], EASY_PUZZLE_HASH)
         conditions = Program.to(assemble(f"(({ConditionOpcode.ASSERT_MY_COIN_ID[0]} 0x{coin.name().hex()}))"))
         await check_conditions(bt, conditions)
 
     @pytest.mark.anyio
     async def test_invalid_coin_announcement(self, bt: BlockTools) -> None:
         blocks = await initial_blocks(bt)
-        coin = blocks[-2].get_included_reward_coins()[0]
+        coin = find_reward_coin(blocks[-2], EASY_PUZZLE_HASH)
         announce = AssertCoinAnnouncement(asserted_id=coin.name(), asserted_msg=b"test_bad")
         conditions = Program.to(
             assemble(
@@ -296,7 +296,7 @@ class TestConditions:
     @pytest.mark.anyio
     async def test_valid_coin_announcement(self, bt: BlockTools) -> None:
         blocks = await initial_blocks(bt)
-        coin = blocks[-2].get_included_reward_coins()[0]
+        coin = find_reward_coin(blocks[-2], EASY_PUZZLE_HASH)
         announce = AssertCoinAnnouncement(asserted_id=coin.name(), asserted_msg=b"test")
         conditions = Program.to(
             assemble(
@@ -374,7 +374,7 @@ class TestConditions:
         """
 
         blocks = await initial_blocks(bt)
-        coin = blocks[-2].get_included_reward_coins()[0]
+        coin = find_reward_coin(blocks[-2], EASY_PUZZLE_HASH)
         coin_announcement = AssertCoinAnnouncement(asserted_id=coin.name(), asserted_msg=b"test")
         puzzle_announcement = AssertPuzzleAnnouncement(asserted_ph=EASY_PUZZLE_HASH, asserted_msg=b"test")
 
@@ -404,7 +404,7 @@ class TestConditions:
     @pytest.mark.anyio
     async def test_coin_messages(self, bt: BlockTools, consensus_mode: ConsensusMode) -> None:
         blocks = await initial_blocks(bt)
-        coin = blocks[-2].get_included_reward_coins()[0]
+        coin = find_reward_coin(blocks[-2], EASY_PUZZLE_HASH)
         conditions = Program.to(
             assemble(
                 f"(({ConditionOpcode.SEND_MESSAGE[0]} 0x3f 'test' 0x{coin.name().hex()})"
@@ -416,7 +416,7 @@ class TestConditions:
     @pytest.mark.anyio
     async def test_parent_messages(self, bt: BlockTools, consensus_mode: ConsensusMode) -> None:
         blocks = await initial_blocks(bt)
-        coin = blocks[-2].get_included_reward_coins()[0]
+        coin = find_reward_coin(blocks[-2], EASY_PUZZLE_HASH)
         conditions = Program.to(
             assemble(
                 f"(({ConditionOpcode.SEND_MESSAGE[0]} 0x24 'test' 0x{coin.parent_coin_info})"
@@ -437,7 +437,7 @@ class TestConditions:
             ('(66 0x27 "foo" {coin}) (67 0x3f "foo" {coin})', Err.MESSAGE_NOT_SENT_OR_RECEIVED),
             ('(66 0 "foo") (67 0 "foo")', None),
             ('(66 0 "foobar") (67 0 "foo")', Err.MESSAGE_NOT_SENT_OR_RECEIVED),
-            ('(66 0x09 "foo" 1750000000000) (67 0x09 "foo" 1750000000000)', None),
+            ('(66 0x09 "foo" 250000000000) (67 0x09 "foo" 250000000000)', None),
             ('(66 -1 "foo")', Err.INVALID_MESSAGE_MODE),
             ('(67 -1 "foo")', Err.INVALID_MESSAGE_MODE),
             ('(66 0x40 "foo")', Err.INVALID_MESSAGE_MODE),
@@ -448,7 +448,7 @@ class TestConditions:
         self, bt: BlockTools, consensus_mode: ConsensusMode, conds: str, expected: Err | None
     ) -> None:
         blocks = await initial_blocks(bt)
-        coin = blocks[-2].get_included_reward_coins()[0]
+        coin = find_reward_coin(blocks[-2], EASY_PUZZLE_HASH)
         conditions = Program.to(assemble("(" + conds.format(coin="0x" + coin.name().hex()) + ")"))
 
         await check_conditions(bt, conditions, expected_err=expected)
@@ -521,7 +521,7 @@ class TestConditions:
 
         sk = AugSchemeMPL.key_gen(b"8" * 32)
         pubkey = sk.get_g1()
-        coin = blocks[-2].get_included_reward_coins()[0]
+        coin = find_reward_coin(blocks[-2], EASY_PUZZLE_HASH)
         for msg in [
             c.AGG_SIG_ME_ADDITIONAL_DATA,
             c.AGG_SIG_PARENT_ADDITIONAL_DATA,

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -46,7 +46,7 @@ def get_plot_id(pos: ProofOfSpace) -> bytes32:
     plot_param = pos.param()
     if plot_param.strength_v2 is not None:
         assert pos.pool_contract_puzzle_hash is not None
-        return calculate_plot_id_v2(pos.pool_contract_puzzle_hash, pos.plot_public_key, plot_param.strength_v2)
+        return calculate_plot_id_v2(pos.pool_contract_puzzle_hash, pos.plot_public_key, uint8(plot_param.strength_v2))
 
     assert pos.pool_public_key is None or pos.pool_contract_puzzle_hash is None
     if pos.pool_public_key is None:


### PR DESCRIPTION
### Purpose:


This is a follow-up to https://github.com/Chia-Network/chia-blockchain/pull/20277
Reducing more use of the `pool_reward_puzzle_hash` feature in `BlockTools`. This isn't supported for v2 plots.

The current test picks the _first_ reward coin, which happens to be the pool reward. Changing this coin to the farmer reward has some consequences. First of all, we need to use `find_reward_coin()` to pick the coin with the puzzle hash we expect, instead of just picking the first one.

The _cost_ of spending the pool reward is 1 byte higher than the farmer reward. This is because the pool reward is 1'750'000'000, whereas the farmer reward is only 25'000'000. 
It requires one byte less to be encoded. The cost of bytes in the generator is 12000 per byte. There are two tests that check the cost of the puzzle, whose cost is now 12000 less. 

### Current Behavior:

The `initial_blocks()` function redirects both farmer rewards and pool rewards into the test wallet.

### New Behavior:

The `initial_blocks()` function only redirects farmer rewards into the test wallet. Thus making the test compatible with v2 plots.
