### PR TITLE
[LABS-302] Forward `send_transaction` and `cat_spend` to `create_signed_transaction`

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -1225,7 +1225,7 @@ async def test_cat_endpoints(wallet_environments: WalletTestFramework, wallet_ty
                 amount=uint64(4),
                 inner_address=addr_1,
                 memos=["the cat memo"],
-                additions=[],
+                additions=[Addition(amount=uint64(0), puzzle_hash=bytes32.zeros)],
             ),
             tx_config=wallet_environments.tx_config,
         )
@@ -1247,7 +1247,7 @@ async def test_cat_endpoints(wallet_environments: WalletTestFramework, wallet_ty
         await env_0.rpc_client.cat_spend(
             CATSpend(
                 wallet_id=cat_0_id,
-                additions=[],
+                additions=[Addition(amount=uint64(0), puzzle_hash=bytes32.zeros)],
                 extra_delta="1",
             ),
             tx_config=wallet_environments.tx_config,

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -1468,6 +1468,22 @@ class Addition(Streamable):
     memos: list[str] | None = None
 
 
+def cat_discrepancy_validation(
+    extra_delta: str | None, tail_reveal: bytes | None, tail_solution: bytes | None
+) -> tuple[int, Program, Program] | None:
+    if extra_delta is None and tail_reveal is None and tail_solution is None:
+        return None
+    elif None in {extra_delta, tail_reveal, tail_solution}:
+        raise ValueError('Must specify "extra_delta", "tail_reveal" and "tail_solution" together.')
+    else:
+        # Curious that mypy doesn't see the elif and know that none of these are None
+        return (
+            int(extra_delta),  # type: ignore[arg-type]
+            Program.from_bytes(tail_reveal),  # type: ignore[arg-type]
+            Program.from_bytes(tail_solution),  # type: ignore[arg-type]
+        )
+
+
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class CATSpend(TransactionEndpointRequest):
@@ -1493,17 +1509,7 @@ class CATSpend(TransactionEndpointRequest):
 
     @property
     def cat_discrepancy(self) -> tuple[int, Program, Program] | None:
-        if self.extra_delta is None and self.tail_reveal is None and self.tail_solution is None:
-            return None
-        elif None in {self.extra_delta, self.tail_reveal, self.tail_solution}:
-            raise ValueError('Must specify "extra_delta", "tail_reveal" and "tail_solution" together.')
-        else:
-            # Curious that mypy doesn't see the elif and know that none of these are None
-            return (
-                int(self.extra_delta),  # type: ignore[arg-type]
-                Program.from_bytes(self.tail_reveal),  # type: ignore[arg-type]
-                Program.from_bytes(self.tail_solution),  # type: ignore[arg-type]
-            )
+        return cat_discrepancy_validation(self.extra_delta, self.tail_reveal, self.tail_solution)
 
 
 @streamable
@@ -1910,6 +1916,10 @@ class CreateSignedTransaction(TransactionEndpointRequest):
     morph_bytes: bytes | None = None
     coin_announcements: list[CSTCoinAnnouncement] = field(default_factory=list)
     puzzle_announcements: list[CSTPuzzleAnnouncement] = field(default_factory=list)
+    # cat specific
+    extra_delta: str | None = None  # str to support negative ints :(
+    tail_reveal: bytes | None = None
+    tail_solution: bytes | None = None
     # Technically this value was meant to support many types here
     # However, only one is supported right now and there are no plans to extend
     # So, as a slight hack, we'll specify that only Clawback is supported
@@ -1946,6 +1956,10 @@ class CreateSignedTransaction(TransactionEndpointRequest):
             )
             for pa in self.puzzle_announcements
         )
+
+    @property
+    def cat_discrepancy(self) -> tuple[int, Program, Program] | None:
+        return cat_discrepancy_validation(self.extra_delta, self.tail_reveal, self.tail_solution)
 
 
 @streamable

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -1910,6 +1910,10 @@ class CreateSignedTransaction(TransactionEndpointRequest):
     morph_bytes: bytes | None = None
     coin_announcements: list[CSTCoinAnnouncement] = field(default_factory=list)
     puzzle_announcements: list[CSTPuzzleAnnouncement] = field(default_factory=list)
+    # Technically this value was meant to support many types here
+    # However, only one is supported right now and there are no plans to extend
+    # So, as a slight hack, we'll specify that only Clawback is supported
+    puzzle_decorator: list[ClawbackPuzzleDecoratorOverride] | None = None
 
     def __post_init__(self) -> None:
         if len(self.additions) < 1:

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -1508,6 +1508,8 @@ class WalletRpcApi:
         action_scope: WalletActionScope,
         extra_conditions: tuple[Condition, ...] = tuple(),
     ) -> SendTransactionResponse:
+        # opportunity to raise
+        self.service.wallet_state_manager.get_wallet(id=request.wallet_id, required_type=Wallet)
         await self.create_signed_transaction(
             CreateSignedTransaction(
                 additions=[
@@ -2007,6 +2009,8 @@ class WalletRpcApi:
         extra_conditions: tuple[Condition, ...] = tuple(),
         hold_lock: bool = True,
     ) -> CATSpendResponse:
+        # opportunity to raise
+        self.service.wallet_state_manager.get_wallet(id=request.wallet_id, required_type=CATWallet)
         await self.create_signed_transaction(
             CreateSignedTransaction(
                 additions=request.additions


### PR DESCRIPTION
The `send_transaction` and `cat_spend` endpoints are simpler and less powerful versions of the `create_signed_transaction` endpoint.  In order to reduce duplication, this PR implements the former endpoints as calls to the latter endpoint much like how `send_transaction_multi` works.  We should probably deprecate all endpoints that are not `create_signed_transaction` but that's a task for another time and day.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes transaction creation by having `send_transaction` and `cat_spend` delegate to `create_signed_transaction`, reducing duplication and aligning behavior.
> 
> - Introduces `cat_discrepancy_validation` and reuses it in `CATSpend.cat_discrepancy` and `CreateSignedTransaction.cat_discrepancy`
> - Extends `CreateSignedTransaction` with CAT-specific fields (`extra_delta`, `tail_reveal`, `tail_solution`) and `puzzle_decorator`
> - Uses `ensure_valid_address` for `XCH` address validation; decodes to `puzzle_hash` before building `Addition`
> - Refactors RPC handlers to build `CreateSignedTransaction` payloads (including `additions`, `coins`, fees, memos, decorators) and call `create_signed_transaction`
> - Propagates `cat_discrepancy` and `puzzle_decorator` in transaction generation
> - Updates tests to reflect new validation paths and `additions` usage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 360afeddf8b7cd7137c936604733846343fee940. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->