### PR TITLE
get_flags, fix pre_sp_tx_block, test  CHIA-3861

### DIFF
--- a/chia/_tests/core/full_node/test_hard_fork_utils.py
+++ b/chia/_tests/core/full_node/test_hard_fork_utils.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+from chia_rs import BlockRecord, get_flags_for_height_and_constants
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint32
+
+from chia.consensus.get_block_challenge import pre_sp_tx_block_height
+from chia.full_node.hard_fork_utils import get_flags
+from chia.simulator.block_tools import BlockTools, load_block_list, test_constants
+from chia.util.block_cache import BlockCache
+
+
+class MockBlocksProtocol(BlockCache):
+    """Mock implementation of BlocksProtocol for testing get_flags."""
+
+    async def get_block_record_from_db(self, header_hash: bytes32) -> BlockRecord | None:
+        return self.try_block_record(header_hash)
+
+    async def lookup_block_generators(self, header_hash: bytes32, generator_refs: set[uint32]) -> dict[uint32, bytes]:
+        return {}
+
+    def add_block_record(self, block_record: BlockRecord) -> None:
+        self.add_block(block_record)
+
+
+@pytest.mark.anyio
+async def test_get_flags_outside_transition_period(bt: BlockTools) -> None:
+    """Test get_flags when block is outside the transition period."""
+    block_list = bt.get_consecutive_blocks(
+        10,
+        block_list_input=[],
+        guarantee_transaction_block=True,
+    )
+    _, _, blocks = load_block_list(block_list, bt.constants)
+    block = block_list[-1]
+    mock_blocks = MockBlocksProtocol(blocks)
+
+    # Before hard fork: block.height < HARD_FORK2_HEIGHT, expects 0
+    constants = test_constants.replace(HARD_FORK2_HEIGHT=uint32(1000))
+    assert block.height < constants.HARD_FORK2_HEIGHT
+    result = await get_flags(constants, mock_blocks, block)
+    assert result == 0
+
+    # After transition period: block.height >= HARD_FORK2_HEIGHT + SUB_EPOCH_BLOCKS
+    constants = test_constants.replace(
+        HARD_FORK2_HEIGHT=uint32(0),
+        SUB_EPOCH_BLOCKS=uint32(min(5, block.height)),
+    )
+    assert block.height >= constants.HARD_FORK2_HEIGHT + constants.SUB_EPOCH_BLOCKS
+    result = await get_flags(constants, mock_blocks, block)
+    assert result == get_flags_for_height_and_constants(block.height, constants)
+
+
+@pytest.mark.anyio
+async def test_get_flags_during_transition_period(bt: BlockTools) -> None:
+    """When block.height is in the transition period, get_flags should walk
+    the chain and return flags based on the latest tx block before signage point."""
+    # We need more blocks to ensure we're in the transition period
+    block_list = bt.get_consecutive_blocks(
+        15,
+        block_list_input=[],
+        guarantee_transaction_block=True,
+    )
+    _, _, blocks = load_block_list(block_list, bt.constants)
+    mock_blocks = MockBlocksProtocol(blocks)
+
+    # Configure constants so that the block is in the transition period
+    # HARD_FORK2_HEIGHT <= block.height < HARD_FORK2_HEIGHT + SUB_EPOCH_BLOCKS
+    block = block_list[-1]
+    # Set HARD_FORK2_HEIGHT to be close to block height but leave room for transition
+    constants = test_constants.replace(
+        HARD_FORK2_HEIGHT=uint32(max(0, block.height - 5)),
+        SUB_EPOCH_BLOCKS=test_constants.SUB_EPOCH_BLOCKS,
+    )
+
+    # Ensure we're in the transition period
+    assert block.height >= constants.HARD_FORK2_HEIGHT
+    assert block.height < constants.HARD_FORK2_HEIGHT + constants.SUB_EPOCH_BLOCKS
+
+    result = await get_flags(constants, mock_blocks, block)
+
+    # The result should be based on the height of the latest tx block before the signage point
+    expected_height = pre_sp_tx_block_height(
+        constants=constants,
+        blocks=mock_blocks,
+        prev_b_hash=block.prev_header_hash,
+        sp_index=block.reward_chain_block.signage_point_index,
+        finished_sub_slots=len(block.finished_sub_slots),
+    )
+    expected = get_flags_for_height_and_constants(expected_height, constants)
+    assert result == expected

--- a/chia/_tests/core/full_node/test_prev_tx_block.py
+++ b/chia/_tests/core/full_node/test_prev_tx_block.py
@@ -15,14 +15,14 @@ def test_prev_tx_block_none() -> None:
         blocks=BlockCache({}),
         prev_b_hash=test_constants.GENESIS_CHALLENGE,
         sp_index=uint8(0),
-        first_in_sub_slot=False,
+        finished_sub_slots=0,
     ) == uint32(0)
     assert pre_sp_tx_block_height(
         constants=test_constants,
         blocks=BlockCache({}),
         prev_b_hash=test_constants.GENESIS_CHALLENGE,
         sp_index=uint8(1),
-        first_in_sub_slot=True,
+        finished_sub_slots=1,
     ) == uint32(0)
 
 
@@ -43,7 +43,7 @@ def test_prev_tx_block_blockrecord_tx(bt: BlockTools) -> None:
             blocks=BlockCache(blocks),
             prev_b_hash=block.prev_header_hash,
             sp_index=block.reward_chain_block.signage_point_index,
-            first_in_sub_slot=len(block.finished_sub_slots) > 0,
+            finished_sub_slots=len(block.finished_sub_slots),
         )
         == latest_tx_before_sp.height
     )
@@ -56,7 +56,7 @@ def test_prev_tx_block_blockrecord_tx(bt: BlockTools) -> None:
             blocks=BlockCache(blocks),
             prev_b_hash=block.prev_header_hash,
             sp_index=block.reward_chain_block.signage_point_index,
-            first_in_sub_slot=len(block.finished_sub_slots) > 0,
+            finished_sub_slots=len(block.finished_sub_slots),
         )
         == latest_tx_before_sp.height
     )
@@ -69,7 +69,7 @@ def test_prev_tx_block_blockrecord_tx(bt: BlockTools) -> None:
             blocks=BlockCache(blocks),
             prev_b_hash=block.prev_header_hash,
             sp_index=block.reward_chain_block.signage_point_index,
-            first_in_sub_slot=len(block.finished_sub_slots) > 0,
+            finished_sub_slots=len(block.finished_sub_slots),
         )
         == latest_tx_before_sp.height
     )
@@ -95,7 +95,7 @@ def test_prev_tx_block_blockrecord_not_tx(bt: BlockTools) -> None:
         blocks=BlockCache(blocks),
         prev_b_hash=block.prev_header_hash,
         sp_index=block.reward_chain_block.signage_point_index,
-        first_in_sub_slot=len(block.finished_sub_slots) > 0,
+        finished_sub_slots=len(block.finished_sub_slots),
     ) == uint32(latest_tx_before_sp.height)
 
 

--- a/chia/consensus/block_header_validation.py
+++ b/chia/consensus/block_header_validation.py
@@ -510,7 +510,7 @@ def validate_unfinished_header_block(
             blocks=blocks,
             prev_b_hash=header_block.prev_header_hash,
             sp_index=header_block.reward_chain_block.signage_point_index,
-            first_in_sub_slot=len(header_block.finished_sub_slots) > 0,
+            finished_sub_slots=len(header_block.finished_sub_slots),
         ),
     )
     if required_iters is None:

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -279,7 +279,7 @@ class Blockchain:
                 blocks=self,
                 prev_b_hash=block.prev_header_hash,
                 sp_index=block.reward_chain_block.signage_point_index,
-                first_in_sub_slot=len(block.finished_sub_slots) > 0,
+                finished_sub_slots=len(block.finished_sub_slots),
             )
             flags = get_flags_for_height_and_constants(prev_tx_height, self.constants)
             additions, removals = additions_and_removals(
@@ -715,7 +715,7 @@ class Blockchain:
             blocks=self,
             prev_b_hash=block.prev_header_hash,
             sp_index=block.reward_chain_block.signage_point_index,
-            first_in_sub_slot=len(block.finished_sub_slots) > 0,
+            finished_sub_slots=len(block.finished_sub_slots),
         )
 
         # With hard fork 2 we ban transactions_generator_ref_list.

--- a/chia/consensus/get_block_challenge.py
+++ b/chia/consensus/get_block_challenge.py
@@ -7,6 +7,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
 
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
+from chia.consensus.pot_iterations import is_overflow_block
 from chia.types.unfinished_header_block import UnfinishedHeaderBlock
 
 log = logging.getLogger(__name__)
@@ -110,17 +111,24 @@ def pre_sp_tx_block(
     *,
     prev_b_hash: bytes32,
     sp_index: uint8,
-    first_in_sub_slot: bool,
+    finished_sub_slots: int,
 ) -> BlockRecord | None:
     if prev_b_hash == constants.GENESIS_CHALLENGE:
         return None
     curr = blocks.block_record(prev_b_hash)
-    before_slot = first_in_sub_slot
+    # For overflow blocks, the SP is in the previous sub-slot, so we need to cross
+    # one extra slot boundary before we're past the SP's slot
+    overflow = is_overflow_block(constants, sp_index)
+    slots_crossed = finished_sub_slots
     while curr.height > 0:
-        if curr.is_transaction_block and (before_slot or curr.signage_point_index < sp_index):
+        if not overflow:
+            before_sp = curr.signage_point_index < sp_index or slots_crossed > 0
+        else:
+            before_sp = slots_crossed >= 2 or (slots_crossed == 1 and curr.signage_point_index < sp_index)
+        if curr.is_transaction_block and before_sp:
             break
         if curr.first_in_sub_slot:
-            before_slot = True
+            slots_crossed += 1
         curr = blocks.block_record(curr.prev_hash)
     return curr
 
@@ -131,14 +139,14 @@ def pre_sp_tx_block_height(
     *,
     prev_b_hash: bytes32,
     sp_index: uint8,
-    first_in_sub_slot: bool,
+    finished_sub_slots: int,
 ) -> uint32:
     latest_tx_block = pre_sp_tx_block(
         constants=constants,
         blocks=blocks,
         prev_b_hash=prev_b_hash,
         sp_index=sp_index,
-        first_in_sub_slot=first_in_sub_slot,
+        finished_sub_slots=finished_sub_slots,
     )
     if latest_tx_block is None:
         return uint32(0)

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -120,7 +120,7 @@ def _pre_validate_block(
                 blocks=blockchain,
                 prev_b_hash=block.prev_header_hash,
                 sp_index=block.reward_chain_block.signage_point_index,
-                first_in_sub_slot=len(block.finished_sub_slots) > 0,
+                finished_sub_slots=len(block.finished_sub_slots),
             )
             err, conds = _run_block(block, prev_generators, prev_tx_height, constants)
 
@@ -231,7 +231,7 @@ async def pre_validate_block(
             blocks=blockchain,
             prev_b_hash=block.prev_header_hash,
             sp_index=block.reward_chain_block.signage_point_index,
-            first_in_sub_slot=len(block.finished_sub_slots) > 0,
+            finished_sub_slots=len(block.finished_sub_slots),
         ),
     )
     if required_iters is None:

--- a/chia/full_node/full_node_rpc_api.py
+++ b/chia/full_node/full_node_rpc_api.py
@@ -15,7 +15,6 @@ from chia_rs import (
     PlotParam,
     SpendBundle,
     SpendBundleConditions,
-    get_flags_for_height_and_constants,
     get_spends_for_trusted_block,
     get_spends_for_trusted_block_with_conditions,
     run_block_generator2,
@@ -25,11 +24,11 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64, uint128
 
 from chia.consensus.blockchain import Blockchain, BlockchainMutexPriority
-from chia.consensus.get_block_challenge import pre_sp_tx_block_height
 from chia.consensus.get_block_generator import get_block_generator
 from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
 from chia.full_node.full_node import FullNode
+from chia.full_node.hard_fork_utils import get_flags
 from chia.protocols.outbound_message import NodeType
 from chia.rpc.rpc_server import Endpoint, EndpointResult
 from chia.types.blockchain_format.proof_of_space import calculate_prefix_bits
@@ -490,14 +489,8 @@ class FullNodeRpcApi:
         if block_generator is None:  # if block is not a transaction block.
             return {"block_spends": []}
 
-        prev_tx_height = pre_sp_tx_block_height(
-            constants=self.service.constants,
-            blocks=self.service.blockchain,
-            prev_b_hash=full_block.prev_header_hash,
-            sp_index=full_block.reward_chain_block.signage_point_index,
-            first_in_sub_slot=len(full_block.finished_sub_slots) > 0,
-        )
-        flags = get_flags_for_height_and_constants(prev_tx_height, self.service.constants)
+        flags = await get_flags(constants=self.service.constants, blocks=self.service.blockchain, block=full_block)
+
         spends = await asyncio.get_running_loop().run_in_executor(
             self.executor,
             get_spends_for_trusted_block,
@@ -521,14 +514,7 @@ class FullNodeRpcApi:
         if block_generator is None:  # if block is not a transaction block.
             return {"block_spends_with_conditions": []}
 
-        prev_tx_height = pre_sp_tx_block_height(
-            constants=self.service.constants,
-            blocks=self.service.blockchain,
-            prev_b_hash=full_block.prev_header_hash,
-            sp_index=full_block.reward_chain_block.signage_point_index,
-            first_in_sub_slot=len(full_block.finished_sub_slots) > 0,
-        )
-        flags = get_flags_for_height_and_constants(prev_tx_height, self.service.constants)
+        flags = await get_flags(constants=self.service.constants, blocks=self.service.blockchain, block=full_block)
         spends_with_conditions = await asyncio.get_running_loop().run_in_executor(
             self.executor,
             get_spends_for_trusted_block_with_conditions,
@@ -807,19 +793,13 @@ class FullNodeRpcApi:
         assert block_generator is not None
 
         try:
-            prev_tx_height = pre_sp_tx_block_height(
-                constants=self.service.constants,
-                blocks=self.service.blockchain,
-                prev_b_hash=block.prev_header_hash,
-                sp_index=block.reward_chain_block.signage_point_index,
-                first_in_sub_slot=len(block.finished_sub_slots) > 0,
-            )
+            flags = await get_flags(constants=self.service.constants, blocks=self.service.blockchain, block=block)
             puzzle, solution = get_puzzle_and_solution_for_coin(
                 block_generator.program,
                 block_generator.generator_refs,
                 self.service.constants.MAX_BLOCK_COST_CLVM,
                 coin_record.coin,
-                get_flags_for_height_and_constants(prev_tx_height, self.service.constants),
+                flags,
             )
             return {"coin_solution": CoinSpend(coin_record.coin, puzzle, solution)}
         except Exception as e:

--- a/chia/full_node/hard_fork_utils.py
+++ b/chia/full_node/hard_fork_utils.py
@@ -1,0 +1,41 @@
+# Returns the previous transaction block up to the blocks signage point
+# we use this for block validation since when the block is farmed we do not know the latest transaction block
+# since a new one might be infused by the time the block is infused
+from __future__ import annotations
+
+from chia_rs import ConsensusConstants, FullBlock, get_flags_for_height_and_constants
+
+from chia.consensus.blockchain_interface import BlocksProtocol
+from chia.consensus.pot_iterations import is_overflow_block
+
+
+async def get_flags(
+    constants: ConsensusConstants,
+    blocks: BlocksProtocol,
+    block: FullBlock,
+) -> int:
+    if block.height < constants.HARD_FORK2_HEIGHT:
+        return 0
+    if block.height >= constants.HARD_FORK2_HEIGHT + constants.SUB_EPOCH_BLOCKS:
+        return get_flags_for_height_and_constants(block.height, constants)
+
+    sp_index = block.reward_chain_block.signage_point_index
+    # For overflow blocks, the SP is in the previous sub-slot, so we need to cross
+    # one extra slot boundary before we're past the SP's slot
+    overflow = is_overflow_block(constants, sp_index)
+    slots_crossed = len(block.finished_sub_slots)
+    curr = await blocks.get_block_record_from_db(block.prev_header_hash)
+    assert curr is not None
+    while curr.height > 0:
+        if not overflow:
+            before_sp = curr.signage_point_index < sp_index or slots_crossed > 0
+        else:
+            before_sp = slots_crossed >= 2 or (slots_crossed == 1 and curr.signage_point_index < sp_index)
+
+        if curr.is_transaction_block and before_sp:
+            break
+        if curr.first_in_sub_slot:
+            slots_crossed += 1
+        curr = await blocks.get_block_record_from_db(curr.prev_hash)
+        assert curr is not None
+    return get_flags_for_height_and_constants(curr.height, constants)

--- a/chia/full_node/hard_fork_utils.py
+++ b/chia/full_node/hard_fork_utils.py
@@ -19,6 +19,9 @@ async def get_flags(
     if block.height >= constants.HARD_FORK2_HEIGHT + constants.SUB_EPOCH_BLOCKS:
         return get_flags_for_height_and_constants(block.height, constants)
 
+    if block.prev_header_hash == constants.GENESIS_CHALLENGE:
+        return get_flags_for_height_and_constants(0, constants)
+
     sp_index = block.reward_chain_block.signage_point_index
     # For overflow blocks, the SP is in the previous sub-slot, so we need to cross
     # one extra slot boundary before we're past the SP's slot

--- a/chia/full_node/hard_fork_utils.py
+++ b/chia/full_node/hard_fork_utils.py
@@ -15,7 +15,7 @@ async def get_flags(
     block: FullBlock,
 ) -> int:
     if block.height < constants.HARD_FORK2_HEIGHT:
-        return 0
+        return get_flags_for_height_and_constants(block.height, constants)
     if block.height >= constants.HARD_FORK2_HEIGHT + constants.SUB_EPOCH_BLOCKS:
         return get_flags_for_height_and_constants(block.height, constants)
 

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1339,7 +1339,7 @@ def _validate_pospace_recent_chain(
             blocks=blocks,
             prev_b_hash=block.prev_header_hash,
             sp_index=block.reward_chain_block.signage_point_index,
-            first_in_sub_slot=len(block.finished_sub_slots) > 0,
+            finished_sub_slots=len(block.finished_sub_slots),
         ),
     )
     if required_iters is None:

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -951,7 +951,7 @@ class BlockTools:
                         blocks=BlockCache(blocks),
                         prev_b_hash=latest_block.header_hash,
                         sp_index=uint8(signage_point_index),
-                        first_in_sub_slot=len(finished_sub_slots_at_ip) > 0,
+                        finished_sub_slots=len(finished_sub_slots_at_ip),
                     )
 
                     qualified_proofs: list[tuple[uint64, ProofOfSpace]] = self.get_pospaces_for_challenge(
@@ -1266,7 +1266,7 @@ class BlockTools:
                         blocks=BlockCache(blocks),
                         prev_b_hash=latest_block.header_hash,
                         sp_index=uint8(signage_point_index),
-                        first_in_sub_slot=len(finished_sub_slots_at_ip) > 0,
+                        finished_sub_slots=len(finished_sub_slots_at_ip),
                     )
 
                     qualified_proofs = self.get_pospaces_for_challenge(
@@ -1917,7 +1917,7 @@ def load_block_list(
             blocks=cache,
             prev_b_hash=full_block.prev_header_hash,
             sp_index=full_block.reward_chain_block.signage_point_index,
-            first_in_sub_slot=len(full_block.finished_sub_slots) > 0,
+            finished_sub_slots=len(full_block.finished_sub_slots),
         )
         required_iters = validate_pospace_and_get_required_iters(
             constants,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
Fix key error for old blocks in several rpc endpoints:

when we are checking if old blocks are above or below the fork we should not only use the cache and fallback to DB
this PR adds a new get_flags function that falls back to DB, the reason for creating a new dedicated function is that the one previously used is used in validation code which requiers not hitting the DB

Fix overflow block handling in `pre_sp_tx_block`:

For overflow blocks, the signage point (SP) is in the previous sub-slot. The original code incorrectly set before_slot =  True after crossing just one slot boundary, which could select
  transaction blocks that are actually after the SP.
  Fix: Track slots_crossed and require overflow blocks to cross 2 slot boundaries (instead of 1) before any transaction 
 
<!-- Does this PR introduce a breaking change? -->

### Current Behavior:
we use the cache for getting flags for endpoints that might be called for very old blocks

### New Behavior:
new get_flags that falls back to DB if the cache misses

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves flag resolution around HF2 and fixes overflow SP handling.
> 
> - New `full_node.hard_fork_utils.get_flags` walks chain with DB fallback to derive `flags` during the HF2 transition; RPC and node APIs now use this instead of computing from `prev_tx_height`
> - Fixes `pre_sp_tx_block` logic for overflow blocks by tracking `finished_sub_slots` (requiring two slot boundaries for overflow), preventing selection of post-SP tx blocks
> - Replaces `first_in_sub_slot` parameter with `finished_sub_slots` across consensus, validation, simulator, and weight proof paths
> - Updates validations to pass correct pre-SP tx height and adjusts call sites in `block_header_validation.py`, `blockchain.py`, `multiprocess_validation.py`, `weight_proof.py`, and simulator
> - Adds tests for `get_flags` during/around transition and updates prev-tx-block tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c25c1241c60cde18131bb76908c2aeef45c9a23a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->