### PR TITLE
add stack info to log string for block validation for unknown error

### DIFF
--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -49,6 +49,7 @@ class PreValidationResult(Streamable):
     required_iters: uint64 | None  # Iff error is None
     conds: SpendBundleConditions | None  # Iff error is None and block is a transaction block
     timing: uint32  # the time (in milliseconds) it took to pre-validate the block
+    extra_string: str = ""
 
     @property
     def validated_signature(self) -> bool:
@@ -158,7 +159,9 @@ def _pre_validate_block(
         error_stack = traceback.format_exc()
         log.error(f"Exception: {error_stack}")
         validation_time = time.monotonic() - validation_start
-        return PreValidationResult(uint16(Err.UNKNOWN.value), None, None, uint32(validation_time * 1000))
+        return PreValidationResult(
+            uint16(Err.UNKNOWN.value), None, None, uint32(validation_time * 1000), extra_string=error_stack
+        )
 
 
 async def pre_validate_block(

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2164,6 +2164,7 @@ class FullNode:
                         raise ValueError(
                             f"Failed to validate block {header_hash} height "
                             f"{block.height}: {Err(pre_validation_result.error).name}"
+                            f" extra: {pre_validation_result.extra_string}"
                         )
                 else:
                     if fork_info is None:


### PR DESCRIPTION
For some temporary debugging for simulator errors propogate up the stack trace if some exception happens during block validation (which causes the UNKNOWN error to be propogated)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds stack trace propagation for block pre-validation failures to aid debugging.
> 
> - Extends `PreValidationResult` with `extra_string` to carry traceback text
> - On exceptions in `_pre_validate_block`, returns `Err.UNKNOWN` with `extra_string` populated
> - In `FullNode.add_block`, includes `extra_string` in raised error message when pre-validation fails
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1782220f59a42207534b26e3f1f754880123b393. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->