### PR TITLE
[LABS-305] Extract signing functionality from wallet RPC to its own library

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -154,6 +154,7 @@ from chia.wallet.wallet_request_types import (
     SendTransaction,
     SendTransactionMulti,
     SetWalletResyncOnStartup,
+    SignMessageByAddress,
     SpendClawbackCoins,
     SplitCoins,
     TakeOffer,
@@ -3127,6 +3128,37 @@ async def test_verify_signature(
         VerifySignature.from_json_dict(updated_request)
     )
     assert res == rpc_response
+
+
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [
+        {
+            "num_environments": 1,
+            "blocks_needed": [1],
+            "reuse_puzhash": True,
+            "trusted": True,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
+async def test_sign_message_by_address(wallet_environments: WalletTestFramework) -> None:
+    client: WalletRpcClient = wallet_environments.environments[0].rpc_client
+
+    message = "foo"
+    address = await client.get_next_address(GetNextAddress(uint32(1)))
+    signed_message = await client.sign_message_by_address(SignMessageByAddress(address.address, message))
+
+    await wallet_environments.environments[0].rpc_client.verify_signature(
+        VerifySignature(
+            message=message,
+            pubkey=signed_message.pubkey,
+            signature=signed_message.signature,
+            signing_mode=signed_message.signing_mode,
+        )
+    )
 
 
 @pytest.mark.parametrize(

--- a/chia/wallet/util/signing.py
+++ b/chia/wallet/util/signing.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from chia_rs import AugSchemeMPL, G1Element, G2Element
+from chia_rs.sized_bytes import bytes32
+
+from chia.types.blockchain_format.program import Program
+from chia.types.signing_mode import CHIP_0002_SIGN_MESSAGE_PREFIX, SigningMode
+from chia.util.bech32m import decode_puzzle_hash
+from chia.util.byte_types import hexstr_to_bytes
+from chia.wallet.puzzles import p2_delegated_conditions
+from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import puzzle_hash_for_synthetic_public_key
+from chia.wallet.wallet_request_types import VerifySignatureResponse
+
+
+def verify_signature(
+    *, signing_mode: SigningMode, public_key: G1Element, message: str, signature: G2Element, address: str | None
+) -> VerifySignatureResponse:
+    """
+    Given a public key, message and signature, verify if it is valid.
+    :param request:
+    :return:
+    """
+    if signing_mode in {SigningMode.CHIP_0002, SigningMode.CHIP_0002_P2_DELEGATED_CONDITIONS}:
+        # CHIP-0002 message signatures are made over the tree hash of:
+        #   ("Chia Signed Message", message)
+        message_to_verify: bytes = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message)).get_tree_hash()
+    elif signing_mode == SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT:
+        # Message is expected to be a hex string
+        message_to_verify = hexstr_to_bytes(message)
+    elif signing_mode == SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT:
+        # Message is expected to be a UTF-8 string
+        message_to_verify = bytes(message, "utf-8")
+    else:
+        raise ValueError(f"Unsupported signing mode: {signing_mode!r}")
+
+    # Verify using the BLS message augmentation scheme
+    is_valid = AugSchemeMPL.verify(
+        public_key,
+        message_to_verify,
+        signature,
+    )
+    if address is not None:
+        # For signatures made by the sign_message_by_address/sign_message_by_id
+        # endpoints, the "address" field should contain the p2_address of the NFT/DID
+        # that was used to sign the message.
+        puzzle_hash: bytes32 = decode_puzzle_hash(address)
+        expected_puzzle_hash: bytes32 | None = None
+        if signing_mode == SigningMode.CHIP_0002_P2_DELEGATED_CONDITIONS:
+            puzzle = p2_delegated_conditions.puzzle_for_pk(Program.to(public_key))
+            expected_puzzle_hash = bytes32(puzzle.get_tree_hash())
+        else:
+            expected_puzzle_hash = puzzle_hash_for_synthetic_public_key(public_key)
+        if puzzle_hash != expected_puzzle_hash:
+            return VerifySignatureResponse(isValid=False, error="Public key doesn't match the address")
+    if is_valid:
+        return VerifySignatureResponse(isValid=is_valid)
+    else:
+        return VerifySignatureResponse(isValid=False, error="Signature is invalid.")

--- a/chia/wallet/util/signing.py
+++ b/chia/wallet/util/signing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from chia_rs import AugSchemeMPL, G1Element, G2Element
+from chia_rs import AugSchemeMPL, G1Element, G2Element, PrivateKey
 from chia_rs.sized_bytes import bytes32
 
 from chia.types.blockchain_format.program import Program
@@ -9,7 +9,10 @@ from chia.util.bech32m import decode_puzzle_hash
 from chia.util.byte_types import hexstr_to_bytes
 from chia.wallet.puzzles import p2_delegated_conditions
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import puzzle_hash_for_synthetic_public_key
-from chia.wallet.wallet_request_types import VerifySignatureResponse
+from chia.wallet.wallet_request_types import SignMessageByAddressResponse, VerifySignatureResponse
+
+# CHIP-0002 message signing as documented at:
+# https://github.com/Chia-Network/chips/blob/80e4611fe52b174bf1a0382b9dff73805b18b8c6/CHIPs/chip-0002.md
 
 
 def verify_signature(
@@ -56,3 +59,20 @@ def verify_signature(
         return VerifySignatureResponse(isValid=is_valid)
     else:
         return VerifySignatureResponse(isValid=False, error="Signature is invalid.")
+
+
+def sign_message(secret_key: PrivateKey, message: str, mode: SigningMode) -> SignMessageByAddressResponse:
+    public_key = secret_key.get_g1()
+    if mode == SigningMode.CHIP_0002_HEX_INPUT:
+        hex_message: bytes = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, bytes.fromhex(message))).get_tree_hash()
+    elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT:
+        hex_message = bytes(message, "utf-8")
+    elif mode == SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT:
+        hex_message = bytes.fromhex(message)
+    else:
+        hex_message = Program.to((CHIP_0002_SIGN_MESSAGE_PREFIX, message)).get_tree_hash()
+    return SignMessageByAddressResponse(
+        pubkey=public_key,
+        signature=AugSchemeMPL.sign(secret_key, hex_message),
+        signing_mode=mode.value,
+    )

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -395,6 +395,17 @@ class VerifySignatureResponse(Streamable):
     error: str | None = None
 
 
+def signing_mode_enum(request: SignMessageByAddress | SignMessageByID) -> SigningMode:
+    if request.is_hex and request.safe_mode:
+        return SigningMode.CHIP_0002_HEX_INPUT
+    elif not request.is_hex and not request.safe_mode:
+        return SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT
+    elif request.is_hex and not request.safe_mode:
+        return SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT
+
+    return SigningMode.CHIP_0002
+
+
 @streamable
 @dataclass(frozen=True)
 class SignMessageByAddress(Streamable):
@@ -405,15 +416,7 @@ class SignMessageByAddress(Streamable):
 
     @property
     def signing_mode_enum(self) -> SigningMode:
-        mode: SigningMode = SigningMode.CHIP_0002
-        if self.is_hex and self.safe_mode:
-            mode = SigningMode.CHIP_0002_HEX_INPUT
-        elif not self.is_hex and not self.safe_mode:
-            mode = SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT
-        elif self.is_hex and not self.safe_mode:
-            mode = SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT
-
-        return mode
+        return signing_mode_enum(self)
 
 
 @streamable
@@ -431,6 +434,10 @@ class SignMessageByID(Streamable):
     message: str
     is_hex: bool = False
     safe_mode: bool = True
+
+    @property
+    def signing_mode_enum(self) -> SigningMode:
+        return signing_mode_enum(self)
 
 
 @streamable

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -403,6 +403,18 @@ class SignMessageByAddress(Streamable):
     is_hex: bool = False
     safe_mode: bool = True
 
+    @property
+    def signing_mode_enum(self) -> SigningMode:
+        mode: SigningMode = SigningMode.CHIP_0002
+        if self.is_hex and self.safe_mode:
+            mode = SigningMode.CHIP_0002_HEX_INPUT
+        elif not self.is_hex and not self.safe_mode:
+            mode = SigningMode.BLS_MESSAGE_AUGMENTATION_UTF8_INPUT
+        elif self.is_hex and not self.safe_mode:
+            mode = SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT
+
+        return mode
+
 
 @streamable
 @dataclass(frozen=True)

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -13,6 +13,7 @@ from chia.data_layer.data_layer_wallet import DataLayerSummary, Mirror
 from chia.data_layer.singleton_record import SingletonRecord
 from chia.pools.pool_wallet_info import PoolWalletInfo
 from chia.types.blockchain_format.program import Program
+from chia.types.signing_mode import SigningMode
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.hash import std_hash
 from chia.util.streamable import Streamable, streamable
@@ -373,6 +374,18 @@ class VerifySignature(Streamable):
     signature: G2Element
     signing_mode: str | None = None
     address: str | None = None
+
+    @property
+    def signing_mode_enum(self) -> SigningMode:
+        # Default to BLS_MESSAGE_AUGMENTATION_HEX_INPUT as this RPC was originally designed to verify
+        # signatures made by `chia keys sign`, which uses BLS_MESSAGE_AUGMENTATION_HEX_INPUT
+        if self.signing_mode is None:
+            return SigningMode.BLS_MESSAGE_AUGMENTATION_HEX_INPUT
+        else:
+            try:
+                return SigningMode(self.signing_mode)
+            except ValueError:
+                raise ValueError(f"Invalid signing mode: {self.signing_mode!r}")
 
 
 @streamable


### PR DESCRIPTION
This PR removes the signing logic that was previously only accessible from the RPC into its own library.  This minimizes the RPC logic and also provides this functionality to other wallet areas potentially.

(it also adds tests for the previously untested `sign_message_by_id`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts message signing/verification into a shared util and refactors RPC and wallets to use it; adds tests for signing by NFT ID and address.
> 
> - **Wallet signing refactor**:
>   - Introduce `chia/wallet/util/signing.py` with `sign_message()` and `verify_signature()`.
>   - Remove ad-hoc `sign_message` methods from `Wallet`, `DIDWallet`, and `NFTWallet`; add helpers like `convert_secret_key_to_synthetic()` and `current_p2_puzzle_hash()`.
> - **RPC updates**:
>   - `wallet_rpc_api.py`: delegate `verify_signature`, `sign_message_by_address`, and `sign_message_by_id` to new signing util; simplify key retrieval and signing flow.
>   - `wallet_request_types.py`: add `signing_mode_enum` helpers and properties; extend request/response types for signing.
> - **Tests**:
>   - Add `test_sign_message_by_nft_id` (NFT signing across modes) and `test_sign_message_by_address`.
>   - Update imports/usages accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d85e99080637898e43190f51e1fef3e395c1e9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->