### PR TITLE
[LABS-306] Simplify `cancel_offers`

### DIFF
--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -2111,6 +2111,14 @@ class CancelOffers(TransactionEndpointRequest):
     cancel_all: bool = False
     asset_id: str = "xch"
 
+    @property
+    def query_key(self) -> bytes32 | None:
+        if self.cancel_all:
+            return None
+        if self.asset_id != "xch":
+            return bytes32.from_hexstr(self.asset_id)
+        return None
+
 
 @streamable
 @dataclass(frozen=True)


### PR DESCRIPTION
This PR simplifies the batch offer cancellation endpoint to remove as much internal logic as possible.  Th primary change is to use `itertools.count` instead of custom batching in a `while` loop.