### PR TITLE
[LABS-294] Add `kw_only` to all wallet RPC types

### DIFF
--- a/chia/_tests/cmds/cmd_test_utils.py
+++ b/chia/_tests/cmds/cmd_test_utils.py
@@ -124,12 +124,14 @@ class TestWalletRpcClient(TestRpcClient):
             w_type = WalletType.POOLING_WALLET
         else:
             raise ValueError(f"Invalid fingerprint: {self.fingerprint}")
-        return GetWalletsResponse([WalletInfoResponse(id=uint32(1), name="", type=uint8(w_type.value), data="")])
+        return GetWalletsResponse(
+            wallets=[WalletInfoResponse(id=uint32(1), name="", type=uint8(w_type.value), data="")]
+        )
 
     async def get_transaction(self, request: GetTransaction) -> GetTransactionResponse:
         self.add_to_log("get_transaction", (request,))
         return GetTransactionResponse(
-            TransactionRecord(
+            transaction=TransactionRecord(
                 confirmed_at_height=uint32(1),
                 created_at_time=uint64(1234),
                 to_puzzle_hash=bytes32([1] * 32),
@@ -149,12 +151,12 @@ class TestWalletRpcClient(TestRpcClient):
                 memos={bytes32([3] * 32): [bytes([4] * 32)]},
                 valid_times=ConditionValidTimes(),
             ),
-            bytes32([2] * 32),
+            transaction_id=bytes32([2] * 32),
         )
 
     async def get_cat_name(self, request: CATGetName) -> CATGetNameResponse:
         self.add_to_log("get_cat_name", (request.wallet_id,))
-        return CATGetNameResponse(request.wallet_id, "test" + str(request.wallet_id))
+        return CATGetNameResponse(wallet_id=request.wallet_id, name="test" + str(request.wallet_id))
 
     async def sign_message_by_address(self, request: SignMessageByAddress) -> SignMessageByAddressResponse:
         self.add_to_log("sign_message_by_address", (request.address, request.message))
@@ -170,7 +172,7 @@ class TestWalletRpcClient(TestRpcClient):
             )
         )
         signing_mode = SigningMode.CHIP_0002.value
-        return SignMessageByAddressResponse(pubkey, signature, signing_mode)
+        return SignMessageByAddressResponse(pubkey=pubkey, signature=signature, signing_mode=signing_mode)
 
     async def sign_message_by_id(self, request: SignMessageByID) -> SignMessageByIDResponse:
         self.add_to_log("sign_message_by_id", (request.id, request.message))
@@ -186,7 +188,9 @@ class TestWalletRpcClient(TestRpcClient):
             )
         )
         signing_mode = SigningMode.CHIP_0002.value
-        return SignMessageByIDResponse(pubkey, signature, bytes32.zeros, signing_mode)
+        return SignMessageByIDResponse(
+            pubkey=pubkey, signature=signature, latest_coin_id=bytes32.zeros, signing_mode=signing_mode
+        )
 
     async def cat_asset_id_to_name(self, request: CATAssetIDToName) -> CATAssetIDToNameResponse:
         """
@@ -195,7 +199,7 @@ class TestWalletRpcClient(TestRpcClient):
         self.add_to_log("cat_asset_id_to_name", (request.asset_id,))
         for i in range(256):
             if request.asset_id == get_bytes32(i):
-                return CATAssetIDToNameResponse(uint32(i + 1), "test" + str(i))
+                return CATAssetIDToNameResponse(wallet_id=uint32(i + 1), name="test" + str(i))
         return CATAssetIDToNameResponse(wallet_id=None, name=None)
 
     async def get_nft_info(self, request: NFTGetInfo) -> NFTGetInfoResponse:
@@ -223,7 +227,7 @@ class TestWalletRpcClient(TestRpcClient):
             supports_did=True,
             p2_address=bytes32([8] * 32),
         )
-        return NFTGetInfoResponse(nft_info)
+        return NFTGetInfoResponse(nft_info=nft_info)
 
     async def nft_calculate_royalties(
         self,
@@ -246,8 +250,8 @@ class TestWalletRpcClient(TestRpcClient):
     ) -> CreateNewWalletResponse:
         self.add_to_log("create_new_wallet", (request, tx_config, extra_conditions, timelock_info))
         return CreateNewWalletResponse(
-            [STD_UTX],
-            [STD_TX],
+            unsigned_transactions=[STD_UTX],
+            transactions=[STD_TX],
             type=(
                 WalletType.NFT if request.wallet_type == CreateNewWalletType.NFT_WALLET else WalletType.DECENTRALIZED_ID
             ).name,

--- a/chia/_tests/cmds/wallet/test_did.py
+++ b/chia/_tests/cmds/wallet/test_did.py
@@ -131,7 +131,7 @@ def test_did_set_name(capsys: object, get_test_cli_clients: tuple[TestRpcClients
     class DidSetNameRpcClient(TestWalletRpcClient):
         async def did_set_wallet_name(self, request: DIDSetWalletName) -> DIDSetWalletNameResponse:
             self.add_to_log("did_set_wallet_name", (request.wallet_id, request.name))
-            return DIDSetWalletNameResponse(request.wallet_id)
+            return DIDSetWalletNameResponse(wallet_id=request.wallet_id)
 
     inst_rpc_client = DidSetNameRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
@@ -239,7 +239,10 @@ def test_did_update_metadata(capsys: object, get_test_cli_clients: tuple[TestRpc
                 (request.wallet_id, request.metadata, tx_config, request.push, extra_conditions, timelock_info),
             )
             return DIDUpdateMetadataResponse(
-                [STD_UTX], [STD_TX], WalletSpendBundle([], G2Element()), uint32(request.wallet_id)
+                unsigned_transactions=[STD_UTX],
+                transactions=[STD_TX],
+                spend_bundle=WalletSpendBundle([], G2Element()),
+                wallet_id=uint32(request.wallet_id),
             )
 
     inst_rpc_client = DidUpdateMetadataRpcClient()
@@ -282,7 +285,7 @@ def test_did_find_lost(capsys: object, get_test_cli_clients: tuple[TestRpcClient
                 "find_lost_did",
                 (request.coin_id, request.recovery_list_hash, request.metadata, request.num_verification),
             )
-            return DIDFindLostDIDResponse(get_bytes32(2))
+            return DIDFindLostDIDResponse(latest_coin_id=get_bytes32(2))
 
     inst_rpc_client = DidFindLostRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
@@ -322,7 +325,9 @@ def test_did_message_spend(capsys: object, get_test_cli_clients: tuple[TestRpcCl
             self.add_to_log(
                 "did_message_spend", (request.wallet_id, tx_config, extra_conditions, request.push, timelock_info)
             )
-            return DIDMessageSpendResponse([STD_UTX], [STD_TX], WalletSpendBundle([], G2Element()))
+            return DIDMessageSpendResponse(
+                unsigned_transactions=[STD_UTX], transactions=[STD_TX], spend_bundle=WalletSpendBundle([], G2Element())
+            )
 
     inst_rpc_client = DidMessageSpendRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
@@ -391,10 +396,10 @@ def test_did_transfer(capsys: object, get_test_cli_clients: tuple[TestRpcClients
                 ),
             )
             return DIDTransferDIDResponse(
-                [STD_UTX],
-                [STD_TX],
-                STD_TX,
-                STD_TX.name,
+                unsigned_transactions=[STD_UTX],
+                transactions=[STD_TX],
+                transaction=STD_TX,
+                transaction_id=STD_TX.name,
             )
 
     inst_rpc_client = DidTransferRpcClient()

--- a/chia/_tests/cmds/wallet/test_nft.py
+++ b/chia/_tests/cmds/wallet/test_nft.py
@@ -90,7 +90,9 @@ def test_nft_mint(capsys: object, get_test_cli_clients: tuple[TestRpcClients, Pa
     class NFTCreateRpcClient(TestWalletRpcClient):
         async def get_nft_wallet_did(self, request: NFTGetWalletDID) -> NFTGetWalletDIDResponse:
             self.add_to_log("get_nft_wallet_did", (request.wallet_id,))
-            return NFTGetWalletDIDResponse("did:chia:1qgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpq4msw0c")
+            return NFTGetWalletDIDResponse(
+                did_id="did:chia:1qgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpq4msw0c"
+            )
 
         async def mint_nft(
             self,
@@ -123,11 +125,11 @@ def test_nft_mint(capsys: object, get_test_cli_clients: tuple[TestRpcClients, Pa
                 ),
             )
             return NFTMintNFTResponse(
-                [STD_UTX],
-                [STD_TX],
-                uint32(request.wallet_id),
-                WalletSpendBundle([], G2Element()),
-                bytes32.zeros.hex(),
+                unsigned_transactions=[STD_UTX],
+                transactions=[STD_TX],
+                wallet_id=uint32(request.wallet_id),
+                spend_bundle=WalletSpendBundle([], G2Element()),
+                nft_id=bytes32.zeros.hex(),
             )
 
     inst_rpc_client = NFTCreateRpcClient()
@@ -215,7 +217,12 @@ def test_nft_add_uri(capsys: object, get_test_cli_clients: tuple[TestRpcClients,
                     extra_conditions,
                 ),
             )
-            return NFTAddURIResponse([STD_UTX], [STD_TX], request.wallet_id, WalletSpendBundle([], G2Element()))
+            return NFTAddURIResponse(
+                unsigned_transactions=[STD_UTX],
+                transactions=[STD_TX],
+                wallet_id=request.wallet_id,
+                spend_bundle=WalletSpendBundle([], G2Element()),
+            )
 
     inst_rpc_client = NFTAddUriRpcClient()
     nft_coin_id = get_bytes32(2).hex()
@@ -285,10 +292,10 @@ def test_nft_transfer(capsys: object, get_test_cli_clients: tuple[TestRpcClients
                 ),
             )
             return NFTTransferNFTResponse(
-                [STD_UTX],
-                [STD_TX],
-                request.wallet_id,
-                WalletSpendBundle([], G2Element()),
+                unsigned_transactions=[STD_UTX],
+                transactions=[STD_TX],
+                wallet_id=request.wallet_id,
+                spend_bundle=WalletSpendBundle([], G2Element()),
             )
 
     inst_rpc_client = NFTTransferRpcClient()
@@ -367,7 +374,7 @@ def test_nft_list(capsys: object, get_test_cli_clients: tuple[TestRpcClients, Pa
                         p2_address=get_bytes32(8),
                     )
                 )
-            return NFTGetNFTsResponse(request.wallet_id, nft_list)
+            return NFTGetNFTsResponse(wallet_id=request.wallet_id, nft_list=nft_list)
 
     inst_rpc_client = NFTListRpcClient()
     launcher_ids = [bytes32([i] * 32).hex() for i in range(50, 60)]
@@ -422,10 +429,10 @@ def test_nft_set_did(capsys: object, get_test_cli_clients: tuple[TestRpcClients,
                 ),
             )
             return NFTSetNFTDIDResponse(
-                [STD_UTX],
-                [STD_TX],
-                request.wallet_id,
-                WalletSpendBundle([], G2Element()),
+                unsigned_transactions=[STD_UTX],
+                transactions=[STD_TX],
+                wallet_id=request.wallet_id,
+                spend_bundle=WalletSpendBundle([], G2Element()),
             )
 
     inst_rpc_client = NFTSetDidRpcClient()

--- a/chia/_tests/cmds/wallet/test_notifications.py
+++ b/chia/_tests/cmds/wallet/test_notifications.py
@@ -41,7 +41,7 @@ def test_notifications_send(capsys: object, get_test_cli_clients: tuple[TestRpcC
                 (request.target, request.message, request.amount, request.fee, request.push, timelock_info),
             )
 
-            return SendNotificationResponse([STD_UTX], [STD_TX], tx=STD_TX)
+            return SendNotificationResponse(unsigned_transactions=[STD_UTX], transactions=[STD_TX], tx=STD_TX)
 
     inst_rpc_client = NotificationsSendRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
@@ -82,7 +82,7 @@ def test_notifications_get(capsys: object, get_test_cli_clients: tuple[TestRpcCl
         async def get_notifications(self, request: GetNotifications) -> GetNotificationsResponse:
             self.add_to_log("get_notifications", (request,))
             return GetNotificationsResponse(
-                [Notification(get_bytes32(1), bytes("hello", "utf8"), uint64(1000000000), uint32(50))]
+                notifications=[Notification(get_bytes32(1), bytes("hello", "utf8"), uint64(1000000000), uint32(50))]
             )
 
     inst_rpc_client = NotificationsGetRpcClient()
@@ -104,7 +104,9 @@ def test_notifications_get(capsys: object, get_test_cli_clients: tuple[TestRpcCl
         "amount: 1000000000",
     ]
     run_cli_command_and_assert(capsys, root_dir, command_args, assert_list)
-    expected_calls: logType = {"get_notifications": [(GetNotifications([get_bytes32(1)], uint32(10), uint32(10)),)]}
+    expected_calls: logType = {
+        "get_notifications": [(GetNotifications(ids=[get_bytes32(1)], start=uint32(10), end=uint32(10)),)]
+    }
     test_rpc_clients.wallet_rpc_client.check_log(expected_calls)
 
 

--- a/chia/_tests/cmds/wallet/test_vcs.py
+++ b/chia/_tests/cmds/wallet/test_vcs.py
@@ -56,9 +56,9 @@ def test_vcs_mint(capsys: object, get_test_cli_clients: tuple[TestRpcClients, Pa
             )
 
             return VCMintResponse(
-                [STD_UTX],
-                [STD_TX],
-                VCRecord(
+                unsigned_transactions=[STD_UTX],
+                transactions=[STD_TX],
+                vc_record=VCRecord(
                     VerifiedCredential(
                         STD_TX.removals[0],
                         LineageProof(None, None, None),
@@ -110,7 +110,7 @@ def test_vcs_get(capsys: object, get_test_cli_clients: tuple[TestRpcClients, Pat
     class VcsGetRpcClient(TestWalletRpcClient):
         async def vc_get_list(self, request: VCGetList) -> VCGetListResponse:
             self.add_to_log("vc_get_list", (request.start, request.end))
-            proofs = [VCProofWithHash(get_bytes32(1), VCProofsRPC([("proof here", "")]))]
+            proofs = [VCProofWithHash(hash=get_bytes32(1), proof=VCProofsRPC(key_value_pairs=[("proof here", "")]))]
             records = [
                 VCRecordWithCoinID(
                     VerifiedCredential(
@@ -123,10 +123,10 @@ def test_vcs_get(capsys: object, get_test_cli_clients: tuple[TestRpcClients, Pat
                         None,
                     ),
                     uint32(0),
-                    bytes32.zeros,
+                    coin_id=bytes32.zeros,
                 )
             ]
-            return VCGetListResponse(records, proofs)
+            return VCGetListResponse(vc_records=records, proofs=proofs)
 
     inst_rpc_client = VcsGetRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
@@ -166,7 +166,7 @@ def test_vcs_update_proofs(capsys: object, get_test_cli_clients: tuple[TestRpcCl
                     timelock_info,
                 ),
             )
-            return VCSpendResponse([STD_UTX], [STD_TX])
+            return VCSpendResponse(unsigned_transactions=[STD_UTX], transactions=[STD_TX])
 
     inst_rpc_client = VcsUpdateProofsRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
@@ -241,7 +241,7 @@ def test_vcs_get_proofs_for_root(capsys: object, get_test_cli_clients: tuple[Tes
     class VcsGetProofsForRootRpcClient(TestWalletRpcClient):
         async def vc_get_proofs_for_root(self, request: VCGetProofsForRoot) -> VCGetProofsForRootResponse:
             self.add_to_log("vc_get_proofs_for_root", (request.root,))
-            return VCGetProofsForRootResponse([("test_proof", "1"), ("test_proof2", "1")])
+            return VCGetProofsForRootResponse(key_value_pairs=[("test_proof", "1"), ("test_proof2", "1")])
 
     inst_rpc_client = VcsGetProofsForRootRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
@@ -264,7 +264,7 @@ def test_vcs_revoke(capsys: object, get_test_cli_clients: tuple[TestRpcClients, 
             self.add_to_log("vc_get", (request.vc_id,))
 
             return VCGetResponse(
-                VCRecord(
+                vc_record=VCRecord(
                     VerifiedCredential(
                         Coin(get_bytes32(1), get_bytes32(2), uint64(12345678)),
                         LineageProof(),
@@ -285,7 +285,7 @@ def test_vcs_revoke(capsys: object, get_test_cli_clients: tuple[TestRpcClients, 
             timelock_info: ConditionValidTimes = ConditionValidTimes(),
         ) -> VCRevokeResponse:
             self.add_to_log("vc_revoke", (request.vc_parent_id, tx_config, request.fee, request.push, timelock_info))
-            return VCRevokeResponse([STD_UTX], [STD_TX])
+            return VCRevokeResponse(unsigned_transactions=[STD_UTX], transactions=[STD_TX])
 
     inst_rpc_client = VcsRevokeRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client
@@ -352,7 +352,7 @@ def test_vcs_approve_r_cats(capsys: object, get_test_cli_clients: tuple[TestRpcC
                     timelock_info,
                 ),
             )
-            return CRCATApprovePendingResponse([STD_UTX], [STD_TX])
+            return CRCATApprovePendingResponse(unsigned_transactions=[STD_UTX], transactions=[STD_TX])
 
     inst_rpc_client = VcsApproveRCATSRpcClient()
     test_rpc_clients.wallet_rpc_client = inst_rpc_client

--- a/chia/_tests/core/cmds/test_wallet.py
+++ b/chia/_tests/core/cmds/test_wallet.py
@@ -21,7 +21,8 @@ TEST_ASSET_ID_NAME_MAPPING: dict[bytes32, tuple[uint32, str]] = {
 
 
 async def cat_name_resolver(request: CATAssetIDToName) -> CATAssetIDToNameResponse:
-    return CATAssetIDToNameResponse(*TEST_ASSET_ID_NAME_MAPPING.get(request.asset_id, (None, None)))
+    wallet_id, name = TEST_ASSET_ID_NAME_MAPPING.get(request.asset_id, (None, None))
+    return CATAssetIDToNameResponse(wallet_id=wallet_id, name=name)
 
 
 @pytest.mark.anyio

--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -219,7 +219,9 @@ async def check_coin_state(wallet_node: WalletNode, coin_id: bytes32) -> bool:
 
 
 async def check_singleton_confirmed(dl: DataLayer, store_id: bytes32) -> bool:
-    return (await dl.wallet_rpc.dl_latest_singleton(DLLatestSingleton(store_id, True))).singleton is not None
+    return (
+        await dl.wallet_rpc.dl_latest_singleton(DLLatestSingleton(launcher_id=store_id, only_confirmed=True))
+    ).singleton is not None
 
 
 async def process_block_and_check_offer_validity(offer: TradingOffer, offer_setup: OfferSetup) -> bool:

--- a/chia/_tests/environments/wallet.py
+++ b/chia/_tests/environments/wallet.py
@@ -171,7 +171,7 @@ class WalletEnvironment:
                 ),
             }
             balance_response: dict[str, int] = (
-                await self.rpc_client.get_wallet_balance(GetWalletBalance(wallet_id))
+                await self.rpc_client.get_wallet_balance(GetWalletBalance(wallet_id=wallet_id))
             ).wallet_balance.to_json_dict()
 
             if not expected_result.items() <= balance_response.items():

--- a/chia/_tests/pools/test_pool_cmdline.py
+++ b/chia/_tests/pools/test_pool_cmdline.py
@@ -326,7 +326,7 @@ async def test_plotnft_cli_show_with_farmer(
         assert "Current state" not in out
 
         wallet_id = await create_new_plotnft(wallet_environments)
-        pw_info = (await wallet_rpc.pw_status(PWStatus(uint32(wallet_id)))).state
+        pw_info = (await wallet_rpc.pw_status(PWStatus(wallet_id=uint32(wallet_id)))).state
 
         await ShowPlotNFTCMD(
             context=ChiaCliContext(root_path=root_path),
@@ -680,7 +680,7 @@ async def test_plotnft_cli_claim(
     # Create a self-pooling plotnft
     wallet_id = await create_new_plotnft(wallet_environments, self_pool=True)
 
-    status = (await wallet_rpc.pw_status(PWStatus(uint32(wallet_id)))).state
+    status = (await wallet_rpc.pw_status(PWStatus(wallet_id=uint32(wallet_id)))).state
     async with wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
         our_ph = await action_scope.get_puzzle_hash(wallet_state_manager)
     bt = wallet_environments.full_node.bt
@@ -878,7 +878,7 @@ async def test_plotnft_cli_change_payout(
     root_path = wallet_environments.environments[0].node.root_path
 
     wallet_id = await create_new_plotnft(wallet_environments)
-    pw_info = (await wallet_rpc.pw_status(PWStatus(uint32(wallet_id)))).state
+    pw_info = (await wallet_rpc.pw_status(PWStatus(wallet_id=uint32(wallet_id)))).state
 
     # This tests what happens when using None for root_path
     mocker.patch("chia.cmds.plotnft_funcs.DEFAULT_ROOT_PATH", root_path)

--- a/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
@@ -1509,7 +1509,7 @@ async def test_cat_change_detection(wallet_environments: WalletTestFramework, wa
             ),
         ],
     )
-    await env.rpc_client.push_tx(PushTX(eve_spend))
+    await env.rpc_client.push_tx(PushTX(spend_bundle=eve_spend))
     await time_out_assert_not_none(5, full_node_api.full_node.mempool_manager.get_spendbundle, eve_spend.name())
     await wallet_environments.process_pending_states(
         [
@@ -1623,7 +1623,7 @@ async def test_cat_melt_balance(wallet_environments: WalletTestFramework) -> Non
                 )
             ],
         )
-    await env.rpc_client.push_tx(PushTX(spend_to_wallet))
+    await env.rpc_client.push_tx(PushTX(spend_bundle=spend_to_wallet))
     await time_out_assert(10, simulator.tx_id_in_mempool, True, spend_to_wallet.name())
 
     await wallet_environments.process_pending_states(
@@ -1675,7 +1675,7 @@ async def test_cat_melt_balance(wallet_environments: WalletTestFramework) -> Non
             ],
         )
         signed_spend, _ = await env.wallet_state_manager.sign_bundle(new_spend.coin_spends)
-        await env.rpc_client.push_tx(PushTX(signed_spend))
+        await env.rpc_client.push_tx(PushTX(spend_bundle=signed_spend))
         await time_out_assert(10, simulator.tx_id_in_mempool, True, signed_spend.name())
 
         await wallet_environments.process_pending_states(

--- a/chia/_tests/wallet/cat_wallet/test_trades.py
+++ b/chia/_tests/wallet/cat_wallet/test_trades.py
@@ -373,7 +373,7 @@ async def test_cat_trades(
     if credential_restricted:
         await client_maker.vc_add_proofs(VCAddProofs.from_vc_proofs(proofs_maker))
         assert (
-            await client_maker.vc_get_proofs_for_root(VCGetProofsForRoot(proof_root_maker))
+            await client_maker.vc_get_proofs_for_root(VCGetProofsForRoot(root=proof_root_maker))
         ).to_vc_proofs().key_value_pairs == proofs_maker.key_value_pairs
         get_list_reponse = await client_maker.vc_get_list(VCGetList())
         assert len(get_list_reponse.vc_records) == 1
@@ -381,7 +381,7 @@ async def test_cat_trades(
 
         await client_taker.vc_add_proofs(VCAddProofs.from_vc_proofs(proofs_taker))
         assert (
-            await client_taker.vc_get_proofs_for_root(VCGetProofsForRoot(proof_root_taker))
+            await client_taker.vc_get_proofs_for_root(VCGetProofsForRoot(root=proof_root_taker))
         ).to_vc_proofs().key_value_pairs == proofs_taker.key_value_pairs
         get_list_reponse = await client_taker.vc_get_list(VCGetList())
         assert len(get_list_reponse.vc_records) == 1

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -302,7 +302,7 @@ async def test_creation_from_backup_file(wallet_environments: WalletTestFramewor
     )
     did_wallet_2 = env_2.wallet_state_manager.get_wallet(id=uint32(2), required_type=DIDWallet)
     current_coin_info_response = await env_0.rpc_client.did_get_current_coin_info(
-        DIDGetCurrentCoinInfo(uint32(env_0.wallet_aliases["did"]))
+        DIDGetCurrentCoinInfo(wallet_id=uint32(env_0.wallet_aliases["did"]))
     )
     assert current_coin_info_response.wallet_id == env_0.wallet_aliases["did"]
 
@@ -370,7 +370,7 @@ async def test_did_find_lost_did(wallet_environments: WalletTestFramework):
     assert len(wallet_node_0.wallet_state_manager.wallets) == 1
     # Find lost DID
     assert did_wallet_0.did_info.origin_coin is not None  # mypy
-    await env_0.rpc_client.find_lost_did(DIDFindLostDID(did_wallet_0.did_info.origin_coin.name().hex()))
+    await env_0.rpc_client.find_lost_did(DIDFindLostDID(coin_id=did_wallet_0.did_info.origin_coin.name().hex()))
     did_wallets = list(
         filter(
             lambda w: (w.type == WalletType.DECENTRALIZED_ID),
@@ -434,7 +434,7 @@ async def test_did_find_lost_did(wallet_environments: WalletTestFramework):
     did_wallet.did_info = dataclasses.replace(did_wallet.did_info, current_inner=new_inner_puzzle)
     # Recovery the coin
     assert did_wallet.did_info.origin_coin is not None  # mypy
-    await env_0.rpc_client.find_lost_did(DIDFindLostDID(did_wallet.did_info.origin_coin.name().hex()))
+    await env_0.rpc_client.find_lost_did(DIDFindLostDID(coin_id=did_wallet.did_info.origin_coin.name().hex()))
     found_coin = await did_wallet.get_coin()
     assert found_coin == coin
     assert did_wallet.did_info.current_inner != new_inner_puzzle
@@ -782,8 +782,8 @@ async def test_get_info(wallet_environments: WalletTestFramework):
     )
     assert did_wallet_1.did_info.origin_coin is not None  # mypy
     coin_id_as_bech32 = encode_puzzle_hash(did_wallet_1.did_info.origin_coin.name(), AddressType.DID.value)
-    response = await api_0.get_did_info(DIDGetInfo(did_wallet_1.did_info.origin_coin.name().hex()))
-    response_with_bech32 = await api_0.get_did_info(DIDGetInfo(coin_id_as_bech32))
+    response = await api_0.get_did_info(DIDGetInfo(coin_id=did_wallet_1.did_info.origin_coin.name().hex()))
+    response_with_bech32 = await api_0.get_did_info(DIDGetInfo(coin_id=coin_id_as_bech32))
     assert response == response_with_bech32
     assert response.did_id == coin_id_as_bech32
     assert response.launcher_id == did_wallet_1.did_info.origin_coin.name()
@@ -803,7 +803,7 @@ async def test_get_info(wallet_environments: WalletTestFramework):
     assert coin.amount % 2 == 1
     coin_id = coin.name()
     with pytest.raises(ValueError, match="The coin is not a DID"):
-        await api_0.get_did_info(DIDGetInfo(coin_id.hex()))
+        await api_0.get_did_info(DIDGetInfo(coin_id=coin_id.hex()))
 
     # Test multiple odd coins
     odd_amount = uint64(1)
@@ -857,7 +857,7 @@ async def test_get_info(wallet_environments: WalletTestFramework):
     )
 
     with pytest.raises(ValueError, match=r"This is not a singleton, multiple children coins found."):
-        await api_0.get_did_info(DIDGetInfo(coin_1.name().hex()))
+        await api_0.get_did_info(DIDGetInfo(coin_id=coin_1.name().hex()))
 
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="irrelevant")

--- a/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_bulk_mint.py
@@ -433,7 +433,12 @@ async def test_nft_mint_rpc(wallet_environments: WalletTestFramework, zero_royal
     )
 
     # check NFT edition numbers
-    nfts = [nft for nft in (await env_1.rpc_client.list_nfts(NFTGetNFTs(uint32(env_1.wallet_aliases["nft"])))).nft_list]
+    nfts = [
+        nft
+        for nft in (
+            await env_1.rpc_client.list_nfts(NFTGetNFTs(wallet_id=uint32(env_1.wallet_aliases["nft"])))
+        ).nft_list
+    ]
     for nft in nfts:
         edition_num = nft.edition_number
         meta_dict = metadata_list[edition_num - 1]

--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -535,7 +535,9 @@ async def test_nft_wallet_creation_and_transfer(wallet_environments: WalletTestF
             NFTSetNFTDID(
                 wallet_id=uint32(env_1.wallet_aliases["nft"]),
                 did_id=None,
-                nft_coin_id=(await env_1.rpc_client.list_nfts(NFTGetNFTs(uint32(env_1.wallet_aliases["nft"]))))
+                nft_coin_id=(
+                    await env_1.rpc_client.list_nfts(NFTGetNFTs(wallet_id=uint32(env_1.wallet_aliases["nft"])))
+                )
                 .nft_list[0]
                 .nft_coin_id,
             ),
@@ -659,10 +661,10 @@ async def test_nft_wallet_rpc_creation_and_list(wallet_environments: WalletTestF
     assert coins[0].data_hash.hex() == "0xD4584AD463139FA8C0D9F68F4B59F184D4584AD463139FA8C0D9F68F4B59F184"[2:].lower()
 
     # test counts
-    assert (await env.rpc_client.count_nfts(NFTCountNFTs(uint32(env.wallet_aliases["nft"])))).count == 2
+    assert (await env.rpc_client.count_nfts(NFTCountNFTs(wallet_id=uint32(env.wallet_aliases["nft"])))).count == 2
     assert (await env.rpc_client.count_nfts(NFTCountNFTs())).count == 2
     with pytest.raises(ResponseFailureError, match="Wallet with id 50 does not exist"):
-        await env.rpc_client.count_nfts(NFTCountNFTs(uint32(50)))
+        await env.rpc_client.count_nfts(NFTCountNFTs(wallet_id=uint32(50)))
 
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="irrelevant")
@@ -715,7 +717,7 @@ async def test_sign_message_by_nft_id(wallet_environments: WalletTestFramework) 
         ]
     )
 
-    nft_list = await env.rpc_client.list_nfts(NFTGetNFTs(uint32(env.wallet_aliases["nft"])))
+    nft_list = await env.rpc_client.list_nfts(NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft"])))
     nft_id = nft_list.nft_list[0].nft_id
 
     # Test general string
@@ -826,7 +828,7 @@ async def test_nft_wallet_rpc_update_metadata(wallet_environments: WalletTestFra
     )
 
     coins: list[NFTInfo] = (
-        await env.rpc_client.list_nfts(NFTGetNFTs(nft_wallet.id(), start_index=uint32(0), num=uint32(1)))
+        await env.rpc_client.list_nfts(NFTGetNFTs(wallet_id=nft_wallet.id(), start_index=uint32(0), num=uint32(1)))
     ).nft_list
     coin = coins[0]
     assert coin.mint_height > 0
@@ -857,7 +859,9 @@ async def test_nft_wallet_rpc_update_metadata(wallet_environments: WalletTestFra
         tx_config=wallet_environments.tx_config,
     )
 
-    coins = (await env.rpc_client.list_nfts(NFTGetNFTs(nft_wallet.id(), start_index=uint32(0), num=uint32(1)))).nft_list
+    coins = (
+        await env.rpc_client.list_nfts(NFTGetNFTs(wallet_id=nft_wallet.id(), start_index=uint32(0), num=uint32(1)))
+    ).nft_list
     assert coins[0].pending_transaction
 
     await wallet_environments.process_pending_states(
@@ -876,7 +880,9 @@ async def test_nft_wallet_rpc_update_metadata(wallet_environments: WalletTestFra
     )
 
     # check that new URI was added
-    coins = (await env.rpc_client.list_nfts(NFTGetNFTs(nft_wallet.id(), start_index=uint32(0), num=uint32(1)))).nft_list
+    coins = (
+        await env.rpc_client.list_nfts(NFTGetNFTs(wallet_id=nft_wallet.id(), start_index=uint32(0), num=uint32(1)))
+    ).nft_list
     assert len(coins) == 1
     coin = coins[0]
     assert coin.mint_height > 0
@@ -915,7 +921,9 @@ async def test_nft_wallet_rpc_update_metadata(wallet_environments: WalletTestFra
         ]
     )
 
-    coins = (await env.rpc_client.list_nfts(NFTGetNFTs(nft_wallet.id(), start_index=uint32(0), num=uint32(1)))).nft_list
+    coins = (
+        await env.rpc_client.list_nfts(NFTGetNFTs(wallet_id=nft_wallet.id(), start_index=uint32(0), num=uint32(1)))
+    ).nft_list
     assert len(coins) == 1
     coin = coins[0]
     assert coin.mint_height > 0
@@ -1005,7 +1013,7 @@ async def test_nft_with_did_wallet_creation(wallet_environments: WalletTestFrame
         NFTWalletWithDID(wallet_id=nft_wallet.id(), did_id=hmr_did_id, did_wallet_id=did_wallet.id())
     ]
 
-    get_did_res = await env.rpc_client.get_nft_wallet_did(NFTGetWalletDID(nft_wallet.id()))
+    get_did_res = await env.rpc_client.get_nft_wallet_did(NFTGetWalletDID(wallet_id=nft_wallet.id()))
     assert get_did_res.did_id == hmr_did_id
 
     # Create a NFT with DID
@@ -1101,7 +1109,7 @@ async def test_nft_with_did_wallet_creation(wallet_environments: WalletTestFrame
     )
     # Check DID NFT
     coins: list[NFTInfo] = (
-        await env.rpc_client.list_nfts(NFTGetNFTs(nft_wallet.id(), start_index=uint32(0), num=uint32(1)))
+        await env.rpc_client.list_nfts(NFTGetNFTs(wallet_id=nft_wallet.id(), start_index=uint32(0), num=uint32(1)))
     ).nft_list
     assert len(coins) == 1
     did_nft = coins[0]
@@ -1117,7 +1125,7 @@ async def test_nft_with_did_wallet_creation(wallet_environments: WalletTestFrame
     nft_wallets = await env.wallet_state_manager.get_all_wallet_info_entries(WalletType.NFT)
     assert len(nft_wallets) == 2
     coins = (
-        await env.rpc_client.list_nfts(NFTGetNFTs(nft_wallet_p2_puzzle, start_index=uint32(0), num=uint32(1)))
+        await env.rpc_client.list_nfts(NFTGetNFTs(wallet_id=nft_wallet_p2_puzzle, start_index=uint32(0), num=uint32(1)))
     ).nft_list
     assert len(coins) == 1
     non_did_nft = coins[0]
@@ -1245,7 +1253,7 @@ async def test_nft_rpc_mint(wallet_environments: WalletTestFramework) -> None:
 
     coins: list[NFTInfo] = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft_w_did"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft_w_did"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -1387,7 +1395,7 @@ async def test_nft_transfer_nft_with_did(wallet_environments: WalletTestFramewor
     # Check DID NFT
     coins: list[NFTInfo] = (
         await env_0.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env_0.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env_0.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -1495,7 +1503,7 @@ async def test_nft_transfer_nft_with_did(wallet_environments: WalletTestFramewor
     assert env_1.wallet_aliases["nft"] == wallet_by_did_response.wallet_id
     coins = (
         await env_1.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env_1.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env_1.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -1563,7 +1571,7 @@ async def test_nft_transfer_nft_with_did(wallet_environments: WalletTestFramewor
     # Check NFT DID is set now
     coins = (
         await env_1.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env_1.wallet_aliases["nft_w_did"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env_1.wallet_aliases["nft_w_did"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -1687,7 +1695,7 @@ async def test_update_metadata_for_nft_did(wallet_environments: WalletTestFramew
 
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -1712,7 +1720,7 @@ async def test_update_metadata_for_nft_did(wallet_environments: WalletTestFramew
 
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -1749,7 +1757,7 @@ async def test_update_metadata_for_nft_did(wallet_environments: WalletTestFramew
     # check that new URI was added
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -1979,7 +1987,7 @@ async def test_nft_bulk_set_did(wallet_environments: WalletTestFramework) -> Non
     # Check DID NFT
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft_w_did"]), start_index=uint32(0), num=uint32(2))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft_w_did"]), start_index=uint32(0), num=uint32(2))
         )
     ).nft_list
     assert len(coins) == 2
@@ -1989,7 +1997,7 @@ async def test_nft_bulk_set_did(wallet_environments: WalletTestFramework) -> Non
     assert nft12.owner_did is not None
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft_no_did"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft_no_did"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -2018,7 +2026,7 @@ async def test_nft_bulk_set_did(wallet_environments: WalletTestFramework) -> Non
     assert set_did_bulk_resp.tx_num == 5  # 1 for each NFT being spent (3), 1 for fee tx, 1 for did tx
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft_w_did"]), start_index=uint32(0), num=uint32(2))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft_w_did"]), start_index=uint32(0), num=uint32(2))
         )
     ).nft_list
     assert len(coins) == 2
@@ -2072,7 +2080,7 @@ async def test_nft_bulk_set_did(wallet_environments: WalletTestFramework) -> Non
     assert env.wallet_aliases["nft_w_did"] == wallet_by_did_response.wallet_id
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft_w_did"]), start_index=uint32(0), num=uint32(3))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft_w_did"]), start_index=uint32(0), num=uint32(3))
         )
     ).nft_list
     assert len(coins) == 3
@@ -2315,7 +2323,7 @@ async def test_nft_bulk_transfer(wallet_environments: WalletTestFramework) -> No
     # Check DID NFT
     coins = (
         await env_0.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env_0.wallet_aliases["nft_w_did"]), start_index=uint32(0), num=uint32(2))
+            NFTGetNFTs(wallet_id=uint32(env_0.wallet_aliases["nft_w_did"]), start_index=uint32(0), num=uint32(2))
         )
     ).nft_list
     assert len(coins) == 2
@@ -2325,7 +2333,7 @@ async def test_nft_bulk_transfer(wallet_environments: WalletTestFramework) -> No
     assert nft12.owner_did is not None
     coins = (
         await env_0.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env_0.wallet_aliases["nft_no_did"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env_0.wallet_aliases["nft_no_did"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -2399,7 +2407,7 @@ async def test_nft_bulk_transfer(wallet_environments: WalletTestFramework) -> No
     await time_out_assert(30, get_wallet_number, 2, env_1.wallet_state_manager)
     coins = (
         await env_1.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env_1.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(3))
+            NFTGetNFTs(wallet_id=uint32(env_1.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(3))
         )
     ).nft_list
     assert len(coins) == 3
@@ -2510,7 +2518,7 @@ async def test_nft_set_did(wallet_environments: WalletTestFramework) -> None:
     # Check DID NFT
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft_no_did"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft_no_did"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -2583,7 +2591,7 @@ async def test_nft_set_did(wallet_environments: WalletTestFramework) -> None:
 
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft_w_did1"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft_w_did1"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -2640,7 +2648,7 @@ async def test_nft_set_did(wallet_environments: WalletTestFramework) -> None:
     # Check NFT DID
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft_w_did2"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft_w_did2"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -2682,7 +2690,7 @@ async def test_nft_set_did(wallet_environments: WalletTestFramework) -> None:
     # Check NFT DID
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft_no_did"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft_no_did"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -2767,7 +2775,7 @@ async def test_set_nft_status(wallet_environments: WalletTestFramework) -> None:
     # Check DID NFT
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -2781,7 +2789,7 @@ async def test_set_nft_status(wallet_environments: WalletTestFramework) -> None:
     )
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1
@@ -2868,7 +2876,7 @@ async def test_nft_sign_message(wallet_environments: WalletTestFramework) -> Non
     # Check DID NFT
     coins = (
         await env.rpc_client.list_nfts(
-            NFTGetNFTs(uint32(env.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
+            NFTGetNFTs(wallet_id=uint32(env.wallet_aliases["nft"]), start_index=uint32(0), num=uint32(1))
         )
     ).nft_list
     assert len(coins) == 1

--- a/chia/_tests/wallet/test_coin_management.py
+++ b/chia/_tests/wallet/test_coin_management.py
@@ -256,7 +256,7 @@ async def test_list(wallet_environments: WalletTestFramework, capsys: pytest.Cap
     assert base_command.rpc_info.client_info is not None
 
     async def not_synced() -> GetSyncStatusResponse:
-        return GetSyncStatusResponse(False, False)
+        return GetSyncStatusResponse(synced=False, syncing=False)
 
     base_command.rpc_info.client_info.client.get_sync_status = not_synced  # type: ignore[method-assign]
     await base_command.run()

--- a/chia/_tests/wallet/test_signer_protocol.py
+++ b/chia/_tests/wallet/test_signer_protocol.py
@@ -178,7 +178,9 @@ async def test_p2dohp_wallet_signer_protocol(wallet_environments: WalletTestFram
     assert utx.signing_instructions.targets[0].message == message
 
     signing_responses: list[SigningResponse] = (
-        await wallet_rpc.execute_signing_instructions(ExecuteSigningInstructions(utx.signing_instructions))
+        await wallet_rpc.execute_signing_instructions(
+            ExecuteSigningInstructions(signing_instructions=utx.signing_instructions)
+        )
     ).signing_responses
     assert len(signing_responses) == 1
     assert signing_responses[0].hook == utx.signing_instructions.targets[0].hook
@@ -288,7 +290,7 @@ async def test_p2dohp_wallet_signer_protocol(wallet_environments: WalletTestFram
 
     # And test that we can get compressed versions if we want
     request = GatherSigningInfo(
-        [Spend.from_coin_spend(coin_spend), Spend.from_coin_spend(not_our_coin_spend)]
+        spends=[Spend.from_coin_spend(coin_spend), Spend.from_coin_spend(not_our_coin_spend)]
     ).to_json_dict()
     response_dict = await wallet_rpc.fetch("gather_signing_info", {"translation": "chip-0029", **request})
     response: GatherSigningInfoResponse = json_deserialize_with_clvm_streamable(

--- a/chia/_tests/wallet/test_wallet_state_manager.py
+++ b/chia/_tests/wallet/test_wallet_state_manager.py
@@ -425,7 +425,7 @@ async def test_puzzle_hash_requests(wallet_environments: WalletTestFramework) ->
             (0,),
         )
     with pytest.raises(ValueError):
-        await rpc_client.extend_derivation_index(ExtendDerivationIndex(uint32(0)))
+        await rpc_client.extend_derivation_index(ExtendDerivationIndex(index=uint32(0)))
 
     # Reset to a normal state
     await wsm.puzzle_store.delete_wallet(wsm.main_wallet.id())
@@ -436,17 +436,17 @@ async def test_puzzle_hash_requests(wallet_environments: WalletTestFramework) ->
 
     # Test an index already created
     with pytest.raises(ValueError):
-        await rpc_client.extend_derivation_index(ExtendDerivationIndex(uint32(0)))
+        await rpc_client.extend_derivation_index(ExtendDerivationIndex(index=uint32(0)))
 
     # Test an index too far in the future
     with pytest.raises(ValueError):
         await rpc_client.extend_derivation_index(
-            ExtendDerivationIndex(uint32(MAX_DERIVATION_INDEX_DELTA + expected_state.highest_index + 1))
+            ExtendDerivationIndex(index=uint32(MAX_DERIVATION_INDEX_DELTA + expected_state.highest_index + 1))
         )
 
     # Test the actual functionality
     assert (
-        await rpc_client.extend_derivation_index(ExtendDerivationIndex(uint32(expected_state.highest_index + 5)))
+        await rpc_client.extend_derivation_index(ExtendDerivationIndex(index=uint32(expected_state.highest_index + 5)))
     ).index == expected_state.highest_index + 5
     expected_state = PuzzleHashState(expected_state.highest_index + 5, expected_state.used_up_to_index)
     assert await get_puzzle_hash_state() == expected_state

--- a/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
@@ -240,7 +240,7 @@ async def test_vc_lifecycle(wallet_environments: WalletTestFramework) -> None:
             WalletStateTransition(),
         ]
     )
-    new_vc_record: VCRecord | None = (await client_0.vc_get(VCGet(vc_record.vc.launcher_id))).vc_record
+    new_vc_record: VCRecord | None = (await client_0.vc_get(VCGet(vc_id=vc_record.vc.launcher_id))).vc_record
     assert new_vc_record is not None
 
     # Spend VC
@@ -296,7 +296,7 @@ async def test_vc_lifecycle(wallet_environments: WalletTestFramework) -> None:
             WalletStateTransition(),
         ]
     )
-    vc_record_updated: VCRecord | None = (await client_0.vc_get(VCGet(vc_record.vc.launcher_id))).vc_record
+    vc_record_updated: VCRecord | None = (await client_0.vc_get(VCGet(vc_id=vc_record.vc.launcher_id))).vc_record
     assert vc_record_updated is not None
     assert vc_record_updated.vc.proof_hash == proof_root
 
@@ -325,7 +325,7 @@ async def test_vc_lifecycle(wallet_environments: WalletTestFramework) -> None:
     # Doing it again just to make sure it doesn't care
     await client_0.vc_add_proofs(VCAddProofs.from_vc_proofs(proofs))
     assert (
-        await client_0.vc_get_proofs_for_root(VCGetProofsForRoot(proof_root))
+        await client_0.vc_get_proofs_for_root(VCGetProofsForRoot(root=proof_root))
     ).to_vc_proofs().key_value_pairs == proofs.key_value_pairs
     get_list_reponse = await client_0.vc_get_list(VCGetList())
     assert len(get_list_reponse.vc_records) == 1
@@ -467,9 +467,9 @@ async def test_vc_lifecycle(wallet_environments: WalletTestFramework) -> None:
     pending_tx = (
         await client_1.get_transactions(
             GetTransactions(
-                uint32(env_1.dealias_wallet_id("crcat")),
-                uint32(0),
-                uint32(1),
+                wallet_id=uint32(env_1.dealias_wallet_id("crcat")),
+                start=uint32(0),
+                end=uint32(1),
                 reverse=True,
                 type_filter=TransactionTypeFilter.include([TransactionType.INCOMING_CRCAT_PENDING]),
             )
@@ -637,7 +637,7 @@ async def test_vc_lifecycle(wallet_environments: WalletTestFramework) -> None:
             ),
         ]
     )
-    vc_record_updated = (await client_1.vc_get(VCGet(vc_record_updated.vc.launcher_id))).vc_record
+    vc_record_updated = (await client_1.vc_get(VCGet(vc_id=vc_record_updated.vc.launcher_id))).vc_record
     assert vc_record_updated is not None
 
     # Revoke VC
@@ -753,7 +753,7 @@ async def test_self_revoke(wallet_environments: WalletTestFramework) -> None:
             )
         ]
     )
-    new_vc_record: VCRecord | None = (await client_0.vc_get(VCGet(vc_record.vc.launcher_id))).vc_record
+    new_vc_record: VCRecord | None = (await client_0.vc_get(VCGet(vc_id=vc_record.vc.launcher_id))).vc_record
     assert new_vc_record is not None
 
     # Test a negative case real quick (mostly unrelated)
@@ -809,7 +809,7 @@ async def test_self_revoke(wallet_environments: WalletTestFramework) -> None:
             )
         ]
     )
-    vc_record_revoked: VCRecord | None = (await client_0.vc_get(VCGet(vc_record.vc.launcher_id))).vc_record
+    vc_record_revoked: VCRecord | None = (await client_0.vc_get(VCGet(vc_id=vc_record.vc.launcher_id))).vc_record
     assert vc_record_revoked is None
     assert (
         len(await (await wallet_node_0.wallet_state_manager.get_or_create_vc_wallet()).store.get_unconfirmed_vcs()) == 0

--- a/chia/cmds/cmds_util.py
+++ b/chia/cmds/cmds_util.py
@@ -236,7 +236,7 @@ async def get_wallet(root_path: Path, wallet_client: WalletRpcClient, fingerprin
 
         if selected_fingerprint is not None:
             try:
-                await wallet_client.log_in(LogIn(uint32(selected_fingerprint)))
+                await wallet_client.log_in(LogIn(fingerprint=uint32(selected_fingerprint)))
             except ValueError as e:
                 raise CliRpcConnectionError(f"Login failed for fingerprint {selected_fingerprint}: {e.args[0]}")
 

--- a/chia/cmds/coin_funcs.py
+++ b/chia/cmds/coin_funcs.py
@@ -221,14 +221,14 @@ async def async_split(
         return []
 
     if number_of_coins is None:
-        response = await client_info.client.get_coin_records_by_names(GetCoinRecordsByNames([target_coin_id]))
+        response = await client_info.client.get_coin_records_by_names(GetCoinRecordsByNames(names=[target_coin_id]))
         if len(response.coin_records) == 0:
             print("Could not find target coin.")
             return []
         assert amount_per_coin is not None
         number_of_coins = int(response.coin_records[0].coin.amount // amount_per_coin.convert_amount(mojo_per_unit))
     elif amount_per_coin is None:
-        response = await client_info.client.get_coin_records_by_names(GetCoinRecordsByNames([target_coin_id]))
+        response = await client_info.client.get_coin_records_by_names(GetCoinRecordsByNames(names=[target_coin_id]))
         if len(response.coin_records) == 0:
             print("Could not find target coin.")
             return []

--- a/chia/cmds/farm_funcs.py
+++ b/chia/cmds/farm_funcs.py
@@ -57,7 +57,7 @@ async def get_wallets_stats(
     include_pool_rewards: bool,
 ) -> GetFarmedAmountResponse | None:
     async with get_any_service_client(WalletRpcClient, root_path, wallet_rpc_port) as (wallet_client, _):
-        return await wallet_client.get_farmed_amount(GetFarmedAmount(include_pool_rewards))
+        return await wallet_client.get_farmed_amount(GetFarmedAmount(include_pool_rewards=include_pool_rewards))
 
 
 async def get_challenges(root_path: Path, farmer_rpc_port: int | None) -> list[dict[str, Any]] | None:

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -55,36 +55,32 @@ from chia.wallet.wallet_node import Balance
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 
-def default_raise() -> Any:  # pragma: no cover
-    raise RuntimeError("This should be impossible to hit and is just for < 3.10 compatibility")
-
-
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class Empty(Streamable):
     pass
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class LogIn(Streamable):
     fingerprint: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class LogInResponse(Streamable):
     fingerprint: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetLoggedInFingerprintResponse(Streamable):
     fingerprint: uint32 | None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetPublicKeysResponse(Streamable):
     keyring_is_locked: bool
     public_key_fingerprints: list[uint32] | None = None
@@ -99,14 +95,14 @@ class GetPublicKeysResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetPrivateKey(Streamable):
     fingerprint: uint32
 
 
 # utility for `GetPrivateKeyResponse`
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetPrivateKeyFormat(Streamable):
     fingerprint: uint32
     sk: PrivateKey
@@ -117,45 +113,45 @@ class GetPrivateKeyFormat(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetPrivateKeyResponse(Streamable):
     private_key: GetPrivateKeyFormat
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GenerateMnemonicResponse(Streamable):
     mnemonic: list[str]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class AddKey(Streamable):
     mnemonic: list[str]
     label: str | None = None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class AddKeyResponse(Streamable):
     fingerprint: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DeleteKey(Streamable):
     fingerprint: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CheckDeleteKey(Streamable):
     fingerprint: uint32
     max_ph_to_search: uint16 = uint16(100)
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CheckDeleteKeyResponse(Streamable):
     fingerprint: uint32
     used_for_farmer_rewards: bool
@@ -164,13 +160,13 @@ class CheckDeleteKeyResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SetWalletResyncOnStartup(Streamable):
     enable: bool = True
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetSyncStatusResponse(Streamable):
     synced: bool
     syncing: bool
@@ -178,13 +174,13 @@ class GetSyncStatusResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetHeightInfoResponse(Streamable):
     height: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class PushTX(Streamable):
     spend_bundle: WalletSpendBundle
 
@@ -201,19 +197,19 @@ class PushTX(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetTimestampForHeight(Streamable):
     height: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetTimestampForHeightResponse(Streamable):
     timestamp: uint64
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetWallets(Streamable):
     type: uint16 | None = None
     include_data: bool = True
@@ -221,27 +217,27 @@ class GetWallets(Streamable):
 
 # utility for GetWalletsResponse
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class WalletInfoResponse(WalletInfo):
     authorized_providers: list[bytes32] = field(default_factory=list)
     flags_needed: list[str] = field(default_factory=list)
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetWalletsResponse(Streamable):
     wallets: list[WalletInfoResponse]
     fingerprint: uint32 | None = None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetWalletBalance(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetWalletBalances(Streamable):
     wallet_ids: list[uint32] | None = None
 
@@ -250,40 +246,40 @@ class GetWalletBalances(Streamable):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class BalanceResponse(Balance):
-    wallet_id: uint32 = field(default_factory=default_raise)
-    wallet_type: uint8 = field(default_factory=default_raise)
+    wallet_id: uint32
+    wallet_type: uint8
     fingerprint: uint32 | None = None
     asset_id: bytes32 | None = None
     pending_approval_balance: uint64 | None = None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetWalletBalanceResponse(Streamable):
     wallet_balance: BalanceResponse
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetWalletBalancesResponse(Streamable):
     wallet_balances: dict[uint32, BalanceResponse]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetTransaction(Streamable):
     transaction_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetTransactionResponse(Streamable):
     transaction: TransactionRecord
     transaction_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetTransactions(Streamable):
     wallet_id: uint32
     start: uint32 | None = None
@@ -337,20 +333,20 @@ class TransactionRecordMetadata:
 
 # utility for GetTransactionsResponse
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class TransactionRecordWithMetadata(TransactionRecord):
     metadata: TransactionRecordMetadata | None = None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetTransactionsResponse(Streamable):
     transactions: list[TransactionRecordWithMetadata]
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetNotifications(Streamable):
     ids: list[bytes32] | None = None
     start: uint32 | None = None
@@ -358,19 +354,19 @@ class GetNotifications(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetNotificationsResponse(Streamable):
     notifications: list[Notification]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DeleteNotifications(Streamable):
     ids: list[bytes32] | None = None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VerifySignature(Streamable):
     message: str
     pubkey: G1Element
@@ -392,7 +388,7 @@ class VerifySignature(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VerifySignatureResponse(Streamable):
     isValid: bool
     error: str | None = None
@@ -410,7 +406,7 @@ def signing_mode_enum(request: SignMessageByAddress | SignMessageByID) -> Signin
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SignMessageByAddress(Streamable):
     address: str
     message: str
@@ -423,7 +419,7 @@ class SignMessageByAddress(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SignMessageByAddressResponse(Streamable):
     pubkey: G1Element
     signature: G2Element
@@ -431,7 +427,7 @@ class SignMessageByAddressResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SignMessageByID(Streamable):
     id: str
     message: str
@@ -444,7 +440,7 @@ class SignMessageByID(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SignMessageByIDResponse(Streamable):
     pubkey: G1Element
     signature: G2Element
@@ -453,13 +449,13 @@ class SignMessageByIDResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetTransactionMemo(Streamable):
     transaction_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetTransactionMemoResponse(Streamable):
     transaction_memos: dict[bytes32, dict[bytes32, list[bytes]]]
 
@@ -485,7 +481,7 @@ class GetTransactionMemoResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetTransactionCount(Streamable):
     wallet_id: uint32
     confirmed: bool | None = None
@@ -493,14 +489,14 @@ class GetTransactionCount(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetTransactionCountResponse(Streamable):
     wallet_id: uint32
     count: uint16
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetNextAddress(Streamable):
     wallet_id: uint32
     new_address: bool = False
@@ -508,23 +504,23 @@ class GetNextAddress(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetNextAddressResponse(Streamable):
     wallet_id: uint32
     address: str
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DeleteUnconfirmedTransactions(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SelectCoins(CoinSelectionConfigLoader):
-    wallet_id: uint32 = field(default_factory=default_raise)
-    amount: uint64 = field(default_factory=default_raise)
+    wallet_id: uint32
+    amount: uint64
     exclude_coins: list[Coin] | None = None  # for backwards compatibility
 
     def __post_init__(self) -> None:
@@ -552,15 +548,15 @@ class SelectCoins(CoinSelectionConfigLoader):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SelectCoinsResponse(Streamable):
     coins: list[Coin]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetSpendableCoins(CoinSelectionConfigLoader):
-    wallet_id: uint32 = field(default_factory=default_raise)
+    wallet_id: uint32
 
     @classmethod
     def from_coin_selection_config(cls, wallet_id: uint32, coin_selection_config: CoinSelectionConfig) -> Self:
@@ -574,7 +570,7 @@ class GetSpendableCoins(CoinSelectionConfigLoader):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetSpendableCoinsResponse(Streamable):
     confirmed_records: list[CoinRecord]
     unconfirmed_removals: list[CoinRecord]
@@ -582,7 +578,7 @@ class GetSpendableCoinsResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetCoinRecordsByNames(Streamable):
     names: list[bytes32]
     start_height: uint32 | None = None
@@ -591,31 +587,31 @@ class GetCoinRecordsByNames(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetCoinRecordsByNamesResponse(Streamable):
     coin_records: list[CoinRecord]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetCurrentDerivationIndexResponse(Streamable):
     index: uint32 | None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class ExtendDerivationIndex(Streamable):
     index: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class ExtendDerivationIndexResponse(Streamable):
     index: uint32 | None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetOffersCountResponse(Streamable):
     total: uint16
     my_offers_count: uint16
@@ -623,7 +619,7 @@ class GetOffersCountResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DefaultCAT(Streamable):
     asset_id: bytes32
     name: str
@@ -631,39 +627,39 @@ class DefaultCAT(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetCATListResponse(Streamable):
     cat_list: list[DefaultCAT]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CATSetName(Streamable):
     wallet_id: uint32
     name: str
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CATSetNameResponse(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CATGetName(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CATGetNameResponse(Streamable):
     wallet_id: uint32
     name: str
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class StrayCAT(Streamable):
     asset_id: bytes32
     name: str
@@ -672,39 +668,39 @@ class StrayCAT(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetStrayCATsResponse(Streamable):
     stray_cats: list[StrayCAT]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CATGetAssetID(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CATGetAssetIDResponse(Streamable):
     wallet_id: uint32
     asset_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CATAssetIDToName(Streamable):
     asset_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CATAssetIDToNameResponse(Streamable):
     wallet_id: uint32 | None
     name: str | None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetOfferSummary(Streamable):
     offer: str
     advanced: bool = False
@@ -715,7 +711,7 @@ class GetOfferSummary(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetOfferSummaryResponse(Streamable):
     id: bytes32
     summary: OfferSummary | None = None
@@ -749,53 +745,53 @@ class GetOfferSummaryResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CheckOfferValidity(Streamable):
     offer: str
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CheckOfferValidityResponse(Streamable):
     valid: bool
     id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDSetWalletName(Streamable):
     wallet_id: uint32
     name: str
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDSetWalletNameResponse(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDGetWalletName(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDGetWalletNameResponse(Streamable):
     wallet_id: uint32
     name: str
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDGetInfo(Streamable):
     coin_id: str
     latest: bool = True
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDGetInfoResponse(Streamable):
     did_id: str
     latest_coin: bytes32
@@ -811,7 +807,7 @@ class DIDGetInfoResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDFindLostDID(Streamable):
     coin_id: str
     recovery_list_hash: bytes32 | None = None
@@ -820,31 +816,31 @@ class DIDFindLostDID(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDFindLostDIDResponse(Streamable):
     latest_coin_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDGetPubkey(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDGetPubkeyResponse(Streamable):
     pubkey: G1Element
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDGetCurrentCoinInfo(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDGetCurrentCoinInfoResponse(Streamable):
     wallet_id: uint32
     my_did: str
@@ -854,26 +850,26 @@ class DIDGetCurrentCoinInfoResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDCreateBackupFile(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDCreateBackupFileResponse(Streamable):
     wallet_id: uint32
     backup_data: str
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDGetDID(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDGetDIDResponse(Streamable):
     wallet_id: uint32
     my_did: str
@@ -881,33 +877,33 @@ class DIDGetDIDResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDGetMetadata(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDGetMetadataResponse(Streamable):
     wallet_id: uint32
     metadata: dict[str, str]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTCountNFTs(Streamable):
     wallet_id: uint32 | None = None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTCountNFTsResponse(Streamable):
     wallet_id: uint32 | None
     count: uint64
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTGetNFTs(Streamable):
     wallet_id: uint32 | None = None
     start_index: uint32 = uint32(0)
@@ -915,38 +911,38 @@ class NFTGetNFTs(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTGetNFTsResponse(Streamable):
     wallet_id: uint32 | None
     nft_list: list[NFTInfo]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTGetByDID(Streamable):
     did_id: str | None = None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTGetByDIDResponse(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTGetWalletDID(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTGetWalletDIDResponse(Streamable):
     did_id: str | None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTSetNFTStatus(Streamable):
     wallet_id: uint32
     coin_id: bytes32
@@ -955,7 +951,7 @@ class NFTSetNFTStatus(Streamable):
 
 # utility for NFTGetWalletsWithDIDsResponse
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTWalletWithDID(Streamable):
     wallet_id: uint32
     did_id: str
@@ -963,27 +959,27 @@ class NFTWalletWithDID(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTGetWalletsWithDIDsResponse(Streamable):
     nft_wallets: list[NFTWalletWithDID]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTGetInfo(Streamable):
     coin_id: str
     latest: bool = True
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTGetInfoResponse(Streamable):
     nft_info: NFTInfo
 
 
 # utility for NFTCalculateRoyalties
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class RoyaltyAsset(Streamable):
     asset: str
     royalty_address: str
@@ -992,14 +988,14 @@ class RoyaltyAsset(Streamable):
 
 # utility for NFTCalculateRoyalties
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class FungibleAsset(Streamable):
     asset: str | None
     amount: uint64
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTCalculateRoyalties(Streamable):
     royalty_assets: list[RoyaltyAsset] = field(default_factory=list)
     fungible_assets: list[FungibleAsset] = field(default_factory=list)
@@ -1013,7 +1009,7 @@ class NFTCalculateRoyalties(Streamable):
 
 # utility for NFTCalculateRoyaltiesResponse
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class RoyaltySummary(Streamable):
     royalty_asset: str
     fungible_asset: str | None
@@ -1022,7 +1018,7 @@ class RoyaltySummary(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTCalculateRoyaltiesResponse(Streamable):
     nft_info: list[RoyaltySummary]
 
@@ -1051,12 +1047,12 @@ class NFTCalculateRoyaltiesResponse(Streamable):
         # backwards compatibility. This means the code below has some logic it
         # probably shouldn't have ignoring "assets" named "success".
         return cls(
-            [
+            nft_info=[
                 RoyaltySummary(
-                    royalty_asset,
-                    summary["asset"],
-                    summary["address"],
-                    uint64(summary["amount"]),
+                    royalty_asset=royalty_asset,
+                    fungible_asset=summary["asset"],
+                    royalty_address=summary["address"],
+                    royalty_amount=uint64(summary["amount"]),
                 )
                 for royalty_asset, summaries in json_dict.items()
                 if royalty_asset != "success"
@@ -1067,65 +1063,65 @@ class NFTCalculateRoyaltiesResponse(Streamable):
 
 # utility for NFTSetDIDBulk
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTCoin(Streamable):
     nft_coin_id: str
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class PWStatus(Streamable):
     wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class PWStatusResponse(Streamable):
     state: PoolWalletInfo
     unconfirmed_transactions: list[TransactionRecord]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLTrackNew(Streamable):
     launcher_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLStopTracking(Streamable):
     launcher_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLLatestSingleton(Streamable):
     launcher_id: bytes32
     only_confirmed: bool = False
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLLatestSingletonResponse(Streamable):
     singleton: SingletonRecord | None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLSingletonsByRoot(Streamable):
     launcher_id: bytes32
     root: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLSingletonsByRootResponse(Streamable):
     singletons: list[SingletonRecord]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLHistory(Streamable):
     launcher_id: bytes32
     min_generation: uint32 | None = None
@@ -1134,45 +1130,45 @@ class DLHistory(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLHistoryResponse(Streamable):
     history: list[SingletonRecord]
     count: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLOwnedSingletonsResponse(Streamable):
     singletons: list[SingletonRecord]
     count: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLGetMirrors(Streamable):
     launcher_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLGetMirrorsResponse(Streamable):
     mirrors: list[Mirror]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCGet(Streamable):
     vc_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCGetResponse(Streamable):
     vc_record: VCRecord | None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCGetList(Streamable):
     start: uint32 = uint32(0)
     end: uint32 = uint32(50)
@@ -1180,7 +1176,7 @@ class VCGetList(Streamable):
 
 # utility for VC endpoints
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCProofsRPC(Streamable):
     key_value_pairs: list[tuple[str, str]]
 
@@ -1189,12 +1185,12 @@ class VCProofsRPC(Streamable):
 
     @classmethod
     def from_vc_proofs(cls, vc_proofs: VCProofs) -> Self:
-        return cls([(key, value) for key, value in vc_proofs.key_value_pairs.items()])
+        return cls(key_value_pairs=[(key, value) for key, value in vc_proofs.key_value_pairs.items()])
 
 
 # utility for VCGetListResponse
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCProofWithHash(Streamable):
     hash: bytes32
     proof: VCProofsRPC | None
@@ -1203,7 +1199,7 @@ class VCProofWithHash(Streamable):
 # utility for VCGetListResponse
 @final
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCRecordWithCoinID(VCRecord):
     coin_id: bytes32
 
@@ -1213,7 +1209,7 @@ class VCRecordWithCoinID(VCRecord):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCGetListResponse(Streamable):
     vc_records: list[VCRecordWithCoinID]
     proofs: list[VCProofWithHash]
@@ -1234,11 +1230,11 @@ class VCGetListResponse(Streamable):
     @classmethod
     def from_json_dict(cls, json_dict: dict[str, Any]) -> VCGetListResponse:
         return cls(
-            [VCRecordWithCoinID.from_json_dict(vc_record) for vc_record in json_dict["vc_records"]],
-            [
+            vc_records=[VCRecordWithCoinID.from_json_dict(vc_record) for vc_record in json_dict["vc_records"]],
+            proofs=[
                 VCProofWithHash(
-                    bytes32.from_hexstr(proof_hash),
-                    None if potential_proofs is None else VCProofsRPC.from_vc_proofs(VCProofs(potential_proofs)),
+                    hash=bytes32.from_hexstr(proof_hash),
+                    proof=None if potential_proofs is None else VCProofsRPC.from_vc_proofs(VCProofs(potential_proofs)),
                 )
                 for proof_hash, potential_proofs in json_dict["proofs"].items()
             ],
@@ -1246,74 +1242,74 @@ class VCGetListResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCAddProofs(VCProofsRPC):
     def to_json_dict(self) -> dict[str, Any]:
         return {"proofs": self.to_vc_proofs().key_value_pairs}
 
     @classmethod
     def from_json_dict(cls, json_dict: dict[str, Any]) -> Self:
-        return cls([(key, value) for key, value in json_dict["proofs"].items()])
+        return cls(key_value_pairs=[(key, value) for key, value in json_dict["proofs"].items()])
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCGetProofsForRoot(Streamable):
     root: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCGetProofsForRootResponse(VCAddProofs):
     pass
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GatherSigningInfo(Streamable):
     spends: list[Spend]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GatherSigningInfoResponse(Streamable):
     signing_instructions: SigningInstructions
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class ApplySignatures(Streamable):
     spends: list[Spend]
     signing_responses: list[SigningResponse]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class ApplySignaturesResponse(Streamable):
     signed_transactions: list[SignedTransaction]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SubmitTransactions(Streamable):
     signed_transactions: list[SignedTransaction]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SubmitTransactionsResponse(Streamable):
     mempool_ids: list[bytes32]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class ExecuteSigningInstructions(Streamable):
     signing_instructions: SigningInstructions
     partial_allowed: bool = False
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class ExecuteSigningInstructionsResponse(Streamable):
     signing_responses: list[SigningResponse]
 
@@ -1351,7 +1347,7 @@ class TransactionEndpointRequest(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class TransactionEndpointResponse(Streamable):
     unsigned_transactions: list[UnsignedTransaction]
     transactions: list[TransactionRecord]
@@ -1359,7 +1355,7 @@ class TransactionEndpointResponse(Streamable):
 
 # utility for SendTransaction
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class ClawbackPuzzleDecoratorOverride(Streamable):
     decorator: str
     clawback_timelock: uint64
@@ -1371,11 +1367,11 @@ class ClawbackPuzzleDecoratorOverride(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SendTransaction(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
-    amount: uint64 = field(default_factory=default_raise)
-    address: str = field(default_factory=default_raise)
+    wallet_id: uint32
+    amount: uint64
+    address: str
     memos: list[str] = field(default_factory=list)
     # Technically this value was meant to support many types here
     # However, only one is supported right now and there are no plans to extend
@@ -1384,44 +1380,44 @@ class SendTransaction(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SendTransactionResponse(TransactionEndpointResponse):
     transaction: TransactionRecord
     transaction_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SpendClawbackCoins(TransactionEndpointRequest):
-    coin_ids: list[bytes32] = field(default_factory=default_raise)
+    coin_ids: list[bytes32]
     batch_size: uint16 | None = None
     force: bool = False
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SpendClawbackCoinsResponse(TransactionEndpointResponse):
     transaction_ids: list[bytes32]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SendNotification(TransactionEndpointRequest):
-    target: bytes32 = field(default_factory=default_raise)
-    message: bytes = field(default_factory=default_raise)
+    target: bytes32
+    message: bytes
     amount: uint64 = uint64(0)
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SendNotificationResponse(TransactionEndpointResponse):
     tx: TransactionRecord
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class PushTransactions(TransactionEndpointRequest):
-    transactions: list[TransactionRecord] = field(default_factory=default_raise)
+    transactions: list[TransactionRecord]
     push: bool | None = True
 
     # We allow for flexibility in transaction parsing here so we need to override
@@ -1440,7 +1436,7 @@ class PushTransactions(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class PushTransactionsResponse(TransactionEndpointResponse):
     pass
 
@@ -1448,10 +1444,10 @@ class PushTransactionsResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class SplitCoins(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
-    number_of_coins: uint16 = field(default_factory=default_raise)
-    amount_per_coin: uint64 = field(default_factory=default_raise)
-    target_coin_id: bytes32 = field(default_factory=default_raise)
+    wallet_id: uint32
+    number_of_coins: uint16
+    amount_per_coin: uint64
+    target_coin_id: bytes32
 
     def __post_init__(self) -> None:
         if self.number_of_coins > 500:
@@ -1461,7 +1457,7 @@ class SplitCoins(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SplitCoinsResponse(TransactionEndpointResponse):
     pass
 
@@ -1469,7 +1465,7 @@ class SplitCoinsResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class CombineCoins(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
+    wallet_id: uint32
     number_of_coins: uint16 = uint16(500)
     largest_first: bool = False
     target_coin_ids: list[bytes32] = field(default_factory=list)
@@ -1488,7 +1484,7 @@ class CombineCoins(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CombineCoinsResponse(TransactionEndpointResponse):
     pass
 
@@ -1496,7 +1492,7 @@ class CombineCoinsResponse(TransactionEndpointResponse):
 # utility for CATSpend/CreateSignedTransaction
 # unfortunate that we can't use CreateCoin but the memos are taken as strings not bytes
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class Addition(Streamable):
     amount: uint64
     puzzle_hash: bytes32
@@ -1522,7 +1518,7 @@ def cat_discrepancy_validation(
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class CATSpend(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
+    wallet_id: uint32
     additions: list[Addition] | None = None
     amount: uint64 | None = None
     inner_address: str | None = None
@@ -1548,7 +1544,7 @@ class CATSpend(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CATSpendResponse(TransactionEndpointResponse):
     transaction: TransactionRecord
     transaction_id: bytes32
@@ -1557,13 +1553,13 @@ class CATSpendResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class DIDMessageSpend(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
+    wallet_id: uint32
     coin_announcements: list[bytes] = field(default_factory=list)
     puzzle_announcements: list[bytes] = field(default_factory=list)
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDMessageSpendResponse(TransactionEndpointResponse):
     spend_bundle: WalletSpendBundle
 
@@ -1571,12 +1567,12 @@ class DIDMessageSpendResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class DIDUpdateMetadata(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
+    wallet_id: uint32
     metadata: dict[str, str] = field(default_factory=dict)
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDUpdateMetadataResponse(TransactionEndpointResponse):
     spend_bundle: WalletSpendBundle
     wallet_id: uint32
@@ -1585,8 +1581,8 @@ class DIDUpdateMetadataResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class DIDTransferDID(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
-    inner_address: str = field(default_factory=default_raise)
+    wallet_id: uint32
+    inner_address: str
     with_recovery_info: bool = True
 
     def __post_init__(self) -> None:
@@ -1596,7 +1592,7 @@ class DIDTransferDID(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DIDTransferDIDResponse(TransactionEndpointResponse):
     transaction: TransactionRecord
     transaction_id: bytes32
@@ -1605,11 +1601,11 @@ class DIDTransferDIDResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class NFTMintNFTRequest(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
-    royalty_address: str | None = field(default_factory=default_raise)
-    target_address: str | None = field(default_factory=default_raise)
-    uris: list[str] = field(default_factory=default_raise)
-    hash: bytes32 = field(default_factory=default_raise)
+    wallet_id: uint32
+    royalty_address: str | None
+    target_address: str | None
+    uris: list[str]
+    hash: bytes32
     royalty_percentage: uint16 = uint16(0)
     meta_uris: list[str] = field(default_factory=list)
     license_uris: list[str] = field(default_factory=list)
@@ -1621,7 +1617,7 @@ class NFTMintNFTRequest(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTMintNFTResponse(TransactionEndpointResponse):
     wallet_id: uint32
     spend_bundle: WalletSpendBundle
@@ -1631,13 +1627,13 @@ class NFTMintNFTResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class NFTSetNFTDID(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
-    nft_coin_id: bytes32 = field(default_factory=default_raise)
+    wallet_id: uint32
+    nft_coin_id: bytes32
     did_id: str | None = None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTSetNFTDIDResponse(TransactionEndpointResponse):
     wallet_id: uint32
     spend_bundle: WalletSpendBundle
@@ -1646,12 +1642,12 @@ class NFTSetNFTDIDResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class NFTSetDIDBulk(TransactionEndpointRequest):
-    nft_coin_list: list[NFTCoin] = field(default_factory=default_raise)
+    nft_coin_list: list[NFTCoin]
     did_id: str | None = None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTSetDIDBulkResponse(TransactionEndpointResponse):
     wallet_id: list[uint32]
     tx_num: uint16
@@ -1661,12 +1657,12 @@ class NFTSetDIDBulkResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class NFTTransferBulk(TransactionEndpointRequest):
-    nft_coin_list: list[NFTCoin] = field(default_factory=default_raise)
-    target_address: str = field(default_factory=default_raise)
+    nft_coin_list: list[NFTCoin]
+    target_address: str
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTTransferBulkResponse(TransactionEndpointResponse):
     wallet_id: list[uint32]
     tx_num: uint16
@@ -1676,11 +1672,11 @@ class NFTTransferBulkResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class CreateNewDL(TransactionEndpointRequest):
-    root: bytes32 = field(default_factory=default_raise)
+    root: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CreateNewDLResponse(TransactionEndpointResponse):
     launcher_id: bytes32
 
@@ -1688,26 +1684,26 @@ class CreateNewDLResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class DLUpdateRoot(TransactionEndpointRequest):
-    launcher_id: bytes32 = field(default_factory=default_raise)
-    new_root: bytes32 = field(default_factory=default_raise)
+    launcher_id: bytes32
+    new_root: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLUpdateRootResponse(TransactionEndpointResponse):
     tx_record: TransactionRecord
 
 
 # utilities for DLUpdateMultiple
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class LauncherRootPair(Streamable):
     launcher_id: bytes32
     new_root: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLUpdateMultipleUpdates(Streamable):
     launcher_root_pairs: list[LauncherRootPair]
 
@@ -1719,10 +1715,10 @@ class DLUpdateMultipleUpdates(Streamable):
     @classmethod
     def from_json_dict(cls, json_dict: dict[str, Any]) -> Self:
         return cls(
-            [
+            launcher_root_pairs=[
                 LauncherRootPair(
-                    bytes32.from_hexstr(key),
-                    bytes32.from_hexstr(value),
+                    launcher_id=bytes32.from_hexstr(key),
+                    new_root=bytes32.from_hexstr(value),
                 )
                 for key, value in json_dict.items()
             ]
@@ -1732,7 +1728,7 @@ class DLUpdateMultipleUpdates(Streamable):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class DLUpdateMultiple(TransactionEndpointRequest):
-    updates: DLUpdateMultipleUpdates = field(default_factory=default_raise)
+    updates: DLUpdateMultipleUpdates
 
     # TODO: deprecate the kinda silly format of this RPC and delete this function
     def to_json_dict(self, _avoid_ban: bool = False) -> dict[str, Any]:
@@ -1740,7 +1736,7 @@ class DLUpdateMultiple(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLUpdateMultipleResponse(TransactionEndpointResponse):
     pass
 
@@ -1748,13 +1744,13 @@ class DLUpdateMultipleResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class DLNewMirror(TransactionEndpointRequest):
-    launcher_id: bytes32 = field(default_factory=default_raise)
-    amount: uint64 = field(default_factory=default_raise)
-    urls: list[str] = field(default_factory=default_raise)
+    launcher_id: bytes32
+    amount: uint64
+    urls: list[str]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLNewMirrorResponse(TransactionEndpointResponse):
     pass
 
@@ -1762,41 +1758,41 @@ class DLNewMirrorResponse(TransactionEndpointResponse):
 @streamable
 @dataclass(frozen=True, kw_only=True)
 class DLDeleteMirror(TransactionEndpointRequest):
-    coin_id: bytes32 = field(default_factory=default_raise)
+    coin_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class DLDeleteMirrorResponse(TransactionEndpointResponse):
     pass
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTTransferNFT(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
-    target_address: str = field(default_factory=default_raise)
-    nft_coin_id: str = field(default_factory=default_raise)
+    wallet_id: uint32
+    target_address: str
+    nft_coin_id: str
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTTransferNFTResponse(TransactionEndpointResponse):
     wallet_id: uint32
     spend_bundle: WalletSpendBundle
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTAddURI(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
-    uri: str = field(default_factory=default_raise)
-    key: str = field(default_factory=default_raise)
-    nft_coin_id: str = field(default_factory=default_raise)
+    wallet_id: uint32
+    uri: str
+    key: str
+    nft_coin_id: str
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTAddURIResponse(TransactionEndpointResponse):
     wallet_id: uint32
     spend_bundle: WalletSpendBundle
@@ -1804,7 +1800,7 @@ class NFTAddURIResponse(TransactionEndpointResponse):
 
 # utility for NFTBulkMint
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTMintMetadata(Streamable):
     uris: list[str]
     hash: bytes32
@@ -1817,10 +1813,10 @@ class NFTMintMetadata(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTMintBulk(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
-    metadata_list: list[NFTMintMetadata] = field(default_factory=default_raise)
+    wallet_id: uint32
+    metadata_list: list[NFTMintMetadata]
     royalty_address: str | None = None
     royalty_percentage: uint16 | None = None
     target_list: list[str] = field(default_factory=list)
@@ -1836,23 +1832,23 @@ class NFTMintBulk(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class NFTMintBulkResponse(TransactionEndpointResponse):
     spend_bundle: WalletSpendBundle
     nft_id_list: list[str]
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class PWJoinPool(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
-    pool_url: str = field(default_factory=default_raise)
-    target_puzzlehash: bytes32 = field(default_factory=default_raise)
-    relative_lock_height: uint32 = field(default_factory=default_raise)
+    wallet_id: uint32
+    pool_url: str
+    target_puzzlehash: bytes32
+    relative_lock_height: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class PWJoinPoolResponse(TransactionEndpointResponse):
     total_fee: uint64
     transaction: TransactionRecord
@@ -1860,13 +1856,13 @@ class PWJoinPoolResponse(TransactionEndpointResponse):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class PWSelfPool(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
+    wallet_id: uint32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class PWSelfPoolResponse(TransactionEndpointResponse):
     total_fee: uint64
     transaction: TransactionRecord
@@ -1874,14 +1870,14 @@ class PWSelfPoolResponse(TransactionEndpointResponse):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class PWAbsorbRewards(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
+    wallet_id: uint32
     max_spends_in_tx: uint16 | None = None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class PWAbsorbRewardsResponse(TransactionEndpointResponse):
     state: PoolWalletInfo
     transaction: TransactionRecord
@@ -1889,63 +1885,63 @@ class PWAbsorbRewardsResponse(TransactionEndpointResponse):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCMint(TransactionEndpointRequest):
-    did_id: str = field(default_factory=default_raise)
+    did_id: str
     target_address: str | None = None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCMintResponse(TransactionEndpointResponse):
     vc_record: VCRecord
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCSpend(TransactionEndpointRequest):
-    vc_id: bytes32 = field(default_factory=default_raise)
+    vc_id: bytes32
     new_puzhash: bytes32 | None = None
     new_proof_hash: bytes32 | None = None
     provider_inner_puzhash: bytes32 | None = None
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCSpendResponse(TransactionEndpointResponse):
     pass
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCRevoke(TransactionEndpointRequest):
-    vc_parent_id: bytes32 = field(default_factory=default_raise)
+    vc_parent_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class VCRevokeResponse(TransactionEndpointResponse):
     pass
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CSTCoinAnnouncement(Streamable):
     coin_id: bytes32
     message: bytes
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CSTPuzzleAnnouncement(Streamable):
     puzzle_hash: bytes32
     message: bytes
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CreateSignedTransaction(TransactionEndpointRequest):
-    additions: list[Addition] = field(default_factory=default_raise)
+    additions: list[Addition]
     wallet_id: uint32 | None = None
     coins: list[Coin] | None = None
     morph_bytes: bytes | None = None
@@ -1998,7 +1994,7 @@ class CreateSignedTransaction(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CreateSignedTransactionsResponse(TransactionEndpointResponse):
     signed_txs: list[TransactionRecord]
     signed_tx: TransactionRecord
@@ -2008,10 +2004,10 @@ _T_SendTransactionMultiProxy = TypeVar("_T_SendTransactionMultiProxy", CATSpend,
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SendTransactionMulti(TransactionEndpointRequest):
     # primarily for cat_spend
-    wallet_id: uint32 = field(default_factory=default_raise)
+    wallet_id: uint32
     additions: list[Addition] | None = None  # for both
     amount: uint64 | None = None
     inner_address: str | None = None
@@ -2086,14 +2082,14 @@ class SendTransactionMulti(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class SendTransactionMultiResponse(TransactionEndpointResponse):
     transaction: TransactionRecord
     transaction_id: bytes32
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class _OfferEndpointResponse(TransactionEndpointResponse):
     offer: Offer  # gotta figure out how to ignore this in streamable
     trade_record: TradeRecord
@@ -2126,10 +2122,10 @@ class _OfferEndpointResponse(TransactionEndpointResponse):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CreateOfferForIDs(TransactionEndpointRequest):
     # a hack for dict[str, int] because streamable doesn't support negative ints
-    offer: dict[str, str] = field(default_factory=default_raise)
+    offer: dict[str, str]
     driver_dict: dict[bytes32, PuzzleInfo] | None = None
     solver: Solver | None = None
     validate_only: bool = False
@@ -2147,15 +2143,15 @@ class CreateOfferForIDs(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CreateOfferForIDsResponse(_OfferEndpointResponse):
     pass
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class TakeOffer(TransactionEndpointRequest):
-    offer: str = field(default_factory=default_raise)
+    offer: str
     solver: Solver | None = None
 
     @cached_property
@@ -2164,20 +2160,20 @@ class TakeOffer(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class TakeOfferResponse(_OfferEndpointResponse):  # Inheriting for de-dup sake
     pass
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetOffer(Streamable):
     trade_id: bytes32
     file_contents: bool = False
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetOfferResponse(Streamable):
     offer: str | None
     trade_record: TradeRecord
@@ -2200,7 +2196,7 @@ class GetOfferResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetAllOffers(Streamable):
     start: uint16 = uint16(0)
     end: uint16 = uint16(10)
@@ -2213,7 +2209,7 @@ class GetAllOffers(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetAllOffersResponse(Streamable):
     offers: list[str] | None
     trade_records: list[TradeRecord]
@@ -2239,22 +2235,22 @@ class GetAllOffersResponse(Streamable):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CancelOffer(TransactionEndpointRequest):
-    trade_id: bytes32 = field(default_factory=default_raise)
-    secure: bool = field(default_factory=default_raise)
+    trade_id: bytes32
+    secure: bool
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CancelOfferResponse(TransactionEndpointResponse):
     pass
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CancelOffers(TransactionEndpointRequest):
-    secure: bool = field(default_factory=default_raise)
+    secure: bool
     batch_fee: uint64 = uint64(0)
     batch_size: uint16 = uint16(5)
     cancel_all: bool = False
@@ -2270,7 +2266,7 @@ class CancelOffers(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CancelOffersResponse(TransactionEndpointResponse):
     pass
 
@@ -2297,9 +2293,9 @@ class DIDType(Enum):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CreateNewWallet(TransactionEndpointRequest):
-    wallet_type: CreateNewWalletType = field(default_factory=default_raise)
+    wallet_type: CreateNewWalletType
     # CAT_WALLET
     mode: WalletCreationMode | None = None  # required
     amount: uint64 | None = None  # required in "new"
@@ -2405,7 +2401,7 @@ class CreateNewWallet(TransactionEndpointRequest):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CreateNewWalletResponse(TransactionEndpointResponse):
     type: str  # Alias for WalletType which is IntEnum and therefore incompatible
     wallet_id: uint32
@@ -2522,26 +2518,26 @@ class CreateNewWalletResponse(TransactionEndpointResponse):
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CRCATApprovePending(TransactionEndpointRequest):
-    wallet_id: uint32 = field(default_factory=default_raise)
-    min_amount_to_claim: uint64 = field(default_factory=default_raise)
+    wallet_id: uint32
+    min_amount_to_claim: uint64
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class CRCATApprovePendingResponse(TransactionEndpointResponse):
     pass
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetFarmedAmount(Streamable):
     include_pool_rewards: bool = False
 
 
 @streamable
-@dataclass(frozen=True)
+@dataclass(kw_only=True, frozen=True)
 class GetFarmedAmountResponse(Streamable):
     farmed_amount: uint64
     pool_reward_amount: uint64


### PR DESCRIPTION
This does what the title says so while it looks large, all it's doing is naming parameters

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns test code with keyword-only wallet RPC APIs; replaces positional construction with explicit named fields and updates assertions accordingly.
> 
> - Switches to named fields in responses like `GetWalletsResponse(wallets=...)`, `GetTransactionResponse(transaction=..., transaction_id=...)`, etc.
> - Updates request creation and expected-call logs to keyword args (e.g., `GetTransactions(wallet_id=..., start=..., end=...)`, `GetWalletBalance(wallet_id=...)`, `PWStatus(wallet_id=...)`).
> - Adjusts numerous CLI wallet/NFT/DID/VC/Data Layer tests to the new signatures; no logic changes outside of argument naming.
> - Modifies test RPC clients to return keyword-initialized responses and to log updated request shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46ef9030492d5a7ff7a10a0dbf2588905af642ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->