### PR TITLE
CHIA-3866 Prioritize trusted peers in FullNodeAPI's send_transaction

### DIFF
--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -19,6 +19,7 @@ from chia.protocols import wallet_protocol
 from chia.protocols.outbound_message import Message, make_msg
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.server.api_protocol import Self
+from chia.server.ws_connection import WSChiaConnection
 from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.simulator.block_tools import test_constants
 from chia.types.blockchain_format.coin import Coin
@@ -624,7 +625,7 @@ async def test_transaction_send_cache(
     logged_spends = []
 
     async def send_transaction(
-        self: Self, request: wallet_protocol.SendTransaction, *, test: bool = False
+        self: Self, request: wallet_protocol.SendTransaction, peer: WSChiaConnection, *, test: bool = False
     ) -> Message | None:
         logged_spends.append(request.transaction.name())
         return None

--- a/chia/apis/full_node_stub.py
+++ b/chia/apis/full_node_stub.py
@@ -285,8 +285,10 @@ class FullNodeApiStub(ApiProtocol, Protocol):
         """Handle removals request from wallet."""
         ...
 
-    @metadata.request()
-    async def send_transaction(self, request: wallet_protocol.SendTransaction, *, test: bool = False) -> Message | None:
+    @metadata.request(peer_required=True)
+    async def send_transaction(
+        self, request: wallet_protocol.SendTransaction, peer: WSChiaConnection, *, test: bool = False
+    ) -> Message | None:
         """Handle transaction send from wallet."""
         ...
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates transaction submission flow to be peer-aware and prioritize trusted peers.
> 
> - Change `FullNodeAPI.send_transaction` (and `full_node_stub`) to require a `peer` argument; compute `high_priority` via `is_trusted(peer)` and enqueue with `peer_id`
> - Catch `TransactionQueueFull` and respond with `TransactionAck` FAILED and error "Transaction queue full"
> - Add test `test_send_transaction_peer_tx_queue_full` and update many tests/helpers to create dummy peers and pass them to `send_transaction`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a5617bc501cf292f7d45dccd3e14704a4e48aca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->