### PR TITLE
CHIA-3843 Wait for nodes to sync in test_ban_for_mismatched_tx_cost_fee

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3435,6 +3435,8 @@ async def test_ban_for_mismatched_tx_cost_fee(
     async def send_from_node_3() -> None:
         await ws_con_3.send_message(msg)
 
+    for node in [full_node_1.full_node, full_node_2.full_node, full_node_3.full_node]:
+        await time_out_assert(5, node.synced)
     await asyncio.gather(send_from_node_2(), send_from_node_3())
     if mismatch_on_reannounce and (mismatch_cost or mismatch_fee):
         # Send a second NewTransaction that doesn't match the first


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

This doesn't happen naturally in time for some slow CI runs in some cases.

### Current Behavior:

We assume the nodes are synced in time to perform the test in question.

### New Behavior:

We wait for the nodes to sync and then perform the test in question.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
