### PR TITLE
Removed unneeded ignores from pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -17,7 +17,6 @@ markers =
 testpaths = chia/_tests/
 filterwarnings =
     error
-    ignore:unclosed file:ResourceWarning
     ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning
     ignore:cannot collect test class:pytest.PytestCollectionWarning
     ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,7 +18,6 @@ testpaths = chia/_tests/
 filterwarnings =
     error
     ignore:unclosed <socket\.socket:ResourceWarning
-    ignore:Unclosed client session:ResourceWarning
     ignore:unclosed file:ResourceWarning
     ignore:unclosed transport:ResourceWarning
     ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,7 +17,6 @@ markers =
 testpaths = chia/_tests/
 filterwarnings =
     error
-    ignore:unclosed <socket\.socket:ResourceWarning
     ignore:unclosed file:ResourceWarning
     ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning
     ignore:cannot collect test class:pytest.PytestCollectionWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,7 +19,6 @@ filterwarnings =
     error
     ignore:unclosed <socket\.socket:ResourceWarning
     ignore:unclosed file:ResourceWarning
-    ignore:unclosed transport:ResourceWarning
     ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning
     ignore:cannot collect test class:pytest.PytestCollectionWarning
     ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning


### PR DESCRIPTION
Just seeing if we can cleanup anything from pytest.ini

I ran the entire Python test suite, and this passes - so these ignores are no longer needed