### PR TITLE
CHIA-3844 Advertise requested mempool transactions instead of sending them

### DIFF
--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -1142,7 +1142,7 @@ async def test_get_items_not_in_filter() -> None:
     # Don't filter anything
     empty_filter = PyBIP158([])
     result = mempool_manager.get_items_not_in_filter(empty_filter)
-    assert result == [sb3, sb2, sb1]
+    assert [item.to_spend_bundle() for item in result] == [sb3, sb2, sb1]
 
     # Filter everything
     full_filter = PyBIP158([bytearray(sb1_name), bytearray(sb2_name), bytearray(sb3_name)])
@@ -1162,16 +1162,16 @@ async def test_get_items_not_in_filter() -> None:
 
     # With a limit of one, sb2 has the highest FPC
     result = mempool_manager.get_items_not_in_filter(sb3_filter, limit=1)
-    assert result == [sb2]
+    assert [item.to_spend_bundle() for item in result] == [sb2]
 
     # With a higher limit, all bundles aside from sb3 get included
     result = mempool_manager.get_items_not_in_filter(sb3_filter, limit=5)
-    assert result == [sb2, sb1]
+    assert [item.to_spend_bundle() for item in result] == [sb2, sb1]
 
     # Filter two of the spend bundles
     sb2_and_3_filter = PyBIP158([bytearray(sb2_name), bytearray(sb3_name)])
     result = mempool_manager.get_items_not_in_filter(sb2_and_3_filter)
-    assert result == [sb1]
+    assert [item.to_spend_bundle() for item in result] == [sb1]
 
 
 @pytest.mark.anyio

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -25,7 +25,6 @@ from chia_rs import (
     PoolTarget,
     RespondToPhUpdates,
     RewardChainBlockUnfinished,
-    SpendBundle,
     SubEpochSummary,
     UnfinishedBlock,
     additions_and_removals,
@@ -813,11 +812,11 @@ class FullNodeAPI:
     ) -> Message | None:
         received_filter = PyBIP158(bytearray(request.filter))
 
-        items: list[SpendBundle] = self.full_node.mempool_manager.get_items_not_in_filter(received_filter)
+        items = self.full_node.mempool_manager.get_items_not_in_filter(received_filter, limit=100)
 
         for item in items:
-            transaction = full_node_protocol.RespondTransaction(item)
-            msg = make_msg(ProtocolMessageTypes.respond_transaction, transaction)
+            transaction = full_node_protocol.NewTransaction(item.name, item.cost, item.fee)
+            msg = make_msg(ProtocolMessageTypes.new_transaction, transaction)
             await peer.send_message(msg)
         return None
 

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -1000,8 +1000,8 @@ class MempoolManager:
         log.log(logging.WARNING if duration > 1 else logging.INFO, f"new_peak() took {duration:0.2f} seconds")
         return NewPeakInfo(txs_added, mempool_item_removals)
 
-    def get_items_not_in_filter(self, mempool_filter: PyBIP158, limit: int = 100) -> list[SpendBundle]:
-        items: list[SpendBundle] = []
+    def get_items_not_in_filter(self, mempool_filter: PyBIP158, limit: int = 100) -> list[MempoolItem]:
+        items: list[MempoolItem] = []
 
         assert limit > 0
 
@@ -1011,7 +1011,7 @@ class MempoolManager:
                 return items
             if mempool_filter.Match(bytearray(item.spend_bundle_name)):
                 continue
-            items.append(item.to_spend_bundle())
+            items.append(item)
 
         return items
 


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

When we connect to a peer and we're requested to send mempool transactions that they don't have (via `RequestMempoolTransactions`) we currently send back spend bundles (via `RespondTransaction`) without any information about their cost and fee.

This doesn't allow us to prioritize these spend bundles when adding them to the mempool, and due to the possibility of connecting to multiple peers we can end up with more than one response for the same spend bundle.

With this patch we send back information about the transactions (via `NewTransaction`) instead of the spend bundles (via `RespondTransaction`), which allows us to prioritize items we didn't see before properly based on their costs and fees.

### Current Behavior:

We send back a list of spend bundles when we're requested for mempool transactions.

### New Behavior:

We send back transactions information when we're requested for mempool transactions.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
