### PR TITLE
CHIA-3821 Full nodes should only accept peer connections post hard fork 2 from nodes that signal support for it

### DIFF
--- a/chia/_tests/connection_utils.py
+++ b/chia/_tests/connection_utils.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.apis import StubMetadataRegistry
 from chia.protocols.outbound_message import NodeType
-from chia.protocols.shared_protocol import default_capabilities
+from chia.protocols.shared_protocol import Capability, default_capabilities
 from chia.server.server import ChiaServer, ssl_context_for_client
 from chia.server.ssl_context import chia_ssl_ca_paths, private_ssl_ca_paths
 from chia.server.ws_connection import WSChiaConnection
@@ -44,8 +44,10 @@ async def add_dummy_connection(
     dummy_port: int,
     type: NodeType = NodeType.FULL_NODE,
     *,
-    additional_capabilities: list[tuple[uint16, str]] = [],
+    additional_capabilities: list[tuple[uint16, str]] | None = None,
 ) -> tuple[asyncio.Queue, bytes32]:
+    if additional_capabilities is None:
+        additional_capabilities = [(uint16(Capability.HARD_FORK_2.value), "1")]
     wsc, peer_id = await add_dummy_connection_wsc(
         server, self_hostname, dummy_port, type, additional_capabilities=additional_capabilities
     )
@@ -58,8 +60,10 @@ async def add_dummy_connection_wsc(
     self_hostname: str,
     dummy_port: int,
     type: NodeType = NodeType.FULL_NODE,
-    additional_capabilities: list[tuple[uint16, str]] = [],
+    additional_capabilities: list[tuple[uint16, str]] | None = None,
 ) -> tuple[WSChiaConnection, bytes32]:
+    if additional_capabilities is None:
+        additional_capabilities = [(uint16(Capability.HARD_FORK_2.value), "1")]
     timeout = aiohttp.ClientTimeout(total=10)
     session = aiohttp.ClientSession(timeout=timeout)
     config = load_config(server.root_path, "config.yaml")

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import dataclasses
 import logging
+import os
 import platform
 import random
 import sqlite3
@@ -3707,3 +3708,37 @@ async def test_node_types_inbound_connections_limit(
     await time_out_assert(5, lambda: peer_id in server.all_connections)
     # New inbound connections should be refused
     assert server.accept_inbound_connections(node_type) is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("has_hard_fork2_capability", [True, False])
+async def test_hard_fork_version_enforcement(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    consensus_mode: ConsensusMode,
+    has_hard_fork2_capability: bool,
+) -> None:
+    """
+    Covers the case where peers connecting to a full node after the hard fork
+    without advertising the HARD_FORK_2 capability get disconnected.
+    """
+    _, server, _ = one_node_one_block
+    additional_capabilities = [(uint16(Capability.HARD_FORK_2.value), "1")] if has_hard_fork2_capability else []
+    wsc, peer_id = await add_dummy_connection_wsc(
+        server, self_hostname, 42, NodeType.FULL_NODE, additional_capabilities=additional_capabilities
+    )
+    staying_connected = consensus_mode < ConsensusMode.HARD_FORK_3_0 or has_hard_fork2_capability
+    if staying_connected:
+        await asyncio.sleep(2)
+        assert peer_id in server.all_connections
+    else:
+        await time_out_assert(5, lambda: wsc.closed)
+        await time_out_assert(5, lambda: peer_id not in server.all_connections)
+
+
+# TODO: Remove the test once we enable this capability
+def test_hard_fork2_capability_on_release_branch() -> None:
+    branch = os.environ.get("GITHUB_REF_NAME")
+    if branch is not None and branch.startswith("release/3."):
+        for capabilities in default_capabilities.values():
+            assert (uint16(Capability.HARD_FORK_2.value), "1") in capabilities

--- a/chia/_tests/core/server/test_server.py
+++ b/chia/_tests/core/server/test_server.py
@@ -64,11 +64,11 @@ async def test_connection_string_conversion(
 ) -> None:
     _, _, server_1, server_2, _ = two_nodes_one_block
     peer = await connect_and_get_peer(server_1, server_2, self_hostname)
-    # 1000 is based on the current implementation (example below), should be reconsidered/adjusted if this test fails
-    # WSChiaConnection(local_type=<NodeType.FULL_NODE: 1>, local_port=50632, local_capabilities=[<Capability.BASE: 1>, <Capability.BLOCK_HEADERS: 2>, <Capability.RATE_LIMITS_V2: 3>], peer_host='127.0.0.1', peer_port=50640, peer_node_id=<bytes32: 566a318f0f656125b4fef0e85fbddcf9bc77f8003d35293c392479fc5d067f4d>, outbound_rate_limiter=<chia.server.rate_limits.RateLimiter object at 0x114a13f50>, inbound_rate_limiter=<chia.server.rate_limits.RateLimiter object at 0x114a13e90>, is_outbound=False, creation_time=1675271096.275591, bytes_read=68, bytes_written=162, last_message_time=1675271096.276271, peer_server_port=50636, active=False, closed=False, connection_type=<NodeType.FULL_NODE: 1>, request_nonce=32768, peer_capabilities=[<Capability.BASE: 1>, <Capability.BLOCK_HEADERS: 2>, <Capability.RATE_LIMITS_V2: 3>], version='', protocol_version='') # noqa
+    # 1100 is based on the current implementation (example below), should be reconsidered/adjusted if this test fails
+    # WSChiaConnection(local_type=<NodeType.FULL_NODE: 1>, local_port=50632, local_capabilities=[<Capability.BASE: 1>, <Capability.BLOCK_HEADERS: 2>, <Capability.RATE_LIMITS_V2: 3>, <Capability.MEMPOOL_UPDATES: 5>, <Capability.HARD_FORK_2: 6>], peer_info=PeerInfo(_ip=IPv4Address('127.0.0.1'), _port=50640), peer_node_id=<bytes32: 566a318f0f656125b4fef0e85fbddcf9bc77f8003d35293c392479fc5d067f4d>, outbound_rate_limiter=<chia.server.rate_limits.RateLimiter object at 0x114a13f50>, inbound_rate_limiter=<chia.server.rate_limits.RateLimiter object at 0x114a13e90>, is_outbound=False, creation_time=1675271096.275591, bytes_read=68, bytes_written=162, last_message_time=1675271096.276271, peer_server_port=50636, closed=False, connection_type=<NodeType.FULL_NODE: 1>, request_nonce=32768, peer_capabilities=[<Capability.BASE: 1>, <Capability.BLOCK_HEADERS: 2>, <Capability.RATE_LIMITS_V2: 3>, <Capability.MEMPOOL_UPDATES: 5>, <Capability.HARD_FORK_2: 6>], version='', protocol_version=<Version('0.0.36')>) # noqa
     converted = method(peer)
     print(converted)
-    assert len(converted) < 1000
+    assert len(converted) < 1100
 
 
 @pytest.mark.anyio

--- a/chia/protocols/shared_protocol.py
+++ b/chia/protocols/shared_protocol.py
@@ -45,6 +45,9 @@ class Capability(IntEnum):
     # This is between a full node and receiving wallet
     MEMPOOL_UPDATES = 5
 
+    # Signals support for Hard Fork 2
+    HARD_FORK_2 = 6
+
 
 # These are the default capabilities used in all outgoing handshakes.
 # "1" means the capability is supported and enabled.

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -9,7 +9,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from ipaddress import IPv4Network, IPv6Network, ip_network
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp import (
     ClientResponseError,
@@ -31,6 +31,7 @@ from chia.protocols.outbound_message import Message, NodeType
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.protocol_state_machine import message_requires_reply
 from chia.protocols.protocol_timing import INVALID_PROTOCOL_BAN_SECONDS
+from chia.protocols.shared_protocol import Capability
 from chia.server.api_protocol import ApiMetadata, ApiProtocol
 from chia.server.introducer_peers import IntroducerPeers
 from chia.server.ssl_context import private_ssl_paths, public_ssl_paths
@@ -41,6 +42,11 @@ from chia.util.errors import Err, ProtocolError
 from chia.util.network import WebServer, is_in_network, is_localhost, is_trusted_peer
 from chia.util.streamable import Streamable
 from chia.util.task_referencer import create_referenced_task
+
+if TYPE_CHECKING:
+    from chia.full_node.full_node import FullNode
+else:
+    FullNode = object
 
 max_message_size = 50 * 1024 * 1024  # 50MB
 
@@ -334,6 +340,22 @@ class ChiaServer:
             )
             await connection.perform_handshake(self._network_id, self.get_port(), self._local_type)
             assert connection.connection_type is not None, "handshake failed to set connection type, still None"
+
+            # Full nodes should only accept peers, post hard fork 2, that
+            # signal support for it.
+            if self._local_type == NodeType.FULL_NODE:
+                full_node: FullNode = self.node
+                peak_height = full_node.blockchain.get_peak_height()
+                if (
+                    peak_height is not None
+                    and peak_height >= full_node.constants.HARD_FORK2_HEIGHT
+                    and Capability.HARD_FORK_2 not in connection.peer_capabilities
+                ):
+                    self.log.info(
+                        f"Disconnecting peer {connection.peer_node_id} with version "
+                        f"{connection.version} not supporting the 3.0 hard fork."
+                    )
+                    raise ProtocolError(Err.INVALID_HANDSHAKE)
 
             # Limit inbound connections to config's specifications.
             if not self.accept_inbound_connections(connection.connection_type) and not is_in_network(

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -147,8 +147,11 @@ async def setup_full_node(
     updated_constants = replace_str_to_bytes(consensus_constants, **overrides)
     local_bt.change_config(config)
     override_capabilities = (
-        None if disable_capabilities is None else get_capability_overrides(NodeType.FULL_NODE, disable_capabilities)
+        get_capability_overrides(NodeType.FULL_NODE, disable_capabilities)
+        if disable_capabilities is not None
+        else list(default_capabilities[NodeType.FULL_NODE])
     )
+    override_capabilities.append((uint16(Capability.HARD_FORK_2.value), "1"))
     service: FullNodeService | SimulatorFullNodeService
     if simulator:
         service = await create_full_node_simulator_service(
@@ -286,12 +289,15 @@ async def setup_wallet_node(
             service_config.pop("full_node_peer", None)
             service_config.pop("full_node_peers", None)
 
+        override_capabilities = list(default_capabilities[NodeType.WALLET])
+        override_capabilities.append((uint16(Capability.HARD_FORK_2.value), "1"))
         service = create_wallet_service(
             local_bt.root_path,
             config,
             consensus_constants,
             keychain,
             connect_to_daemon=False,
+            override_capabilities=override_capabilities,
         )
 
         try:

--- a/chia/wallet/start_wallet.py
+++ b/chia/wallet/start_wallet.py
@@ -7,6 +7,7 @@ from multiprocessing import freeze_support
 from typing import Any
 
 from chia_rs import ConsensusConstants
+from chia_rs.sized_ints import uint16
 
 from chia.apis import StubMetadataRegistry
 from chia.consensus.constants import replace_str_to_bytes
@@ -38,6 +39,7 @@ def create_wallet_service(
     consensus_constants: ConsensusConstants,
     keychain: Keychain | None = None,
     connect_to_daemon: bool = True,
+    override_capabilities: list[tuple[uint16, str]] | None = None,
 ) -> WalletService:
     service_config = config[SERVICE_NAME]
 
@@ -73,6 +75,7 @@ def create_wallet_service(
         rpc_info=rpc_info,
         connect_to_daemon=connect_to_daemon,
         stub_metadata_for_type=StubMetadataRegistry,
+        override_capabilities=override_capabilities,
     )
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes inbound full-node handshake acceptance logic based on chain height and peer-advertised capabilities, which can disconnect peers if misconfigured or if the fork height detection is wrong. Scope is limited to full-node inbound connections and test/service capability wiring.
> 
> **Overview**
> Adds a new handshake capability, `Capability.HARD_FORK_2`, and wires it into tests/service setup.
> 
> Full nodes now **enforce post–Hard Fork 2 connectivity** by disconnecting inbound peers once the local peak height is at/above `HARD_FORK2_HEIGHT` if the peer did not advertise `HARD_FORK_2` during the handshake (`ChiaServer.incoming_connection`).
> 
> Test utilities and simulator/wallet service setup are updated to advertise `HARD_FORK_2` by default (including a new wallet `override_capabilities` plumbing), and new tests validate both enforcement behavior and that release branches include the capability; a server string-length assertion is adjusted for the larger connection repr.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fb81c6293f5d1332e4ee32b00c94373c60318e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->