### PR TITLE
Cherry-pick CHIA-3867 Simplify TransactionQueue's put (#20392)

### DIFF
--- a/chia/_tests/core/full_node/test_tx_processing_queue.py
+++ b/chia/_tests/core/full_node/test_tx_processing_queue.py
@@ -226,13 +226,13 @@ async def test_peer_queue_prioritization_fallback() -> None:
     tx2 = get_transaction_queue_entry(peer3, 1, peers_with_tx2)
     queue.put(tx2, peer3)
     # tx2 gets top priority with FPC 1.0
-    assert math.isclose(queue._queue_dict[peer3].queue[0][0], -1.0)
+    assert math.isclose(queue._normal_priority_queues[peer3].queue[0][0], -1.0)
     entry = await queue.pop()
     # NOTE: This whole test file uses `index` as an addition to
     # `TransactionQueueEntry` for easier testing, hence this type ignore here
     # and everywhere else.
     assert entry.index == 1  # type: ignore[attr-defined]
     # tx1 comes next due to lowest priority fallback
-    assert math.isinf(queue._queue_dict[peer3].queue[0][0])
+    assert math.isinf(queue._normal_priority_queues[peer3].queue[0][0])
     entry = await queue.pop()
     assert entry.index == 0  # type: ignore[attr-defined]


### PR DESCRIPTION
PR #20392. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines transaction queuing logic and aligns tests with new internals.
> 
> - **Refactor `TransactionQueue`**: Simplifies `put()` by early-returning for local/high-priority, centralizing per-peer queue creation, capacity checks, and FPC-based prioritization; uses `float("inf")` fallback when fee/cost not advertised
> - Renames internal map from `'_queue_dict'` to `'_normal_priority_queues'` and updates `pop()` round-robin and cleanup accordingly
> - **Tests updated**: Adjust references to `'_normal_priority_queues'` and verify prioritization fallback behavior in `test_peer_queue_prioritization_fallback`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a8a3aa7cf21e9bc41be9fbdf7fe9838c901529f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->