### PR TITLE
Mempoolwjb

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -100,9 +100,6 @@ class Mempool:
         self.mempool_info: MempoolInfo = mempool_info
         self.fee_estimator: FeeEstimatorInterface = fee_estimator
 
-    def __del__(self) -> None:
-        self._db_conn.close()
-
     def _row_to_item(self, row: sqlite3.Row) -> MempoolItem:
         name = bytes32(row[0])
         fee = int(row[2])

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -412,6 +412,10 @@ class Mempool:
                     item_cost + cost_sum > self.mempool_info.max_block_clvm_cost
                     or fee + fee_sum > DEFAULT_CONSTANTS.MAX_COIN_AMOUNT
                 ):
+                    log.info(
+                        f"WJB item_cost {item_cost} + cost_sum {cost_sum} > self.mempool_info.max_block_clvm_cost {self.mempool_info.max_block_clvm_cost} or fee {fee} + fee_sum {fee_sum} > DEFAULT_CONSTANTS.MAX_COIN_AMOUNT {DEFAULT_CONSTANTS.MAX_COIN_AMOUNT}"
+                    )
+                    log.info(f"WJB name {name} fee {fee} item {item}")
                     break
                 coin_spends.extend(unique_coin_spends)
                 additions.extend(unique_additions)
@@ -422,6 +426,7 @@ class Mempool:
             except Exception as e:
                 log.debug(f"Exception while checking a mempool item for deduplication: {e}")
                 continue
+        log.info(f"WJB done")
         if processed_spend_bundles == 0:
             return None
         log.info(

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -216,6 +216,8 @@ class MempoolManager:
 
     def shut_down(self) -> None:
         self.pool.shutdown(wait=True)
+        log.info("Closing mempool DB connection")
+        self.mempool._db_conn.close()
 
     def create_bundle_from_mempool(
         self, last_tb_header_hash: bytes32, item_inclusion_filter: Optional[Callable[[bytes32], bool]] = None


### PR DESCRIPTION
TEST do not merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a high-priority blockchain mutex around end-of-sub-slot handling, increases mempool bundle assembly logging, and explicitly closes the mempool DB during shutdown.
> 
> - **Full node API (`chia/full_node/full_node_api.py`)**:
>   - Wrap `respond_end_of_sub_slot` in high-priority `priority_mutex`; fetch last transaction block and attempt `mempool_manager.create_bundle_from_mempool(...)` with traceback/error logging.
> - **Mempool (`chia/full_node/mempool.py`)**:
>   - Add detailed logging during `create_bundle_from_mempool_items` (break conditions and completion).
>   - Remove `__del__` DB auto-close.
> - **Mempool Manager (`chia/full_node/mempool_manager.py`)**:
>   - On `shut_down()`, log and explicitly close `mempool._db_conn`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8b4c4a5cbec9c4c620c17f0cda388522dcd3742. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->