### PR TITLE
bump chia_rs to 0.35.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -876,38 +876,38 @@ pytest = ">=8.3.3,<9.0.0"
 
 [[package]]
 name = "chia-rs"
-version = "0.35.1"
+version = "0.35.2"
 description = ""
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "chia_rs-0.35.1-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:2168f57f9b9ee9eeed7ec0a30ee5f5303c8f3d2185c7257da7cbf8720f41f290"},
-    {file = "chia_rs-0.35.1-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:40af6160498c0711e168f8b8d74e29e6f852d44342030b4010a15f3f57971bec"},
-    {file = "chia_rs-0.35.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:21909208f0ef07e8836a8e49368278aa7f9704fb228fbefa46d86878038ac7a1"},
-    {file = "chia_rs-0.35.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:314c4f42cdeaea94834d3b15c05fb49ec0eb502293a9dd23239d69dbcbcaa15a"},
-    {file = "chia_rs-0.35.1-cp310-cp310-win_amd64.whl", hash = "sha256:d3c4b9b06bc9f15412b0b945abe5a1ffb2135ab436f23a6e3bb321ddc80f6f2f"},
-    {file = "chia_rs-0.35.1-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:d4d50aba8b9fe9942ceba1c56d5e815cc0f06ea08487089bac1b675e430bee82"},
-    {file = "chia_rs-0.35.1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:cd6609ebe9fa43d5e2413de038f9d0b74303f8a3565f35d7c1930b86f3b59e49"},
-    {file = "chia_rs-0.35.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:154aacdba456e681474fbc448b0eee91009abe05fee395f33f5baabfd9354326"},
-    {file = "chia_rs-0.35.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:27e464ad5ed9720d4f9675214fa075d7d6e28225cf7b7cb82c70dc55383661b9"},
-    {file = "chia_rs-0.35.1-cp311-cp311-win_amd64.whl", hash = "sha256:2e416a9d3cc03efa756420533eb982e46ea49f7bc0adf4c14513bf88aa74c618"},
-    {file = "chia_rs-0.35.1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:92660b83cab5c90d276490a1f5c2cb8f78f3506be29ba17c1a07733cec62836c"},
-    {file = "chia_rs-0.35.1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:aa742dd3f0f49effc737c6dd20f816d9ca0b355bc106b12734f8c4c98104067e"},
-    {file = "chia_rs-0.35.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9cfcc72d1e505df5055f34501c7889aedc8885b375035fcda69f54249e6a84a8"},
-    {file = "chia_rs-0.35.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0d7a80a92a9680b00f1bcb9a9f3d424195b9bd79f83d2044f688e717c1af2d5d"},
-    {file = "chia_rs-0.35.1-cp312-cp312-win_amd64.whl", hash = "sha256:c4188ad56e690e593a8b5f4b8ab69ea2b4b90aa8533614c922e688d1648582da"},
-    {file = "chia_rs-0.35.1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:6c735b0f8139e0e40428a1b3a9c2c92104ac18f8f0365c9de8f534c8aeea2c19"},
-    {file = "chia_rs-0.35.1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:963bbde14126e94c59879b597bf0b3b7dcb5d03a19343bd90b18c7f2ff9c401f"},
-    {file = "chia_rs-0.35.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:b15bdd23b7135eab7061b9a763c34c89f1bf72d3434d5f3f7f251b33b9519ed4"},
-    {file = "chia_rs-0.35.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ec6dc7dc52d567796f6b34697a71eff0f80a95b99fadc04b91631b41c260dc16"},
-    {file = "chia_rs-0.35.1-cp313-cp313-win_amd64.whl", hash = "sha256:ba1959a6985366965ff38ed61deccdc05a01ce9d034de9f96bdb4160b36e53dc"},
-    {file = "chia_rs-0.35.1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:61afcd3cf661fce0bf135df2a50fb79fc84f2081f2f814d4a3d14d9d8f2f2881"},
-    {file = "chia_rs-0.35.1-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:5e62dffb40f3558cf8e0350e772a4bbdb6e80d95a46a109bf077d04567d63155"},
-    {file = "chia_rs-0.35.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0aad362c96fa447f11efd484a82ff69495743693f946c67c7de84f445dc88d03"},
-    {file = "chia_rs-0.35.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:31fdb16032698fd5258194838dcd8b46317f838e79487eeb3196a0178ffb5e39"},
-    {file = "chia_rs-0.35.1-cp314-cp314-win_amd64.whl", hash = "sha256:6357b94ff70f002699beeb1b00b8a4359c86f00b4881996410b718c828d573a9"},
-    {file = "chia_rs-0.35.1.tar.gz", hash = "sha256:09745a0639f700ebc5626f92db9d5131ddaab4bc791e364cff21f8bd7556e85f"},
+    {file = "chia_rs-0.35.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:0729cd8ff4776d9b948f0bbbb81e53f6b3becb9a2a46b34ec04ffb5e55e256e1"},
+    {file = "chia_rs-0.35.2-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:55791fff5c3aff457fd1fda3f371b14e1c08649d7c7076794736487f1e2a4671"},
+    {file = "chia_rs-0.35.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:c670f785e8a5698aeb31b059f47bcc86b114d0e1f49afebe7208d9d594212378"},
+    {file = "chia_rs-0.35.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:2b9e2121e60133518419df96c3e065cd43337a25d4c005d3e61d1e36ea532f2c"},
+    {file = "chia_rs-0.35.2-cp310-cp310-win_amd64.whl", hash = "sha256:32de4883965b123277b84b490069971cde002656da86b622acbc8f43809e36ea"},
+    {file = "chia_rs-0.35.2-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:c71b3aa2f5e65bb1c820cabcd3c78204a546db400d86e3092bf88d146c7046fd"},
+    {file = "chia_rs-0.35.2-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:8d52d8ecd7af7ed0c2dee4b795fed159dd7cd7d999ee18ef5acb97dd29b31e85"},
+    {file = "chia_rs-0.35.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:06d10363445308c4d3766cec9d28f7594b238ce31f4b4284ba58ad0aca5ca23e"},
+    {file = "chia_rs-0.35.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:be30286f3e06727ec86b1444a5a6c6f924e72d93675573d15b8b14699febc560"},
+    {file = "chia_rs-0.35.2-cp311-cp311-win_amd64.whl", hash = "sha256:07e89af79eb94e0453be182b14aef5eab3a1bd4e2653477d39eccf9db1c7b7e0"},
+    {file = "chia_rs-0.35.2-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:040010e1a1e12acd7ae8f6bd9f9a6463c0d243d009556afc036bf64cce94c81a"},
+    {file = "chia_rs-0.35.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:1748882a708eb97aa2221982b4975dccc04bbd99247738a9d9d38b01826ca5aa"},
+    {file = "chia_rs-0.35.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:73323d4f762d44fefd9a7c8cf3d02dd0566880ab504b095e861a6efe4d48a6bb"},
+    {file = "chia_rs-0.35.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:3913d5668c4b9932b9f8c4eaf4b7726fc2c1f91846ae0c53cff9ef736499a9c9"},
+    {file = "chia_rs-0.35.2-cp312-cp312-win_amd64.whl", hash = "sha256:280edab0700ecc433f631ba5806c0c6c57dbbac78e58667c933c84207465fe6f"},
+    {file = "chia_rs-0.35.2-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:56d1fc2b1ed433c05f1983decbe6e59e637d041f208edadb4ee958e717f251aa"},
+    {file = "chia_rs-0.35.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:397865128a4f1142cbe7114faeaaf118669973e08b74d957e72b5b6bb0452d35"},
+    {file = "chia_rs-0.35.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:80c3a7c35c87fae544e3ef59af8e5260d5299db3652f1b8b595c66ad8c2070e1"},
+    {file = "chia_rs-0.35.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ab5ee1f840d859a1416ad915cc67b4b1829a22353a44702a0c1164bc268f8d94"},
+    {file = "chia_rs-0.35.2-cp313-cp313-win_amd64.whl", hash = "sha256:003bb7c9edddb78200a6fb885ae25b1852667a1cd98ebba9c06fded39740bb79"},
+    {file = "chia_rs-0.35.2-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:d065717112ac7dca1fae86188cc4c17d05f29d0dec2173b555e3e3f15b1478b8"},
+    {file = "chia_rs-0.35.2-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:e0f57e35d5d92213593f5ba97ea59619be00b57a5de189f1f384a023a242a7dc"},
+    {file = "chia_rs-0.35.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0c0d606747bf7872343be9e14e44ce8edbeb6235bae1100bd8831817130cf15b"},
+    {file = "chia_rs-0.35.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e31682e92c9a4474312b9ffd6fce780427ac97856cd93ea09f880cd9a42b7e8e"},
+    {file = "chia_rs-0.35.2-cp314-cp314-win_amd64.whl", hash = "sha256:55e1d6e1b8e86eda777e4d47358ddedc3dd1d36cde99ca8e1e41a9654ebd60b0"},
+    {file = "chia_rs-0.35.2.tar.gz", hash = "sha256:752461cfd30f90d9774db0c517f31543c87327ef6509528686613cf4168135fc"},
 ]
 
 [package.dependencies]
@@ -4022,4 +4022,4 @@ upnp = ["miniupnpc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <4"
-content-hash = "3a9572ac6d414f58ba7c6ffb40cd7f32c04de6950eef629d8478eeb232df01cc"
+content-hash = "3b64b435f6c54866be48aa9e83b251e019fb71edd5628ee7a9f370da4faeaf16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ boto3 = ">=1.35.43"  # AWS S3 for Data Layer S3 plugin
 chiabip158 = ">=1.5.2"  # bip158-style wallet filters
 chiapos = ">=2.0.10"  # proof of space
 chia-puzzles-py = ">=0.20.1"
-chia_rs = ">=0.35.1, <0.36"
+chia_rs = ">=0.35.2, <0.36"
 chiavdf = ">=1.1.10"  # timelord and vdf verification
 click = ">=8.1.7"  # For the CLI
 clvm = ">=0.9.14"


### PR DESCRIPTION

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades `chia_rs` to `0.35.2`.
> 
> - Updates dependency constraint in `pyproject.toml`
> - Refreshes `poetry.lock` with new wheels/tarball hashes and `content-hash`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86e1138658d502e51aaf0f40594acf70e94f949c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->