### PR TITLE
[LABS-311] Extract `track_new_launcher_id` from `dl_track_new`

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1700,7 +1700,7 @@ class WalletStateManager:
                     elif coin_state.created_height is not None:
                         wallet_identifier, coin_data = await self.determine_coin_type(peer, coin_state, fork_height)
                         try:
-                            dl_wallet = self.get_dl_wallet()
+                            dl_wallet = await self.get_dl_wallet()
                         except ValueError:
                             pass
                         else:
@@ -2012,12 +2012,7 @@ class WalletStateManager:
                                     and inner_puzhash is not None
                                     and (await self.puzzle_store.puzzle_hash_exists(inner_puzhash))
                                 ):
-                                    try:
-                                        dl_wallet = self.get_dl_wallet()
-                                    except ValueError:
-                                        dl_wallet = await DataLayerWallet.create_new_dl_wallet(
-                                            self,
-                                        )
+                                    dl_wallet = await self.get_dl_wallet(create_if_not_found=True)
                                     await dl_wallet.track_new_launcher_id(
                                         child.coin.name(),
                                         peer,
@@ -2591,14 +2586,18 @@ class WalletStateManager:
 
         return puzzle_hash
 
-    def get_dl_wallet(self) -> DataLayerWallet:
+    async def get_dl_wallet(self, *, create_if_not_found: bool = False) -> DataLayerWallet:
         for wallet in self.wallets.values():
             if wallet.type() == WalletType.DATA_LAYER.value:
                 assert isinstance(wallet, DataLayerWallet), (
                     f"WalletType.DATA_LAYER should be a DataLayerWallet instance got: {type(wallet).__name__}"
                 )
                 return wallet
-        raise ValueError("DataLayerWallet not available")
+        if create_if_not_found:
+            async with self.lock:
+                return await DataLayerWallet.create_new_dl_wallet(self)
+        else:
+            raise ValueError("DataLayerWallet not available")
 
     async def get_or_create_vc_wallet(self) -> VCWallet:
         for _, wallet in self.wallets.items():


### PR DESCRIPTION
The purpose of this PR is to extract some peer discovery logic from the RPC.  There was a related change made to make WSM's `get_dl_wallet` method optionally create the new DL wallet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors Data Layer wallet initialization and tracking flow.
> 
> - Moves peer discovery/retry into `DataLayerWallet.track_new_launcher_id` (introduces internal `_track_new_launcher_id`); RPC no longer loops peers or handles `LauncherCoinNotFoundError` directly
> - Makes `WalletStateManager.get_dl_wallet` async and add `create_if_not_found` to auto-create the DL wallet; updates callers across RPC and sync paths to `await` it
> - Simplifies DL RPCs (`dl_track_new`, `dl_*` endpoints) to use the new async getter and streamlined tracking, and removes unused imports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef2037384b7b575b68a569cbb791d4f95c9bd793. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->