### PR TITLE
[LABS-303] Simplify `spend_clawback_coins`

### DIFF
--- a/chia/_tests/wallet/test_wallet_coin_store.py
+++ b/chia/_tests/wallet/test_wallet_coin_store.py
@@ -13,7 +13,7 @@ from chia.util.streamable import Streamable, UInt32Range, UInt64Range, Versioned
 from chia.wallet.puzzles.clawback.metadata import ClawbackMetadata
 from chia.wallet.util.query_filter import AmountFilter, HashFilter
 from chia.wallet.util.wallet_types import CoinType, WalletType
-from chia.wallet.wallet_coin_record import WalletCoinRecord
+from chia.wallet.wallet_coin_record import WalletCoinRecord, WalletCoinRecordMetadataParsingError
 from chia.wallet.wallet_coin_store import CoinRecordOrder, GetCoinRecords, GetCoinRecordsResult, WalletCoinStore
 
 clawback_metadata = ClawbackMetadata(uint64(0), bytes32(b"1" * 32), bytes32(b"2" * 32))
@@ -133,7 +133,7 @@ class DummyWalletCoinRecords:
     ],
 )
 def test_wallet_coin_record_parsed_metadata_failures(invalid_record: WalletCoinRecord, error: str) -> None:
-    with pytest.raises(ValueError, match=error):
+    with pytest.raises(WalletCoinRecordMetadataParsingError, match=error):
         invalid_record.parsed_metadata()
 
 

--- a/chia/wallet/wallet_coin_record.py
+++ b/chia/wallet/wallet_coin_record.py
@@ -16,17 +16,8 @@ from chia.wallet.vc_wallet.cr_cat_drivers import CRCATMetadata, CRCATVersion
 MetadataTypes = ClawbackMetadata | CRCATMetadata
 
 
-@dataclass(frozen=True, kw_only=True)
 class WalletCoinRecordMetadataParsingError(Exception):
-    coin_id: bytes32
-    metadata: VersionedBlob | None
-    coin_type: CoinType
-
-    def __repr__(self) -> str:
-        return f"Unknown metadata {self.metadata} for coin_id {self.coin_id} of type {self.coin_type}"
-
-    def __str__(self) -> str:
-        return self.__repr__()
+    pass
 
 
 @dataclass(frozen=True)
@@ -54,7 +45,7 @@ class WalletCoinRecord:
 
     def parsed_metadata(self) -> MetadataTypes:
         if self.metadata is None:
-            raise ValueError("Can't parse None metadata")
+            raise WalletCoinRecordMetadataParsingError("Can't parse None metadata")
         if self.coin_type == CoinType.CLAWBACK and self.metadata.version == ClawbackVersion.V1.value:
             return ClawbackMetadata.from_bytes(self.metadata.blob)
         if (
@@ -63,9 +54,7 @@ class WalletCoinRecord:
         ):
             return CRCATMetadata.from_bytes(self.metadata.blob)
         raise WalletCoinRecordMetadataParsingError(
-            coin_id=self.coin.name(),
-            metadata=self.metadata,
-            coin_type=self.coin_type,
+            f"Unknown metadata {self.metadata} for coin_id {self.coin.name()} of type {self.coin_type}"
         )
 
     def name(self) -> bytes32:

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -100,7 +100,7 @@ from chia.wallet.vc_wallet.vc_store import VCProofs
 from chia.wallet.vc_wallet.vc_wallet import VCWallet
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_action_scope import WalletActionScope
-from chia.wallet.wallet_coin_record import WalletCoinRecord
+from chia.wallet.wallet_coin_record import WalletCoinRecord, WalletCoinRecordMetadataParsingError
 from chia.wallet.wallet_coin_store import CoinRecordOrder, GetCoinRecords, unspent_range
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_node import WalletNode, get_wallet_db_path
@@ -1577,7 +1577,7 @@ class WalletRpcApi:
                 coin_batch = {
                     coin_record.coin: coin_record.parsed_metadata() for coin_record in records_list[i : i + batch_size]
                 }
-            except ValueError as e:
+            except WalletCoinRecordMetadataParsingError as e:
                 log.error("Failed to spend clawback coin: %s", e)
                 continue
             await self.service.wallet_state_manager.spend_clawback_coins(

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -72,7 +72,7 @@ from chia.wallet.nft_wallet.uncurry_nft import UncurriedNFT
 from chia.wallet.outer_puzzles import AssetType
 from chia.wallet.puzzle_drivers import PuzzleInfo
 from chia.wallet.puzzles import p2_delegated_conditions
-from chia.wallet.puzzles.clawback.metadata import AutoClaimSettings, ClawbackMetadata
+from chia.wallet.puzzles.clawback.metadata import AutoClaimSettings
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import puzzle_hash_for_synthetic_public_key
 from chia.wallet.signer_protocol import SigningResponse
 from chia.wallet.singleton import (
@@ -1559,7 +1559,6 @@ class WalletRpcApi:
         :param fee: transaction fee in mojos
         :return:
         """
-        # Get inner puzzle
         coin_records = await self.service.wallet_state_manager.coin_store.get_coin_records(
             coin_id_filter=HashFilter.include(request.coin_ids),
             coin_type=CoinType.CLAWBACK,
@@ -1567,31 +1566,23 @@ class WalletRpcApi:
             spent_range=UInt32Range(stop=uint32(0)),
         )
 
-        coins: dict[Coin, ClawbackMetadata] = {}
         batch_size = (
             request.batch_size
             if request.batch_size is not None
             else self.service.wallet_state_manager.config.get("auto_claim", {}).get("batch_size", 50)
         )
-        for coin_id, coin_record in coin_records.coin_id_to_record.items():
+        records_list = list(coin_records.coin_id_to_record.values())
+        for i in range(0, len(records_list), batch_size):
             try:
-                metadata = coin_record.parsed_metadata()
-                assert isinstance(metadata, ClawbackMetadata)
-                coins[coin_record.coin] = metadata
-                if len(coins) >= batch_size:
-                    await self.service.wallet_state_manager.spend_clawback_coins(
-                        coins,
-                        request.fee,
-                        action_scope,
-                        request.force,
-                        extra_conditions=extra_conditions,
-                    )
-                    coins = {}
-            except Exception as e:
-                log.error(f"Failed to spend clawback coin {coin_id.hex()}: %s", e)
-        if len(coins) > 0:
+                coin_batch = {
+                    coin_record.coin: coin_record.parsed_metadata() for coin_record in records_list[i : i + batch_size]
+                }
+            except ValueError as e:
+                log.error("Failed to spend clawback coin: %s", e)
+                continue
             await self.service.wallet_state_manager.spend_clawback_coins(
-                coins,
+                # Semantically, we're guaranteed the right type here, but the typing isn't there
+                coin_batch,  # type: ignore[arg-type]
                 request.fee,
                 action_scope,
                 request.force,


### PR DESCRIPTION
This PR makes a small simplification to the `spend_clawback_coins` RPC to eliminate a duplicate function call.

Some pains were taken to preserve the existing behavior of skipping a batch if there's a corrupted coin in the set.  How valuable this behavior is, I'm not sure, but I don't want to add controversy where it can be avoided.