### PR TITLE
Update poetry version to 2.2.1

### DIFF
--- a/requirements-poetry.txt
+++ b/requirements-poetry.txt
@@ -1,4 +1,4 @@
 # keep this matching with what dependabot uses
-poetry==2.2.0
+poetry==2.2.1
 poetry-dynamic-versioning[plugin]
 poetry-plugin-export


### PR DESCRIPTION
Maintaining version consistency with dependabot-core

https://github.com/dependabot/dependabot-core/blob/main/python/helpers/requirements.txt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version bump with minimal code impact; risk is limited to potential tooling/packaging behavior changes in the newer Poetry patch release.
> 
> **Overview**
> Updates the pinned `poetry` version in `requirements-poetry.txt` from `2.2.0` to `2.2.1` to stay in sync with Dependabot's expected tooling version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e62728ec1a8cd6e04eb682612b16214c631b3de4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->