### PR TITLE
Explore bringing back v2 plot pool keys support

### DIFF
--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -145,14 +145,6 @@ def b32(key: str) -> bytes32:
         height=uint32(DEFAULT_CONSTANTS.HARD_FORK2_HEIGHT - 1),
         expected_error="v2 proof support has not yet activated",
     ),
-    ProofOfSpaceCase(
-        id="v2 plot with pool pk",
-        pos_challenge=bytes32(b"1" * 32),
-        plot_size=PlotParam.make_v2(2),
-        plot_public_key=G1Element(),
-        pool_public_key=G1Element(),
-        expected_error="v2 plots require pool_contract_puzzle_hash, pool public key is not supported",
-    ),
 )
 def test_verify_and_get_quality_string(caplog: pytest.LogCaptureFixture, case: ProofOfSpaceCase) -> None:
     caplog.set_level(logging.INFO)

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -345,10 +345,6 @@ def create_unfinished_block(
 
     cc_sp_hash: bytes32 = slot_cc_challenge
 
-    if proof_of_space.param().strength_v2 is not None:
-        # v2 plots don't support pool public key
-        assert proof_of_space.pool_public_key is None
-
     # Only enters this if statement if we are in testing mode (making VDF proofs here)
     if signage_point.cc_vdf is not None:
         assert signage_point.rc_vdf is not None

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -769,11 +769,6 @@ def validate_unfinished_header_block(
         assert header_block.reward_chain_block.proof_of_space.pool_contract_puzzle_hash is None
         assert header_block.foliage.foliage_block_data.pool_signature is not None
 
-        # v2 plots require pool contract puzzle hash, not pool pk
-        # TODO: todo_v2_plots add test coverage of this check
-        if header_block.reward_chain_block.proof_of_space.param().strength_v2 is not None:
-            return None, ValidationError(Err.INVALID_POOL_TARGET)
-
         if not AugSchemeMPL.verify(
             header_block.reward_chain_block.proof_of_space.pool_public_key,
             bytes(header_block.foliage.foliage_block_data.pool_target),

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -837,12 +837,6 @@ class BlockTools:
         if num_blocks == 0:
             return block_list
 
-        if block_list[-1].height >= constants.HARD_FORK2_HEIGHT and pool_reward_puzzle_hash is not None:
-            raise ValueError(
-                "block height is past hard fork 2 activation. v2 plots don't "
-                "support pool puzzle hashes, only contract hashes"
-            )
-
         blocks: dict[bytes32, BlockRecord]
         if block_list[-1].header_hash == self._block_cache_header:
             height_to_hash = self._block_cache_height_to_hash

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -236,17 +236,12 @@ class FullNodeSimulator(FullNodeAPI):
 
             current_blocks = await self.get_all_full_blocks()
             target = request.puzzle_hash
-            pool_target: bytes32 | None = target
-            if current_blocks[-1].height >= self.full_node.constants.HARD_FORK2_HEIGHT - 1:
-                # v2 plots (which we start farming at the hard fork activation)
-                # don't support specifying the pool target
-                pool_target = None
             more = self.bt.get_consecutive_blocks(
                 1,
                 time_per_block=time_per_block,
                 transaction_data=spend_bundle,
                 farmer_reward_puzzle_hash=target,
-                pool_reward_puzzle_hash=pool_target,
+                pool_reward_puzzle_hash=target,
                 block_list_input=current_blocks,
                 guarantee_transaction_block=True,
                 current_time=current_time,
@@ -293,16 +288,11 @@ class FullNodeSimulator(FullNodeAPI):
                 spend_bundle = mempool_bundle[0]
             current_blocks = await self.get_all_full_blocks()
             target = request.puzzle_hash
-            pool_target: bytes32 | None = target
-            if current_blocks[-1].height >= self.full_node.constants.HARD_FORK2_HEIGHT - 1:
-                # v2 plots (which we start farming at the hard fork activation)
-                # don't support specifying the pool target
-                pool_target = None
             more = self.bt.get_consecutive_blocks(
                 1,
                 transaction_data=spend_bundle,
                 farmer_reward_puzzle_hash=target,
-                pool_reward_puzzle_hash=pool_target,
+                pool_reward_puzzle_hash=target,
                 block_list_input=current_blocks,
                 current_time=current_time,
                 time_per_block=time_per_block,
@@ -320,15 +310,10 @@ class FullNodeSimulator(FullNodeAPI):
         current_blocks = await self.get_all_full_blocks()
         block_count = new_index - old_index
 
-        pool_target: bytes32 | None = coinbase_ph
-        if current_blocks[-1].height >= self.full_node.constants.HARD_FORK2_HEIGHT - 1:
-            # v2 plots (which we start farming at the hard fork activation)
-            # don't support specifying the pool target
-            pool_target = None
         more_blocks = self.bt.get_consecutive_blocks(
             block_count,
             farmer_reward_puzzle_hash=coinbase_ph,
-            pool_reward_puzzle_hash=pool_target,
+            pool_reward_puzzle_hash=coinbase_ph,
             block_list_input=current_blocks[: old_index + 1],
             force_overflow=True,
             guarantee_transaction_block=True,
@@ -417,13 +402,7 @@ class FullNodeSimulator(FullNodeAPI):
             expected_peak_height = 0 if original_peak_height is None else original_peak_height
             extra_blocks = [[False, False]] if original_peak_height is None else []  # Farm genesis block first
 
-            if expected_peak_height >= self.full_node.constants.HARD_FORK2_HEIGHT - 1:
-                # v2 plots (which we start farming at the hard fork activation)
-                # don't support specifying the pool target, so we only get the
-                # farmer reward, not the pool reward
-                expected_reward_coin_count = count
-            else:
-                expected_reward_coin_count = 2 * count
+            expected_reward_coin_count = 2 * count
 
             for to_wallet, tx_block in [*extra_blocks, *([[True, False]] * (count - 1)), [True, True], [False, True]]:
                 # This complicated application of the last two blocks being transaction


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores support for v2 plots using a pool public key and aligns consensus/simulator code accordingly.
> 
> - Updates `get_plot_id` to derive v2 plot IDs from either `pool_public_key` or `pool_contract_puzzle_hash`; changes `calculate_plot_id_v2` to accept either type
> - Removes v2-only restriction checks: no longer asserts/returns errors when v2 plots use a pool public key in block creation and header validation
> - Simulator changes: always pass `pool_reward_puzzle_hash=target` in farming/reorg paths; removes HF2 gating and related error path in `BlockTools`
> - Test updates: drop case expecting v2-with-pool-pk failure; adjust reward expectations to consistently count both farmer and pool rewards
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c6821a3e0f6c14708e6c6f9dd27d749366ea5b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->