### PR TITLE
Add db prune command

### DIFF
--- a/chia/_tests/cmds/test_db_prune.py
+++ b/chia/_tests/cmds/test_db_prune.py
@@ -925,8 +925,12 @@ class TestDbPruneWithCoinRecords:
                 for i in range(5):
                     coin_name = rand_hash()
                     spent_coins.append(coin_name)
-                    # Confirmed at height 50, spent at height 80 (above new_peak)
+                    # Confirmed at height 50, spent at height 80 (above new_peak); coinbase=1
                     add_coin_record(conn, coin_name, 50, 80, 1, rand_hash(), rand_hash(), 1000)
+                # Non-coinbase coin spent above new_peak (exercises reset for coinbase=0)
+                non_coinbase_spent_above = rand_hash()
+                spent_coins.append(non_coinbase_spent_above)
+                add_coin_record(conn, non_coinbase_spent_above, 50, 80, 0, rand_hash(), rand_hash(), 1000)
 
                 # Add coins spent below new_peak (should remain spent)
                 for i in range(3):

--- a/chia/_tests/cmds/test_db_prune.py
+++ b/chia/_tests/cmds/test_db_prune.py
@@ -1,0 +1,551 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+from chia_rs.sized_bytes import bytes32
+
+from chia._tests.util.temp_file import TempFile
+from chia.cmds.db_prune_func import db_prune_func, prune_db
+from chia.util.lock import Lockfile
+
+
+def rand_hash() -> bytes32:
+    return bytes32.random()
+
+
+def make_version(conn: sqlite3.Connection, version: int) -> None:
+    conn.execute("CREATE TABLE database_version(version int)")
+    conn.execute("INSERT INTO database_version VALUES (?)", (version,))
+    conn.commit()
+
+
+def make_peak(conn: sqlite3.Connection, peak_hash: bytes32) -> None:
+    conn.execute("CREATE TABLE IF NOT EXISTS current_peak(key int PRIMARY KEY, hash blob)")
+    conn.execute("INSERT OR REPLACE INTO current_peak VALUES(?, ?)", (0, peak_hash))
+    conn.commit()
+
+
+def make_block_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS full_blocks("
+        "header_hash blob PRIMARY KEY,"
+        "prev_hash blob,"
+        "height bigint,"
+        "sub_epoch_summary blob,"
+        "is_fully_compactified tinyint,"
+        "in_main_chain tinyint,"
+        "block blob,"
+        "block_record blob)"
+    )
+
+
+def add_block(
+    conn: sqlite3.Connection, header_hash: bytes32, prev_hash: bytes32, height: int, in_main_chain: bool
+) -> None:
+    conn.execute(
+        "INSERT INTO full_blocks VALUES(?, ?, ?, NULL, 0, ?, NULL, NULL)",
+        (
+            header_hash,
+            prev_hash,
+            height,
+            int(in_main_chain),
+        ),
+    )
+
+
+def get_block_count(conn: sqlite3.Connection) -> int:
+    with closing(conn.execute("SELECT COUNT(*) FROM full_blocks")) as cursor:
+        return int(cursor.fetchone()[0])
+
+
+def get_max_height(conn: sqlite3.Connection) -> int:
+    with closing(conn.execute("SELECT MAX(height) FROM full_blocks")) as cursor:
+        return int(cursor.fetchone()[0])
+
+
+def get_peak_height(conn: sqlite3.Connection) -> int:
+    with closing(conn.execute("SELECT hash FROM current_peak WHERE key = 0")) as cursor:
+        peak_hash = cursor.fetchone()[0]
+    with closing(conn.execute("SELECT height FROM full_blocks WHERE header_hash = ?", (peak_hash,))) as cursor:
+        return int(cursor.fetchone()[0])
+
+
+def create_test_db(db_file: Path, peak_height: int, orphan_rate: int = 4) -> dict[int, bytes32]:
+    """
+    Create a test database with blocks from height 0 to peak_height.
+    Every `orphan_rate` blocks, add an orphan block at that height.
+    Returns a dict mapping height to header_hash for main chain blocks.
+    """
+    height_to_hash: dict[int, bytes32] = {}
+
+    with closing(sqlite3.connect(db_file)) as conn:
+        make_version(conn, 2)
+        make_block_table(conn)
+
+        prev = rand_hash()  # genesis prev hash
+        for height in range(peak_height + 1):
+            header_hash = rand_hash()
+            add_block(conn, header_hash, prev, height, True)
+            height_to_hash[height] = header_hash
+            if orphan_rate > 0 and height % orphan_rate == 0 and height > 0:
+                # Insert an orphan block at this height
+                add_block(conn, rand_hash(), prev, height, False)
+            prev = header_hash
+
+        make_peak(conn, height_to_hash[peak_height])
+        conn.commit()
+
+    return height_to_hash
+
+
+class TestDbPrune:
+    def test_prune_basic(self) -> None:
+        """Test basic pruning removes blocks from peak."""
+        with TempFile() as db_file:
+            peak_height = 1000
+            blocks_back = 300
+            create_test_db(db_file, peak_height, orphan_rate=0)
+
+            prune_db(db_file, blocks_back=blocks_back)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                new_peak_height = peak_height - blocks_back
+                # Should have blocks from 0 to new_peak_height
+                assert get_block_count(conn) == new_peak_height + 1
+                assert get_max_height(conn) == new_peak_height
+                # Peak should be updated
+                assert get_peak_height(conn) == new_peak_height
+
+    def test_prune_with_orphans(self) -> None:
+        """Test pruning removes both main chain and orphan blocks above cutoff."""
+        with TempFile() as db_file:
+            peak_height = 1000
+            blocks_back = 300
+            orphan_rate = 4
+            create_test_db(db_file, peak_height, orphan_rate=orphan_rate)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                initial_count = get_block_count(conn)
+                # Main chain: 1001 blocks (0-1000)
+                # Orphans: 250 blocks (at heights 4, 8, 12, ..., 1000)
+                assert initial_count > peak_height + 1
+
+            prune_db(db_file, blocks_back=blocks_back)
+
+            new_peak_height = peak_height - blocks_back
+            with closing(sqlite3.connect(db_file)) as conn:
+                # All blocks above new_peak_height should be gone
+                with closing(
+                    conn.execute("SELECT COUNT(*) FROM full_blocks WHERE height > ?", (new_peak_height,))
+                ) as cursor:
+                    assert cursor.fetchone()[0] == 0
+                # Peak should be updated
+                assert get_peak_height(conn) == new_peak_height
+
+    def test_prune_nothing_to_prune(self) -> None:
+        """Test pruning when blocks_back >= peak_height does nothing."""
+        with TempFile() as db_file:
+            peak_height = 100
+            blocks_back = 200
+            create_test_db(db_file, peak_height, orphan_rate=0)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                initial_count = get_block_count(conn)
+                initial_peak = get_peak_height(conn)
+
+            prune_db(db_file, blocks_back=blocks_back)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                # Nothing should be deleted
+                assert get_block_count(conn) == initial_count
+                assert get_peak_height(conn) == initial_peak
+
+    def test_prune_blocks_back_equals_peak(self) -> None:
+        """Test pruning when blocks_back equals peak_height does nothing."""
+        with TempFile() as db_file:
+            peak_height = 100
+            blocks_back = 100
+            create_test_db(db_file, peak_height, orphan_rate=0)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                initial_count = get_block_count(conn)
+
+            prune_db(db_file, blocks_back=blocks_back)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                assert get_block_count(conn) == initial_count
+
+    def test_prune_small_chain(self) -> None:
+        """Test pruning a small chain with default blocks_back."""
+        with TempFile() as db_file:
+            peak_height = 50
+            blocks_back = 300  # Default
+            create_test_db(db_file, peak_height, orphan_rate=0)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                initial_count = get_block_count(conn)
+
+            # Should not prune anything since peak_height < blocks_back
+            prune_db(db_file, blocks_back=blocks_back)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                assert get_block_count(conn) == initial_count
+
+    def test_prune_aggressive(self) -> None:
+        """Test aggressive pruning with small blocks_back."""
+        with TempFile() as db_file:
+            peak_height = 1000
+            blocks_back = 10
+            create_test_db(db_file, peak_height, orphan_rate=0)
+
+            prune_db(db_file, blocks_back=blocks_back)
+
+            new_peak_height = peak_height - blocks_back
+            with closing(sqlite3.connect(db_file)) as conn:
+                # Should have blocks from 0 to new_peak_height
+                assert get_block_count(conn) == new_peak_height + 1
+                assert get_max_height(conn) == new_peak_height
+                assert get_peak_height(conn) == new_peak_height
+
+    def test_prune_updates_peak(self) -> None:
+        """Test that pruning updates the current_peak correctly."""
+        with TempFile() as db_file:
+            peak_height = 500
+            blocks_back = 100
+            height_to_hash = create_test_db(db_file, peak_height, orphan_rate=0)
+
+            prune_db(db_file, blocks_back=blocks_back)
+
+            new_peak_height = peak_height - blocks_back
+            with closing(sqlite3.connect(db_file)) as conn:
+                # Peak should be updated to the block at new_peak_height
+                with closing(conn.execute("SELECT hash FROM current_peak WHERE key = 0")) as cursor:
+                    new_peak_hash = bytes32(cursor.fetchone()[0])
+                assert new_peak_hash == height_to_hash[new_peak_height]
+
+                # Old peak block should be gone
+                with closing(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM full_blocks WHERE header_hash = ?", (height_to_hash[peak_height],)
+                    )
+                ) as cursor:
+                    assert cursor.fetchone()[0] == 0
+
+
+class TestDbPruneErrors:
+    def test_prune_missing_file(self) -> None:
+        """Test pruning non-existent database raises error."""
+        with pytest.raises(RuntimeError) as excinfo:
+            prune_db(Path("/nonexistent/path/to/db.sqlite"), blocks_back=300)
+        assert "Database file does not exist" in str(excinfo.value)
+
+    def test_prune_wrong_version(self) -> None:
+        """Test pruning database with wrong version raises error."""
+        with TempFile() as db_file:
+            with closing(sqlite3.connect(db_file)) as conn:
+                make_version(conn, 1)
+
+            with pytest.raises(RuntimeError) as excinfo:
+                prune_db(db_file, blocks_back=300)
+            assert "Database has the wrong version (1 expected 2)" in str(excinfo.value)
+
+    def test_prune_version_3(self) -> None:
+        """Test pruning database with future version raises error."""
+        with TempFile() as db_file:
+            with closing(sqlite3.connect(db_file)) as conn:
+                make_version(conn, 3)
+
+            with pytest.raises(RuntimeError) as excinfo:
+                prune_db(db_file, blocks_back=300)
+            assert "Database has the wrong version (3 expected 2)" in str(excinfo.value)
+
+    def test_prune_missing_version_table(self) -> None:
+        """Test pruning database without version table raises error."""
+        with TempFile() as db_file:
+            with closing(sqlite3.connect(db_file)) as conn:
+                make_block_table(conn)
+                conn.commit()
+
+            with pytest.raises(RuntimeError) as excinfo:
+                prune_db(db_file, blocks_back=300)
+            assert "Database is missing version table" in str(excinfo.value)
+
+    def test_prune_missing_peak_table(self) -> None:
+        """Test pruning database without peak table raises error."""
+        with TempFile() as db_file:
+            with closing(sqlite3.connect(db_file)) as conn:
+                make_version(conn, 2)
+                make_block_table(conn)
+                conn.commit()
+
+            with pytest.raises(RuntimeError) as excinfo:
+                prune_db(db_file, blocks_back=300)
+            assert "Database is missing current_peak table" in str(excinfo.value)
+
+    def test_prune_missing_peak_block(self) -> None:
+        """Test pruning database with missing peak block raises error."""
+        with TempFile() as db_file:
+            fake_peak = rand_hash()
+            with closing(sqlite3.connect(db_file)) as conn:
+                make_version(conn, 2)
+                make_block_table(conn)
+                make_peak(conn, fake_peak)
+                conn.commit()
+
+            with pytest.raises(RuntimeError) as excinfo:
+                prune_db(db_file, blocks_back=300)
+            assert "Database is missing the peak block" in str(excinfo.value)
+
+    def test_prune_empty_peak(self) -> None:
+        """Test pruning database with empty peak raises error."""
+        with TempFile() as db_file:
+            with closing(sqlite3.connect(db_file)) as conn:
+                make_version(conn, 2)
+                make_block_table(conn)
+                conn.execute("CREATE TABLE IF NOT EXISTS current_peak(key int PRIMARY KEY, hash blob)")
+                conn.commit()
+
+            with pytest.raises(RuntimeError) as excinfo:
+                prune_db(db_file, blocks_back=300)
+            assert "Database is missing current_peak" in str(excinfo.value)
+
+
+class TestDbPruneFuncWithLock:
+    def test_prune_full_node_running(self, tmp_path: Path) -> None:
+        """Test that pruning fails when full_node is running (lock held)."""
+        root_path = tmp_path / "chia_root"
+        root_path.mkdir()
+        run_path = root_path / "run"
+        run_path.mkdir()
+
+        # Create a minimal config
+        config_path = root_path / "config"
+        config_path.mkdir()
+        config_file = config_path / "config.yaml"
+        config_file.write_text(
+            """
+full_node:
+  selected_network: mainnet
+  database_path: db/blockchain_v2_mainnet.sqlite
+"""
+        )
+
+        # Simulate full_node running by holding the lock
+        lock_path = run_path / "chia_full_node"
+        with Lockfile.create(lock_path):
+            with pytest.raises(RuntimeError) as excinfo:
+                db_prune_func(root_path, blocks_back=300)
+            assert "Cannot prune database while full_node is running" in str(excinfo.value)
+
+    def test_prune_full_node_not_running(self, tmp_path: Path) -> None:
+        """Test that pruning succeeds when full_node is not running."""
+        root_path = tmp_path / "chia_root"
+        root_path.mkdir()
+        run_path = root_path / "run"
+        run_path.mkdir()
+
+        # Create a database file
+        db_path = root_path / "db"
+        db_path.mkdir()
+        db_file = db_path / "blockchain_v2_mainnet.sqlite"
+        create_test_db(db_file, peak_height=500, orphan_rate=0)
+
+        # Create a minimal config pointing to the db
+        config_path = root_path / "config"
+        config_path.mkdir()
+        config_file = config_path / "config.yaml"
+        config_file.write_text(
+            """
+full_node:
+  selected_network: mainnet
+  database_path: db/blockchain_v2_mainnet.sqlite
+"""
+        )
+
+        # Should succeed - no lock held
+        db_prune_func(root_path, blocks_back=100)
+
+        # Verify pruning happened - removed 100 blocks from peak
+        with closing(sqlite3.connect(db_file)) as conn:
+            assert get_peak_height(conn) == 400
+            assert get_max_height(conn) == 400
+            assert get_block_count(conn) == 401
+
+
+class TestDbPruneBlockCounts:
+    def test_prune_counts_correct(self) -> None:
+        """Test that block counts before and after pruning are correct."""
+        with TempFile() as db_file:
+            peak_height = 500
+            blocks_back = 200
+            orphan_rate = 5
+            create_test_db(db_file, peak_height, orphan_rate=orphan_rate)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                # Count initial blocks
+                initial_total = get_block_count(conn)
+                with closing(conn.execute("SELECT COUNT(*) FROM full_blocks WHERE in_main_chain = 1")) as cursor:
+                    initial_main = cursor.fetchone()[0]
+                with closing(conn.execute("SELECT COUNT(*) FROM full_blocks WHERE in_main_chain = 0")) as cursor:
+                    initial_orphans = cursor.fetchone()[0]
+
+                # Main chain should be 501 blocks (0-500)
+                assert initial_main == peak_height + 1
+                # Orphans at heights 5, 10, 15, ..., 500 = 100 orphans
+                assert initial_orphans == peak_height // orphan_rate
+                assert initial_total == initial_main + initial_orphans
+
+            prune_db(db_file, blocks_back=blocks_back)
+
+            new_peak_height = peak_height - blocks_back  # 300
+            with closing(sqlite3.connect(db_file)) as conn:
+                # After pruning, should have blocks from 0 to 300
+                # Main chain blocks from 0 to 300 = 301 blocks
+                with closing(conn.execute("SELECT COUNT(*) FROM full_blocks WHERE in_main_chain = 1")) as cursor:
+                    final_main = cursor.fetchone()[0]
+                assert final_main == new_peak_height + 1
+
+                # Orphans at heights 5, 10, 15, ..., 300
+                # That's 300 / 5 = 60 orphans
+                with closing(conn.execute("SELECT COUNT(*) FROM full_blocks WHERE in_main_chain = 0")) as cursor:
+                    final_orphans = cursor.fetchone()[0]
+                expected_orphans = new_peak_height // orphan_rate
+                assert final_orphans == expected_orphans
+
+    def test_prune_removes_all_above_new_peak(self) -> None:
+        """Test that ALL blocks above new peak are removed."""
+        with TempFile() as db_file:
+            peak_height = 200
+            blocks_back = 50
+            create_test_db(db_file, peak_height, orphan_rate=2)
+
+            prune_db(db_file, blocks_back=blocks_back)
+
+            new_peak_height = peak_height - blocks_back
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                # No main chain blocks above new peak
+                with closing(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM full_blocks WHERE height > ? AND in_main_chain = 1", (new_peak_height,)
+                    )
+                ) as cursor:
+                    assert cursor.fetchone()[0] == 0
+
+                # No orphan blocks above new peak
+                with closing(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM full_blocks WHERE height > ? AND in_main_chain = 0", (new_peak_height,)
+                    )
+                ) as cursor:
+                    assert cursor.fetchone()[0] == 0
+
+                # Max height should be new_peak_height
+                assert get_max_height(conn) == new_peak_height
+
+
+class TestDbPruneEdgeCases:
+    def test_prune_almost_all(self) -> None:
+        """Test pruning almost all blocks, leaving only genesis."""
+        with TempFile() as db_file:
+            peak_height = 100
+            blocks_back = 100  # This means new peak = 0
+            create_test_db(db_file, peak_height, orphan_rate=0)
+
+            # blocks_back == peak_height means nothing to prune
+            prune_db(db_file, blocks_back=blocks_back)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                # Should still have all blocks since blocks_back >= peak_height
+                assert get_block_count(conn) == peak_height + 1
+
+    def test_prune_to_height_one(self) -> None:
+        """Test pruning to leave blocks 0 and 1."""
+        with TempFile() as db_file:
+            peak_height = 100
+            blocks_back = 99  # new peak = 1
+            create_test_db(db_file, peak_height, orphan_rate=0)
+
+            prune_db(db_file, blocks_back=blocks_back)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                # Should have blocks 0 and 1
+                assert get_block_count(conn) == 2
+                assert get_max_height(conn) == 1
+                assert get_peak_height(conn) == 1
+
+    def test_prune_single_block_chain(self) -> None:
+        """Test pruning a chain with only the genesis block."""
+        with TempFile() as db_file:
+            peak_height = 0
+            create_test_db(db_file, peak_height, orphan_rate=0)
+
+            prune_db(db_file, blocks_back=300)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                # Should still have the genesis block
+                assert get_block_count(conn) == 1
+                assert get_peak_height(conn) == 0
+
+    def test_prune_successive(self) -> None:
+        """Test successive prunes work correctly."""
+        with TempFile() as db_file:
+            peak_height = 1000
+            create_test_db(db_file, peak_height, orphan_rate=0)
+
+            # First prune: 1000 -> 900
+            prune_db(db_file, blocks_back=100)
+            with closing(sqlite3.connect(db_file)) as conn:
+                assert get_peak_height(conn) == 900
+
+            # Second prune: 900 -> 700
+            prune_db(db_file, blocks_back=200)
+            with closing(sqlite3.connect(db_file)) as conn:
+                assert get_peak_height(conn) == 700
+
+            # Third prune: 700 -> 650
+            prune_db(db_file, blocks_back=50)
+            with closing(sqlite3.connect(db_file)) as conn:
+                assert get_peak_height(conn) == 650
+                assert get_block_count(conn) == 651
+
+    def test_prune_with_orphans_at_new_peak(self) -> None:
+        """Test pruning when there are orphan blocks at the new peak height."""
+        with TempFile() as db_file:
+            with closing(sqlite3.connect(db_file)) as conn:
+                make_version(conn, 2)
+                make_block_table(conn)
+
+                # Create a chain from height 0 to 99
+                prev = rand_hash()
+                height_to_hash: dict[int, bytes32] = {}
+                for height in range(100):
+                    header_hash = rand_hash()
+                    add_block(conn, header_hash, prev, height, True)
+                    height_to_hash[height] = header_hash
+                    prev = header_hash
+
+                # Add orphan blocks at heights including the new peak height (70)
+                for height in [60, 70, 80, 90]:
+                    add_block(conn, rand_hash(), rand_hash(), height, False)
+
+                make_peak(conn, height_to_hash[99])
+                conn.commit()
+
+            # peak=99, blocks_back=29, new_peak=70
+            prune_db(db_file, blocks_back=29)
+
+            with closing(sqlite3.connect(db_file)) as conn:
+                # Peak should now be 70
+                assert get_peak_height(conn) == 70
+                # Blocks at height > 70 should be gone
+                with closing(conn.execute("SELECT COUNT(*) FROM full_blocks WHERE height > 70")) as cursor:
+                    assert cursor.fetchone()[0] == 0
+                # Orphan at height 70 should still exist
+                with closing(
+                    conn.execute("SELECT COUNT(*) FROM full_blocks WHERE height = 70 AND in_main_chain = 0")
+                ) as cursor:
+                    assert cursor.fetchone()[0] == 1

--- a/chia/_tests/cmds/test_db_prune.py
+++ b/chia/_tests/cmds/test_db_prune.py
@@ -1268,9 +1268,7 @@ full_node:
             "full_node:\n  selected_network: mainnet\n  database_path: db/blockchain_v2_mainnet.sqlite\n"
         )
         ctx = ChiaCliContext(root_path=root_path)
-        result = CliRunner().invoke(
-            db_prune_cmd, ["50", "--no-integrity-check"], obj=ctx.to_click()
-        )
+        result = CliRunner().invoke(db_prune_cmd, ["50", "--no-integrity-check"], obj=ctx.to_click())
         assert result.exit_code == 0
         assert "Skipping integrity check" in result.output
         assert "Pruning complete" in result.output
@@ -1292,9 +1290,7 @@ full_node:
             "full_node:\n  selected_network: mainnet\n  database_path: db/blockchain_v2_mainnet.sqlite\n"
         )
         ctx = ChiaCliContext(root_path=root_path)
-        result = CliRunner().invoke(
-            db_prune_cmd, ["50", "--full-integrity-check"], obj=ctx.to_click()
-        )
+        result = CliRunner().invoke(db_prune_cmd, ["50", "--full-integrity-check"], obj=ctx.to_click())
         assert result.exit_code == 0
         assert "Running full integrity check" in result.output
         assert "Pruning complete" in result.output

--- a/chia/_tests/cmds/test_db_prune.py
+++ b/chia/_tests/cmds/test_db_prune.py
@@ -510,7 +510,7 @@ class TestDbPruneSingleTransaction:
             create_test_db(db_file, peak_height=100, orphan_rate=0)
             prune_db(db_file, blocks_back=10)
             out = capsys.readouterr().out
-            assert "Running sampled integrity check" in out
+            assert "Performing a brief integrity check" in out
             assert "Pruning complete" in out
 
     def test_prune_full_integrity_check_succeeds(self, capsys: pytest.CaptureFixture[str]) -> None:
@@ -519,7 +519,7 @@ class TestDbPruneSingleTransaction:
             create_test_db(db_file, peak_height=100, orphan_rate=0)
             prune_db(db_file, blocks_back=20, full_integrity_check=True)
             out = capsys.readouterr().out
-            assert "Running full integrity check" in out
+            assert "Performing full integrity check" in out
             assert "Pruning complete" in out
             with closing(sqlite3.connect(db_file)) as conn:
                 assert get_peak_height(conn) == 80
@@ -824,7 +824,7 @@ class TestDbPruneFuncUncoveredLines:
             with closing(sqlite3.connect(db_file)) as conn:
                 _run_sampled_integrity_check(conn)
             out = capsys.readouterr().out
-            assert "Running sampled integrity check" in out
+            assert "Performing a brief integrity check" in out
             assert " ok" in out
 
     def test_full_integrity_check_prints_ok(self, capsys: pytest.CaptureFixture[str]) -> None:
@@ -834,7 +834,7 @@ class TestDbPruneFuncUncoveredLines:
             with closing(sqlite3.connect(db_file)) as conn:
                 _run_full_integrity_check(conn)
             out = capsys.readouterr().out
-            assert "Running full integrity check" in out
+            assert "Performing full integrity check" in out
             assert " ok" in out
 
     def test_full_integrity_check_progress_dots(self, capsys: pytest.CaptureFixture[str]) -> None:
@@ -853,7 +853,7 @@ class TestDbPruneFuncUncoveredLines:
                 with patch.object(threading.Event, "wait", patched_wait):
                     _run_full_integrity_check(conn)
             out = capsys.readouterr().out
-            assert "Running full integrity check" in out
+            assert "Performing full integrity check" in out
             assert "." in out
             assert " ok" in out
 
@@ -1709,7 +1709,7 @@ full_node:
         ctx = ChiaCliContext(root_path=root_path)
         result = CliRunner().invoke(db_prune_cmd, ["50", "--full-integrity-check"], obj=ctx.to_click())
         assert result.exit_code == 0
-        assert "Running full integrity check" in result.output
+        assert "Performing full integrity check" in result.output
         assert "Pruning complete" in result.output
         with closing(sqlite3.connect(db_file)) as conn:
             assert get_peak_height(conn) == 150

--- a/chia/_tests/cmds/test_db_prune.py
+++ b/chia/_tests/cmds/test_db_prune.py
@@ -854,6 +854,8 @@ class TestDbPruneFuncUncoveredLines:
                         return real_conn.execute(sql, parameters, *args, **kwargs)
 
                 wrapper = FallbackRaisesWrapper()
+                # Exercise __getattr__ (line 843) so delegation to real_conn is covered
+                assert callable(getattr(wrapper, "commit"))
                 with pytest.raises(RuntimeError) as excinfo:
                     _run_sampled_integrity_check(wrapper)  # type: ignore[arg-type]
                 assert "Database integrity check failed" in str(excinfo.value)

--- a/chia/_tests/cmds/test_prune_full_sync.py
+++ b/chia/_tests/cmds/test_prune_full_sync.py
@@ -1,0 +1,385 @@
+"""
+Integration tests for verifying full_node starts and syncs correctly after pruning.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from chia_rs import CoinRecord, ConsensusConstants
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint32
+
+from chia._tests.core.node_height import node_height_exactly
+from chia._tests.util.time_out_assert import time_out_assert
+from chia.cmds.db_prune_func import prune_db
+from chia.consensus.coin_store_protocol import CoinStoreProtocol
+from chia.simulator.block_tools import create_block_tools_async
+from chia.simulator.keyring import TempKeyring
+from chia.simulator.setup_services import setup_full_node
+from chia.types.peer_info import PeerInfo
+
+log = logging.getLogger(__name__)
+
+
+async def get_all_coin_records(coin_store: CoinStoreProtocol, max_height: uint32) -> dict[bytes32, CoinRecord]:
+    """Get all coin records from the coin store up to a given height."""
+    all_records: dict[bytes32, CoinRecord] = {}
+    for height in range(max_height + 1):
+        records = await coin_store.get_coins_added_at_height(uint32(height))
+        for record in records:
+            all_records[record.coin.name()] = record
+    return all_records
+
+
+def compare_coin_records(records1: dict[bytes32, CoinRecord], records2: dict[bytes32, CoinRecord]) -> tuple[bool, str]:
+    """
+    Compare two sets of coin records and return whether they match.
+    Returns (match: bool, message: str) where message explains any differences.
+    """
+    if len(records1) != len(records2):
+        return False, f"Different number of coin records: {len(records1)} vs {len(records2)}"
+
+    for coin_name, record1 in records1.items():
+        if coin_name not in records2:
+            return False, f"Coin {coin_name.hex()[:16]}... missing from second set"
+        record2 = records2[coin_name]
+        if record1.coin != record2.coin:
+            return False, f"Coin {coin_name.hex()[:16]}... has different coin data"
+        if record1.confirmed_block_index != record2.confirmed_block_index:
+            msg = (
+                f"Coin {coin_name.hex()[:16]}... confirmed at different heights: "
+                f"{record1.confirmed_block_index} vs {record2.confirmed_block_index}"
+            )
+            return False, msg
+        if record1.spent_block_index != record2.spent_block_index:
+            msg = (
+                f"Coin {coin_name.hex()[:16]}... spent at different heights: "
+                f"{record1.spent_block_index} vs {record2.spent_block_index}"
+            )
+            return False, msg
+        if record1.coinbase != record2.coinbase:
+            return False, f"Coin {coin_name.hex()[:16]}... has different coinbase flag"
+
+    return True, "All coin records match"
+
+
+@pytest.mark.anyio
+async def test_full_node_starts_after_prune(
+    self_hostname: str,
+    blockchain_constants: ConsensusConstants,
+) -> None:
+    """
+    Test that a full_node can start correctly after its database has been pruned,
+    and that coin records are preserved correctly below the prune height.
+
+    This test:
+    1. Creates a full_node with 200 transaction blocks
+    2. Stops the node
+    3. Prunes 50 blocks from the peak (new peak = 149)
+    4. Restarts the full_node
+    5. Verifies it starts with the correct peak height
+    6. Verifies coin records are intact for heights <= 149
+    """
+    config_overrides = {"full_node.max_sync_wait": 0}
+    db_name = "blockchain_prune_test.db"
+
+    with TempKeyring(populate=True) as keychain:
+        async with create_block_tools_async(
+            constants=blockchain_constants, keychain=keychain, config_overrides=config_overrides
+        ) as bt:
+            # Generate test blocks with transactions to create coin records
+            blocks = bt.get_consecutive_blocks(200, guarantee_transaction_block=True)
+
+            # First, create the node and add blocks to build a blockchain
+            async with setup_full_node(
+                blockchain_constants,
+                db_name,
+                self_hostname,
+                bt,
+                simulator=False,
+                db_version=2,
+                reuse_db=True,
+            ) as service:
+                full_node = service._api.full_node
+
+                # Add all blocks to the blockchain
+                for block in blocks:
+                    await full_node.add_block(block)
+
+                # Verify we have the expected peak
+                peak = full_node.blockchain.get_peak()
+                assert peak is not None
+                assert peak.height == 199
+
+                # Store coin records before pruning for comparison
+                records_before_prune = await get_all_coin_records(full_node.coin_store, uint32(149))
+                num_coins_before = len(records_before_prune)
+                log.info(f"Coin records at height <= 149 before prune: {num_coins_before}")
+
+            # Node is now stopped. Prune the database.
+            db_path = bt.root_path / db_name
+            assert db_path.exists(), f"Database file not found: {db_path}"
+
+            # Prune 50 blocks - new peak should be at height 149
+            prune_db(db_path, blocks_back=50)
+
+            # Restart the node with the pruned database
+            async with setup_full_node(
+                blockchain_constants,
+                db_name,
+                self_hostname,
+                bt,
+                simulator=False,
+                db_version=2,
+                reuse_db=True,
+            ) as service2:
+                full_node2 = service2._api.full_node
+
+                # Verify the node started with the correct pruned peak
+                peak2 = full_node2.blockchain.get_peak()
+                assert peak2 is not None
+                assert peak2.height == 149, f"Expected peak height 149, got {peak2.height}"
+
+                # Verify coin records at heights <= 149 are preserved
+                records_after_prune = await get_all_coin_records(full_node2.coin_store, uint32(149))
+                log.info(f"Coin records at height <= 149 after prune: {len(records_after_prune)}")
+
+                # Compare coin records
+                match, message = compare_coin_records(records_before_prune, records_after_prune)
+                assert match, f"Coin records changed after prune: {message}"
+
+
+@pytest.mark.anyio
+async def test_pruned_node_can_sync_forward(
+    self_hostname: str,
+    blockchain_constants: ConsensusConstants,
+) -> None:
+    """
+    Test that a pruned full_node can sync forward when connected to a node with more blocks,
+    and that the coin records match after syncing.
+
+    This test:
+    1. Creates full_node_1 with 100 transaction blocks (to create coin records)
+    2. Creates full_node_2 with the same 100 blocks
+    3. Stops full_node_2
+    4. Adds 50 more transaction blocks to full_node_1 (now at height 149)
+    5. Prunes full_node_2's database by 30 blocks (new peak = 69)
+    6. Restarts full_node_2 and connects to full_node_1
+    7. Verifies full_node_2 syncs forward to height 149
+    8. Verifies coin records match between both nodes
+    """
+    config_overrides = {"full_node.max_sync_wait": 0}
+    db_name_1 = "blockchain_sync_source.db"
+    db_name_2 = "blockchain_sync_pruned.db"
+
+    with TempKeyring(populate=True) as keychain1, TempKeyring(populate=True) as keychain2:
+        async with (
+            create_block_tools_async(
+                constants=blockchain_constants, keychain=keychain1, config_overrides=config_overrides
+            ) as bt1,
+            create_block_tools_async(
+                constants=blockchain_constants, keychain=keychain2, config_overrides=config_overrides
+            ) as bt2,
+        ):
+            # Generate initial blocks with transaction blocks to create coin records
+            # guarantee_transaction_block=True ensures blocks have transactions/rewards
+            initial_blocks = bt1.get_consecutive_blocks(100, guarantee_transaction_block=True)
+
+            # Set up node 1 with initial blocks
+            async with setup_full_node(
+                blockchain_constants,
+                db_name_1,
+                self_hostname,
+                bt1,
+                simulator=False,
+                db_version=2,
+                reuse_db=True,
+            ) as service1:
+                full_node_1 = service1._api
+                for block in initial_blocks:
+                    await full_node_1.full_node.add_block(block)
+
+                # Set up node 2 with the same initial blocks
+                async with setup_full_node(
+                    blockchain_constants,
+                    db_name_2,
+                    self_hostname,
+                    bt2,
+                    simulator=False,
+                    db_version=2,
+                    reuse_db=True,
+                ) as service2:
+                    full_node_2 = service2._api
+                    for block in initial_blocks:
+                        await full_node_2.full_node.add_block(block)
+
+                    # Verify both nodes are at height 99
+                    peak1 = full_node_1.full_node.blockchain.get_peak()
+                    peak2 = full_node_2.full_node.blockchain.get_peak()
+                    assert peak1 is not None and peak1.height == 99
+                    assert peak2 is not None and peak2.height == 99
+
+                # Node 2 is now stopped. Add more blocks to node 1 with transactions.
+                additional_blocks = bt1.get_consecutive_blocks(
+                    50, block_list_input=initial_blocks, guarantee_transaction_block=True
+                )
+                for block in additional_blocks[100:]:  # Only add the new blocks
+                    await full_node_1.full_node.add_block(block)
+
+                # Node 1 is now at height 149
+                peak1_after = full_node_1.full_node.blockchain.get_peak()
+                assert peak1_after is not None and peak1_after.height == 149
+
+                # Prune node 2's database by 30 blocks (new peak = 69)
+                db_path_2 = bt2.root_path / db_name_2
+                prune_db(db_path_2, blocks_back=30)
+
+                # Restart node 2 with the pruned database
+                async with setup_full_node(
+                    blockchain_constants,
+                    db_name_2,
+                    self_hostname,
+                    bt2,
+                    simulator=False,
+                    db_version=2,
+                    reuse_db=True,
+                ) as service2_restarted:
+                    full_node_2_restarted = service2_restarted._api
+
+                    # Verify pruned node starts at the correct height
+                    peak_after_prune = full_node_2_restarted.full_node.blockchain.get_peak()
+                    assert peak_after_prune is not None
+                    assert peak_after_prune.height == 69, f"Expected height 69, got {peak_after_prune.height}"
+
+                    # Connect node 2 to node 1
+                    await full_node_2_restarted.full_node.server.start_client(
+                        PeerInfo(self_hostname, full_node_1.full_node.server.get_port()),
+                        on_connect=full_node_2_restarted.full_node.on_connect,
+                    )
+
+                    # Node 2 should sync to node 1's height (149)
+                    await time_out_assert(
+                        60,
+                        node_height_exactly,
+                        True,
+                        full_node_2_restarted,
+                        149,
+                    )
+
+                    # Verify coin records match between both nodes
+                    # Get all coin records from both nodes
+                    coin_store_1 = full_node_1.full_node.coin_store
+                    coin_store_2 = full_node_2_restarted.full_node.coin_store
+
+                    records_1 = await get_all_coin_records(coin_store_1, uint32(149))
+                    records_2 = await get_all_coin_records(coin_store_2, uint32(149))
+
+                    # Log some stats for debugging
+                    log.info(f"Node 1 has {len(records_1)} coin records")
+                    log.info(f"Node 2 has {len(records_2)} coin records")
+
+                    # Verify the coin records match
+                    match, message = compare_coin_records(records_1, records_2)
+                    assert match, f"Coin records do not match after sync: {message}"
+
+                    # Additional verification: check that we have a reasonable number of coins
+                    # Each block should have at least reward coins (farmer + pool rewards)
+                    assert len(records_1) >= 149, f"Expected at least 149 coin records, got {len(records_1)}"
+
+
+@pytest.mark.anyio
+async def test_pruned_node_can_receive_new_blocks(
+    self_hostname: str,
+    blockchain_constants: ConsensusConstants,
+) -> None:
+    """
+    Test that a pruned full_node can receive and process new blocks,
+    and that coin records are correctly maintained.
+
+    This test:
+    1. Creates a full_node with 100 transaction blocks
+    2. Stops the node
+    3. Prunes 20 blocks (new peak = 79)
+    4. Restarts the node
+    5. Manually adds blocks from 80-119
+    6. Verifies the node processes them correctly (peak = 119)
+    7. Verifies coin records are correctly accumulated
+    """
+    config_overrides = {"full_node.max_sync_wait": 0}
+    db_name = "blockchain_prune_new_blocks.db"
+
+    with TempKeyring(populate=True) as keychain:
+        async with create_block_tools_async(
+            constants=blockchain_constants, keychain=keychain, config_overrides=config_overrides
+        ) as bt:
+            # Generate 120 blocks total with transactions
+            all_blocks = bt.get_consecutive_blocks(120, guarantee_transaction_block=True)
+            initial_blocks = all_blocks[:100]
+
+            # Create node with initial blocks
+            async with setup_full_node(
+                blockchain_constants,
+                db_name,
+                self_hostname,
+                bt,
+                simulator=False,
+                db_version=2,
+                reuse_db=True,
+            ) as service:
+                full_node = service._api.full_node
+                for block in initial_blocks:
+                    await full_node.add_block(block)
+                peak = full_node.blockchain.get_peak()
+                assert peak is not None and peak.height == 99
+
+                # Store coin records at height 79 for later comparison
+                records_at_79 = await get_all_coin_records(full_node.coin_store, uint32(79))
+                log.info(f"Coin records at height <= 79 before prune: {len(records_at_79)}")
+
+            # Prune 20 blocks
+            db_path = bt.root_path / db_name
+            prune_db(db_path, blocks_back=20)
+
+            # Restart and add new blocks
+            async with setup_full_node(
+                blockchain_constants,
+                db_name,
+                self_hostname,
+                bt,
+                simulator=False,
+                db_version=2,
+                reuse_db=True,
+            ) as service2:
+                full_node2 = service2._api.full_node
+
+                # Verify pruned state
+                peak = full_node2.blockchain.get_peak()
+                assert peak is not None
+                assert peak.height == 79
+
+                # Verify coin records at height <= 79 are preserved after prune
+                records_after_prune = await get_all_coin_records(full_node2.coin_store, uint32(79))
+                match, message = compare_coin_records(records_at_79, records_after_prune)
+                assert match, f"Coin records at height <= 79 changed after prune: {message}"
+
+                # The pruned node needs to first get the blocks between 80-99
+                # before it can add blocks 100-119
+                # So we add all blocks from 80 onwards
+                for block in all_blocks[80:]:
+                    await full_node2.add_block(block)
+
+                # Verify final state
+                final_peak = full_node2.blockchain.get_peak()
+                assert final_peak is not None
+                assert final_peak.height == 119, f"Expected height 119, got {final_peak.height}"
+
+                # Verify we have coin records for all heights now
+                final_records = await get_all_coin_records(full_node2.coin_store, uint32(119))
+                log.info(f"Total coin records after adding all blocks: {len(final_records)}")
+
+                # We should have at least as many coins as before plus new ones
+                assert len(final_records) >= len(records_at_79), (
+                    f"Expected at least {len(records_at_79)} coins, got {len(final_records)}"
+                )

--- a/chia/_tests/cmds/test_prune_full_sync.py
+++ b/chia/_tests/cmds/test_prune_full_sync.py
@@ -70,7 +70,7 @@ def compare_coin_records(records1: dict[bytes32, CoinRecord], records2: dict[byt
     "num_blocks,blocks_back,compare_height",
     [
         (200, 50, 149),  # many coins: exercises compare_coin_records branch checks (>= 3 records)
-        (2, 1, 0),      # few coins at height <= 0: exercises else branch (< 3 records)
+        (2, 1, 0),  # few coins at height <= 0: exercises else branch (< 3 records)
     ],
 )
 async def test_full_node_starts_after_prune(
@@ -125,9 +125,7 @@ async def test_full_node_starts_after_prune(
                 assert peak.height == num_blocks - 1
 
                 # Store coin records before pruning for comparison
-                records_before_prune = await get_all_coin_records(
-                    full_node.coin_store, uint32(compare_height)
-                )
+                records_before_prune = await get_all_coin_records(full_node.coin_store, uint32(compare_height))
                 num_coins_before = len(records_before_prune)
                 log.info(f"Coin records at height <= {compare_height} before prune: {num_coins_before}")
 
@@ -222,9 +220,7 @@ async def test_full_node_starts_after_prune(
                 )
 
                 # Verify coin records at heights <= compare_height are preserved
-                records_after_prune = await get_all_coin_records(
-                    full_node2.coin_store, uint32(compare_height)
-                )
+                records_after_prune = await get_all_coin_records(full_node2.coin_store, uint32(compare_height))
                 log.info(f"Coin records at height <= {compare_height} after prune: {len(records_after_prune)}")
 
                 # Compare coin records

--- a/chia/cmds/db.py
+++ b/chia/cmds/db.py
@@ -87,7 +87,12 @@ def db_backup_cmd(ctx: click.Context, db_backup_file: str | None, no_indexes: bo
         print(f"FAILED: {e}")
 
 
-@db_cmd.command("prune", help="prune blocks from the peak, rolling back the chain by the specified number of blocks")
+@db_cmd.command(
+    "prune",
+    help="Prune blocks from the peak, rolling back the chain by the specified number "
+    "of blocks. It is best to make a backup of the database or rely on the database "
+    "torrent to recover the database.",
+)
 @click.argument("blocks_back", type=int, default=300, required=False)
 @click.option("--db", "in_db_path", default=None, type=click.Path(), help="Specifies which database file to prune")
 @click.pass_context

--- a/chia/cmds/db.py
+++ b/chia/cmds/db.py
@@ -95,13 +95,33 @@ def db_backup_cmd(ctx: click.Context, db_backup_file: str | None, no_indexes: bo
 )
 @click.argument("blocks_back", type=int, default=300, required=False)
 @click.option("--db", "in_db_path", default=None, type=click.Path(), help="Specifies which database file to prune")
+@click.option(
+    "--no-integrity-check",
+    is_flag=True,
+    default=False,
+    help="Skip integrity check (fastest; use only if the database is known good).",
+)
+@click.option(
+    "--full-integrity-check",
+    is_flag=True,
+    default=False,
+    help="Run full PRAGMA integrity_check (thorough but slow on very large DBs).",
+)
 @click.pass_context
-def db_prune_cmd(ctx: click.Context, blocks_back: int, in_db_path: str | None) -> None:
+def db_prune_cmd(
+    ctx: click.Context,
+    blocks_back: int,
+    in_db_path: str | None,
+    no_integrity_check: bool,
+    full_integrity_check: bool,
+) -> None:
     try:
         db_prune_func(
             ChiaCliContext.set_default(ctx).root_path,
             None if in_db_path is None else Path(in_db_path),
             blocks_back=blocks_back,
+            skip_integrity_check=no_integrity_check,
+            full_integrity_check=full_integrity_check,
         )
     except RuntimeError as e:
         print(f"FAILED: {e}")

--- a/chia/cmds/db.py
+++ b/chia/cmds/db.py
@@ -6,6 +6,7 @@ import click
 
 from chia.cmds.cmd_classes import ChiaCliContext
 from chia.cmds.db_backup_func import db_backup_func
+from chia.cmds.db_prune_func import db_prune_func
 from chia.cmds.db_upgrade_func import db_upgrade_func
 from chia.cmds.db_validate_func import db_validate_func
 
@@ -81,6 +82,21 @@ def db_backup_cmd(ctx: click.Context, db_backup_file: str | None, no_indexes: bo
             ChiaCliContext.set_default(ctx).root_path,
             None if db_backup_file is None else Path(db_backup_file),
             no_indexes=no_indexes,
+        )
+    except RuntimeError as e:
+        print(f"FAILED: {e}")
+
+
+@db_cmd.command("prune", help="prune blocks from the peak, rolling back the chain by the specified number of blocks")
+@click.argument("blocks_back", type=int, default=300, required=False)
+@click.option("--db", "in_db_path", default=None, type=click.Path(), help="Specifies which database file to prune")
+@click.pass_context
+def db_prune_cmd(ctx: click.Context, blocks_back: int, in_db_path: str | None) -> None:
+    try:
+        db_prune_func(
+            ChiaCliContext.set_default(ctx).root_path,
+            None if in_db_path is None else Path(in_db_path),
+            blocks_back=blocks_back,
         )
     except RuntimeError as e:
         print(f"FAILED: {e}")

--- a/chia/cmds/db_prune_func.py
+++ b/chia/cmds/db_prune_func.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+from chia.daemon.server import service_launch_lock_path
+from chia.util.config import load_config
+from chia.util.lock import Lockfile, LockfileError
+from chia.util.path import path_from_root
+
+
+def db_prune_func(
+    root_path: Path,
+    in_db_path: Path | None = None,
+    *,
+    blocks_back: int = 300,
+) -> None:
+    """
+    Prune the blockchain database by removing blocks from the peak.
+
+    This removes the most recent blocks_back blocks from the peak, making
+    the block at (peak_height - blocks_back) the new peak when full_node restarts.
+    It will refuse to run if the full_node service is currently running.
+    """
+    # Check if full_node is running by trying to acquire its lock
+    full_node_lock_path = service_launch_lock_path(root_path, "chia_full_node")
+    try:
+        with Lockfile.create(full_node_lock_path, timeout=0.1):
+            # We got the lock, so full_node is not running
+            pass
+    except LockfileError:
+        raise RuntimeError(
+            "Cannot prune database while full_node is running. "
+            "Please stop the full_node service first with 'chia stop node'"
+        )
+
+    config: dict[str, Any] = load_config(root_path, "config.yaml")["full_node"]
+    if in_db_path is None:
+        selected_network: str = config["selected_network"]
+        db_pattern: str = config["database_path"]
+        db_path_replaced: str = db_pattern.replace("CHALLENGE", selected_network)
+        in_db_path = path_from_root(root_path, db_path_replaced)
+
+    prune_db(in_db_path, blocks_back=blocks_back)
+
+
+def prune_db(db_path: Path, *, blocks_back: int) -> None:
+    """
+    Prune the database by removing the most recent blocks_back blocks from the peak.
+
+    This removes blocks at height > (peak_height - blocks_back), making the block
+    at (peak_height - blocks_back) the new peak when full_node is restarted.
+    Also removes any orphan blocks at those heights.
+    """
+    if not db_path.exists():
+        raise RuntimeError(f"Database file does not exist: {db_path}")
+
+    print(f"Opening database: {db_path}")
+
+    with closing(sqlite3.connect(db_path)) as conn:
+        # Check database version
+        try:
+            with closing(conn.execute("SELECT * FROM database_version")) as cursor:
+                row = cursor.fetchone()
+                if row is None or row == []:
+                    raise RuntimeError("Database is missing version field")
+                if row[0] != 2:
+                    raise RuntimeError(f"Database has the wrong version ({row[0]} expected 2)")
+        except sqlite3.OperationalError:
+            raise RuntimeError("Database is missing version table")
+
+        # Get the peak height
+        try:
+            with closing(conn.execute("SELECT hash FROM current_peak WHERE key = 0")) as cursor:
+                row = cursor.fetchone()
+                if row is None or row == []:
+                    raise RuntimeError("Database is missing current_peak")
+                peak_hash = row[0]
+        except sqlite3.OperationalError:
+            raise RuntimeError("Database is missing current_peak table")
+
+        with closing(conn.execute("SELECT height FROM full_blocks WHERE header_hash = ?", (peak_hash,))) as cursor:
+            row = cursor.fetchone()
+            if row is None:
+                raise RuntimeError("Database is missing the peak block")
+            peak_height = row[0]
+
+        print(f"Current peak height: {peak_height}")
+
+        if blocks_back >= peak_height:
+            print(f"blocks_back ({blocks_back}) >= peak_height ({peak_height}). Nothing to prune.")
+            return
+
+        new_peak_height = peak_height - blocks_back
+
+        print(f"Pruning {blocks_back} blocks from height {new_peak_height + 1} to {peak_height}")
+        print(f"Block at height {new_peak_height} will become the new peak")
+
+        # Get the new peak hash (the block at new_peak_height in the main chain)
+        with closing(
+            conn.execute(
+                "SELECT header_hash FROM full_blocks WHERE height = ? AND in_main_chain = 1",
+                (new_peak_height,),
+            )
+        ) as cursor:
+            row = cursor.fetchone()
+            if row is None:
+                raise RuntimeError(f"Cannot find main chain block at height {new_peak_height}")
+            new_peak_hash = row[0]
+
+        # Count blocks to be deleted (all blocks above new_peak_height)
+        with closing(
+            conn.execute(
+                "SELECT COUNT(*) FROM full_blocks WHERE height > ?",
+                (new_peak_height,),
+            )
+        ) as cursor:
+            total_to_delete = cursor.fetchone()[0]
+
+        if total_to_delete == 0:
+            print("No blocks to prune.")
+            return
+
+        print(f"Blocks to prune: {total_to_delete}")
+
+        # Delete blocks in batches to show progress
+        batch_size = 1000
+        deleted = 0
+
+        while True:
+            conn.execute(
+                "DELETE FROM full_blocks WHERE height > ? AND rowid IN "
+                "(SELECT rowid FROM full_blocks WHERE height > ? LIMIT ?)",
+                (new_peak_height, new_peak_height, batch_size),
+            )
+            conn.commit()
+
+            rows_deleted = conn.total_changes - deleted
+            if rows_deleted == 0:
+                break
+            deleted = conn.total_changes
+            print(f"\rDeleted {deleted}/{total_to_delete} blocks...", end="", flush=True)
+
+        print(f"\rDeleted {deleted} blocks.                              ")
+
+        # Update the current_peak to point to the new peak
+        conn.execute("UPDATE current_peak SET hash = ? WHERE key = 0", (new_peak_hash,))
+        conn.commit()
+        print(f"Updated peak to height {new_peak_height}")
+
+        # Get the new database info
+        with closing(conn.execute("SELECT COUNT(*) FROM full_blocks")) as cursor:
+            remaining_blocks = cursor.fetchone()[0]
+
+        with closing(
+            conn.execute("SELECT MIN(height), MAX(height) FROM full_blocks WHERE in_main_chain = 1")
+        ) as cursor:
+            row = cursor.fetchone()
+            min_height = row[0]
+            max_height = row[1]
+
+        print(f"Remaining blocks in database: {remaining_blocks}")
+        print(f"Main chain height range: {min_height} to {max_height}")
+        print("\nPruning complete. Run 'VACUUM' on the database to reclaim disk space if desired.")
+        print("You can do this with: chia db backup")
+        print("Then replace the original database with the backup.")

--- a/chia/cmds/db_prune_func.py
+++ b/chia/cmds/db_prune_func.py
@@ -235,7 +235,7 @@ def prune_db(
         def _progress_callback() -> int:
             progress_count[0] += 1
             if progress_count[0] % 10 == 0:
-                print(".", flush=True)
+                print(".", end="", flush=True)
             return 0
 
         conn.execute("BEGIN IMMEDIATE")

--- a/chia/cmds/db_prune_func.py
+++ b/chia/cmds/db_prune_func.py
@@ -55,6 +55,9 @@ def prune_db(db_path: Path, *, blocks_back: int) -> None:
     Also removes any orphan blocks at those heights and cleans up related data
     (coin records, hints) so the node can sync forward correctly.
     """
+    if blocks_back < 0:
+        raise RuntimeError(f"blocks_back must be a non-negative integer, got {blocks_back}")
+
     if not db_path.exists():
         raise RuntimeError(f"Database file does not exist: {db_path}")
 
@@ -90,8 +93,8 @@ def prune_db(db_path: Path, *, blocks_back: int) -> None:
 
         print(f"Current peak height: {peak_height}")
 
-        if blocks_back >= peak_height:
-            print(f"blocks_back ({blocks_back}) >= peak_height ({peak_height}). Nothing to prune.")
+        if blocks_back > peak_height:
+            print(f"blocks_back ({blocks_back}) > peak_height ({peak_height}). Nothing to prune.")
             return
 
         new_peak_height = peak_height - blocks_back

--- a/chia/cmds/db_prune_func.py
+++ b/chia/cmds/db_prune_func.py
@@ -36,7 +36,14 @@ def db_prune_func(
     full_node_lock_path = service_launch_lock_path(root_path, "chia_full_node")
     try:
         with Lockfile.create(full_node_lock_path, timeout=0.1):
-            prune_db(in_db_path, blocks_back=blocks_back)
+            try:
+                prune_db(in_db_path, blocks_back=blocks_back)
+            except RuntimeError:
+                raise
+            except sqlite3.Error as e:
+                raise RuntimeError(f"Database error during prune: {e}")
+            except Exception as e:
+                raise RuntimeError(f"Unexpected error during prune: {e}")
     except LockfileError:
         raise RuntimeError(
             "Cannot prune database while full_node is running. "
@@ -62,6 +69,11 @@ def prune_db(db_path: Path, *, blocks_back: int) -> None:
     print(f"Opening database: {db_path}")
 
     with closing(sqlite3.connect(db_path)) as conn:
+        with closing(conn.execute("PRAGMA integrity_check")) as cursor:
+            result = cursor.fetchone()[0]
+            if result != "ok":
+                raise RuntimeError(f"Database integrity check failed: {result}")
+
         # Check database version
         try:
             with closing(conn.execute("SELECT * FROM database_version")) as cursor:
@@ -127,84 +139,46 @@ def prune_db(db_path: Path, *, blocks_back: int) -> None:
 
         print(f"Blocks to prune: {total_blocks_to_delete}")
 
-        # Update the current_peak FIRST for crash safety.
-        # If interrupted after this point, the database remains in a recoverable state
-        # with the peak pointing to a valid block. Orphan blocks/coins above the peak
-        # are harmless and can be cleaned up by re-running prune.
-        conn.execute("UPDATE current_peak SET hash = ? WHERE key = 0", (new_peak_hash,))
-        conn.commit()
-        print(f"Updated peak to height {new_peak_height}")
+        # Single transaction: all mutations in one BEGIN IMMEDIATE / commit.
+        # Progress handler prints dots during long operations so the user sees activity.
+        progress_count: list[int] = [0]
 
-        # Clean up coin_record and hints tables if they exist
-        # This is necessary for the node to sync forward correctly after pruning
+        def _progress_callback() -> int:
+            progress_count[0] += 1
+            if progress_count[0] % 10 == 0:
+                print(".", flush=True)
+            return 0
+
+        conn.execute("BEGIN IMMEDIATE")
+        conn.set_progress_handler(_progress_callback, 10000)
         try:
-            print("Cleaning up coin records and hints...")
+            # Update peak first (crash safety: peak points to valid block).
+            print("Updating peak...")
+            conn.execute("UPDATE current_peak SET hash = ? WHERE key = 0", (new_peak_hash,))
 
-            # 1. Delete hints for coins that will be deleted (must do this BEFORE deleting coins)
+            # Delete hints for coins that will be deleted (must be before deleting coins).
+            print("Deleting hints...")
             try:
-                with closing(
-                    conn.execute(
-                        "SELECT COUNT(*) FROM hints WHERE coin_id IN "
-                        "(SELECT coin_name FROM coin_record WHERE confirmed_index > ?)",
-                        (new_peak_height,),
-                    )
-                ) as cursor:
-                    hints_to_delete = cursor.fetchone()[0]
-                if hints_to_delete > 0:
-                    print(f"  Deleting {hints_to_delete} hints for coins above height {new_peak_height}...")
-                    conn.execute(
-                        "DELETE FROM hints WHERE coin_id IN "
-                        "(SELECT coin_name FROM coin_record WHERE confirmed_index > ?)",
-                        (new_peak_height,),
-                    )
-                    conn.commit()
+                conn.execute(
+                    "DELETE FROM hints WHERE coin_id IN (SELECT coin_name FROM coin_record WHERE confirmed_index > ?)",
+                    (new_peak_height,),
+                )
             except sqlite3.OperationalError:
-                # hints table might not exist in all databases
-                pass
+                pass  # hints table might not exist
 
-            # 2. Delete coins that were created (confirmed) at heights above new_peak_height
-            with closing(
-                conn.execute("SELECT COUNT(*) FROM coin_record WHERE confirmed_index > ?", (new_peak_height,))
-            ) as cursor:
-                coins_to_delete = cursor.fetchone()[0]
+            # Delete coin records confirmed above new peak.
+            print("Deleting coin records...")
+            try:
+                conn.execute(
+                    "DELETE FROM coin_record WHERE confirmed_index > ?",
+                    (new_peak_height,),
+                )
+            except sqlite3.OperationalError:
+                pass  # coin_record table might not exist in minimal DBs
 
-            if coins_to_delete > 0:
-                print(f"  Deleting {coins_to_delete} coin records created above height {new_peak_height}...")
-                # Delete in batches for large databases using rowid
-                coin_batch_size = 1000
-                deleted_coins = 0
-                while True:
-                    conn.execute(
-                        "DELETE FROM coin_record WHERE rowid IN "
-                        "(SELECT rowid FROM coin_record WHERE confirmed_index > ? LIMIT ?)",
-                        (new_peak_height, coin_batch_size),
-                    )
-                    conn.commit()
-                    # Check how many are left
-                    with closing(
-                        conn.execute("SELECT COUNT(*) FROM coin_record WHERE confirmed_index > ?", (new_peak_height,))
-                    ) as cursor:
-                        remaining = cursor.fetchone()[0]
-                    deleted_coins = coins_to_delete - remaining
-                    if remaining == 0:
-                        break
-                    print(f"\r    Deleted {deleted_coins}/{coins_to_delete} coin records...", end="", flush=True)
-                print(f"\r    Deleted {deleted_coins} coin records.                    ")
-
-            # 3. Reset spent_index for coins that were spent at heights above new_peak_height
-            #    (they need to become unspent again)
-            with closing(
-                conn.execute("SELECT COUNT(*) FROM coin_record WHERE spent_index > ?", (new_peak_height,))
-            ) as cursor:
-                coins_to_unspend = cursor.fetchone()[0]
-
-            if coins_to_unspend > 0:
-                print(f"  Resetting {coins_to_unspend} coin records that were spent above height {new_peak_height}...")
-                # Reset spent_index for coins spent above the new peak.
-                # If the coin is not a reward coin (coinbase=0) and its parent has
-                # the same puzzle_hash and amount and is spent, set spent_index to -1
-                # to preserve fast-forward singleton state. Otherwise set to 0.
-                # This matches the logic in coin_store.py rollback_to_block.
+            # Reset spent_index for coins spent above new peak (make them unspent).
+            print("Resetting spent coin records...")
+            try:
                 conn.execute(
                     """
                     UPDATE coin_record
@@ -227,82 +201,51 @@ def prune_db(db_path: Path, *, blocks_back: int) -> None:
                     """,
                     (new_peak_height,),
                 )
-                conn.commit()
-                print(f"    Reset {coins_to_unspend} coin records.")
-        except sqlite3.OperationalError:
-            # coin_record table might not exist in minimal test databases
-            pass
+            except sqlite3.OperationalError:
+                pass
 
-        # Delete blocks in batches to show progress
-        print("Deleting blocks...")
-        batch_size = 1000
-        deleted = 0
+            # Delete blocks above new peak.
+            print("Deleting blocks...")
+            conn.execute("DELETE FROM full_blocks WHERE height > ?", (new_peak_height,))
 
-        while True:
-            conn.execute(
-                "DELETE FROM full_blocks WHERE height > ? AND rowid IN "
-                "(SELECT rowid FROM full_blocks WHERE height > ? LIMIT ?)",
-                (new_peak_height, new_peak_height, batch_size),
-            )
-            conn.commit()
-
-            # Check how many blocks remain to be deleted
-            with closing(
-                conn.execute("SELECT COUNT(*) FROM full_blocks WHERE height > ?", (new_peak_height,))
-            ) as cursor:
-                remaining = cursor.fetchone()[0]
-
-            deleted = total_blocks_to_delete - remaining
-            if remaining == 0:
-                break
-            print(f"\r  Deleted {deleted}/{total_blocks_to_delete} blocks...", end="", flush=True)
-
-        print(f"\r  Deleted {deleted} blocks.                              ")
-
-        # Clean up sub_epoch_segments_v3 table - delete entries for blocks that no longer exist
-        # This is important because stale segment data can affect weight proof validation
-        # and fork point calculation during sync
-        try:
-            with closing(
-                conn.execute(
-                    "SELECT COUNT(*) FROM sub_epoch_segments_v3 WHERE ses_block_hash NOT IN "
-                    "(SELECT header_hash FROM full_blocks)"
-                )
-            ) as cursor:
-                orphan_segments = cursor.fetchone()[0]
-            if orphan_segments > 0:
-                print(f"Cleaning up {orphan_segments} orphaned sub-epoch segment entries...")
+            # Clean up sub_epoch_segments for blocks that no longer exist.
+            print("Cleaning up sub-epoch segments...")
+            try:
                 conn.execute(
                     "DELETE FROM sub_epoch_segments_v3 WHERE ses_block_hash NOT IN "
                     "(SELECT header_hash FROM full_blocks)"
                 )
-                conn.commit()
-        except sqlite3.OperationalError:
-            # sub_epoch_segments_v3 table might not exist in all databases
-            pass
+            except sqlite3.OperationalError:
+                pass  # table might not exist
 
-        # Get the new database info
-        with closing(conn.execute("SELECT COUNT(*) FROM full_blocks")) as cursor:
-            remaining_blocks = cursor.fetchone()[0]
+            conn.commit()
 
-        with closing(
-            conn.execute("SELECT MIN(height), MAX(height) FROM full_blocks WHERE in_main_chain = 1")
-        ) as cursor:
-            row = cursor.fetchone()
-            min_height = row[0]
-            max_height = row[1]
+            # Summary (read after commit).
+            with closing(conn.execute("SELECT COUNT(*) FROM full_blocks")) as cursor:
+                remaining_blocks = cursor.fetchone()[0]
+            with closing(
+                conn.execute("SELECT MIN(height), MAX(height) FROM full_blocks WHERE in_main_chain = 1")
+            ) as cursor:
+                row = cursor.fetchone()
+                min_height = row[0]
+                max_height = row[1]
+            try:
+                with closing(conn.execute("SELECT COUNT(*) FROM coin_record")) as cursor:
+                    remaining_coins = cursor.fetchone()[0]
+                coin_count_msg = f"Remaining coin records: {remaining_coins}"
+            except sqlite3.OperationalError:
+                coin_count_msg = ""
 
-        try:
-            with closing(conn.execute("SELECT COUNT(*) FROM coin_record")) as cursor:
-                remaining_coins = cursor.fetchone()[0]
-            coin_count_msg = f"Remaining coin records: {remaining_coins}"
-        except sqlite3.OperationalError:
-            coin_count_msg = ""
+            print(f"\nRemaining blocks in database: {remaining_blocks}")
+            print(f"Main chain height range: {min_height} to {max_height}")
+            if coin_count_msg:
+                print(coin_count_msg)
+            print("\nPruning complete. Run 'VACUUM' on the database to reclaim disk space if desired.")
+            print("You can do this with: chia db backup")
+            print("Then replace the original database with the backup.")
 
-        print(f"Remaining blocks in database: {remaining_blocks}")
-        print(f"Main chain height range: {min_height} to {max_height}")
-        if coin_count_msg:
-            print(coin_count_msg)
-        print("\nPruning complete. Run 'VACUUM' on the database to reclaim disk space if desired.")
-        print("You can do this with: chia db backup")
-        print("Then replace the original database with the backup.")
+        except Exception as e:
+            conn.rollback()
+            raise RuntimeError(f"Prune failed: {e}")
+        finally:
+            conn.set_progress_handler(None, 0)


### PR DESCRIPTION
### Purpose:

This adds a new CLI command to prune the blockchain database by removing blocks from the peak, effectively rolling back the chain.

- Removes the specified number of blocks from the current peak
- Updates current_peak to point to the new peak block
- Removes both main chain and orphan blocks above the new peak
- Refuses to run if full_node is currently running (checks service lock)
- Default is 300 blocks back from peak
- Usage: `chia db prune [BLOCKS_BACK]`

### Testing Notes:

A suite of tests and integration tests to verify full_node starts and syncs correctly after pruning (test_prune_full_sync.py)


<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Destructive in-place blockchain DB mutations (blocks, coins, peak) can brick a node if misused; mitigated by lock check, transactions, and integrity checks but operators must backup first.
> 
> **Overview**
> Adds **`chia db prune [BLOCKS_BACK]`** (default 300) to trim the v2 full-node SQLite DB from the current peak: updates `current_peak`, deletes main-chain and orphan blocks above the new height, and cleans related **hints**, **coin_record** rows (including resetting `spent_index` for spends above the cutoff), and orphaned **sub_epoch_segments_v3** entries.
> 
> **`db_prune_func`** resolves the DB from config or `--db`, runs a **sampled** integrity check by default (or `--full-integrity-check` / `--no-integrity-check`), refuses to run while **full_node** holds its launch lock, and performs mutations in a single **`BEGIN IMMEDIATE`** transaction with rollback on failure.
> 
> Ships broad **unit** coverage (`test_db_prune.py`) and **simulator integration** tests (`test_prune_full_sync.py`) for restart, forward sync, and coin-state consistency after prune.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c5eafcc89f81e3f03b8a4c6b71d999391825d98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->