### PR TITLE
checkpoint: into main from release/2.6.0  @ 8f8d27aca479cb1456899acf7a4127aa06d4763f

### DIFF
--- a/chia/_tests/util/test_testnet_overrides.py
+++ b/chia/_tests/util/test_testnet_overrides.py
@@ -8,19 +8,19 @@ from chia.consensus.default_constants import update_testnet_overrides
 def test_testnet11() -> None:
     overrides: dict[str, Any] = {}
     update_testnet_overrides("testnet11", overrides)
-    assert overrides == {"PLOT_SIZE_V2": 28, "SOFT_FORK8_HEIGHT": 3680000}
+    assert overrides == {"PLOT_SIZE_V2": 28, "SOFT_FORK8_HEIGHT": 3720000}
 
 
 def test_min_plot_size() -> None:
     overrides: dict[str, Any] = {"MIN_PLOT_SIZE": 18}
     update_testnet_overrides("testnet11", overrides)
-    assert overrides == {"MIN_PLOT_SIZE_V1": 18, "PLOT_SIZE_V2": 28, "SOFT_FORK8_HEIGHT": 3680000}
+    assert overrides == {"MIN_PLOT_SIZE_V1": 18, "PLOT_SIZE_V2": 28, "SOFT_FORK8_HEIGHT": 3720000}
 
 
 def test_max_plot_size() -> None:
     overrides: dict[str, Any] = {"MAX_PLOT_SIZE": 32}
     update_testnet_overrides("testnet11", overrides)
-    assert overrides == {"MAX_PLOT_SIZE_V1": 32, "PLOT_SIZE_V2": 28, "SOFT_FORK8_HEIGHT": 3680000}
+    assert overrides == {"MAX_PLOT_SIZE_V1": 32, "PLOT_SIZE_V2": 28, "SOFT_FORK8_HEIGHT": 3720000}
 
 
 def test_mainnet() -> None:

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -113,7 +113,7 @@ def update_testnet_overrides(network_id: str, overrides: dict[str, Any]) -> None
         if "PLOT_SIZE_V2" not in overrides:
             overrides["PLOT_SIZE_V2"] = 28
         if "SOFT_FORK8_HEIGHT" not in overrides:
-            overrides["SOFT_FORK8_HEIGHT"] = 3680000
+            overrides["SOFT_FORK8_HEIGHT"] = 3720000
     if network_id == "testneta":
         if "HARD_FORK_HEIGHT" not in overrides:
             overrides["HARD_FORK_HEIGHT"] = 3693395

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -38,7 +38,7 @@ network_overrides: &network_overrides
       SUB_SLOT_ITERS_STARTING: 67108864
       # Forks activated from the beginning on this network
       HARD_FORK_HEIGHT: 0
-      SOFT_FORK8_HEIGHT: 3680000
+      SOFT_FORK8_HEIGHT: 3720000
       PLOT_FILTER_128_HEIGHT: 6029568
       PLOT_FILTER_64_HEIGHT: 11075328
       PLOT_FILTER_32_HEIGHT: 16121088


### PR DESCRIPTION
Source hash: 8f8d27aca479cb1456899acf7a4127aa06d4763f
Remaining commits: 6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple constant bump affecting only testnet configuration and corresponding tests; no mainnet or security-sensitive logic changes.
> 
> **Overview**
> Updates the default `SOFT_FORK8_HEIGHT` for `testnet11`/`testneta` overrides from `3680000` to `3720000` in `update_testnet_overrides`.
> 
> Aligns `initial-config.yaml` and the associated tests to the new activation height.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b175bdf4ee6fcbdbfbe3d327d96db47d756e2ba5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->