### PR TITLE
Bring-in CHIA-3887 Skip fetching additions and removals for non transaction blocks in FullNodeAPI's request_header_blocks

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -66,7 +66,7 @@ from chia.protocols.full_node_protocol import NewTransaction, RespondTransaction
 from chia.protocols.outbound_message import Message, NodeType, make_msg
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.shared_protocol import Capability, default_capabilities
-from chia.protocols.wallet_protocol import SendTransaction, TransactionAck
+from chia.protocols.wallet_protocol import RespondBlockHeaders, SendTransaction, TransactionAck
 from chia.server.address_manager import AddressManager
 from chia.server.node_discovery import FullNodePeers
 from chia.server.server import ChiaServer
@@ -3567,3 +3567,22 @@ async def test_send_transaction_peer_tx_queue_full(
     response = wallet_protocol.TransactionAck.from_bytes(response_msg.data)
     assert MempoolInclusionStatus(response.status) == MempoolInclusionStatus.FAILED
     assert response.error == "Transaction queue full"
+
+
+@pytest.mark.limit_consensus_modes(reason="save time")
+@pytest.mark.anyio
+async def test_request_header_blocks_non_tx_block(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+) -> None:
+    """
+    Tests handling of non transaction blocks in `request_header_blocks`.
+    """
+    full_node_api, _, bt = one_node_one_block
+    # Farm a non transaction block
+    blocks = bt.get_consecutive_blocks(1, await full_node_api.get_all_full_blocks())
+    assert blocks[-1].is_transaction_block() is False
+    await full_node_api.full_node.add_block(blocks[-1])
+    msg = await full_node_api.request_header_blocks(wallet_protocol.RequestHeaderBlocks(uint32(0), uint32(1)))
+    assert msg is not None
+    response = RespondBlockHeaders.from_bytes(msg.data)
+    assert len(response.header_blocks) == 2

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1581,6 +1581,9 @@ class FullNodeAPI:
         blocks: list[FullBlock] = await self.full_node.block_store.get_blocks_by_hash(header_hashes)
         header_blocks = []
         for block in blocks:
+            if not block.is_transaction_block():
+                header_blocks.append(get_block_header(block))
+                continue
             added_coins_records_coroutine = self.full_node.coin_store.get_coins_added_at_height(block.height)
             removed_coins_records_coroutine = self.full_node.coin_store.get_coins_removed_at_height(block.height)
             added_coins_records, removed_coins_records = await asyncio.gather(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to a deprecated header-blocks endpoint plus a targeted test; primary risk is incorrect header contents for non-tx blocks, which the new test partially covers.
> 
> **Overview**
> Updates `FullNodeAPI.request_header_blocks` to **skip fetching coin additions/removals** for *non-transaction blocks*, returning a basic header via `get_block_header(block)` instead of querying the coin store.
> 
> Adds a regression test (`test_request_header_blocks_non_tx_block`) to farm a non-tx block and assert `RespondBlockHeaders` still returns the expected number of headers, and updates imports accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d43c0ba7016f3edc77bc211eb4bf05b6e7f781b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 1 potential issue for commit <u>0d43c0b</u></sup><!-- /BUGBOT_STATUS -->