### PR TITLE
relax PoS validation in weight proofs

### DIFF
--- a/chia/consensus/pot_iterations.py
+++ b/chia/consensus/pot_iterations.py
@@ -55,6 +55,7 @@ def validate_pospace_and_get_required_iters(
     height: uint32,
     difficulty: uint64,
     prev_transaction_block_height: uint32,  # this is the height of the last tx block before the current block SP
+    height_agnostic: bool = False,
 ) -> uint64 | None:
     q_str: bytes32 | None = verify_and_get_quality_string(
         proof_of_space,
@@ -63,6 +64,7 @@ def validate_pospace_and_get_required_iters(
         cc_sp_hash,
         height=height,
         prev_transaction_block_height=prev_transaction_block_height,
+        height_agnostic=height_agnostic,
     )
     if q_str is None:
         return None

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1385,7 +1385,7 @@ def __validate_pospace(
         cc_sp_hash,
         height,
         curr_diff,
-        height,  # this is only used for plot ID filter in this call, not phase-out
+        uint32(0),  # not used, since height_agnostic=True
         height_agnostic=True,
     )
     if required_iters is None:

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1385,7 +1385,7 @@ def __validate_pospace(
         cc_sp_hash,
         height,
         curr_diff,
-        uint32(max(0, height - constants.MAX_SUB_SLOT_BLOCKS)),
+        height,  # this is only used for plot ID filter in this call, not phase-out
         height_agnostic=True,
     )
     if required_iters is None:

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1386,6 +1386,7 @@ def __validate_pospace(
         height,
         curr_diff,
         uint32(max(0, height - constants.MAX_SUB_SLOT_BLOCKS)),
+        height_agnostic=True,
     )
     if required_iters is None:
         log.error("could not verify proof of space")

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -1330,7 +1330,7 @@ class BlockTools:
                             f"refs: {len(full_block.transactions_generator_ref_list):3} "
                             f"iters: {block_record.total_iters} "
                             f"[{'TransactionBlock ' if block_record.is_transaction_block else ''}"
-                            f"{'V1 ' if proof_of_space.param().size_v1 else 'V2 '}]"
+                            f"{'V1 ' if proof_of_space.param().size_v1 else 'V2 '}"
                             "Overflow]"
                         )
                         last_timestamp = new_timestamp


### PR DESCRIPTION
### Purpose:

When validating proofs of space in weight proofs, we don't necessarily know the height of the block, or the previous transaction block height.

This information is technically required to validate the proof-of-space. The reason for this is that the 3.0 hard fork will introduce a phase-out schedule for v1 plots, where the validity of a v1 proof depends on how far long the phase-out we've come.

Since we don't know the height, this patch relaxes the validation to not apply the phase-out to v1 plots.

We also use the height to determine the plot filter schedule. However, both the v1 and v2 plot filters relax over time, so using the peak block height will already use the most relaxed plot filter for the lower heights.

### Current Behavior:

* We don't support the v1 phase-out in weight proofs

### New Behavior:

* we _do_ support the v1 phase-out, by not applying it to weight proofs