### PR TITLE
Fix weight proof timeout on slow connections

### DIFF
--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -530,11 +530,7 @@ async def test_weight_proof_timeout_slow_connection(
     def nodes_synced() -> bool:
         peak_1 = full_node_1.full_node.blockchain.get_peak()
         peak_2 = full_node_2.full_node.blockchain.get_peak()
-        return (
-            peak_1 is not None
-            and peak_2 is not None
-            and peak_1.height == peak_2.height
-        )
+        return peak_1 is not None and peak_2 is not None and peak_1.height == peak_2.height
 
     # This should complete successfully even with slow connection
     # because heartbeat is now weight_proof_timeout + 30 = 150s, which is > 120s timeout

--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -557,12 +557,22 @@ async def test_weight_proof_timeout_slow_connection(
     assert nodes_synced()
     assert send_count > 0  # Verify that messages were sent
 
+    # Verify that a weight proof message was actually sent during sync
+    # If no weight proof was requested, the test would fail later with a confusing error
+    assert weight_proof_start_time is not None, (
+        "No weight proof message (respond_proof_of_weight) was sent during sync. "
+        "The test requires a weight proof to verify the heartbeat fix works correctly."
+    )
+    assert weight_proof_end_time is not None, (
+        "Weight proof message transmission did not complete. "
+        "This indicates the weight proof response was not fully sent."
+    )
+
     # Verify that the sync process (which includes weight proof download) took longer than 60 seconds
     # This proves the heartbeat fix is working (old 60s heartbeat would have closed the connection)
     log.info(f"Sync process took {sync_duration:.2f} seconds")
-    if weight_proof_start_time is not None and weight_proof_end_time is not None:
-        weight_proof_duration = weight_proof_end_time - weight_proof_start_time
-        log.info(f"Weight proof message transmission took {weight_proof_duration:.2f} seconds")
+    weight_proof_duration = weight_proof_end_time - weight_proof_start_time
+    log.info(f"Weight proof message transmission took {weight_proof_duration:.2f} seconds")
 
     # The sync process should take longer than 60 seconds to verify the heartbeat fix works
     # This ensures that with the old 60s heartbeat, the connection would have been closed

--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -484,7 +484,7 @@ async def test_bad_peak_cache_invalidation(
 
 @pytest.mark.anyio
 async def test_weight_proof_timeout_slow_connection(
-    two_nodes: list[FullNodeAPI],
+    two_nodes: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
     default_1000_blocks: list[FullBlock],
     self_hostname: str,
     monkeypatch: pytest.MonkeyPatch,
@@ -494,9 +494,7 @@ async def test_weight_proof_timeout_slow_connection(
     This test verifies that the websocket heartbeat is properly configured to be
     longer than weight_proof_timeout, preventing premature connection closure.
     """
-    full_node_1, full_node_2 = two_nodes
-    server_1 = full_node_1.full_node.server
-    server_2 = full_node_2.full_node.server
+    full_node_1, full_node_2, server_1, server_2, _bt = two_nodes
 
     # Set a weight_proof_timeout that's longer than the old hardcoded heartbeat (60s)
     # but shorter than the new heartbeat (which should be weight_proof_timeout + 30)

--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -530,11 +530,12 @@ async def test_weight_proof_timeout_slow_connection(
 
     # Wait for sync - this will trigger weight proof download
     def nodes_synced() -> bool:
+        peak_1 = full_node_1.full_node.blockchain.get_peak()
+        peak_2 = full_node_2.full_node.blockchain.get_peak()
         return (
-            full_node_1.full_node.blockchain.get_peak() is not None
-            and full_node_2.full_node.blockchain.get_peak() is not None
-            and full_node_1.full_node.blockchain.get_peak().height
-            == full_node_2.full_node.blockchain.get_peak().height
+            peak_1 is not None
+            and peak_2 is not None
+            and peak_1.height == peak_2.height
         )
 
     # This should complete successfully even with slow connection

--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import sys
 import time
@@ -777,3 +778,5 @@ async def test_start_with_multiple_keys(
 
     await restart_with_fingerprint(fingerprint_2)
     assert wallet_node.wallet_state_manager.private_key == initial_sk
+
+

--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import sys
 import time
@@ -778,5 +777,3 @@ async def test_start_with_multiple_keys(
 
     await restart_with_fingerprint(fingerprint_2)
     assert wallet_node.wallet_state_manager.private_key == initial_sk
-
-

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -302,7 +302,12 @@ class ChiaServer:
             reason = f"Peer {request.remote} is banned, refusing connection"
             self.log.warning(reason)
             raise web.HTTPForbidden(reason=reason)
-        ws = web.WebSocketResponse(max_msg_size=max_message_size)
+        # Use weight_proof_timeout for heartbeat to prevent connection closure
+        # during slow weight proof downloads. Default to 360 seconds if not configured.
+        # Add a buffer (30s) to ensure heartbeat is longer than weight_proof_timeout.
+        wp_timeout = self.config.get("weight_proof_timeout", 360)
+        heartbeat = max(60, wp_timeout + 30)
+        ws = web.WebSocketResponse(max_msg_size=max_message_size, heartbeat=heartbeat)
         await ws.prepare(request)
         ssl_object = request.get_extra_info("ssl_object")
         if ssl_object is None:
@@ -431,11 +436,16 @@ class ChiaServer:
             url = f"wss://{ip}:{target_node.port}/ws"
             self.log.debug(f"Connecting: {url}, Peer info: {target_node}")
             try:
+                # Use weight_proof_timeout for heartbeat to prevent connection closure
+                # during slow weight proof downloads. Default to 360 seconds if not configured.
+                # Add a buffer (30s) to ensure heartbeat is longer than weight_proof_timeout.
+                wp_timeout = self.config.get("weight_proof_timeout", 360)
+                heartbeat = max(60, wp_timeout + 30)
                 ws = await session.ws_connect(
                     url,
                     autoclose=True,
                     autoping=True,
-                    heartbeat=60,
+                    heartbeat=heartbeat,
                     ssl=self.ssl_client_context,
                     max_msg_size=max_message_size,
                 )

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -307,7 +307,7 @@ class ChiaServer:
         # node types that actually use weight proofs. Default to 360 seconds if not configured.
         # Add a buffer (30s) to ensure heartbeat is longer than weight_proof_timeout.
         if self._local_type in {NodeType.FULL_NODE, NodeType.WALLET}:
-            wp_timeout = self.config.get("weight_proof_timeout", 360)
+            wp_timeout = float(self.config.get("weight_proof_timeout", 360))
             heartbeat = max(60, wp_timeout + 30)
         else:
             heartbeat = 60  # Default heartbeat for other node types
@@ -445,7 +445,7 @@ class ChiaServer:
                 # node types that actually use weight proofs. Default to 360 seconds if not configured.
                 # Add a buffer (30s) to ensure heartbeat is longer than weight_proof_timeout.
                 if self._local_type in {NodeType.FULL_NODE, NodeType.WALLET}:
-                    wp_timeout = self.config.get("weight_proof_timeout", 360)
+                    wp_timeout = float(self.config.get("weight_proof_timeout", 360))
                     heartbeat = max(60, wp_timeout + 30)
                 else:
                     heartbeat = 60  # Default heartbeat for other node types


### PR DESCRIPTION
- Configure websocket heartbeat to respect weight_proof_timeout
- Set heartbeat to weight_proof_timeout + 30 seconds (with 60s minimum)
- Prevents premature connection closure during slow weight proof downloads
- Applied to both client and server-side websocket connections
- Add test for slow connection weight proof download scenario

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->
#### Problem
On low-speed connections, the weight proof timeout was not honored because the websocket connection would close before the entire weight proof could be downloaded. The websocket heartbeat was hardcoded to 60 seconds, which was shorter than the default weight_proof_timeout of 360 seconds.

#### Solution
- Configure websocket heartbeat to respect weight_proof_timeout configuration
- Set heartbeat to `max(60, weight_proof_timeout + 30)` seconds
- Applied to both client-side and server-side websocket connections
- This ensures the connection stays alive long enough for slow weight proof downloads to complete

#### Changes
- Modified `chia/server/server.py` to set heartbeat based on weight_proof_timeout for both incoming and outgoing connections
- Added test `test_weight_proof_timeout_slow_connection` in `chia/_tests/core/full_node/full_sync/test_full_sync.py` to verify the fix works on slow connections

#### Testing
- Test simulates slow connection by adding delays to weight proof message transmission
- Verifies that weight proof download completes successfully even with slow connection
- Heartbeat (150s) is longer than timeout (120s) in test scenario

### Current Behavior:

All weight proofs timeout after 60s and ignore weight_proof_timeout 

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->
Today all nodes will only wait 60 seconds for a weight proof due to the underlying issue. Once someone upgrades with the current default config.yaml, they will wait 390 seconds for all weight proofs.


### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

Will also test on some low speed links. This may require upgrade logic to bring new node installs down to a lower weight_proof_timeout for backwards-ish compatibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts websocket heartbeat to prevent premature disconnects during weight proof transfers on slow links.
> 
> - Introduces `_calculate_heartbeat()` in `server.py`; applies computed heartbeat to both incoming `WebSocketResponse` and outgoing `ws_connect`
> - Heartbeat for `FULL_NODE`/`WALLET` now `max(60, weight_proof_timeout + 30)`; others remain at 60s
> - Adds `test_weight_proof_timeout_slow_connection` to simulate bandwidth-limited weight proof response and assert sync completes (>60s duration)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c724c9671b815db2bdc949a2bd1bbc339bb2620. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->