### PR TITLE
fix(ci): Use format option for diff-cover to generate reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -329,7 +329,7 @@ jobs:
           compare-branch: ${{ github.base_ref == '' && steps.parent-commit.outputs.hash || format('origin/{0}', github.base_ref) }}
         run: |
           set -o pipefail
-          diff-cover --config-file=.diffcover.toml --compare-branch=${{ env.compare-branch }} --fail-under=100 --html-report=coverage-reports/diff-cover.html --markdown-report=coverage-reports/diff-cover.md coverage-reports/coverage.xml | tee coverage-reports/diff-cover-stdout
+          diff-cover --config-file=.diffcover.toml --compare-branch=${{ env.compare-branch }} --fail-under=100 --format html:coverage-reports/diff-cover.html,markdown:coverage-reports/diff-cover.md coverage-reports/coverage.xml | tee coverage-reports/diff-cover-stdout
           COV_STATUS="${PIPESTATUS[0]}"
           echo "COV_STATUS=$COV_STATUS" >> "$GITHUB_ENV"
           if [[ $COV_STATUS != '0' && "$GITHUB_BASE_REF" != '' ]]; then


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

This uses the newer --format option for creating coverage reports

### Current Behavior:

```
/home/runner/work/chia-blockchain/chia-blockchain/.venv/lib/python3.12/site-packages/diff_cover/diff_cover_tool.py:305: UserWarning: The --html-report option is deprecated. Use --format html:coverage-reports/diff-cover.html instead.
  warnings.warn(
/home/runner/work/chia-blockchain/chia-blockchain/.venv/lib/python3.12/site-packages/diff_cover/diff_cover_tool.py:325: UserWarning: The --markdown-report option is deprecated. Use --format markdown:coverage-reports/diff-cover.md instead.
  warnings.warn(
```

### New Behavior:

😎

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
