### PR TITLE
update expected_plot_size() to match the latest proof of space format

### DIFF
--- a/chia/_tests/core/consensus/test_pot_iterations.py
+++ b/chia/_tests/core/consensus/test_pot_iterations.py
@@ -142,4 +142,4 @@ def test_expected_plot_size_v1() -> None:
 def test_expected_plot_size_v2() -> None:
     for strength in [2, 3, 4, 5, 6, 7]:
         plot_size = _expected_plot_size(PlotParam.make_v2(strength), test_constants)
-        assert plot_size == 1_879_213_114
+        assert plot_size == 988_513_566

--- a/chia/consensus/pos_quality.py
+++ b/chia/consensus/pos_quality.py
@@ -7,17 +7,6 @@ from chia_rs.sized_ints import uint64
 # This is not used in consensus, only for display purposes
 UI_ACTUAL_SPACE_CONSTANT_FACTOR = 0.78
 
-# TODO: todo_v2_plots these values prelimenary. When the plotter is complete,
-# replace this table with a closed form formula
-v2_plot_sizes: dict[int, uint64] = {
-    18: uint64(1_048_737),
-    20: uint64(4_824_084),
-    22: uint64(21_812_958),
-    24: uint64(97_318_160),
-    26: uint64(429_539_960),
-    28: uint64(1_879_213_114),
-}
-
 
 def _expected_plot_size(size: PlotParam, constants: ConsensusConstants) -> uint64:
     """
@@ -33,4 +22,7 @@ def _expected_plot_size(size: PlotParam, constants: ConsensusConstants) -> uint6
         k = size.size_v1
         return uint64(((2 * k) + 1) * (2 ** (k - 1)))
     else:
-        return v2_plot_sizes[constants.PLOT_SIZE_V2]
+        k = constants.PLOT_SIZE_V2
+        # TODO: todo_v2_plots this formula may change slightly before the
+        # final version of the plotter. Revisit this when the plotter is complete
+        return uint64((2**k) * (k + 1.46) / 8)


### PR DESCRIPTION
### Purpose:

With the second iteration of v2 proof of space, we have a new formula for expected plot size (for v2 plots).

### Current Behavior:

We used a table because the k -> plot_size function was complicated

### New Behavior:

We use a formula, because the k -> plot_size function is simple