### PR TITLE
move db close out of gc so no more thread errors

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -144,9 +144,6 @@ class Mempool:
         self.mempool_info: MempoolInfo = mempool_info
         self.fee_estimator: FeeEstimatorInterface = fee_estimator
 
-    def __del__(self) -> None:
-        self._db_conn.close()
-
     def _row_to_item(self, row: sqlite3.Row) -> MempoolItem:
         name = bytes32(row[0])
         fee = int(row[2])

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -976,7 +976,7 @@ class MempoolManager:
                     # Item was in mempool, but after the new block it's a double spend.
                     # Item is most likely included in the block.
                     included_items.append(MempoolItemInfo(item.cost, item.fee, item.height_added_to_mempool))
-             old_pool._db_conn.close()
+            old_pool._db_conn.close()
 
         potential_txs = self._pending_cache.drain(new_peak.height)
         potential_txs.update(self._conflict_cache.drain())

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -369,6 +369,8 @@ class MempoolManager:
 
     def shut_down(self) -> None:
         self.pool.shutdown(wait=True)
+        log.info("Closing mempool DB connection")
+        self.mempool._db_conn.close()
 
     # TODO: remove this, use create_generator() instead
     def create_bundle_from_mempool(self, last_tb_header_hash: bytes32) -> tuple[SpendBundle, list[Coin]] | None:

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -976,6 +976,7 @@ class MempoolManager:
                     # Item was in mempool, but after the new block it's a double spend.
                     # Item is most likely included in the block.
                     included_items.append(MempoolItemInfo(item.cost, item.fee, item.height_added_to_mempool))
+             old_pool._db_conn.close()
 
         potential_txs = self._pending_cache.drain(new_peak.height)
         potential_txs.update(self._conflict_cache.drain())


### PR DESCRIPTION
DO NOT MERGE plz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes implicit DB close from `Mempool.__del__` and explicitly closes the mempool SQLite connection in `MempoolManager.shut_down()` and after slow-path `new_peak` reinit, with added logging.
> 
> - **Mempool lifecycle**:
>   - Remove implicit DB close by deleting `Mempool.__del__`.
>   - Explicitly close mempool DB connection:
>     - On shutdown in `MempoolManager.shut_down()` (with info log).
>     - After slow-path mempool rebuild in `MempoolManager.new_peak()` (`old_pool._db_conn.close()`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f2b2000c3aca4bbbe03ab00ee8be45160c61929. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->