### PR TITLE
CHIA-3883 Tolerate quote related cost mismatch for older nodes

### DIFF
--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -41,8 +41,6 @@ from chia.full_node.eligible_coin_spends import (
 from chia.full_node.mempool import MAX_SKIPPED_ITEMS, PRIORITY_TX_THRESHOLD
 from chia.full_node.mempool_manager import (
     MEMPOOL_MIN_FEE_INCREASE,
-    QUOTE_BYTES,
-    QUOTE_EXECUTION_COST,
     MempoolManager,
     TimelockConditions,
     can_replace,
@@ -63,7 +61,7 @@ from chia.simulator.wallet_tools import WalletTool
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import DEFAULT_FLAGS, INFINITE_COST, Program
 from chia.types.blockchain_format.serialized_program import SerializedProgram
-from chia.types.clvm_cost import CLVMCost
+from chia.types.clvm_cost import QUOTE_BYTES, QUOTE_EXECUTION_COST, CLVMCost
 from chia.types.coin_spend import make_spend
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -36,7 +36,7 @@ from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
 from chia.full_node.mempool import MEMPOOL_ITEM_FEE_LIMIT, Mempool, MempoolRemoveInfo, MempoolRemoveReason
 from chia.full_node.pending_tx_cache import ConflictTxCache, PendingTxCache
 from chia.types.blockchain_format.coin import Coin
-from chia.types.clvm_cost import CLVMCost
+from chia.types.clvm_cost import QUOTE_BYTES, QUOTE_EXECUTION_COST, CLVMCost
 from chia.types.fee_rate import FeeRate
 from chia.types.generator_types import NewBlockGenerator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
@@ -138,11 +138,6 @@ class SpendBundleAddInfo:
 class NewPeakInfo:
     spend_bundle_ids: list[bytes32]
     removals: list[MempoolRemoveInfo]
-
-
-# For block overhead cost calculation
-QUOTE_BYTES = 2
-QUOTE_EXECUTION_COST = 20
 
 
 def is_atom_canonical(clvm_buffer: bytes, offset: int) -> tuple[int, bool]:

--- a/chia/types/clvm_cost.py
+++ b/chia/types/clvm_cost.py
@@ -11,3 +11,7 @@ are charged a higher rate, depending on their arguments.
 """
 
 CLVMCost = NewType("CLVMCost", uint64)
+
+# For block overhead cost calculation
+QUOTE_BYTES = 2
+QUOTE_EXECUTION_COST = 20


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches peer-banning logic for transaction advertisements; an incorrect tolerance could weaken DoS protections or cause false negatives/positives when banning peers.
> 
> **Overview**
> Full nodes now **tolerate a specific, known transaction cost mismatch** from older peers (<= 2.4.3) when processing `NewTransaction` advertisements, avoiding bans when the advertised cost differs only by the wrapper quote’s byte+execution overhead.
> 
> The quote overhead constants (`QUOTE_BYTES`, `QUOTE_EXECUTION_COST`) are centralized in `chia/types/clvm_cost.py` (and removed from `mempool_manager.py`), and tests are updated to cover both tolerated and non-tolerated mismatch scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bf135b0f5371f45db7e1c0ee10ba8818919f9c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->