### PR TITLE
Pin alls-green to release/v1.2.2; use GITHUB_OUTPUT in reflow-version

### DIFF
--- a/.github/workflows/reflow-version.yml
+++ b/.github/workflows/reflow-version.yml
@@ -45,7 +45,7 @@ jobs:
           elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.release_type }}" =~ $REG_RC ]]; then
             TAG_TYPE=rc
           fi
-          echo "tag-type=${TAG_TYPE}" | tee -a "$$GITHUB_OUTPUT"
+          echo "tag-type=${TAG_TYPE}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Create installer version number
         id: version-number

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,7 @@ jobs:
             matrix: "3.12"
 
     steps:
-      - uses: re-actors/alls-green@release/v1.2
+      - uses: re-actors/alls-green@release/v1.2.2
         id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,7 @@ jobs:
             matrix: "3.12"
 
     steps:
-      - uses: re-actors/alls-green@release/v1.2.2
+      - uses: re-actors/alls-green@v1.2.2
         id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION

### Purpose:
-Github is deprecating set-output and that means that allsgreen had to bump a minor version to remove that:
https://github.com/re-actors/alls-green/releases
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Current Behavior:
Some runners are failing:
<img width="2266" height="592" alt="image" src="https://github.com/user-attachments/assets/7efd01aa-503c-4e1e-9e1a-ccd149dc30fe" />


### New Behavior:

Uses release/v1.2.2

### Testing Notes:
-Not sure why this is pinned in the first place but assuming good CI runs, can be ignored.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes: fixes a GitHub Actions output variable typo and updates a pinned third-party action version; risk is limited to workflow execution behavior.
> 
> **Overview**
> Fixes output publishing in `reflow-version.yml` by writing to the correct `GITHUB_OUTPUT` file (removing an erroneous extra `$` that could prevent `tag-type` from being set).
> 
> Updates the `test.yml` coverage job to use `re-actors/alls-green@v1.2.2` instead of `release/v1.2`, aligning with the action’s newer release that avoids deprecated output mechanisms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac3699f1a5946c77fb8f5a95f971f875a2e59639. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->