### PR TITLE
checkpoint: into main from release/2.6.0  @ a19365ac4ef9e85fd7fd69a2cd654441bc121afa

### DIFF
--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -668,12 +668,12 @@ class Streamable:
     def parse(cls, f: BinaryIO) -> Self:
         # Create the object without calling __init__() to avoid unnecessary post-init checks in strictdataclass
         obj: Self = object.__new__(cls)
-        for field in cls._streamable_fields:
+        for field in cls.streamable_fields():
             object.__setattr__(obj, field.name, field.parse_function(f))
         return obj
 
     def stream(self, f: BinaryIO) -> None:
-        for field in self._streamable_fields:
+        for field in self.streamable_fields():
             field.stream_function(getattr(self, field.name), f)
 
     def get_hash(self) -> bytes32:

--- a/chia/wallet/conditions.py
+++ b/chia/wallet/conditions.py
@@ -14,7 +14,7 @@ from chia.types.blockchain_format.program import Program
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.util.casts import int_from_bytes, int_to_bytes
 from chia.util.hash import std_hash
-from chia.util.streamable import Streamable, streamable
+from chia.util.streamable import Streamable, StreamableFields, streamable
 
 _T_Condition = TypeVar("_T_Condition", bound="Condition")
 
@@ -1432,6 +1432,27 @@ class ConditionValidTimes(ConditionValidTimesAbsolute):
     min_blocks_since_created: uint32 | None = None  # ASSERT_HEIGHT_RELATIVE
     max_secs_after_created: uint64 | None = None  # ASSERT_BEFORE_SECONDS_RELATIVE
     max_blocks_after_created: uint32 | None = None  # ASSERT_BEFORE_HEIGHT_RELATIVE
+
+    @classmethod
+    def streamable_fields(cls) -> StreamableFields:
+        # A hack to serialize the fields in the order before this was inherited
+        order_map = {
+            name: i
+            for i, name in enumerate(
+                [
+                    "min_secs_since_created",
+                    "min_time",
+                    "min_blocks_since_created",
+                    "min_height",
+                    "max_secs_after_created",
+                    "max_time",
+                    "max_blocks_after_created",
+                    "max_height",
+                ]
+            )
+        }
+
+        return tuple(sorted(cls._streamable_fields, key=lambda item: order_map[item.name]))
 
     def to_conditions(self) -> list[Condition]:
         final_condition_list = super().to_conditions()


### PR DESCRIPTION
Source hash: a19365ac4ef9e85fd7fd69a2cd654441bc121afa
Remaining commits: 4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures serialization honors subclass-defined field order and preserves backward compatibility for wallet conditions.
> 
> - `Streamable.parse` and `stream` now iterate over `streamable_fields()` instead of `_streamable_fields`, allowing subclasses to override field order
> - `ConditionValidTimes` adds a `streamable_fields()` override to serialize fields in the previous (pre-inheritance) order; import updated to include `StreamableFields`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f36001ef9f942615271883c082e8bc2de16530cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->