### PR TITLE
[LABS-301] Extract `split_coins` and `combine_coins` RPCs to `WalletStateManager`

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -3697,13 +3697,13 @@ async def test_combine_coins(wallet_environments: WalletTestFramework, capsys: p
     )
 
     # Test some error cases first
-    with pytest.raises(ResponseFailureError, match="greater then the maximum limit"):
+    with pytest.raises(ValueError, match="greater then the maximum limit"):
         await dataclasses.replace(xch_combine_request, number_of_coins=uint16(501)).run()
 
-    with pytest.raises(ResponseFailureError, match="You need at least two coins to combine"):
+    with pytest.raises(ValueError, match="You need at least two coins to combine"):
         await dataclasses.replace(xch_combine_request, number_of_coins=uint16(0)).run()
 
-    with pytest.raises(ResponseFailureError, match="More coin IDs specified than desired number of coins to combine"):
+    with pytest.raises(ValueError, match="More coin IDs specified than desired number of coins to combine"):
         await dataclasses.replace(xch_combine_request, input_coins=(bytes32.zeros,) * 100).run()
 
     # We catch this one

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -3502,8 +3502,11 @@ async def test_split_coins(wallet_environments: WalletTestFramework, capsys: pyt
         }
     )
 
-    with pytest.raises(ResponseFailureError, match="501 coins is greater then the maximum limit of 500 coins"):
+    with pytest.raises(ValueError, match="501 coins is greater then the maximum limit of 500 coins"):
         await dataclasses.replace(xch_request, number_of_coins=501).run()
+
+    with pytest.raises(ValueError, match="Cannot split into 0 new coins"):
+        await dataclasses.replace(xch_request, number_of_coins=0).run()
 
     with pytest.raises(ResponseFailureError, match="Could not find coin with ID 00000000000000000"):
         await dataclasses.replace(xch_request, target_coin_id=bytes32.zeros).run()
@@ -3534,10 +3537,6 @@ async def test_split_coins(wallet_environments: WalletTestFramework, capsys: pyt
         await env.rpc_client.split_coins(rpc_request, wallet_environments.tx_config)
 
     del env.wallet_state_manager.wallets[uint32(42)]
-
-    await dataclasses.replace(xch_request, number_of_coins=0).run()
-    output = (capsys.readouterr()).out
-    assert "Transaction sent" not in output
 
     with wallet_environments.new_puzzle_hashes_allowed():
         await xch_request.run()

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -1430,7 +1430,7 @@ class CombineCoins(TransactionEndpointRequest):
             raise ValueError(
                 f"{self.number_of_coins} coins is greater then the maximum limit of {self.coin_num_limit} coins."
             )
-        if self.number_of_coins < 1:
+        if self.number_of_coins < 2:
             raise ValueError("You need at least two coins to combine")
         if len(self.target_coin_ids) > self.number_of_coins:
             raise ValueError("More coin IDs specified than desired number of coins to combine")

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -1402,6 +1402,12 @@ class SplitCoins(TransactionEndpointRequest):
     amount_per_coin: uint64 = field(default_factory=default_raise)
     target_coin_id: bytes32 = field(default_factory=default_raise)
 
+    def __post_init__(self) -> None:
+        if self.number_of_coins > 500:
+            raise ValueError(f"{self.number_of_coins} coins is greater then the maximum limit of 500 coins.")
+        if self.number_of_coins == 0:
+            raise ValueError("Cannot split into 0 new coins")
+
 
 @streamable
 @dataclass(frozen=True)

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -1425,6 +1425,16 @@ class CombineCoins(TransactionEndpointRequest):
     target_coin_amount: uint64 | None = None
     coin_num_limit: uint16 = uint16(500)
 
+    def __post_init__(self) -> None:
+        if self.number_of_coins > self.coin_num_limit:
+            raise ValueError(
+                f"{self.number_of_coins} coins is greater then the maximum limit of {self.coin_num_limit} coins."
+            )
+        if self.number_of_coins < 1:
+            raise ValueError("You need at least two coins to combine")
+        if len(self.target_coin_ids) > self.number_of_coins:
+            raise ValueError("More coin IDs specified than desired number of coins to combine")
+
 
 @streamable
 @dataclass(frozen=True)

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from chia_rs import AugSchemeMPL, Coin, CoinSpend, CoinState, G1Element, G2Element, PrivateKey
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint8, uint16, uint32, uint64
+from chia_rs.sized_ints import uint16, uint32, uint64
 from clvm_tools.binutils import assemble
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward
@@ -89,7 +89,7 @@ from chia.wallet.util.clvm_streamable import json_serialize_with_clvm_streamable
 from chia.wallet.util.compute_hints import compute_spend_hints_and_additions
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.curry_and_treehash import NIL_TREEHASH
-from chia.wallet.util.query_filter import FilterMode, HashFilter
+from chia.wallet.util.query_filter import HashFilter
 from chia.wallet.util.transaction_type import CLAWBACK_INCOMING_TRANSACTION_TYPES, TransactionType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, TXConfig, TXConfigLoader
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend_for_coin_state
@@ -1414,93 +1414,17 @@ class WalletRpcApi:
     async def combine_coins(
         self, request: CombineCoins, action_scope: WalletActionScope, extra_conditions: tuple[Condition, ...] = tuple()
     ) -> CombineCoinsResponse:
-        # Some "number of coins" validation
-        if request.number_of_coins > request.coin_num_limit:
-            raise ValueError(
-                f"{request.number_of_coins} coins is greater then the maximum limit of {request.coin_num_limit} coins."
-            )
-        if request.number_of_coins < 1:
-            raise ValueError("You need at least two coins to combine")
-        if len(request.target_coin_ids) > request.number_of_coins:
-            raise ValueError("More coin IDs specified than desired number of coins to combine")
-
-        if request.wallet_id not in self.service.wallet_state_manager.wallets:
-            raise ValueError(f"Wallet with ID {request.wallet_id} does not exist")
-        wallet = self.service.wallet_state_manager.wallets[request.wallet_id]
-        if not isinstance(wallet, (Wallet, CATWallet)):
-            raise ValueError("Cannot combine coins from non-fungible wallet types")
-
-        coins: list[Coin] = []
-
-        # First get the coin IDs specified
-        if request.target_coin_ids != []:
-            coins.extend(
-                cr.coin
-                for cr in (
-                    await self.service.wallet_state_manager.coin_store.get_coin_records(
-                        wallet_id=request.wallet_id,
-                        coin_id_filter=HashFilter(request.target_coin_ids, mode=uint8(FilterMode.include.value)),
-                    )
-                ).records
-            )
-
-        async with action_scope.use() as interface:
-            interface.side_effects.selected_coins.extend(coins)
-
-        # Next let's select enough coins to meet the target + fee if there is one
-        fungible_amount_needed = uint64(0) if request.target_coin_amount is None else request.target_coin_amount
-        if isinstance(wallet, Wallet):
-            fungible_amount_needed = uint64(fungible_amount_needed + request.fee)
-        amount_selected = sum(c.amount for c in coins)
-        if amount_selected < fungible_amount_needed:  # implicit fungible_amount_needed > 0 here
-            coins.extend(
-                await wallet.select_coins(
-                    amount=uint64(fungible_amount_needed - amount_selected), action_scope=action_scope
-                )
-            )
-
-        if len(coins) > request.number_of_coins:
-            raise ValueError(
-                f"Options specified cannot be met without selecting more coins than specified: {len(coins)}"
-            )
-
-        # Now let's select enough coins to get to the target number to combine
-        if len(coins) < request.number_of_coins:
-            async with action_scope.use() as interface:
-                coins.extend(
-                    cr.coin
-                    for cr in (
-                        await self.service.wallet_state_manager.coin_store.get_coin_records(
-                            wallet_id=request.wallet_id,
-                            limit=uint32(request.number_of_coins - len(coins)),
-                            order=CoinRecordOrder.amount,
-                            coin_id_filter=HashFilter(
-                                [c.name() for c in interface.side_effects.selected_coins],
-                                mode=uint8(FilterMode.exclude.value),
-                            ),
-                            reverse=request.largest_first,
-                        )
-                    ).records
-                )
-
-        async with action_scope.use() as interface:
-            interface.side_effects.selected_coins.extend(coins)
-
-        primary_output_amount = (
-            uint64(sum(c.amount for c in coins)) if request.target_coin_amount is None else request.target_coin_amount
-        )
-        if isinstance(wallet, Wallet):
-            primary_output_amount = uint64(primary_output_amount - request.fee)
-
-        await wallet.generate_signed_transaction(
-            [primary_output_amount],
-            [await action_scope.get_puzzle_hash(self.service.wallet_state_manager)],
-            action_scope,
-            request.fee,
-            coins=set(coins),
+        await self.service.wallet_state_manager.combine_coins(
+            action_scope=action_scope,
+            wallet_id=request.wallet_id,
+            number_of_coins=request.number_of_coins,
+            largest_first=request.largest_first,
+            coin_num_limit=request.coin_num_limit,
+            fee=request.fee,
+            target_coin_amount=request.target_coin_amount,
+            target_coin_ids=request.target_coin_ids if request.target_coin_ids != [] else None,
             extra_conditions=extra_conditions,
         )
-
         return CombineCoinsResponse([], [])  # tx_endpoint will take care to fill this out
 
     @marshal

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 import aiosqlite
 from chia_rs import AugSchemeMPL, CoinSpend, CoinState, ConsensusConstants, G1Element, G2Element, PrivateKey
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint16, uint32, uint64, uint128
+from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
 
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.coinbase import farmer_parent_id, pool_parent_id
@@ -105,7 +105,7 @@ from chia.wallet.util.compute_hints import compute_spend_hints_and_additions
 from chia.wallet.util.compute_memos import compute_memos
 from chia.wallet.util.curry_and_treehash import NIL_TREEHASH
 from chia.wallet.util.puzzle_decorator import PuzzleDecoratorManager
-from chia.wallet.util.query_filter import HashFilter
+from chia.wallet.util.query_filter import FilterMode, HashFilter
 from chia.wallet.util.transaction_type import CLAWBACK_INCOMING_TRANSACTION_TYPES, TransactionType
 from chia.wallet.util.tx_config import TXConfig, TXConfigLoader
 from chia.wallet.util.wallet_sync_utils import (
@@ -123,7 +123,7 @@ from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_action_scope import WalletActionScope, new_wallet_action_scope
 from chia.wallet.wallet_blockchain import WalletBlockchain
 from chia.wallet.wallet_coin_record import MetadataTypes, WalletCoinRecord
-from chia.wallet.wallet_coin_store import WalletCoinStore
+from chia.wallet.wallet_coin_store import CoinRecordOrder, WalletCoinStore
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_interested_store import WalletInterestedStore
 from chia.wallet.wallet_nft_store import WalletNftStore
@@ -2877,5 +2877,95 @@ class WalletStateManager:
             action_scope,
             fee,
             coins=coins,
+            extra_conditions=extra_conditions,
+        )
+
+    async def combine_coins(
+        self,
+        *,
+        action_scope: WalletActionScope,
+        wallet_id: uint32,
+        number_of_coins: uint16,
+        largest_first: bool,
+        coin_num_limit: uint16,
+        fee: uint64,
+        target_coin_amount: uint64 | None = None,
+        target_coin_ids: list[bytes32] | None = None,
+        extra_conditions: tuple[Condition, ...] = tuple(),
+    ) -> None:
+        if wallet_id not in self.wallets:
+            raise ValueError(f"Wallet with ID {wallet_id} does not exist")
+        wallet = self.wallets[wallet_id]
+        if not isinstance(wallet, (Wallet, CATWallet)):
+            raise ValueError("Cannot combine coins from non-fungible wallet types")
+
+        coins: list[Coin] = []
+
+        # First get the coin IDs specified
+        if target_coin_ids is not None:
+            coins.extend(
+                cr.coin
+                for cr in (
+                    await self.coin_store.get_coin_records(
+                        wallet_id=wallet_id,
+                        coin_id_filter=HashFilter(target_coin_ids, mode=uint8(FilterMode.include.value)),
+                    )
+                ).records
+            )
+
+        async with action_scope.use() as interface:
+            interface.side_effects.selected_coins.extend(coins)
+
+        # Next let's select enough coins to meet the target + fee if there is one
+        fungible_amount_needed = uint64(0) if target_coin_amount is None else target_coin_amount
+        if isinstance(wallet, Wallet):
+            fungible_amount_needed = uint64(fungible_amount_needed + fee)
+        amount_selected = sum(c.amount for c in coins)
+        if amount_selected < fungible_amount_needed:  # implicit fungible_amount_needed > 0 here
+            coins.extend(
+                await wallet.select_coins(
+                    amount=uint64(fungible_amount_needed - amount_selected), action_scope=action_scope
+                )
+            )
+
+        if len(coins) > number_of_coins:
+            raise ValueError(
+                f"Options specified cannot be met without selecting more coins than specified: {len(coins)}"
+            )
+
+        # Now let's select enough coins to get to the target number to combine
+        if len(coins) < number_of_coins:
+            async with action_scope.use() as interface:
+                coins.extend(
+                    cr.coin
+                    for cr in (
+                        await self.coin_store.get_coin_records(
+                            wallet_id=wallet_id,
+                            limit=uint32(number_of_coins - len(coins)),
+                            order=CoinRecordOrder.amount,
+                            coin_id_filter=HashFilter(
+                                [c.name() for c in interface.side_effects.selected_coins],
+                                mode=uint8(FilterMode.exclude.value),
+                            ),
+                            reverse=largest_first,
+                        )
+                    ).records
+                )
+
+        async with action_scope.use() as interface:
+            interface.side_effects.selected_coins.extend(coins)
+
+        primary_output_amount = (
+            uint64(sum(c.amount for c in coins)) if target_coin_amount is None else target_coin_amount
+        )
+        if isinstance(wallet, Wallet):
+            primary_output_amount = uint64(primary_output_amount - fee)
+
+        await wallet.generate_signed_transaction(
+            [primary_output_amount],
+            [await action_scope.get_puzzle_hash(self)],
+            action_scope,
+            fee,
+            coins=set(coins),
             extra_conditions=extra_conditions,
         )


### PR DESCRIPTION
This is mostly a code move.  Removing this logic from the client means that potentially other clients can access it but mostly it's just so that there's less of a layer violation.  Couple of real changes:

1) Validation of coin limits has been implemented in the request type which means there will be a client-side failure instead of a server failure when using our client code.  I think it's better to fail earlier if possible, and again this means that more of the code is in its proper place.  It's possible we might in the future want the limit to be configurable in which case we can make that change, but given how it is now, I think this change is fine.
2) Specifying that you want to split into 0 coins is now an error rather than a transaction-less pass.  It never makes sense to do this, so better to throw an error.