### PR TITLE
[LABS-387] Revert accidental RPC parameter name change

### DIFF
--- a/chia/_tests/cmds/wallet/test_nft.py
+++ b/chia/_tests/cmds/wallet/test_nft.py
@@ -114,7 +114,7 @@ def test_nft_mint(capsys: object, get_test_cli_clients: tuple[TestRpcClients, Pa
                     request.edition_total,
                     request.edition_number,
                     request.fee,
-                    request.royalty_amount,
+                    request.royalty_percentage,
                     request.did_id,
                     request.push,
                     tx_config,

--- a/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
+++ b/chia/_tests/wallet/nft_wallet/test_nft_wallet.py
@@ -1206,7 +1206,7 @@ async def test_nft_rpc_mint(wallet_environments: WalletTestFramework) -> None:
             license_uris=license_uris,
             edition_total=uint64(st),
             edition_number=uint64(sn),
-            royalty_amount=uint16(royalty_percentage),
+            royalty_percentage=uint16(royalty_percentage),
             push=True,
         ),
         tx_config=wallet_environments.tx_config,

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -1329,7 +1329,7 @@ async def mint_nft(
                     edition_total=uint64(edition_total) if edition_total is not None else uint64(1),
                     edition_number=uint64(edition_number) if edition_number is not None else uint64(1),
                     fee=fee,
-                    royalty_amount=uint16(royalty_percentage),
+                    royalty_percentage=uint16(royalty_percentage),
                     did_id=did_id,
                     push=push,
                 ),

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -1604,7 +1604,7 @@ class NFTMintNFTRequest(TransactionEndpointRequest):
     target_address: str | None = field(default_factory=default_raise)
     uris: list[str] = field(default_factory=default_raise)
     hash: bytes32 = field(default_factory=default_raise)
-    royalty_amount: uint16 = uint16(0)
+    royalty_percentage: uint16 = uint16(0)
     meta_uris: list[str] = field(default_factory=list)
     license_uris: list[str] = field(default_factory=list)
     edition_number: uint64 = uint64(1)

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -2624,7 +2624,7 @@ class WalletRpcApi:
         log.debug("Got minting RPC request: %s", request)
         assert self.service.wallet_state_manager
         nft_wallet = self.service.wallet_state_manager.get_wallet(id=request.wallet_id, required_type=NFTWallet)
-        if request.royalty_amount == 10000:
+        if request.royalty_percentage == 10000:
             raise ValueError("Royalty percentage cannot be 100%")
         if request.royalty_address is not None:
             royalty_puzhash = decode_puzzle_hash(request.royalty_address)
@@ -2660,7 +2660,7 @@ class WalletRpcApi:
             action_scope,
             target_puzhash,
             royalty_puzhash,
-            request.royalty_amount,
+            request.royalty_percentage,
             did_id,
             request.fee,
             extra_conditions=extra_conditions,


### PR DESCRIPTION
This was accidentally renamed from `royalty_percentage` to `royalty_amount` in https://github.com/Chia-Network/chia-blockchain/commit/760a65fd0bdeaa770150cae6fff4edd56de5ce37 .  This PR reverts that breaking change.  I blame the original dev of the endpoint for their poor consistency in variable naming :)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores the correct NFT mint parameter name to maintain RPC compatibility.
> 
> - Rename `NFTMintNFTRequest` field from `royalty_amount` back to `royalty_percentage`
> - Update RPC handler to use `request.royalty_percentage` (incl. 100% check) and pass through to wallet minting
> - Adjust CLI construction in `wallet_funcs.py` to send `royalty_percentage`
> - Update unit and integration tests to expect/use `royalty_percentage`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83001ca9d048218100ce7ee33fa2612d87aef2da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->