### PR TITLE
cache master SK to local SK and pool SK key derivations

### DIFF
--- a/chia/plotting/cache.py
+++ b/chia/plotting/cache.py
@@ -5,6 +5,7 @@ import time
 import traceback
 from collections.abc import ItemsView, KeysView, ValuesView
 from dataclasses import dataclass, field
+from functools import lru_cache
 from math import ceil
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -12,7 +13,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from chia.plotting.prover import ProverProtocol
 
-from chia_rs import G1Element
+from chia_rs import G1Element, PrivateKey
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint16, uint64
 
@@ -25,6 +26,11 @@ from chia.wallet.derive_keys import master_sk_to_local_sk
 log = logging.getLogger(__name__)
 
 CURRENT_VERSION: int = 2
+
+
+@lru_cache
+def cached_master_sk_to_local_sk(master: PrivateKey) -> PrivateKey:
+    return master_sk_to_local_sk(master)
 
 
 @streamable
@@ -69,7 +75,7 @@ class CacheEntry:
             assert isinstance(pool_public_key_or_puzzle_hash, bytes32)
             pool_contract_puzzle_hash = pool_public_key_or_puzzle_hash
 
-        local_sk = master_sk_to_local_sk(local_master_sk)
+        local_sk = cached_master_sk_to_local_sk(local_master_sk)
 
         plot_public_key: G1Element = generate_plot_public_key(
             local_sk.get_g1(), farmer_public_key, pool_contract_puzzle_hash is not None


### PR DESCRIPTION
### Purpose:

To speed up tests that farm blocks. We currently don't have very many test plots for CI, but with v2 plots we will need more plot files, since each plot is smaller. As the number of plot files scales, so does the number of times we need to perform key derivation for plot keys.

### Current Behavior:

We perform key derivation for plots on-demand

### New Behavior:

We cache the key derivations in BlockTools and the plot manager.

### Testing Notes:

This primarily speeds-up (future) tests with v2 plots, where there are many more plot files. But it provides a measurable speed-up for existing tests as well.

Before:
```
103.87s call     chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py::test_subscribe_for_ph_reorg[ConsensusMode.HARD_FORK_3_0]
53.61s call     chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py::test_subscribe_for_ph_reorg[ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT]
12.68s call     chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py::test_subscribe_for_ph_reorg[ConsensusMode.HARD_FORK_2_0]
11.09s call     chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py::test_subscribe_for_ph_reorg[ConsensusMode.PLAIN]
```

After:
```
75.81s call     chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py::test_subscribe_for_ph_reorg[ConsensusMode.HARD_FORK_3_0]
48.28s call     chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py::test_subscribe_for_ph_reorg[ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT]
10.76s call     chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py::test_subscribe_for_ph_reorg[ConsensusMode.PLAIN]
9.82s call     chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py::test_subscribe_for_ph_reorg[ConsensusMode.HARD_FORK_2_0]
```