### PR TITLE
Add extra ignore in pytest.ini to prevent occasional breaking for a DeprecationWarning

### DIFF
--- a/chia/__init__.py
+++ b/chia/__init__.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import importlib.metadata
+from importlib.metadata import version, PackageNotFoundError
 import sys
 
 __version__: str
+
 try:
-    __version__ = importlib.metadata.version("chia-blockchain")
-except importlib.metadata.PackageNotFoundError:
-    # package is not installed
-    __version__ = "unknown"
-except KeyError:
+    __version__ = version("chia-blockchain")
+except (PackageNotFoundError, KeyError):
     __version__ = "unknown"
 
 try:

--- a/chia/__init__.py
+++ b/chia/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from importlib.metadata import version, PackageNotFoundError
 import sys
+from importlib.metadata import PackageNotFoundError, version
 
 __version__: str
 

--- a/chia/__init__.py
+++ b/chia/__init__.py
@@ -9,6 +9,8 @@ try:
 except importlib.metadata.PackageNotFoundError:
     # package is not installed
     __version__ = "unknown"
+except KeyError:
+    __version__ = "unknown"
 
 try:
     assert False

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,3 +25,4 @@ filterwarnings =
     ignore:cannot collect test class:pytest.PytestCollectionWarning
     ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
     ignore:record_property is incompatible with junit_family:pytest.PytestWarning
+    ignore:Implicit None on return values is deprecated and will raise


### PR DESCRIPTION
### Purpose:

Previously pytest would occasionally fail with the following error:
```
ImportError while loading conftest '/chia-blockchain/chia/_tests/conftest.py'.
chia/__init__.py:8: in <module>
    __version__ = version("chia-blockchain")
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
E   DeprecationWarning: Implicit None on return values is deprecated and will raise KeyErrors.
```

We handle KeyErrors in practice, so the best course of action is to explicitly ignore this warning. 