### PR TITLE
DataLayerRpcApi service cannot be None - so remove check

### DIFF
--- a/chia/data_layer/data_layer_rpc_api.py
+++ b/chia/data_layer/data_layer_rpc_api.py
@@ -141,15 +141,11 @@ class DataLayerRpcApi:
         return []
 
     async def wallet_log_in(self, request: dict[str, Any]) -> EndpointResult:
-        if self.service is None:
-            raise Exception("Data layer not created")
         fingerprint = cast(int, request["fingerprint"])
         await self.service.wallet_log_in(fingerprint=fingerprint)
         return {}
 
     async def create_data_store(self, request: dict[str, Any]) -> EndpointResult:
-        if self.service is None:
-            raise Exception("Data layer not created")
         fee = get_fee(self.service.config, request)
         verbose = request.get("verbose", False)
         txs, value = await self.service.create_store(uint64(fee))
@@ -159,8 +155,6 @@ class DataLayerRpcApi:
             return {"id": value.hex()}
 
     async def get_owned_stores(self, request: dict[str, Any]) -> EndpointResult:
-        if self.service is None:
-            raise Exception("Data layer not created")
         singleton_records = await self.service.get_owned_stores()
         return {"store_ids": [singleton.launcher_id.hex() for singleton in singleton_records]}
 
@@ -174,8 +168,6 @@ class DataLayerRpcApi:
             resolved_root_hash = bytes32.from_hexstr(root_hash)
         else:
             resolved_root_hash = unspecified
-        if self.service is None:
-            raise Exception("Data layer not created")
         value = await self.service.get_value(store_id=store_id, key=key, root_hash=resolved_root_hash)
         hex = None
         if value is not None:
@@ -193,8 +185,6 @@ class DataLayerRpcApi:
             resolved_root_hash = bytes32.from_hexstr(root_hash)
         else:
             resolved_root_hash = unspecified
-        if self.service is None:
-            raise Exception("Data layer not created")
 
         if page is None:
             keys = await self.service.get_keys(store_id, resolved_root_hash)
@@ -230,8 +220,6 @@ class DataLayerRpcApi:
             resolved_root_hash = bytes32.from_hexstr(root_hash)
         else:
             resolved_root_hash = unspecified
-        if self.service is None:
-            raise Exception("Data layer not created")
 
         if page is None:
             keys_values = await self.service.get_keys_values(store_id, resolved_root_hash)
@@ -262,8 +250,6 @@ class DataLayerRpcApi:
     async def get_ancestors(self, request: dict[str, Any]) -> EndpointResult:
         store_id = bytes32.from_hexstr(request["id"])
         node_hash = bytes32.from_hexstr(request["hash"])
-        if self.service is None:
-            raise Exception("Data layer not created")
         value = await self.service.get_ancestors(node_hash, store_id)
         return {"ancestors": value}
 
@@ -277,8 +263,6 @@ class DataLayerRpcApi:
         store_id = bytes32.from_hexstr(request["id"])
         submit_on_chain = request.get("submit_on_chain", True)
         # todo input checks
-        if self.service is None:
-            raise Exception("Data layer not created")
         transaction_record = await self.service.batch_update(store_id, changelist, uint64(fee), submit_on_chain)
         if submit_on_chain:
             if transaction_record is None:
@@ -293,8 +277,6 @@ class DataLayerRpcApi:
         fee = get_fee(self.service.config, request)
         store_updates = [process_change_multistore(update) for update in request["store_updates"]]
         submit_on_chain = request.get("submit_on_chain", True)
-        if self.service is None:
-            raise Exception("Data layer not created")
         transaction_records = await self.service.multistore_batch_update(store_updates, uint64(fee), submit_on_chain)
         if submit_on_chain:
             if transaction_records == []:
@@ -326,8 +308,6 @@ class DataLayerRpcApi:
         value = hexstr_to_bytes(request["value"])
         store_id = bytes32.from_hexstr(request["id"])
         # todo input checks
-        if self.service is None:
-            raise Exception("Data layer not created")
         changelist = [{"action": "insert", "key": key, "value": value}]
         transaction_record = await self.service.batch_update(store_id, changelist, uint64(fee))
         assert transaction_record is not None
@@ -342,8 +322,6 @@ class DataLayerRpcApi:
         key = hexstr_to_bytes(request["key"])
         store_id = bytes32.from_hexstr(request["id"])
         # todo input checks
-        if self.service is None:
-            raise Exception("Data layer not created")
         changelist = [{"action": "delete", "key": key}]
         transaction_record = await self.service.batch_update(store_id, changelist, uint64(fee))
         assert transaction_record is not None
@@ -353,8 +331,6 @@ class DataLayerRpcApi:
         """get hash of latest tree root"""
         store_id = bytes32.from_hexstr(request["id"])
         # todo input checks
-        if self.service is None:
-            raise Exception("Data layer not created")
         rec = await self.service.get_root(store_id)
         if rec is None:
             raise Exception(f"Failed to get root for {store_id.hex()}")
@@ -364,8 +340,6 @@ class DataLayerRpcApi:
         """get hash of latest tree root saved in our local datastore"""
         store_id = bytes32.from_hexstr(request["id"])
         # todo input checks
-        if self.service is None:
-            raise Exception("Data layer not created")
         res = await self.service.get_local_root(store_id)
         return {"hash": res}
 
@@ -375,8 +349,6 @@ class DataLayerRpcApi:
         """
         store_ids = request["ids"]
         # todo input checks
-        if self.service is None:
-            raise Exception("Data layer not created")
         roots = []
         for id in store_ids:
             id_bytes = bytes32.from_hexstr(id)
@@ -393,8 +365,6 @@ class DataLayerRpcApi:
         if store_id is None:
             raise Exception("missing store id in request")
 
-        if self.service is None:
-            raise Exception("Data layer not created")
         store_id_bytes = bytes32.from_hexstr(store_id)
         urls = request.get("urls", [])
         await self.service.subscribe(store_id=store_id_bytes, urls=urls)
@@ -408,8 +378,6 @@ class DataLayerRpcApi:
         retain_data = request.get("retain", False)
         if store_id is None:
             raise Exception("missing store id in request")
-        if self.service is None:
-            raise Exception("Data layer not created")
         store_id_bytes = bytes32.from_hexstr(store_id)
         await self.service.unsubscribe(store_id_bytes, retain_data)
         return {}
@@ -418,14 +386,10 @@ class DataLayerRpcApi:
         """
         List current subscriptions
         """
-        if self.service is None:
-            raise Exception("Data layer not created")
         subscriptions: list[Subscription] = await self.service.get_subscriptions()
         return {"store_ids": [sub.store_id.hex() for sub in subscriptions]}
 
     async def remove_subscriptions(self, request: dict[str, Any]) -> EndpointResult:
-        if self.service is None:
-            raise Exception("Data layer not created")
         store_id = request.get("id")
         if store_id is None:
             raise Exception("missing store id in request")
@@ -456,8 +420,6 @@ class DataLayerRpcApi:
         """
         get history of state hashes for a store
         """
-        if self.service is None:
-            raise Exception("Data layer not created")
         store_id = request["id"]
         id_bytes = bytes32.from_hexstr(store_id)
         records = await self.service.get_root_history(id_bytes)
@@ -470,8 +432,6 @@ class DataLayerRpcApi:
         """
         get kv diff between two root hashes
         """
-        if self.service is None:
-            raise Exception("Data layer not created")
         store_id = request["id"]
         id_bytes = bytes32.from_hexstr(store_id)
         hash_1 = request["hash_1"]
@@ -573,8 +533,6 @@ class DataLayerRpcApi:
     async def get_sync_status(self, request: dict[str, Any]) -> EndpointResult:
         store_id = request["id"]
         id_bytes = bytes32.from_hexstr(store_id)
-        if self.service is None:
-            raise Exception("Data layer not created")
         sync_status = await self.service.get_sync_status(id_bytes)
 
         return {
@@ -587,8 +545,6 @@ class DataLayerRpcApi:
         }
 
     async def check_plugins(self, request: dict[str, Any]) -> EndpointResult:
-        if self.service is None:
-            raise Exception("Data layer not created")
         plugin_status = await self.service.check_plugins()
 
         return plugin_status.marshal()


### PR DESCRIPTION
My reading of the code (and cursor agrees) is that DataLayerRpcApi cannot have a None service
```
    def __init__(self, data_layer: DataLayer):  # , wallet: DataLayerWallet):
        self.service: DataLayer = data_layer
        self.service_name = "chia_data_layer"
```

And no code removes this or otherwise sets it to None. Also note that none of the other `RpcApi` classes have this check either

Removing check to simplify code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely removes defensive checks in an RPC wrapper; behavior should be unchanged under normal operation, but could change error surface if `DataLayerRpcApi` is ever instantiated with an invalid/missing service.
> 
> **Overview**
> `DataLayerRpcApi` no longer checks `self.service is None` (and no longer raises "Data layer not created") across its RPC endpoints, relying on the invariant that the RPC API is always constructed with a valid `DataLayer` service.
> 
> This is a mechanical simplification that changes failure mode from a custom early exception to whatever error occurs if the invariant is violated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af1a60acd220edc178a27ecbad7ca10b60af9023. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->