### PR TITLE
Add apt-get update before installing dependencies

### DIFF
--- a/install-timelord.sh
+++ b/install-timelord.sh
@@ -95,6 +95,9 @@ if [ -e "$THE_PATH" ]; then
 else
   if [ -e venv/bin/python ] && test "$UBUNTU_DEBIAN"; then
     echo "Installing chiavdf dependencies on Ubuntu/Debian"
+    # Update package lists before install
+    echo "apt-get update"
+    sudo apt-get update
     # Install remaining needed development tools - assumes venv and prior run of install.sh
     echo "apt-get install libgmp-dev libboost-python-dev $PYTHON_DEV_DEPENDENCY libboost-system-dev build-essential -y"
     sudo apt-get install libgmp-dev libboost-python-dev "$PYTHON_DEV_DEPENDENCY" libboost-system-dev build-essential -y


### PR DESCRIPTION
Apply #20471 to release branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small install-script change limited to Ubuntu/Debian dependency setup; main risk is longer install time or update failures on constrained systems.
> 
> **Overview**
> Adds an `apt-get update` step to `install-timelord.sh` before installing Ubuntu/Debian build dependencies for `chiavdf`, improving reliability when package indexes are stale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51a07455bc7f489d5d59465a2e719c31b13a1208. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->