### PR TITLE
Check MMR root is not set before hard fork

### DIFF
--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -877,6 +877,15 @@ def validate_finished_header_block(
     if validate_unfinished_err is not None:
         return None, validate_unfinished_err
 
+    # hard fork 2 activates when the previous transaction block has reached
+    # HARD_FORK2_HEIGHT. We don't necessarily know exactly when that is, but
+    # if *this* block hasn't exceeded it, it has definitely not activated
+    if (
+        header_block.height <= constants.HARD_FORK2_HEIGHT
+        and header_block.reward_chain_block.header_mmr_root is not None
+    ):
+        return None, ValidationError(Err.INVALID_MMR_ROOT)
+
     assert required_iters is not None
 
     if header_block.height == 0:

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -197,6 +197,9 @@ class Err(Enum):
     # the transactions generator uses overlong encoding of CLVM atoms in its
     # serialization
     INVALID_TRANSACTIONS_GENERATOR_ENCODING = 148
+    # if the merkle mountain range commitment to the previous chain is invalid,
+    # or present before hard fork 2
+    INVALID_MMR_ROOT = 149
 
 
 class ValidationError(Exception):


### PR DESCRIPTION
### Purpose:

Make sure the merkle mountain range root is not set before the hard fork. This check is redundant, because the reward chain block would not be considered valid if it's set. But it makes it clear and deliberate that it's disallowed.

### Current Behavior:

We check the MMR root indirectly by comparing the reward chain block against what we expect it to be.

### New Behavior:

We check the MMR root directly, to ensure it's not set before the hard fork.