### PR TITLE
Augmented usage fix

### DIFF
--- a/chia/_tests/blockchain/blockchain_test_utils.py
+++ b/chia/_tests/blockchain/blockchain_test_utils.py
@@ -78,7 +78,7 @@ async def _validate_and_add_block(
             conds = SpendBundleConditions([], 0, 0, 0, None, None, [], 0, 0, 0, True, 0, 0, 0, 0, 0)
         results = PreValidationResult(None, uint64(1), conds, uint32(0))
     else:
-        # Reusing the same instance across validations matches production behavior
+        # use augmented blockchain if provided
         aug_blockchain = augmented_blockchain if augmented_blockchain is not None else AugmentedBlockchain(blockchain)
         future = await pre_validate_block(
             blockchain.constants,

--- a/chia/_tests/blockchain/blockchain_test_utils.py
+++ b/chia/_tests/blockchain/blockchain_test_utils.py
@@ -48,6 +48,7 @@ async def _validate_and_add_block(
     expected_error: Err | None = None,
     skip_prevalidation: bool = False,
     fork_info: ForkInfo | None = None,
+    augmented_blockchain: AugmentedBlockchain | None = None,
 ) -> None:
     # Tries to validate and add the block, and checks that there are no errors in the process and that the
     # block is added to the peak.
@@ -77,9 +78,11 @@ async def _validate_and_add_block(
             conds = SpendBundleConditions([], 0, 0, 0, None, None, [], 0, 0, 0, True, 0, 0, 0, 0, 0)
         results = PreValidationResult(None, uint64(1), conds, uint32(0))
     else:
+        # Reusing the same instance across validations matches production behavior
+        aug_blockchain = augmented_blockchain if augmented_blockchain is not None else AugmentedBlockchain(blockchain)
         future = await pre_validate_block(
             blockchain.constants,
-            AugmentedBlockchain(blockchain),
+            aug_blockchain,
             block,
             blockchain.pool,
             None,
@@ -154,6 +157,7 @@ async def _validate_and_add_block_multi_result(
     expected_result: list[AddBlockResult],
     skip_prevalidation: bool = False,
     fork_info: ForkInfo | None = None,
+    augmented_blockchain: AugmentedBlockchain | None = None,
 ) -> None:
     try:
         await _validate_and_add_block(
@@ -161,6 +165,7 @@ async def _validate_and_add_block_multi_result(
             block,
             skip_prevalidation=skip_prevalidation,
             fork_info=fork_info,
+            augmented_blockchain=augmented_blockchain,
         )
     except Exception as e:
         assert isinstance(e, AssertionError)
@@ -175,6 +180,7 @@ async def _validate_and_add_block_no_error(
     block: FullBlock,
     skip_prevalidation: bool = False,
     fork_info: ForkInfo | None = None,
+    augmented_blockchain: AugmentedBlockchain | None = None,
 ) -> None:
     # adds a block and ensures that there is no error. However, does not ensure that block extended the peak of
     # the blockchain
@@ -188,4 +194,5 @@ async def _validate_and_add_block_no_error(
         ],
         skip_prevalidation=skip_prevalidation,
         fork_info=fork_info,
+        augmented_blockchain=augmented_blockchain,
     )

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -3254,17 +3254,28 @@ class TestReorgs:
 
         blocks_reorg_chain = bt.get_consecutive_blocks(7, blocks[:10], seed=b"2")
         fork_info = ForkInfo(-1, -1, bt.constants.GENESIS_CHALLENGE)
+        # Create one AugmentedBlockchain instance and reuse it across fork chain validations
+        # This matches production behavior where batches reuse the same instance
+        aug_chain = AugmentedBlockchain(b)
         for reorg_block in blocks_reorg_chain:
             if reorg_block.height < 10:
                 await _validate_and_add_block(
-                    b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK, fork_info=fork_info
+                    b,
+                    reorg_block,
+                    expected_result=AddBlockResult.ALREADY_HAVE_BLOCK,
+                    fork_info=fork_info,
+                    augmented_blockchain=aug_chain,
                 )
             elif reorg_block.height < 15:
                 await _validate_and_add_block(
-                    b, reorg_block, expected_result=AddBlockResult.ADDED_AS_ORPHAN, fork_info=fork_info
+                    b,
+                    reorg_block,
+                    expected_result=AddBlockResult.ADDED_AS_ORPHAN,
+                    fork_info=fork_info,
+                    augmented_blockchain=aug_chain,
                 )
             elif reorg_block.height >= 15:
-                await _validate_and_add_block(b, reorg_block, fork_info=fork_info)
+                await _validate_and_add_block(b, reorg_block, fork_info=fork_info, augmented_blockchain=aug_chain)
         peak = b.get_peak()
         assert peak is not None
         assert peak.height == 16
@@ -3297,15 +3308,23 @@ class TestReorgs:
         fork_info = ForkInfo(fork_block.height, fork_block.height, fork_block.header_hash)
         blocks_reorg_chain = bt.get_consecutive_blocks(7, blocks[:10], seed=b"2")
         assert blocks_reorg_chain[reorg_point].is_transaction_block() is False
+        # Reuse one AugmentedBlockchain instance for the fork chain
+        aug_chain = AugmentedBlockchain(b)
         for reorg_block in blocks_reorg_chain:
             if reorg_block.height < 10:
-                await _validate_and_add_block(b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK)
+                await _validate_and_add_block(
+                    b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK, augmented_blockchain=aug_chain
+                )
             elif reorg_block.height < reorg_point:
                 await _validate_and_add_block(
-                    b, reorg_block, expected_result=AddBlockResult.ADDED_AS_ORPHAN, fork_info=fork_info
+                    b,
+                    reorg_block,
+                    expected_result=AddBlockResult.ADDED_AS_ORPHAN,
+                    fork_info=fork_info,
+                    augmented_blockchain=aug_chain,
                 )
             elif reorg_block.height >= reorg_point:
-                await _validate_and_add_block(b, reorg_block, fork_info=fork_info)
+                await _validate_and_add_block(b, reorg_block, fork_info=fork_info, augmented_blockchain=aug_chain)
 
             if reorg_block.is_transaction_block():
                 reorg_last_tx_block = reorg_block.header_hash
@@ -3398,6 +3417,10 @@ class TestReorgs:
 
         first_peak = b.get_peak()
         fork_info2 = None
+        # Reuse one AugmentedBlockchain instance for orphan blocks only
+        # Once blocks become NEW_PEAK, don't reuse (underlying blockchain has changed)
+        aug_chain: AugmentedBlockchain | None = AugmentedBlockchain(b)
+        reorg_started = False
         for reorg_block in reorg_blocks:
             if (reorg_block.height % 100) == 0:
                 peak = b.get_peak()
@@ -3409,16 +3432,32 @@ class TestReorgs:
                 )
 
             if reorg_block.height < num_blocks_chain_2_start:
-                await _validate_and_add_block(b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK)
+                await _validate_and_add_block(
+                    b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK, augmented_blockchain=aug_chain
+                )
             elif reorg_block.weight <= chain_1_weight:
                 if fork_info2 is None:
                     fork_info2 = ForkInfo(reorg_block.height - 1, reorg_block.height - 1, reorg_block.prev_header_hash)
                 await _validate_and_add_block(
-                    b, reorg_block, expected_result=AddBlockResult.ADDED_AS_ORPHAN, fork_info=fork_info2
+                    b,
+                    reorg_block,
+                    expected_result=AddBlockResult.ADDED_AS_ORPHAN,
+                    fork_info=fork_info2,
+                    augmented_blockchain=aug_chain,
                 )
             elif reorg_block.weight > chain_1_weight:
+                # Don't reuse AugmentedBlockchain after blocks commit as NEW_PEAK
+                # Each NEW_PEAK changes the underlying blockchain
+                if reorg_started:
+                    aug_chain = None  # Create fresh instance for each NEW_PEAK block
+                else:
+                    reorg_started = True
                 await _validate_and_add_block(
-                    b, reorg_block, expected_result=AddBlockResult.NEW_PEAK, fork_info=fork_info2
+                    b,
+                    reorg_block,
+                    expected_result=AddBlockResult.NEW_PEAK,
+                    fork_info=fork_info2,
+                    augmented_blockchain=aug_chain,
                 )
 
         # if these asserts fires, there was no reorg
@@ -3505,6 +3544,8 @@ class TestReorgs:
         # Reorg to alternate chain that is 1 height longer
         blocks_reorg_chain = bt.get_consecutive_blocks(16, [], seed=b"2")
         fork_info = ForkInfo(-1, -1, bt.constants.GENESIS_CHALLENGE)
+        # Reuse one AugmentedBlockchain instance for the first fork chain
+        aug_chain = AugmentedBlockchain(b)
         for reorg_block in blocks_reorg_chain:
             if reorg_block.height < 15:
                 await _validate_and_add_block_multi_result(
@@ -3512,26 +3553,37 @@ class TestReorgs:
                     reorg_block,
                     expected_result=[AddBlockResult.ADDED_AS_ORPHAN, AddBlockResult.ALREADY_HAVE_BLOCK],
                     fork_info=fork_info,
+                    augmented_blockchain=aug_chain,
                 )
             elif reorg_block.height >= 15:
-                await _validate_and_add_block(b, reorg_block, fork_info=fork_info)
+                await _validate_and_add_block(b, reorg_block, fork_info=fork_info, augmented_blockchain=aug_chain)
 
         # Back to original chain
         blocks_reorg_chain_2 = bt.get_consecutive_blocks(3, blocks, seed=b"3")
 
         # we start from the beginning to make sure fork_info is built correctly
         fork_info = ForkInfo(-1, -1, bt.constants.GENESIS_CHALLENGE)
+        # Reuse one AugmentedBlockchain instance for the second fork chain
+        aug_chain2 = AugmentedBlockchain(b)
         for reorg_block in blocks_reorg_chain_2:
             if reorg_block.height < 15:
                 await _validate_and_add_block(
-                    b, reorg_block, expected_result=AddBlockResult.ALREADY_HAVE_BLOCK, fork_info=fork_info
+                    b,
+                    reorg_block,
+                    expected_result=AddBlockResult.ALREADY_HAVE_BLOCK,
+                    fork_info=fork_info,
+                    augmented_blockchain=aug_chain2,
                 )
             elif reorg_block.height < 16:
                 await _validate_and_add_block(
-                    b, reorg_block, expected_result=AddBlockResult.ADDED_AS_ORPHAN, fork_info=fork_info
+                    b,
+                    reorg_block,
+                    expected_result=AddBlockResult.ADDED_AS_ORPHAN,
+                    fork_info=fork_info,
+                    augmented_blockchain=aug_chain2,
                 )
             else:
-                await _validate_and_add_block(b, reorg_block, fork_info=fork_info)
+                await _validate_and_add_block(b, reorg_block, fork_info=fork_info, augmented_blockchain=aug_chain2)
 
         peak = b.get_peak()
         assert peak is not None
@@ -3581,8 +3633,10 @@ class TestReorgs:
             await _validate_and_add_block(b, block)
         fork_block = blocks[11]
         fork_info = ForkInfo(fork_block.height, fork_block.height, fork_block.header_hash)
+        # Reuse one AugmentedBlockchain instance for the fork chain
+        aug_chain = AugmentedBlockchain(b)
         for block in blocks_fork[12:]:
-            await _validate_and_add_block_no_error(b, block, fork_info=fork_info)
+            await _validate_and_add_block_no_error(b, block, fork_info=fork_info, augmented_blockchain=aug_chain)
 
     @pytest.mark.anyio
     async def test_get_header_blocks_in_range_tx_filter(self, empty_blockchain: Blockchain, bt: BlockTools) -> None:

--- a/chia/consensus/augmented_chain.py
+++ b/chia/consensus/augmented_chain.py
@@ -60,11 +60,12 @@ class AugmentedBlockchain:
                     f"New block's prev_hash must match last added block. "
                     f"Expected {last_header_hash.hex()[:16]}, got {block_record.prev_hash.hex()[:16]}"
                 )
-        elif not self._underlying.contains_block(block_record.prev_hash, uint32(block_record.height - 1)):
-            raise AugmentedBlockchainValidationError(
-                f"First added block's prev_hash must be contained in underlying peak."
-                f"Expected {block_record.prev_hash.hex()[:16]}, got {block_record.prev_hash.hex()[:16]}"
-            )
+        elif block_record.height > 0:
+            if not self._underlying.contains_block(block_record.prev_hash, uint32(block_record.height - 1)):
+                raise AugmentedBlockchainValidationError(
+                    f"First added block's prev_hash must exist in underlying blockchain. "
+                    f"Block height {block_record.height}, prev_hash {block_record.prev_hash.hex()[:16]} not found"
+                )
 
         self._extra_blocks[block_record.header_hash] = (block, block_record)
         self._height_to_hash[block_record.height] = block_record.header_hash

--- a/chia/consensus/augmented_chain.py
+++ b/chia/consensus/augmented_chain.py
@@ -54,13 +54,6 @@ class AugmentedBlockchain:
             max_height = max(self._height_to_hash.keys())
             last_header_hash = self._height_to_hash[max_height]
 
-            # New block must be the next sequential block
-            if block_record.height != max_height + 1:
-                raise AugmentedBlockchainValidationError(
-                    f"Blocks must be added in sequential order. "
-                    f"Expected height {max_height + 1}, got {block_record.height}"
-                )
-
             # New block must chain to the last added block
             if block_record.prev_hash != last_header_hash:
                 raise AugmentedBlockchainValidationError(

--- a/chia/consensus/augmented_chain.py
+++ b/chia/consensus/augmented_chain.py
@@ -60,6 +60,11 @@ class AugmentedBlockchain:
                     f"New block's prev_hash must match last added block. "
                     f"Expected {last_header_hash.hex()[:16]}, got {block_record.prev_hash.hex()[:16]}"
                 )
+        elif not self._underlying.contains_block(block_record.prev_hash, uint32(block_record.height - 1)):
+            raise AugmentedBlockchainValidationError(
+                f"First added block's prev_hash must be contained in underlying peak."
+                f"Expected {block_record.prev_hash.hex()[:16]}, got {block_record.prev_hash.hex()[:16]}"
+            )
 
         self._extra_blocks[block_record.header_hash] = (block, block_record)
         self._height_to_hash[block_record.height] = block_record.header_hash

--- a/chia/consensus/augmented_chain.py
+++ b/chia/consensus/augmented_chain.py
@@ -61,7 +61,7 @@ class AugmentedBlockchain:
                     f"Expected {last_header_hash.hex()[:16]}, got {block_record.prev_hash.hex()[:16]}"
                 )
         elif block_record.height > 0:
-            if not self._underlying.contains_block(block_record.prev_hash, uint32(block_record.height - 1)):
+            if self._underlying.try_block_record(block_record.prev_hash) is None:
                 raise AugmentedBlockchainValidationError(
                     f"First added block's prev_hash must exist in underlying blockchain. "
                     f"Block height {block_record.height}, prev_hash {block_record.prev_hash.hex()[:16]} not found"

--- a/chia/consensus/augmented_chain.py
+++ b/chia/consensus/augmented_chain.py
@@ -10,7 +10,7 @@ from chia.consensus.blockchain_interface import BlocksProtocol
 from chia.util.errors import Err
 
 
-class AugmentedBlockchainValidationError(Exception):
+class AugmentedBlockchainValidationError(AssertionError):
     pass
 
 
@@ -54,7 +54,6 @@ class AugmentedBlockchain:
             max_height = max(self._height_to_hash.keys())
             last_header_hash = self._height_to_hash[max_height]
 
-            # New block must chain to the last added block
             if block_record.prev_hash != last_header_hash:
                 raise AugmentedBlockchainValidationError(
                     f"New block's prev_hash must match last added block. "


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
make sure blocks that are added to AugmentedBlockchain are in order and belong to one chain
<!-- Does this PR introduce a breaking change? -->

### Current Behavior:
we allow arbitrary blocks to be added even though usage other then tests follow the invariant of allowing only the next block to be added


### New Behavior:
we make sure that block_record.prev_hash != last_header_hash in add_extra_block
we change the tests to correctly use the AugmentedBlockchain
<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens AugmentedBlockchain integrity and aligns tests with intended usage.
> 
> - Introduces `AugmentedBlockchainValidationError` and tightens `add_extra_block` to enforce: matching `header_hash`, sequential `prev_hash` continuity to the last added block, and that the first added block’s `prev_hash` exists in the underlying chain
> - Test utilities now accept an optional `augmented_blockchain` and use it for record lookups and prevalidation; callers updated to reuse one instance across fork/reorg validation, with a reset when switching to a new peak path
> - Adds new tests for sequential ordering and first-block `prev_hash` validation; updates existing reorg tests to pass the shared augmented chain instance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea928717ebd17aff0c17f99face409b1ec691939. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->