### PR TITLE
bump chia_rs and update uses of RewardChainBlock and SubEpochSummary

### DIFF
--- a/benchmarks/block_store.py
+++ b/benchmarks/block_store.py
@@ -99,6 +99,7 @@ async def run_add_block_benchmark(version: int) -> None:
                     uint8(random.randint(0, 255)),  # num_blocks_overflow: uint8
                     None,  # new_difficulty: Optional[uint64]
                     None,  # new_sub_slot_iters: Optional[uint64]
+                    None,  # challenge_merkle_root: Optional[bytes32]
                 )
 
             has_pool_pk = random.randint(0, 1)
@@ -126,6 +127,7 @@ async def run_add_block_benchmark(version: int) -> None:
                 rand_g2(),  # reward_chain_sp_signature
                 rand_vdf(),  # reward_chain_ip_vdf
                 rand_vdf() if deficit < 16 else None,
+                None,  # header_mmr_root
                 is_transaction,
             )
 

--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -384,6 +384,7 @@ async def test_block_ses_mismatch(
             s.num_blocks_overflow,
             uint64(s.new_difficulty * 2) if s.new_difficulty is not None else None,
             uint64(s.new_sub_slot_iters * 2) if s.new_sub_slot_iters is not None else None,
+            None,
         )
         # manually try sync with wrong sub epoch summary list
         await server_2.start_client(PeerInfo(self_hostname, server_1.get_port()), None)

--- a/chia/_tests/core/full_node/test_block_height_map.py
+++ b/chia/_tests/core/full_node/test_block_height_map.py
@@ -22,7 +22,7 @@ def gen_block_hash(height: int) -> bytes32:
 def gen_ses(height: int) -> SubEpochSummary:
     prev_ses = gen_block_hash(height + 0xFA0000)
     reward_chain_hash = gen_block_hash(height + 0xFC0000)
-    return SubEpochSummary(prev_ses, reward_chain_hash, uint8(0), None, None)
+    return SubEpochSummary(prev_ses, reward_chain_hash, uint8(0), None, None, None)
 
 
 async def new_block(

--- a/chia/_tests/util/benchmarks.py
+++ b/chia/_tests/util/benchmarks.py
@@ -94,6 +94,7 @@ def rand_full_block() -> FullBlock:
         rand_g2(),
         rand_vdf(),
         rand_vdf(),
+        None,
         True,
     )
 

--- a/chia/_tests/util/network_protocol_data.py
+++ b/chia/_tests/util/network_protocol_data.py
@@ -243,6 +243,7 @@ sub_epochs = SubEpochData(
     uint8(190),
     uint64(10527522631566046685),
     uint64(989988965238543242),
+    None,
 )
 
 classgroup_element = ClassgroupElement.get_default_element()
@@ -320,6 +321,7 @@ reward_chain_block = RewardChainBlock(
     g2_element,
     vdf_info,
     vdf_info,
+    None,
     False,
 )
 
@@ -1057,6 +1059,7 @@ sub_epoch_summary = SubEpochSummary(
     uint8(4),
     uint64(14666749803532899046),
     uint64(10901191956946573440),
+    None,
 )
 
 new_peak_timelord = timelord_protocol.NewPeakTimelord(

--- a/chia/_tests/util/protocol_messages_json.py
+++ b/chia/_tests/util/protocol_messages_json.py
@@ -264,6 +264,7 @@ respond_proof_of_weight_json: dict[str, Any] = {
                 "num_blocks_overflow": 190,
                 "new_sub_slot_iters": 10527522631566046685,
                 "new_difficulty": 989988965238543242,
+                "challenge_merkle_root": None,
             }
         ],
         "sub_epoch_segments": [
@@ -460,6 +461,7 @@ respond_proof_of_weight_json: dict[str, Any] = {
                             "data": "0x08000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
                         },
                     },
+                    "header_mmr_root": None,
                     "is_transaction_block": False,
                 },
                 "challenge_chain_sp_proof": {
@@ -654,6 +656,7 @@ respond_blocks_json: dict[str, Any] = {
                         "data": "0x08000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
                     },
                 },
+                "header_mmr_root": None,
                 "is_transaction_block": False,
             },
             "challenge_chain_sp_proof": {
@@ -830,6 +833,7 @@ respond_blocks_json: dict[str, Any] = {
                         "data": "0x08000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
                     },
                 },
+                "header_mmr_root": None,
                 "is_transaction_block": False,
             },
             "challenge_chain_sp_proof": {
@@ -1012,6 +1016,7 @@ respond_block_json: dict[str, Any] = {
                     "data": "0x08000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
                 },
             },
+            "header_mmr_root": None,
             "is_transaction_block": False,
         },
         "challenge_chain_sp_proof": {
@@ -1562,6 +1567,7 @@ respond_header_block_json: dict[str, Any] = {
                     "data": "0x08000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
                 },
             },
+            "header_mmr_root": None,
             "is_transaction_block": False,
         },
         "challenge_chain_sp_proof": {
@@ -1743,6 +1749,7 @@ respond_block_headers_json: dict[str, Any] = {
                         "data": "0x08000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
                     },
                 },
+                "header_mmr_root": None,
                 "is_transaction_block": False,
             },
             "challenge_chain_sp_proof": {
@@ -1998,6 +2005,7 @@ respond_header_blocks_json: dict[str, Any] = {
                         "data": "0x08000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
                     },
                 },
+                "header_mmr_root": None,
                 "is_transaction_block": False,
             },
             "challenge_chain_sp_proof": {
@@ -2632,6 +2640,7 @@ new_peak_timelord_json: dict[str, Any] = {
                 "data": "0x08000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
             },
         },
+        "header_mmr_root": None,
         "is_transaction_block": False,
     },
     "difficulty": 7661623532867338566,
@@ -2643,6 +2652,7 @@ new_peak_timelord_json: dict[str, Any] = {
         "num_blocks_overflow": 4,
         "new_difficulty": 14666749803532899046,
         "new_sub_slot_iters": 10901191956946573440,
+        "challenge_merkle_root": None,
     },
     "previous_reward_challenges": [
         ["0x5bb65d8662d561ed2fc17e4177ba61c43017ee7e5418091d38968e36ce380d11", 134240022887890669757150210097251845335]
@@ -2706,6 +2716,7 @@ new_unfinished_block_timelord_json: dict[str, Any] = {
         "num_blocks_overflow": 4,
         "new_difficulty": 14666749803532899046,
         "new_sub_slot_iters": 10901191956946573440,
+        "challenge_merkle_root": None,
     },
     "rc_prev": "0x0f90296b605904a794e4e98852e3b22e0d9bee2fa07abb12df6cecbdb778e1e5",
 }

--- a/chia/_tests/util/test_full_block_utils.py
+++ b/chia/_tests/util/test_full_block_utils.py
@@ -100,6 +100,7 @@ def get_reward_chain_block(height: uint32) -> Generator[RewardChainBlock, None, 
                             g2(),  # reward_chain_sp_signature
                             vdf(),  # reward_chain_ip_vdf
                             infused_challenge_chain_ip_vdf,
+                            None,  # header_mmr_root
                             has_transactions,
                         )
 

--- a/chia/_tests/wallet/wallet_block_tools.py
+++ b/chia/_tests/wallet/wallet_block_tools.py
@@ -187,6 +187,7 @@ def finish_block(
             G2Element(),
             DEFAULT_VDF_INFO,
             DEFAULT_VDF_INFO,
+            None,  # header_mmr_root
             prev_block is not None,
         ),
         DEFAULT_VDF_PROOF,

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -485,6 +485,7 @@ def unfinished_block_to_full_block(
         unfinished_block.reward_chain_block.reward_chain_sp_signature,
         rc_ip_vdf,
         icc_ip_vdf,
+        None,
         is_transaction_block,
     )
     if prev_block is None:

--- a/chia/consensus/make_sub_epoch_summary.py
+++ b/chia/consensus/make_sub_epoch_summary.py
@@ -52,6 +52,7 @@ def make_sub_epoch_summary(
             uint8(0),
             None,
             None,
+            None,
         )
     if prev_ses_block is None:
         curr: BlockRecord = prev_prev_block
@@ -69,6 +70,7 @@ def make_sub_epoch_summary(
         uint8(prev_ses_block.height % constants.SUB_EPOCH_BLOCKS),
         new_difficulty,
         new_sub_slot_iters,
+        None,  # challenge_merkle_root
     )
 
 

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -715,7 +715,7 @@ def _create_sub_epoch_data(
     #  New work difficulty and iterations per sub-slot
     sub_slot_iters = sub_epoch_summary.new_sub_slot_iters
     new_difficulty = sub_epoch_summary.new_difficulty
-    return SubEpochData(reward_chain_hash, previous_sub_epoch_overflows, sub_slot_iters, new_difficulty)
+    return SubEpochData(reward_chain_hash, previous_sub_epoch_overflows, sub_slot_iters, new_difficulty, None)
 
 
 async def _challenge_block_vdfs(
@@ -879,6 +879,7 @@ def _map_sub_epoch_summaries(
             data.num_blocks_overflow,
             data.new_difficulty,
             data.new_sub_slot_iters,
+            None,
         )
 
         if idx < len(sub_epoch_data) - 1:

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -672,6 +672,7 @@ class Timelord:
                         block.reward_chain_block.reward_chain_sp_signature,
                         rc_info,
                         icc_info,
+                        None,  # header_mmr_root
                         is_transaction_block,
                     )
                     if self.last_state.state_type == StateType.FIRST_SUB_SLOT:

--- a/poetry.lock
+++ b/poetry.lock
@@ -876,38 +876,38 @@ pytest = ">=8.3.3,<9.0.0"
 
 [[package]]
 name = "chia-rs"
-version = "0.34.0"
+version = "0.35.0"
 description = ""
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "chia_rs-0.34.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:0e9fa87a86a9b4aa298beb8c93de2b72862daa4549fcfa6291793854dfe694c2"},
-    {file = "chia_rs-0.34.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:87caf41ae381058be771efe2d5de1a109e8f9e4dd602f0c6a7c43069a3ae5afb"},
-    {file = "chia_rs-0.34.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:14dac068b657c0604b8a46cfcbe56c17cf8209d4cbb2394357545ef96dc3062a"},
-    {file = "chia_rs-0.34.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:13177c339df2395863f50d2c3eac1085942ed26eb4955090cbf1920e8e97616e"},
-    {file = "chia_rs-0.34.0-cp310-cp310-win_amd64.whl", hash = "sha256:0cfd7855917baa448c0ab6a250a2f703437b1f65c3808e30264a59a9c85afa2c"},
-    {file = "chia_rs-0.34.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:c4e285eb0058698760a2d543a95eec38c51f04a5badede371dd34f0942290f0c"},
-    {file = "chia_rs-0.34.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:c1118678650b327abd80121ebbc0e8be19879a622b9a2dfa7eb8ac426fab5d92"},
-    {file = "chia_rs-0.34.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:2c4aed56c4b61ff1f2ad0f1cb2aba952962cb2af47ec9e24bc8f746246bdf6b5"},
-    {file = "chia_rs-0.34.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7c0daddaf48b4b48887a91ef5b2d0bf34594d9408e4c007e3a258b07fae76185"},
-    {file = "chia_rs-0.34.0-cp311-cp311-win_amd64.whl", hash = "sha256:ffb86edc4c06022430fefe3879a0ad4ff14fd7c4ddcb5c2ff6dcdcba4e9642c2"},
-    {file = "chia_rs-0.34.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:c1a8bfcbdab7260457a9825ec47e952c941a6a05adecfe7e9d63fa9d89e18fae"},
-    {file = "chia_rs-0.34.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:b48ba473a8ea1b11eb8b00cb46477669a06e70e9253ea4bff998818c978626e4"},
-    {file = "chia_rs-0.34.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:a272a434c918bbe482970a281297c7b06e5696c0df5ca659ee69ac8bff23c5ec"},
-    {file = "chia_rs-0.34.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:3ab106c69028fc365a8deba979cdc2ecadc4dedaf76fb0b3b8267b72dd2e27f1"},
-    {file = "chia_rs-0.34.0-cp312-cp312-win_amd64.whl", hash = "sha256:19c1806056d2fdc7a1fc5942a091c31de8838105c7edb0a1a6e673b5dde69d27"},
-    {file = "chia_rs-0.34.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:40ea59028703ff09affdfb94650af8c6c29b4dd2fee151d91f18334e3c2196b9"},
-    {file = "chia_rs-0.34.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:b8e697e9429fa2cbdda5837fb287dd5e0a6fa7f9d20bdb38d0288294d90dde60"},
-    {file = "chia_rs-0.34.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f2cffd3e3945f1ee0b5781f8126848374a7220861df8c43bef803cf9082f3db2"},
-    {file = "chia_rs-0.34.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f3af294153c3cfa67e196ea60ff4c88f824bd419ab8aca4cee6e5656374f5de1"},
-    {file = "chia_rs-0.34.0-cp313-cp313-win_amd64.whl", hash = "sha256:79ddfaf576c003bab874a97b48def22a5d77ffd535a3a8c5bfd0c4450796a4fb"},
-    {file = "chia_rs-0.34.0-cp39-cp39-macosx_13_0_arm64.whl", hash = "sha256:b465803f1fb881a298f3c905ba47df1fe6dfec9ffbd8c687e5d1503e0f20a839"},
-    {file = "chia_rs-0.34.0-cp39-cp39-macosx_13_0_x86_64.whl", hash = "sha256:55bbf61ad26dc43901b1397baaf608f39bc7961d59b411d57c9a004d323ba2ef"},
-    {file = "chia_rs-0.34.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:540ea9fc35b2809f4a26db123c60e755f457f764fa70ac1b68dafdbe4ec592cb"},
-    {file = "chia_rs-0.34.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:85a3f843153e2af41bbd961b03d159d7f6767755146bdcf84fa51d167dc100b1"},
-    {file = "chia_rs-0.34.0-cp39-cp39-win_amd64.whl", hash = "sha256:b9598078ef2c512bafd6f6a6f71bc1a4084fad2e99cae1eb2a4c49f976343ccc"},
-    {file = "chia_rs-0.34.0.tar.gz", hash = "sha256:bc1e469f3482a97ee65e891badea2da0833eac94fb814aeda2ec5efc69bb2535"},
+    {file = "chia_rs-0.35.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:017f41f9aac58df5b97ddb528da85e7d86446061615af39d2bcd29bf1625ecfd"},
+    {file = "chia_rs-0.35.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:f4780e2c858c3d4dd0dbd7938739089f8644474633af0ffbc2f432fe0eb00949"},
+    {file = "chia_rs-0.35.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:84962c41b00b29ae7e71450253646951762a913983d42cba24ea0415e2ed7f13"},
+    {file = "chia_rs-0.35.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:d5a31dd9a65f187108e8eba5025814b3b5f749b72943267aacc93df51b8d333e"},
+    {file = "chia_rs-0.35.0-cp310-cp310-win_amd64.whl", hash = "sha256:b9ea895bbf28f2a7d0509a25c6300b0d734e14922bea392034d372f59b0bb4ea"},
+    {file = "chia_rs-0.35.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:36e7100eb85b92ba703876cbab30796d2dc7ad60aa4004e1038226fe553fafe5"},
+    {file = "chia_rs-0.35.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:fa06fbafc98be54052916e48d0b47f0b10264077f2b60d7e934e0f317b1c3d56"},
+    {file = "chia_rs-0.35.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:652b27081da04a770df1b47e553f5dde4defc28d6c488a58f1dfc0397902098d"},
+    {file = "chia_rs-0.35.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:525c3c17f9102a0f2a1d79774f2654266f36ee91f971dce1cbc5ff89b71edaf8"},
+    {file = "chia_rs-0.35.0-cp311-cp311-win_amd64.whl", hash = "sha256:6b6149b5ddfe1c2548babe3e18afecbd7c4d62e2cda5d27c02d781fabae241b1"},
+    {file = "chia_rs-0.35.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:452030cec6220380c2e2ca711ad4206515a5a493c8877ecbd2e6f669077677e6"},
+    {file = "chia_rs-0.35.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:fad6c68b8c1ed27acca46704c5048c431dfc4afc110048cd5ec97983095ae156"},
+    {file = "chia_rs-0.35.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:7a166ca40ee72b4c53add5063b54e4f93171bdc79f5c3d537b9bb516efa95737"},
+    {file = "chia_rs-0.35.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2b2c357b2dda27a3eb38c5bfabfe8f1e4141e51f06997f4c8fb96fc26301dedf"},
+    {file = "chia_rs-0.35.0-cp312-cp312-win_amd64.whl", hash = "sha256:6909865490ef91ea04cc64b6bfe37c28c250c62286f2ddb101e619b37016680a"},
+    {file = "chia_rs-0.35.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:4533537cc2fbc056e82dd3b060eb5cbe921069ce79d11c2eb515cb50f9e63d74"},
+    {file = "chia_rs-0.35.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:7d4f2fe981561f88bb6a1bd646644d8063d702469494f36f18d879f3252a21d0"},
+    {file = "chia_rs-0.35.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:3180921f188ac5f5635dacff96607793072cb5107aefa2e645f289f8780d982e"},
+    {file = "chia_rs-0.35.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:321f8aee3f56e2992c71343edd5fba913fc7b4e68642049b252f7d9bfeb86f74"},
+    {file = "chia_rs-0.35.0-cp313-cp313-win_amd64.whl", hash = "sha256:208f4ecd5beea377cb585799fd2f15f34e58fa5e47d0e436f9d1ca47e472a331"},
+    {file = "chia_rs-0.35.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:10e6ab4a5369681093928b523fe81460a73006cf796ab5ac67d627c53f7dbef2"},
+    {file = "chia_rs-0.35.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:d6a77b3a63c4a4dd23cd76a6b0eb32a4a78382f00149fdc8351d5c63a0e32822"},
+    {file = "chia_rs-0.35.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:498edd70f1a3454490942aee131d1967ad4c1bab7b4aa340bca2087a47786eb8"},
+    {file = "chia_rs-0.35.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:347ff311c2c584b3a51bd9e04d9139f8a0920089fc04bf859c68e0519f47ec95"},
+    {file = "chia_rs-0.35.0-cp314-cp314-win_amd64.whl", hash = "sha256:b83ff3a7bde42e3c9de9a5bb59b68d749ec37e7cd8543cd74bcb502f236efeee"},
+    {file = "chia_rs-0.35.0.tar.gz", hash = "sha256:a09040d07e1a6ad137eb89febccc0ba82919454fc923657e175164607ec69124"},
 ]
 
 [package.dependencies]
@@ -4023,4 +4023,4 @@ upnp = ["miniupnpc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <4"
-content-hash = "2db7770d36c327a240a239fbc37f37a7e4a1652af1a76bf789b901edea9af56f"
+content-hash = "4a1ab350b6deffe7fee62c88552b1de2a2663205a202a99b4599ecd52b9757fd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ boto3 = ">=1.35.43"  # AWS S3 for Data Layer S3 plugin
 chiabip158 = ">=1.5.2"  # bip158-style wallet filters
 chiapos = ">=2.0.10"  # proof of space
 chia-puzzles-py = ">=0.20.1"
-chia_rs = ">=0.34, <0.35"
+chia_rs = ">=0.35, <0.36"
 chiavdf = ">=1.1.10"  # timelord and vdf verification
 click = ">=8.1.7"  # For the CLI
 clvm = ">=0.9.14"


### PR DESCRIPTION
### Purpose:

The new chia_rs supports an additional (backwards compatible) field, merkle mountain range root, in `RewardChainBlock` and `SubEpochSummary`.