### PR TITLE
fix plot filter for v2 plots

### DIFF
--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -291,10 +291,10 @@ def test_calculate_prefix_bits_v1(height: uint32, expected: int) -> None:
     argvalues=[
         (0, 5),
         (0xFFFFFFFA, 5),
-        (0xFFFFFFFB, 6),
-        (0xFFFFFFFC, 7),
-        (0xFFFFFFFD, 8),
-        (0xFFFFFFFF, 8),
+        (0xFFFFFFFB, 4),
+        (0xFFFFFFFC, 3),
+        (0xFFFFFFFD, 2),
+        (0xFFFFFFFF, 2),
     ],
 )
 def test_calculate_prefix_bits_v2(height: uint32, expected: int) -> None:

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -211,13 +211,14 @@ def passes_plot_filter(
 
 def calculate_prefix_bits(constants: ConsensusConstants, height: uint32, plot_param: PlotParam) -> int:
     if plot_param.strength_v2 is not None:
+        prefix_bits = int(constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2)
         if height >= constants.PLOT_FILTER_V2_THIRD_ADJUSTMENT_HEIGHT:
-            return constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2 + 3
-        if height >= constants.PLOT_FILTER_V2_SECOND_ADJUSTMENT_HEIGHT:
-            return constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2 + 2
-        if height >= constants.PLOT_FILTER_V2_FIRST_ADJUSTMENT_HEIGHT:
-            return constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2 + 1
-        return constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2
+            prefix_bits -= 3
+        elif height >= constants.PLOT_FILTER_V2_SECOND_ADJUSTMENT_HEIGHT:
+            prefix_bits -= 2
+        elif height >= constants.PLOT_FILTER_V2_FIRST_ADJUSTMENT_HEIGHT:
+            prefix_bits -= 1
+        return max(0, prefix_bits)
 
     prefix_bits = int(constants.NUMBER_ZERO_BITS_PLOT_FILTER_V1)
     if height >= constants.PLOT_FILTER_32_HEIGHT:


### PR DESCRIPTION
### Purpose:

The plot filter schedule was implemented incorrectly for v2 plots.
We start with the plot filter size defined by `ConsensusConstants` and we reduce the filter by one bit for each adjustment. This matches the behvior of the v1 plot filter schedule.

Fewer bits in the plot filter means more plots will pass the filter, since it specifies how many leading zero-bits are required.

### Current Behavior:

The plot filter for v2 plots *tightens* over time.

### New Behavior:

The plot filter for v2 plots is *relaxed* over time.