### PR TITLE
Add unhide .venv step to install.sh on macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -171,6 +171,13 @@ fi
 # shellcheck disable=SC2086
 .penv/bin/poetry sync ${EXTRAS}
 
+# On macOS, files/directories can be marked with the "hidden" flag.
+# This clears the flag if it can.
+if [ "$(uname)" = "Darwin" ] && command -v chflags >/dev/null 2>&1; then
+  # Don't fail install if this can't be changed (permissions/FS limitations, etc.)
+  chflags -R nohidden .venv 2>/dev/null || true
+fi
+
 if [ -e venv ]; then
   if [ -d venv ] && [ ! -L venv ]; then
     echo "The 'venv' directory already exists. Please delete it before installing."


### PR DESCRIPTION

### Purpose:

If the .venv file is hidden in macOS it can cause problems with importing in Python.
As `install.sh` is responsible for creating and tending to the venv, this PR adds a remedy to that step. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, macOS-gated shell change that best-effort runs `chflags` and ignores failures; minimal impact outside installation flow.
> 
> **Overview**
> Adds a macOS-only post-install step in `install.sh` to clear the Finder “hidden” flag on the newly created `.venv` directory (via `chflags -R nohidden .venv`), without failing the install if the operation isn’t permitted.
> 
> This runs after `poetry sync` and before the script creates/updates the `venv` symlink, reducing issues where a hidden `.venv` interferes with usage on macOS.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 565ec64d146541d1d91dfc6293fbe5137616c1dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->