### PR TITLE
Run apt update before the apt install in install-timelord.sh to ensure package lists are up to date

### DIFF
--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -95,6 +95,9 @@ if [ -e "$THE_PATH" ]; then
 else
   if [ -e venv/bin/python ] && test "$UBUNTU_DEBIAN"; then
     echo "Installing chiavdf dependencies on Ubuntu/Debian"
+    # Update package lists before install
+    echo "apt-get update"
+    sudo apt-get update
     # Install remaining needed development tools - assumes venv and prior run of install.sh
     echo "apt-get install libgmp-dev libboost-python-dev $PYTHON_DEV_DEPENDENCY libboost-system-dev build-essential -y"
     sudo apt-get install libgmp-dev libboost-python-dev "$PYTHON_DEV_DEPENDENCY" libboost-system-dev build-essential -y


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small change limited to the Ubuntu/Debian install path; main risk is slower installs or transient failures if `apt-get update` errors.
> 
> **Overview**
> Ensures Ubuntu/Debian installs in `install-timelord.sh` run `sudo apt-get update` before installing build dependencies for `chiavdf`, reducing failures due to stale package indexes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit babfbd9ab9ae961c4ac667963ca24fe571a48776. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->