### PR TITLE
move test_constants_modified

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -28,7 +28,6 @@ from pytest import MonkeyPatch
 from chia._tests import ether
 from chia._tests.core.data_layer.util import ChiaRoot
 from chia._tests.core.node_height import node_height_at_least
-from chia._tests.simulation.test_simulation import test_constants_modified
 from chia._tests.util.misc import (
     BenchmarkRunner,
     ComparableEnum,
@@ -99,6 +98,20 @@ from chia.simulator.keyring import TempKeyring
 from chia.util.keyring_wrapper import KeyringWrapper
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, TXConfig
 from chia.wallet.wallet_node import Balance
+
+test_constants_modified = test_constants.replace(
+    DIFFICULTY_STARTING=uint64(2**8),
+    DISCRIMINANT_SIZE_BITS=uint16(1024),
+    SUB_EPOCH_BLOCKS=uint32(140),
+    WEIGHT_PROOF_THRESHOLD=uint8(2),
+    WEIGHT_PROOF_RECENT_BLOCKS=uint32(350),
+    MAX_SUB_SLOT_BLOCKS=uint32(50),
+    NUM_SPS_SUB_SLOT=uint8(32),  # Must be a power of 2
+    EPOCH_BLOCKS=uint32(280),
+    SUB_SLOT_ITERS_STARTING=uint64(2**20),
+    NUMBER_ZERO_BITS_PLOT_FILTER_V1=uint8(5),
+    NUMBER_ZERO_BITS_PLOT_FILTER_V2=uint8(5),
+)
 
 
 @pytest.fixture(name="ether_setup", autouse=True)

--- a/chia/_tests/simulation/test_simulation.py
+++ b/chia/_tests/simulation/test_simulation.py
@@ -12,8 +12,9 @@ import dns.rdtypes.IN.AAAA
 import pytest
 from chia_rs import BlockRecord
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint8, uint16, uint32, uint64
+from chia_rs.sized_ints import uint16, uint32, uint64
 
+from chia._tests.conftest import test_constants_modified
 from chia._tests.core.node_height import node_height_at_least
 from chia._tests.util.setup_nodes import FullSystem, OldSimulatorsAndWallets
 from chia._tests.util.time_out_assert import time_out_assert
@@ -24,7 +25,7 @@ from chia.full_node.full_node import FullNode
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols.outbound_message import NodeType
 from chia.server.server import ChiaServer
-from chia.simulator.block_tools import BlockTools, create_block_tools_async, test_constants
+from chia.simulator.block_tools import BlockTools, create_block_tools_async
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.keyring import TempKeyring
 from chia.simulator.setup_services import setup_full_node
@@ -35,20 +36,6 @@ from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.wallet_node import WalletNode
 
 chiapos_version = importlib.metadata.version("chiapos")
-
-test_constants_modified = test_constants.replace(
-    DIFFICULTY_STARTING=uint64(2**8),
-    DISCRIMINANT_SIZE_BITS=uint16(1024),
-    SUB_EPOCH_BLOCKS=uint32(140),
-    WEIGHT_PROOF_THRESHOLD=uint8(2),
-    WEIGHT_PROOF_RECENT_BLOCKS=uint32(350),
-    MAX_SUB_SLOT_BLOCKS=uint32(50),
-    NUM_SPS_SUB_SLOT=uint8(32),  # Must be a power of 2
-    EPOCH_BLOCKS=uint32(280),
-    SUB_SLOT_ITERS_STARTING=uint64(2**20),
-    NUMBER_ZERO_BITS_PLOT_FILTER_V1=uint8(5),
-    NUMBER_ZERO_BITS_PLOT_FILTER_V2=uint8(5),
-)
 
 
 # TODO: Ideally, the db_version should be the (parameterized) db_version


### PR DESCRIPTION
from `test_simulation.py` into `conftest.py` to avoid circular dependencies.
`conftest.py` defines the test fixtures, some of which are built using these test constants. `test_simulation.py` uses the test fixtures.

This PR brings the dependencies to:

`test_simulation.py` -> test-fixture -> `conftest.py`