### PR TITLE
Fix the GITHUB_OUTPUT in reflow-version and pin alls-green to the per version

### DIFF
--- a/.github/workflows/reflow-version.yml
+++ b/.github/workflows/reflow-version.yml
@@ -45,7 +45,7 @@ jobs:
           elif [[ "${{ github.event.release.tag_name }}" =~ $REG_RC ]] || [[ "${{ inputs.release_type }}" =~ $REG_RC ]]; then
             TAG_TYPE=rc
           fi
-          echo "tag-type=${TAG_TYPE}" | tee -a "$$GITHUB_OUTPUT"
+          echo "tag-type=${TAG_TYPE}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Create installer version number
         id: version-number

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,7 @@ jobs:
             matrix: "3.12"
 
     steps:
-      - uses: re-actors/alls-green@release/v1.2
+      - uses: re-actors/alls-green@v1.2.2
         id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
### Purpose:
To fix existing errors with the syntax of GITHUB_OUTPUT and fix the version for the alls-green.

### Current Behavior:

Github runner were failing due to improper version

### New Behavior:

Solves potential failure issues

### Testing Notes:

This change has been approved and is on main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only changes: fixes an output env var typo and pins an action version, mainly affecting workflow execution reliability.
> 
> **Overview**
> Fixes the `reflow-version` workflow to correctly append the `tag-type` output to `$GITHUB_OUTPUT`, resolving a syntax issue that could prevent job outputs from being set.
> 
> Pins the `re-actors/alls-green` action used in the `test` workflow coverage job to `v1.2.2` instead of the `release/v1.2` ref for more stable CI behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58712d95e15a8e01d40674754d8e8672730bda33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->