### PR TITLE
optimize block tools (speed-up: 15x)

### DIFF
--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -386,7 +386,7 @@ class BlockTools:
         prev_tx_height: uint32,
         dummy_block_references: bool,
         include_transactions: bool,
-        transaction_data: SpendBundle | None,
+        block_generator: NewBlockGenerator | None,
         block_refs: list[uint32],
     ) -> NewBlockGenerator | None:
         if prev_tx_height >= self.constants.HARD_FORK2_HEIGHT:
@@ -408,26 +408,12 @@ class BlockTools:
         else:
             dummy_refs = []
 
-        if transaction_data is not None:
-            # this means the caller passed in transaction_data
+        if block_generator is not None:
+            # this means the caller passed in block_generator
             # to be included in the block.
-            additions = compute_additions_unchecked(transaction_data)
-            removals = transaction_data.removals()
-            if curr.height >= self.constants.HARD_FORK_HEIGHT:
-                program = simple_solution_generator_backrefs(transaction_data).program
-            else:
-                program = simple_solution_generator(transaction_data).program
-            block_refs = []
-            cost = compute_block_cost(program, self.constants, uint32(curr.height + 1), prev_tx_height)
-            return NewBlockGenerator(
-                program,
-                [],
-                block_refs,
-                transaction_data.aggregated_signature,
-                additions,
-                removals,
-                cost,
-            )
+            assert block_refs == [], "block references cannot be combined with block_generator"
+            assert not dummy_block_references, "(dummy) block references cannot be combined with block_generator"
+            return block_generator
 
         if include_transactions:
             # if the caller did not pass in specific
@@ -868,6 +854,26 @@ class BlockTools:
         # this variable is true whenever there is a pending sub-epoch or epoch that needs to be added in the next block.
         pending_ses: bool = False
 
+        block_generator: NewBlockGenerator | None = None
+        if transaction_data is not None:
+            additions = compute_additions_unchecked(transaction_data)
+            removals = transaction_data.removals()
+            if curr.height >= self.constants.HARD_FORK_HEIGHT:
+                program = simple_solution_generator_backrefs(transaction_data).program
+            else:
+                program = simple_solution_generator(transaction_data).program
+            block_refs = []
+            cost = compute_block_cost(program, self.constants, uint32(curr.height + 1), prev_tx_height)
+            block_generator = NewBlockGenerator(
+                program,
+                [],
+                block_refs,
+                transaction_data.aggregated_signature,
+                additions,
+                removals,
+                cost,
+            )
+
         # Start at the last block in block list
         # Get the challenge for that slot
         while True:
@@ -970,7 +976,7 @@ class BlockTools:
                             available_coins,
                             prev_tx_height=prev_tx_height,
                             dummy_block_references=dummy_block_references,
-                            transaction_data=transaction_data,
+                            block_generator=block_generator,
                             include_transactions=include_transactions,
                             block_refs=block_refs,
                         )
@@ -1008,7 +1014,7 @@ class BlockTools:
                             overflow_rc_challenge=None,
                         )
                         if block_record.is_transaction_block:
-                            transaction_data = None
+                            block_generator = None
                             block_refs = []
                             keep_going_until_tx_block = False
                             assert full_block.foliage_transaction_block is not None
@@ -1276,7 +1282,7 @@ class BlockTools:
                             available_coins,
                             prev_tx_height=prev_tx_height,
                             dummy_block_references=dummy_block_references,
-                            transaction_data=transaction_data,
+                            block_generator=block_generator,
                             include_transactions=include_transactions,
                             block_refs=block_refs,
                         )
@@ -1314,7 +1320,7 @@ class BlockTools:
                             overflow_rc_challenge=overflow_rc_challenge,
                         )
                         if block_record.is_transaction_block:
-                            transaction_data = None
+                            block_generator = None
                             block_refs = []
                             keep_going_until_tx_block = False
                             assert full_block.foliage_transaction_block is not None


### PR DESCRIPTION
### Purpose:

Right now, `BlockTools` allows us to pass in `transaction_data` to be used for the next transaction block. However, `BlockTools` doesn't know up-front if the block we're farming will end up a transaction block or not, so we create the block generator every time we farm a block, until it turns into a transaction block.

We have some tests that include a large number of coins, and farm many non-TX blocks until we get the spends included. We waste a lot of time creating (and compressing the CLVM) every time we farm a block, just to throw it away.

This patch generates the block generator once, at the beginning of the `get_consecutive_blocks()` function, and clear it once it's included in a transaction block.

In one of our tests, this brings the test time down to 26 seconds from 391 seconds.

### Current Behavior:

Before farming a block, we create a block generator based in the passed in `transaction_data`. If the block turns out to not be a transaction block, that work was wasted.

### New Behavior:

Before starting the loop of farming blocks, we create a block generator based in the passed in `transaction_data`. We then pass in the same block generator into the new blocks until it's included in a transaction block. Performing the work only once.

One caveat is that we use the block height to determine whether we compress the CLVM or not. With this change, we only check the height at the beginning. We don't re-generate the block generator if we pass the activation height. I don't think this matters for any of the tests that use `transaction_data`.

### Testing Notes:

Here's an example from the 3.0 hard fork tests (using v2 proofs).

before:
```
pytest -s -n 0 --log-cli-level=INFO "chia/_tests/blockchain/test_blockchain.py::TestBodyValidation::test_cost_exceeds_max[ConsensusMode.HARD_FORK_3_0-5716000]"
19:49:35 chia.simulator.block_tools: INFO Created block 0 iters: 208
19:49:38 chia.simulator.block_tools: INFO Created Block    1 prev-tx:    0 diff: 64 time: 18.75 additions:  0 removals:  0 refs:   0 iters: 457 [TransactionBlock V1]
19:49:41 chia.simulator.block_tools: INFO Created Block    2 prev-tx:    1 diff: 64 time: 18.75 additions:  0 removals:  0 refs:   0 iters: 713 [TransactionBlock V1]
19:56:04 chia.simulator.block_tools: INFO Created Block    3 prev-tx:    2 diff: 64 time: 18.75 additions: 7002 removals:  1 refs:   0 iters: 969 [TransactionBlock V1]
PASSED

=================================================================================== 1 passed in 391.23s (0:06:31) ===================================================================================
```


after:
```
pytest -s -n 0 --log-cli-level=INFO "chia/_tests/blockchain/test_blockchain.py::TestBodyValidation::test_cost_exceeds_max[ConsensusMode.HARD_FORK_3_0-5716000]"
19:48:20 chia.simulator.block_tools: INFO Created block 0 iters: 208
19:48:24 chia.simulator.block_tools: INFO Created Block    1 prev-tx:    0 diff: 64 time: 18.75 additions:  0 removals:  0 refs:   0 iters: 457 [TransactionBlock V1]
19:48:28 chia.simulator.block_tools: INFO Created Block    2 prev-tx:    1 diff: 64 time: 18.75 additions:  0 removals:  0 refs:   0 iters: 713 [TransactionBlock V1]
19:48:43 chia.simulator.block_tools: INFO Created Block    3 prev-tx:    2 diff: 64 time: 18.75 additions: 7002 removals:  1 refs:   0 iters: 969 [TransactionBlock V1]
PASSED

======================================================================================== 1 passed in 26.15s =========================================================================================
```