### PR TITLE
fix overflow handling in test helper

### DIFF
--- a/chia/_tests/core/full_node/test_prev_tx_block.py
+++ b/chia/_tests/core/full_node/test_prev_tx_block.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from chia_rs import FullBlock
+from chia_rs import ConsensusConstants, FullBlock
 from chia_rs.sized_ints import uint8, uint32
 
 from chia.consensus.get_block_challenge import pre_sp_tx_block_height
+from chia.consensus.pot_iterations import is_overflow_block
 from chia.simulator.block_tools import BlockTools, load_block_list, test_constants
 from chia.util.block_cache import BlockCache
 
@@ -35,11 +36,11 @@ def test_prev_tx_block_blockrecord_tx(bt: BlockTools) -> None:
     )
     _, _, blocks = load_block_list(block_list, bt.constants)
     block = block_list[-1]
-    latest_tx_before_sp = find_tx_before_sp(block_list)
+    latest_tx_before_sp = find_tx_before_sp(block_list, bt.constants)
     assert latest_tx_before_sp is not None
     assert (
         pre_sp_tx_block_height(
-            constants=test_constants,
+            constants=bt.constants,
             blocks=BlockCache(blocks),
             prev_b_hash=block.prev_header_hash,
             sp_index=block.reward_chain_block.signage_point_index,
@@ -48,11 +49,11 @@ def test_prev_tx_block_blockrecord_tx(bt: BlockTools) -> None:
         == latest_tx_before_sp.height
     )
     block = block_list[-2]
-    latest_tx_before_sp = find_tx_before_sp(block_list[:-1])
+    latest_tx_before_sp = find_tx_before_sp(block_list[:-1], bt.constants)
     assert latest_tx_before_sp is not None
     assert (
         pre_sp_tx_block_height(
-            constants=test_constants,
+            constants=bt.constants,
             blocks=BlockCache(blocks),
             prev_b_hash=block.prev_header_hash,
             sp_index=block.reward_chain_block.signage_point_index,
@@ -61,11 +62,11 @@ def test_prev_tx_block_blockrecord_tx(bt: BlockTools) -> None:
         == latest_tx_before_sp.height
     )
     block = block_list[-3]
-    latest_tx_before_sp = find_tx_before_sp(block_list[:-2])
+    latest_tx_before_sp = find_tx_before_sp(block_list[:-2], bt.constants)
     assert latest_tx_before_sp is not None
     assert (
         pre_sp_tx_block_height(
-            constants=test_constants,
+            constants=bt.constants,
             blocks=BlockCache(blocks),
             prev_b_hash=block.prev_header_hash,
             sp_index=block.reward_chain_block.signage_point_index,
@@ -88,10 +89,10 @@ def test_prev_tx_block_blockrecord_not_tx(bt: BlockTools) -> None:
     )
     _, _, blocks = load_block_list(block_list, bt.constants)
     block = block_list[-1]
-    latest_tx_before_sp = find_tx_before_sp(block_list)
+    latest_tx_before_sp = find_tx_before_sp(block_list, bt.constants)
     assert latest_tx_before_sp is not None
     assert pre_sp_tx_block_height(
-        constants=test_constants,
+        constants=bt.constants,
         blocks=BlockCache(blocks),
         prev_b_hash=block.prev_header_hash,
         sp_index=block.reward_chain_block.signage_point_index,
@@ -100,21 +101,23 @@ def test_prev_tx_block_blockrecord_not_tx(bt: BlockTools) -> None:
 
 
 # get the latest infused transaction block before the signage point of the last block in the list
-def find_tx_before_sp(block_list: list[FullBlock]) -> FullBlock | None:
-    before_slot = False
-    before_sp = False
-    if len(block_list[-1].finished_sub_slots) > 0:
-        before_slot = True
+def find_tx_before_sp(block_list: list[FullBlock], constants: ConsensusConstants) -> FullBlock | None:
     sp_index = block_list[-1].reward_chain_block.signage_point_index
+    overflow = is_overflow_block(constants, sp_index)
+    slots_crossed = len(block_list[-1].finished_sub_slots)
     idx = len(block_list) - 2
     curr = None
     while idx > 0:
         curr = block_list[idx]
-        if curr.reward_chain_block.signage_point_index < sp_index:
-            before_sp = True
-        if curr.foliage_transaction_block is not None and (before_slot or before_sp):
+        if not overflow:
+            before_sp = curr.reward_chain_block.signage_point_index < sp_index or slots_crossed > 0
+        else:
+            before_sp = slots_crossed >= 2 or (
+                slots_crossed == 1 and curr.reward_chain_block.signage_point_index < sp_index
+            )
+        if curr.foliage_transaction_block is not None and before_sp:
             break
         if len(curr.finished_sub_slots) > 0:
-            before_slot = True
+            slots_crossed += 1
         idx -= 1
     return curr

--- a/chia/wallet/wallet_weight_proof_handler.py
+++ b/chia/wallet/wallet_weight_proof_handler.py
@@ -88,7 +88,7 @@ def get_wp_fork_point(constants: ConsensusConstants, old_wp: WeightProof | None,
         count = idx + 1
         overflow = new_wp.sub_epochs[idx + 1].num_blocks_overflow
 
-    if new_wp.recent_chain_data[0].height < old_wp.recent_chain_data[-1].height:
+    if new_wp.recent_chain_data[0].height <= old_wp.recent_chain_data[-1].height:
         # Try to find an exact fork point
         new_wp_index = 0
         old_wp_index = 0


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly test-helper logic changes plus a small boundary fix in fork-point detection; low risk but could affect weight-proof validation behavior at equal-height boundaries.
> 
> **Overview**
> Fixes the `test_prev_tx_block` helper `find_tx_before_sp` to correctly account for *overflow blocks* and sub-slot crossings when selecting the latest transaction block before a signage point, and updates tests to pass `ConsensusConstants`/use `bt.constants` instead of `test_constants`.
> 
> Adjusts wallet weight proof fork-point detection in `get_wp_fork_point` to treat equal starting heights (`<=` instead of `<`) as eligible for exact fork-point search, improving handling of boundary cases where the two proofs’ recent chains start at the same height.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ab64ab196c6a53f9994d2e8798e7caeda6cc441. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->