### PR TITLE
Prevent None version in __init__.py

### DIFF
--- a/chia/__init__.py
+++ b/chia/__init__.py
@@ -10,7 +10,7 @@ try:
 except (PackageNotFoundError, KeyError):
     __version__ = "unknown"
 
-if __version__ == None:
+if __version__ is None:
     __version__ = "unknown"
 
 try:

--- a/chia/__init__.py
+++ b/chia/__init__.py
@@ -10,6 +10,9 @@ try:
 except (PackageNotFoundError, KeyError):
     __version__ = "unknown"
 
+if __version__ == None:
+    __version__ = "unknown"
+
 try:
     assert False
 except AssertionError:


### PR DESCRIPTION
### Purpose:

For some reason `version()` still gives a response of `None` sometimes, causing issues. 
This PR means that `None` will be treated as '`unknown'` version, which the software handles much more elegantly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny initialization change that only affects version string reporting; minimal behavioral impact and no security/data handling risk.
> 
> **Overview**
> Prevents `chia.__version__` from being `None` by coercing a `None` result from `importlib.metadata.version("chia-blockchain")` to `"unknown"`, matching the existing fallback behavior for missing metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f6d442dce4fdb45c62ab1887ee24b29b410f4a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->