### PR TITLE
CHIA-3883 Tolerate quote related cost mismatch for older nodes

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -95,6 +95,7 @@ from chia.types.blockchain_format.proof_of_space import (
 )
 from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFProof
+from chia.types.clvm_cost import QUOTE_BYTES, QUOTE_EXECUTION_COST
 from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
@@ -3388,6 +3389,7 @@ async def test_pending_tx_cache_retry_on_new_peak(
 @pytest.mark.parametrize("mismatch_fee", [True, False])
 @pytest.mark.parametrize("tx_already_seen", [True, False])
 @pytest.mark.parametrize("mismatch_on_reannounce", [True, False])
+@pytest.mark.parametrize("tolerated_quote_cost_diff", [True, False])
 async def test_ban_for_mismatched_tx_cost_fee(
     three_nodes: list[FullNodeAPI],
     bt: BlockTools,
@@ -3396,6 +3398,7 @@ async def test_ban_for_mismatched_tx_cost_fee(
     mismatch_fee: bool,
     tx_already_seen: bool,
     mismatch_on_reannounce: bool,
+    tolerated_quote_cost_diff: bool,
 ) -> None:
     """
     Tests that a peer gets banned if it sends a `NewTransaction` message with a
@@ -3406,6 +3409,8 @@ async def test_ban_for_mismatched_tx_cost_fee(
     the ones specified in the `NewTransaction` message.
     With `mismatch_on_reannounce` we control whether the peer sent us the same
     transaction twice with different cost and fee.
+    With `tolerated_quote_cost_diff` we cover older nodes with a specific cost
+    mismatch due to the byte size cost and execution cost of the wrapper quote.
     """
     full_node_1, full_node_2, full_node_3 = three_nodes
     server_1 = full_node_1.full_node.server
@@ -3439,7 +3444,9 @@ async def test_ban_for_mismatched_tx_cost_fee(
     assert mempool_item is not None
     # Now send a NewTransaction with a cost and/or fee mismatch from the second
     # full node.
-    cost = uint64(mempool_item.cost + 1) if mismatch_cost else mempool_item.cost
+    quote_cost = QUOTE_BYTES * node.constants.COST_PER_BYTE + QUOTE_EXECUTION_COST
+    cost_diff = quote_cost if tolerated_quote_cost_diff else 0
+    cost = uint64(mempool_item.cost + 1) if mismatch_cost else uint64(mempool_item.cost + cost_diff)
     fee = uint64(mempool_item.fee + 1) if mismatch_fee else mempool_item.fee
     msg = make_msg(ProtocolMessageTypes.new_transaction, NewTransaction(mempool_item.name, cost, fee))
     # We won't ban localhost, so let's set a different ip address for the

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -41,8 +41,6 @@ from chia.full_node.eligible_coin_spends import (
 from chia.full_node.mempool import MAX_SKIPPED_ITEMS, PRIORITY_TX_THRESHOLD
 from chia.full_node.mempool_manager import (
     MEMPOOL_MIN_FEE_INCREASE,
-    QUOTE_BYTES,
-    QUOTE_EXECUTION_COST,
     MempoolManager,
     TimelockConditions,
     can_replace,
@@ -63,7 +61,7 @@ from chia.simulator.wallet_tools import WalletTool
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import DEFAULT_FLAGS, INFINITE_COST, Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
-from chia.types.clvm_cost import CLVMCost
+from chia.types.clvm_cost import QUOTE_BYTES, QUOTE_EXECUTION_COST, CLVMCost
 from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -67,6 +67,7 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.types.block_protocol import BlockInfo
 from chia.types.blockchain_format.coin import Coin, hash_coin_ids
 from chia.types.blockchain_format.proof_of_space import verify_and_get_quality_string
+from chia.types.clvm_cost import QUOTE_BYTES, QUOTE_EXECUTION_COST
 from chia.types.generator_types import BlockGenerator, NewBlockGenerator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.peer_info import PeerInfo
@@ -220,11 +221,17 @@ class FullNodeAPI:
         # If already seen, the cost and fee must match, otherwise ban the peer
         mempool_item = self.full_node.mempool_manager.get_mempool_item(transaction.transaction_id, include_pending=True)
         if mempool_item is not None:
-            if mempool_item.cost != transaction.cost or mempool_item.fee != transaction.fees:
+            # Older nodes (2.4.3 and earlier) compute the cost slightly
+            # differently. They include the byte cost and execution cost of
+            # the quote for the puzzle.
+            tolerated_diff = QUOTE_BYTES * self.full_node.constants.COST_PER_BYTE + QUOTE_EXECUTION_COST
+            if (transaction.cost != mempool_item.cost and transaction.cost != mempool_item.cost + tolerated_diff) or (
+                transaction.fees != mempool_item.fee
+            ):
                 self.log.warning(
-                    f"Banning peer {peer.peer_node_id}. Sent us an already seen tx {transaction.transaction_id} "
-                    f"with mismatch on cost {transaction.cost} vs validation cost {mempool_item.cost} and/or "
-                    f"fee {transaction.fees} vs {mempool_item.fee}."
+                    f"Banning peer {peer.peer_node_id} version {peer.version}. Sent us an already seen tx "
+                    f"{transaction.transaction_id} with mismatch on cost {transaction.cost} vs validation "
+                    f"cost {mempool_item.cost} and/or fee {transaction.fees} vs {mempool_item.fee}."
                 )
                 await peer.close(CONSENSUS_ERROR_BAN_SECONDS)
             return None
@@ -244,11 +251,19 @@ class FullNodeAPI:
                     return None
                 prev = current_map.get(peer.peer_node_id)
                 if prev is not None:
-                    if prev.advertised_fee != transaction.fees or prev.advertised_cost != transaction.cost:
+                    # Older nodes (2.4.3 and earlier) compute the cost slightly
+                    # differently. They include the byte cost and execution cost of
+                    # the quote for the puzzle.
+                    tolerated_diff = QUOTE_BYTES * self.full_node.constants.COST_PER_BYTE + QUOTE_EXECUTION_COST
+                    if prev.advertised_fee != transaction.fees or (
+                        prev.advertised_cost != transaction.cost
+                        and abs(prev.advertised_cost - transaction.cost) != tolerated_diff
+                    ):
                         self.log.warning(
-                            f"Banning peer {peer.peer_node_id}. Sent us a new tx {transaction.transaction_id} with "
-                            f"mismatch on cost {transaction.cost} vs previous advertised cost {prev.advertised_cost} "
-                            f"and/or fee {transaction.fees} vs previous advertised fee {prev.advertised_fee}."
+                            f"Banning peer {peer.peer_node_id} version {peer.version}. Sent us a new tx "
+                            f"{transaction.transaction_id} with mismatch on cost {transaction.cost} vs "
+                            f"previous advertised cost {prev.advertised_cost} and/or fee {transaction.fees} "
+                            f"vs previous advertised fee {prev.advertised_fee}."
                         )
                         await peer.close(CONSENSUS_ERROR_BAN_SECONDS)
                     return None

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -36,7 +36,7 @@ from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
 from chia.full_node.mempool import MEMPOOL_ITEM_FEE_LIMIT, Mempool, MempoolRemoveInfo, MempoolRemoveReason
 from chia.full_node.pending_tx_cache import ConflictTxCache, PendingTxCache
 from chia.types.blockchain_format.coin import Coin
-from chia.types.clvm_cost import CLVMCost
+from chia.types.clvm_cost import QUOTE_BYTES, QUOTE_EXECUTION_COST, CLVMCost
 from chia.types.fee_rate import FeeRate
 from chia.types.generator_types import NewBlockGenerator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
@@ -138,11 +138,6 @@ class SpendBundleAddInfo:
 class NewPeakInfo:
     spend_bundle_ids: list[bytes32]
     removals: list[MempoolRemoveInfo]
-
-
-# For block overhead cost calculation
-QUOTE_BYTES = 2
-QUOTE_EXECUTION_COST = 20
 
 
 def is_atom_canonical(clvm_buffer: bytes, offset: int) -> tuple[int, bool]:

--- a/chia/types/clvm_cost.py
+++ b/chia/types/clvm_cost.py
@@ -11,3 +11,7 @@ are charged a higher rate, depending on their arguments.
 """
 
 CLVMCost = NewType("CLVMCost", uint64)
+
+# For block overhead cost calculation
+QUOTE_BYTES = 2
+QUOTE_EXECUTION_COST = 20


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches peer-banning/transaction-advertisement validation paths; an incorrect tolerance could weaken DoS protections or cause missed bans, though the allowed delta is small and narrowly scoped.
> 
> **Overview**
> Prevents false-positive bans when peers advertise a transaction `cost` that differs only by the legacy *wrapper quote* overhead (nodes <=2.4.3), by accepting a tolerated delta while still banning for other fee/cost mismatches.
> 
> This centralizes `QUOTE_BYTES`/`QUOTE_EXECUTION_COST` in `chia/types/clvm_cost.py` (removing the local definition from `mempool_manager.py`) and updates tests to cover the tolerated-diff scenario and import the constants from the new location.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fb5695d4bf94c389be845be17b7b091380d2391. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->