### PR TITLE
Cherry-pick CHIA-3866 Prioritize trusted peers in FullNodeAPI's send_transaction

### DIFF
--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -19,6 +19,7 @@ from chia.protocols import wallet_protocol
 from chia.protocols.outbound_message import Message, make_msg
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.server.api_protocol import Self
+from chia.server.ws_connection import WSChiaConnection
 from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.simulator.block_tools import test_constants
 from chia.types.blockchain_format.coin import Coin
@@ -624,7 +625,7 @@ async def test_transaction_send_cache(
     logged_spends = []
 
     async def send_transaction(
-        self: Self, request: wallet_protocol.SendTransaction, *, test: bool = False
+        self: Self, request: wallet_protocol.SendTransaction, peer: WSChiaConnection, *, test: bool = False
     ) -> Message | None:
         logged_spends.append(request.transaction.name())
         return None

--- a/chia/apis/full_node_stub.py
+++ b/chia/apis/full_node_stub.py
@@ -285,8 +285,10 @@ class FullNodeApiStub(ApiProtocol, Protocol):
         """Handle removals request from wallet."""
         ...
 
-    @metadata.request()
-    async def send_transaction(self, request: wallet_protocol.SendTransaction, *, test: bool = False) -> Message | None:
+    @metadata.request(peer_required=True)
+    async def send_transaction(
+        self, request: wallet_protocol.SendTransaction, peer: WSChiaConnection, *, test: bool = False
+    ) -> Message | None:
         """Handle transaction send from wallet."""
         ...
 


### PR DESCRIPTION
PR #20401.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements peer-aware transaction submission with prioritization and proper back-pressure handling.
> 
> - Change `send_transaction` to `send_transaction(request, peer, *, test=False)` with `peer_required=True` in API metadata
> - Prioritize trusted peers when enqueueing; include `peer_id` in queue put; catch `TransactionQueueFull` and return `TransactionAck` with FAILED and "Transaction queue full"
> - Update stubs and numerous tests/helpers to pass a `WSChiaConnection` peer (e.g., use `add_dummy_connection[_wsc]`/`connect_and_get_peer`); adjust helper signatures to accept `peer`
> - Add test to verify correct `TransactionAck` when a peer's transaction queue is full
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba926a6ae7990cb363d3cfcffdfa4ca88c91cfe2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->