### PR TITLE
CHIA-3856 Use an adapted version of deficit round robin algorithm in TransactionQueue's pop

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -286,7 +286,9 @@ class FullNode:
                 single_threaded=single_threaded,
             ) as self._mempool_manager:
                 # Transactions go into this queue from the server, and get sent to respond_transaction
-                self._transaction_queue = TransactionQueue(1000, self.log)
+                self._transaction_queue = TransactionQueue(
+                    1000, self.log, max_tx_clvm_cost=uint64(self.constants.MAX_BLOCK_COST_CLVM // 2)
+                )
                 self._transaction_queue_task: asyncio.Task[None] = create_referenced_task(self._handle_transactions())
 
                 self._init_weight_proof = create_referenced_task(self.initialize_weight_proof())


### PR DESCRIPTION
### Purpose:

Converts `TransactionQueue`'s `pop` from a simple round robin across peers to a deficit round robin.

### Current Behavior:

`TransactionQueue`'s `pop` implements a simple round robin across peers.

### New Behavior:

`TransactionQueue`'s `pop` implements an adapted version of the deficit round robin algorithm.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements cost-aware, per-peer fair scheduling for transaction processing.
> 
> - Rewrites `TransactionQueue.pop()` to a deficit round robin: per-peer `PeerTransactionsQueue` with priority by negative fee-per-cost (FPC), deficit counters in CLVM cost, and periodic cleanup of empty peers
> - Adds `max_tx_clvm_cost` fallback for transactions without advertised cost; plumbs into `FullNode` queue init and all tests
> - Replaces `_normal_priority_queues` with `_peers_transactions_queues` and adds internal cursor/cleanup tracking
> - Updates and expands tests: prioritization fallback, fairness/cleanup, and detailed deficit round robin behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d261984476ff9bd7c4b6792538c3a85437d06557. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->