### PR TITLE
async is_empty() not awaited

### DIFF
--- a/chia/wallet/cat_wallet/r_cat_wallet.py
+++ b/chia/wallet/cat_wallet/r_cat_wallet.py
@@ -162,7 +162,7 @@ class RCATWallet(CATWallet):
         cat_wallet: CATWallet,
         hidden_puzzle_hash: bytes32,
     ) -> bool:
-        if not cat_wallet.lineage_store.is_empty():
+        if not await cat_wallet.lineage_store.is_empty():
             cat_wallet.log.error("Received a revocable CAT to a CAT wallet that already has CATs")
             return False
         replace_self = cls()


### PR DESCRIPTION
This async `is_empty` function was not awaited

Discovered during python 3.14 testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Await lineage_store.is_empty() in RCATWallet.convert_to_revocable to correctly detect non-empty CAT wallets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6fdc6d05340bcd9b2eb2d89665af85e0971fc7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->