### PR TITLE
fix reorg edge case handling in the wallet protocol

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1865,7 +1865,6 @@ class FullNodeAPI:
             if request.previous_height is not None
             else self.full_node.blockchain.constants.GENESIS_CHALLENGE
         )
-        assert previous_header_hash is not None
 
         if request.header_hash != previous_header_hash:
             rejection = wallet_protocol.RejectPuzzleState(uint8(wallet_protocol.RejectStateReason.REORG))
@@ -1937,7 +1936,6 @@ class FullNodeAPI:
             if request.previous_height is not None
             else self.full_node.blockchain.constants.GENESIS_CHALLENGE
         )
-        assert previous_header_hash is not None
 
         if request.header_hash != previous_header_hash:
             rejection = wallet_protocol.RejectCoinState(uint8(wallet_protocol.RejectStateReason.REORG))


### PR DESCRIPTION
### Purpose:

When a wallet asks for coin state or puzzle state, we handle the case where we may have reorged and the block the wallet is referring to no longer exists. However, we currently *assert* if our new fork doesn't have a block at the same *height*.

This is a rare case, presumably, but not impossible. You can reorg to a heavier and shorter chain.

This simply removes the assert and lets the regular reorg-case handle the failure with a proper error message return.

### Current Behavior:

If the wallet's chain is longer than ours, we assert and disconnect the peer. It doesn't get any error message.

### New Behavior:

If the wallet's chain is longer than ours, we returns a `REORG` error code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that removes an assertion and falls back to existing `REORG` rejection handling; low blast radius but affects wallet sync behavior during rare reorg cases.
> 
> **Overview**
> Fixes an edge case in wallet `RequestPuzzleState`/`RequestCoinState` handling where the node could assert when `height_to_hash(previous_height)` returned `None` (e.g., a shorter/heavier reorg).
> 
> The code now skips the assert and lets the existing header-hash mismatch path return a `REORG` rejection message instead of disconnecting/crashing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c4ed7ffe2b6566f8f0a678777e829389388a0de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->