### PR TITLE
blocktools double sub epoch summary hash bug

### DIFF
--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -1072,6 +1072,8 @@ class BlockTools:
                         height_to_hash[uint32(full_block.height)] = full_block.header_hash
                         latest_block = blocks[full_block.header_hash]
                         finished_sub_slots_at_ip = []
+                        # Reset pending_ses when a new block is created
+                        pending_ses = False
 
                         if num_blocks <= 0 and not keep_going_until_tx_block:
                             self._block_cache_header = block_list[-1].header_hash
@@ -1148,7 +1150,7 @@ class BlockTools:
 
                 self.log.info(f"Sub epoch summary: {sub_epoch_summary} for block {latest_block.height + 1}")
             else:  # the previous block is not the last block of the sub-epoch or epoch
-                pending_ses = False
+                # Don't reset pending_ses to False here - it will be reset when a new block is created
                 ses_hash = None
                 new_sub_slot_iters = None
                 new_difficulty = None
@@ -1379,6 +1381,8 @@ class BlockTools:
                         height_to_hash[uint32(full_block.height)] = full_block.header_hash
                         latest_block = blocks[full_block.header_hash]
                         finished_sub_slots_at_ip = []
+                        # Reset pending_ses when a new block is created
+                        pending_ses = False
 
                         if num_blocks <= 0 and not keep_going_until_tx_block:
                             self._block_cache_header = block_list[-1].header_hash


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
fix an issue with blocktools where we put sub_epoch_summary hash in multiple slots in a block finishing the sub-epoch
<!-- Does this PR introduce a breaking change? -->

### Current Behavior:
we reset pending ses  between slots that makes us put it in multiple finished slots 
### New Behavior:
reset pending ses on new block
<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes sub-epoch summary handling in the simulator to avoid duplicate SES hashes across slots.
> 
> - In `block_tools.py`, stop clearing `pending_ses` at end-of-slot when no SES is produced; instead, set `pending_ses=True` when an SES is generated and reset it to `False` only when a new block is created (normal and overflow paths)
> - Ensures the SES hash is included once, not in multiple consecutive finished sub-slots
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f584bd17d8631fc43c443f26088e3b211d4117b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->