### PR TITLE
CHIA-3867 Simplify TransactionQueue's put

### DIFF
--- a/chia/_tests/core/full_node/test_tx_processing_queue.py
+++ b/chia/_tests/core/full_node/test_tx_processing_queue.py
@@ -226,13 +226,13 @@ async def test_peer_queue_prioritization_fallback() -> None:
     tx2 = get_transaction_queue_entry(peer3, 1, peers_with_tx2)
     queue.put(tx2, peer3)
     # tx2 gets top priority with FPC 1.0
-    assert math.isclose(queue._queue_dict[peer3].queue[0][0], -1.0)
+    assert math.isclose(queue._normal_priority_queues[peer3].queue[0][0], -1.0)
     entry = await queue.pop()
     # NOTE: This whole test file uses `index` as an addition to
     # `TransactionQueueEntry` for easier testing, hence this type ignore here
     # and everywhere else.
     assert entry.index == 1  # type: ignore[attr-defined]
     # tx1 comes next due to lowest priority fallback
-    assert math.isinf(queue._queue_dict[peer3].queue[0][0])
+    assert math.isinf(queue._normal_priority_queues[peer3].queue[0][0])
     entry = await queue.pop()
     assert entry.index == 0  # type: ignore[attr-defined]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Simplifies transaction queuing and internal naming**
> 
> - Renames `TransactionQueue` internal map from `'_queue_dict'` to `'_normal_priority_queues'`
> - Streamlines `put`: early-return for high/local priority with semaphore release, lazy-creates per-peer `PriorityQueue`, centralizes size check and raises `TransactionQueueFull` consistently
> - Consolidates FPC-based prioritization and fallback to `float('inf')` when peer lacks advertised cost/fee
> - Updates tests to reference `'_normal_priority_queues'` and validate priority ordering and fallback behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7bcdc86df5b2cc908d703d03e78d4b23df65208. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->