### PR TITLE
Cherry-pick CHIA-3856 Use an adapted version of deficit round robin algorithm in TransactionQueue's pop

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -286,7 +286,9 @@ class FullNode:
                 single_threaded=single_threaded,
             ) as self._mempool_manager:
                 # Transactions go into this queue from the server, and get sent to respond_transaction
-                self._transaction_queue = TransactionQueue(1000, self.log)
+                self._transaction_queue = TransactionQueue(
+                    1000, self.log, max_tx_clvm_cost=uint64(self.constants.MAX_BLOCK_COST_CLVM // 2)
+                )
                 self._transaction_queue_task: asyncio.Task[None] = create_referenced_task(self._handle_transactions())
 
                 self._init_weight_proof = create_referenced_task(self.initialize_weight_proof())


### PR DESCRIPTION
PR #20351.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements fair, cost-aware scheduling in `TransactionQueue` and updates usage/tests.
> 
> - Introduces `PeerTransactionsQueue` with per-peer priority queue (by negative FPC) and a CLVM-cost deficit counter; `pop()` now uses a deficit round-robin across peers, spending deficit by each peer’s top tx advertised cost
> - Falls back to `max_tx_clvm_cost` when a tx lacks advertised cost; periodically cleans up empty peer queues every 100 pops
> - Changes `TransactionQueue` constructor to require `max_tx_clvm_cost`; `FullNode.manage()` now passes `uint64(constants.MAX_BLOCK_COST_CLVM // 2)`
> - Updates tests to pass `max_tx_clvm_cost`, adjust internal attribute access, and adds a new test covering DRR behavior, fallback cost, deficits, and periodic cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3992cf6e5d409870f481c84a6c0feebbf0e0003. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->