### PR TITLE
Eliminate rate limits and bans for exempt peer networks

### DIFF
--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -330,6 +330,7 @@ class ChiaServer:
                 outbound_rate_limit_percent=self._outbound_rate_limit_percent,
                 local_capabilities_for_handshake=self._local_capabilities_for_handshake,
                 stub_metadata_for_type=self.stub_metadata_for_type,
+                exempt_peer_networks=self.exempt_peer_networks,
             )
             await connection.perform_handshake(self._network_id, self.get_port(), self._local_type)
             assert connection.connection_type is not None, "handshake failed to set connection type, still None"
@@ -482,6 +483,7 @@ class ChiaServer:
                 local_capabilities_for_handshake=self._local_capabilities_for_handshake,
                 stub_metadata_for_type=self.stub_metadata_for_type,
                 session=session,
+                exempt_peer_networks=self.exempt_peer_networks,
             )
             await connection.perform_handshake(self._network_id, server_port, self._local_type)
             await self.connection_added(connection, on_connect)
@@ -549,6 +551,12 @@ class ChiaServer:
                     f"Trying to ban trusted peer {connection.peer_info.host} for {ban_time}, but will not ban"
                 )
                 ban_time = 0
+            elif is_in_network(connection.peer_info.host, self.exempt_peer_networks):
+                self.log.warning(
+                    f"Trying to ban exempt peer {connection.peer_info.host} for {ban_time}, but will not ban"
+                )
+                ban_time = 0
+
         if ban_time > 0:
             self.ban_peer(connection.peer_info.host, ban_time)
 

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -7,6 +7,7 @@ import time
 import traceback
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from ipaddress import IPv4Network, IPv6Network
 from typing import Any
 
 from aiohttp import ClientSession, WebSocketError, WSCloseCode, WSMessage, WSMsgType
@@ -36,7 +37,7 @@ from chia.util.errors import ApiError, ConsensusError, Err, ProtocolError, Times
 from chia.util.log_exceptions import log_exceptions
 
 # Each message is prepended with LENGTH_BYTES bytes specifying the length
-from chia.util.network import is_localhost
+from chia.util.network import is_in_network, is_localhost
 from chia.util.streamable import Streamable
 from chia.util.task_referencer import create_referenced_task
 
@@ -125,6 +126,11 @@ class WSChiaConnection:
         repr=False,
     )
 
+    exempt_peer_networks: list[IPv4Network | IPv6Network] = field(
+        default_factory=list,
+        repr=False,
+    )
+
     @classmethod
     def create(
         cls,
@@ -142,6 +148,7 @@ class WSChiaConnection:
         local_capabilities_for_handshake: list[tuple[uint16, str]],
         stub_metadata_for_type: dict[NodeType, ApiMetadata],
         session: ClientSession | None = None,
+        exempt_peer_networks: list[IPv4Network | IPv6Network] = [],
     ) -> WSChiaConnection:
         assert ws._writer is not None
         peername = ws._writer.transport.get_extra_info("peername")
@@ -631,7 +638,9 @@ class WSChiaConnection:
             message, self.local_capabilities, self.peer_capabilities
         )
         if limiter_msg is not None:
-            if not is_localhost(self.peer_info.host):
+            if not is_localhost(self.peer_info.host) and not is_in_network(
+                self.peer_info.host, self.exempt_peer_networks
+            ):
                 message_type = ProtocolMessageTypes(message.type)
                 last_time = self.log_rate_limit_last_time[message_type]
                 now = time.monotonic()
@@ -654,7 +663,8 @@ class WSChiaConnection:
                 return None
             else:
                 self.log.debug(
-                    f"Not rate limiting ourselves. message type: {ProtocolMessageTypes(message.type).name}, "
+                    f"Not rate limiting ourselves or exempt peers. "
+                    f"message type: {ProtocolMessageTypes(message.type).name}, "
                     f"peer: {self.peer_info.host}"
                 )
 
@@ -705,7 +715,11 @@ class WSChiaConnection:
                 full_message_loaded, self.local_capabilities, self.peer_capabilities
             )
             if limiter_msg is not None:
-                if self.local_type == NodeType.FULL_NODE and not is_localhost(self.peer_info.host):
+                if (
+                    self.local_type == NodeType.FULL_NODE
+                    and not is_localhost(self.peer_info.host)
+                    and not is_in_network(self.peer_info.host, self.exempt_peer_networks)
+                ):
                     details = ", ".join([f"{self.peer_info.host}", f"message: {message_type}", limiter_msg])
                     self.log.error(f"Peer has been rate limited and will be disconnected: {details}")
                     # Only full node disconnects peers, to prevent abuse and crashing timelords, farmers, etc

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -181,6 +181,7 @@ class WSChiaConnection:
             received_message_callback=received_message_callback,
             stub_metadata_for_type=stub_metadata_for_type,
             session=session,
+            exempt_peer_networks=exempt_peer_networks,
         )
 
     def _get_extra_info(self, name: str) -> Any | None:


### PR DESCRIPTION
Currently, the `exempt_peer_networks` option is only used to bypass connection limits (eg, how many nodes or wallets can connect to your node) and nothing else. But it seems useful to extend this. One use case is you want to run a local trusted node on the same network, but not necessarily on the same host. Currently, only localhost is exempt from rate limits and banning.

This PR will not apply rate limits, nor will it ban any peers that are in the `exempt_peer_networks` list. This allows a trusted node to be in the `exempt_peer_networks` and it will behave the same as running a node on the localhost 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Peers in `exempt_peer_networks` now bypass rate limiting and bans; wiring added through server/connection with tests covering exemptions.
> 
> - **Networking/Server**
>   - Pass `exempt_peer_networks` into `WSChiaConnection` for both inbound (`incoming_connection`) and outbound (`start_client`) paths.
>   - In `connection_closed()`, skip banning for hosts in `exempt_peer_networks` (with warning), in addition to existing localhost/trusted-peer exemptions.
> - **WebSocket Connection**
>   - Add `exempt_peer_networks` field and plumb via `create()`.
>   - Outbound: when rate limit triggers, do not rate-limit localhost or peers in `exempt_peer_networks`; refine log message.
>   - Inbound: only disconnect/ban for rate limiting if not localhost and not in `exempt_peer_networks`; otherwise log and continue.
> - **Tests**
>   - Add `test_connection_closed_banning` verifying no bans for localhost, trusted peers, and peers in `exempt_peer_networks`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ce16f8a143325aa2d8272c1b1e8a8dd789302a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->