### PR TITLE
Make sure to close DB connection when getting DB limit info

### DIFF
--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -120,10 +120,9 @@ def get_host_parameter_limit() -> int:
     # NOTE: This does not account for dynamically adjusted limits since it makes a
     #       separate db and connection.  If aiosqlite adds support we should use it.
     if sys.version_info >= (3, 11):
-        connection = sqlite3.connect(":memory:")
-
-        limit_number = sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER
-        host_parameter_limit = connection.getlimit(limit_number)
+        with contextlib.closing(sqlite3.connect(":memory:")) as connection:
+            limit_number = sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER
+            host_parameter_limit = connection.getlimit(limit_number)
     # guessing based on defaults, seems you can't query
 
     # https://www.sqlite.org/changes.html#version_3_32_0


### PR DESCRIPTION
This was driving me nuts.

Anytime you ran `pytest -s` with anything even simply `--collect-only` you would get this `ResourceWarning: unclosed database in <sqlite3.Connection object` printed on the console using Python 3.11+ (I typically test with 3.13)

It took me a while to narrow this down, but the DBWrapper2 class was calling `get_host_parameter_limit()` on *import*, so just importing this would cause the sqlite DB to get opened but not explicitly closed.

Used the contextlib `closing` manager to automatically call close on the connection. Could also just as easily simply called close, but trying to use improved patterns