### PR TITLE
Re-enable accidentally disabled T100 (breakpoints)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -92,7 +92,7 @@ ignore = [
     "COM812",  # trailing commas: ~5000 errors
     "CPY001",  # copyright notices: ~900 errors
     "TC",  # type checking linting: ~1700 errors  # Too much reliance on runtime types to enable this
-    "T",  # using print: ~1300 errors  # might want to enable this but not for CLI or tools/
+    "T20",  # using print: ~1300 errors  # might want to enable this but not for CLI or tools/
     "TD",  # formatting of TODOs: ~800 errors
     "DOC",  # also docstrings: ~700 errors
     "ARG",  # unused arguments: ~500 errors


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Narrows Ruff rule ignore scope to re-enable breakpoint checks.
> 
> - In `ruff.toml`, replaces `"T"` with `"T20"` in `lint.ignore`, re-enabling `T100` (breakpoints) while continuing to ignore print-related `T20x` rules
> - No application code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e0fadddcb4f308efd67e7185f3adf8d7831bcc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->