### PR TITLE
Blockchain does not have run_generator()

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -296,9 +296,7 @@ class TestBlockHeaderValidation:
         assert peak.height == len(blocks) - 1
 
     @pytest.mark.anyio
-    async def test_unfinished_blocks(
-        self, empty_blockchain: Blockchain, softfork_height: uint32, bt: BlockTools
-    ) -> None:
+    async def test_unfinished_blocks(self, empty_blockchain: Blockchain, bt: BlockTools) -> None:
         blockchain = empty_blockchain
         blocks = bt.get_consecutive_blocks(3)
         for block in blocks[:-1]:
@@ -322,8 +320,13 @@ class TestBlockHeaderValidation:
         if unf.transactions_generator is not None:  # pragma: no cover
             block_generator = await get_block_generator(blockchain.lookup_block_generators, unf)
             assert block_generator is not None
-            block_bytes = bytes(unf)
-            npc_result = await blockchain.run_generator(block_bytes, block_generator, height=softfork_height)
+            npc_result = get_name_puzzle_conditions(
+                block_generator,
+                unf.transactions_info.cost,
+                mempool_mode=False,
+                height=block.height,
+                constants=bt.constants,
+            )
 
         validate_res = await blockchain.validate_unfinished_block(unf, npc_result, False)
         err = validate_res.error
@@ -350,8 +353,13 @@ class TestBlockHeaderValidation:
         if unf.transactions_generator is not None:  # pragma: no cover
             block_generator = await get_block_generator(blockchain.lookup_block_generators, unf)
             assert block_generator is not None
-            block_bytes = bytes(unf)
-            npc_result = await blockchain.run_generator(block_bytes, block_generator, height=softfork_height)
+            npc_result = get_name_puzzle_conditions(
+                block_generator,
+                unf.transactions_info.cost,
+                mempool_mode=False,
+                height=block.height,
+                constants=bt.constants,
+            )
         validate_res = await blockchain.validate_unfinished_block(unf, npc_result, False)
         assert validate_res.error is None
 
@@ -402,9 +410,7 @@ class TestBlockHeaderValidation:
         assert peak.height == num_blocks - 1
 
     @pytest.mark.anyio
-    async def test_unf_block_overflow(
-        self, empty_blockchain: Blockchain, softfork_height: uint32, bt: BlockTools
-    ) -> None:
+    async def test_unf_block_overflow(self, empty_blockchain: Blockchain, bt: BlockTools) -> None:
         blockchain = empty_blockchain
 
         blocks: list[FullBlock] = []
@@ -441,8 +447,13 @@ class TestBlockHeaderValidation:
                 if block.transactions_generator is not None:  # pragma: no cover
                     block_generator = await get_block_generator(blockchain.lookup_block_generators, unf)
                     assert block_generator is not None
-                    block_bytes = bytes(unf)
-                    npc_result = await blockchain.run_generator(block_bytes, block_generator, height=softfork_height)
+                    npc_result = get_name_puzzle_conditions(
+                        block_generator,
+                        unf.transactions_info.cost,
+                        mempool_mode=False,
+                        height=block.height,
+                        constants=bt.constants,
+                    )
                 validate_res = await blockchain.validate_unfinished_block(
                     unf, npc_result, skip_overflow_ss_validation=True
                 )


### PR DESCRIPTION
In this test, these calls are never made, but just here in case something changes.

Note the `# pragma: no cover` of all of these code sections. This (invalid) code isn't executed, which is why it's been allowed to stay.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes unfinished block validation tests to avoid calling a non-existent `Blockchain.run_generator`.
> 
> - In `test_unfinished_blocks` and `test_unf_block_overflow`, compute `npc_result` using `get_name_puzzle_conditions(block_generator, cost, mempool_mode=False, height, constants)` instead of `run_generator`
> - Remove `bytes(unf)` conversions and `softfork_height` test arg; adjust method signatures accordingly
> - No production code changes; test-only refactor
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe5736c69ed46f52d74674b4f3f894e644e3f760. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->