### PR TITLE
[CHIA-3897] Prevent dangling SAVEPOINTs by shielding against cancellation

### DIFF
--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -341,9 +341,10 @@ class DBWrapper2:
             try:
                 with _suppress_task_cancellation():
                     await self._write_connection.execute(f"ROLLBACK TO {name}")
-            except Exception:
-                # ROLLBACK may fail if the SAVEPOINT was never created (e.g.
-                # CancelledError interrupted execute before aiosqlite ran it).
+            except sqlite3.OperationalError:
+                # Catches "no such savepoint" when the SAVEPOINT was never
+                # created (e.g. CancelledError interrupted execute before
+                # aiosqlite ran it). All other errors are propagated.
                 pass
             raise
         finally:
@@ -352,8 +353,9 @@ class DBWrapper2:
             try:
                 with _suppress_task_cancellation():
                     await self._write_connection.execute(f"RELEASE {name}")
-            except Exception:
-                # RELEASE may fail if the SAVEPOINT was never created.
+            except sqlite3.OperationalError:
+                # Catches "no such savepoint" when the SAVEPOINT was never
+                # created. All other errors are propagated.
                 pass
 
     @contextlib.asynccontextmanager


### PR DESCRIPTION
### Purpose

Prevent orphan SAVEPOINTs on the SQLite writer connection by ensuring cleanup (`ROLLBACK TO` / `RELEASE`) always runs and completes even when a task is cancelled.

### Current Behavior (before this change)

`_savepoint_ctx` creates a SAVEPOINT via an unshielded `await` before the `try` block. If the task is cancelled during that `await`, the SQL may execute on the aiosqlite background thread (creating the SAVEPOINT in SQLite) while `CancelledError` is raised before Python enters the `try` block. Since `finally` never runs, `RELEASE` or `ROLLBACK TO` is never issued and the SAVEPOINT is orphaned.

An orphan SAVEPOINT acts as a phantom parent transaction. Every subsequent SAVEPOINT nests inside it, and every subsequent RELEASE merges into the orphan instead of committing. In WAL mode, data written by the writer becomes invisible to all reader connections, causing the node's in-memory cache to diverge from what readers can see.

### Changes

**SAVEPOINT creation moved inside the `try` block.** aiosqlite queues SQL synchronously via `put_nowait()` before awaiting the result future. If the `await` is cancelled, the SQL may still execute on the background thread — creating a SAVEPOINT in SQLite that Python doesn't know about. Placing the creation inside the `try` ensures the `except`/`finally` can clean up this orphan.

The SAVEPOINT creation itself is **not** shielded from cancellation. Protecting it would only delay the inevitable: `_suppress_task_cancellation` re-arms the cancellation on exit, so the caller's writes after `yield` would be cancelled at their first `await` anyway — and the SAVEPOINT would be rolled back regardless.

**Cancellation protection on ROLLBACK and RELEASE via `_suppress_task_cancellation()` (new).** This is where protection actually matters — cleanup must complete even when `_must_cancel` is `True`, otherwise the orphan remains. The context manager provides two layers:

1. `anyio.CancelScope(shield=True)` — prevents new `task.cancel()` calls from being delivered through anyio's scope tree (e.g. scope timeouts, task group cancellation) during the `await`.
2. `task.uncancel()` (Python 3.11+) — clears any already-pending `_must_cancel` flag so the `await` is not immediately interrupted. On exit, the cancellations are re-applied so they fire at the next unprotected `await`.

The anyio shield alone is insufficient because `CancelScope._restart_cancellation_in_parent()` re-calls `task.cancel()` when each shield exits, re-arming `_must_cancel` before the next protected `await` can start. Neither layer protects against a direct `task.cancel()` call from code outside anyio's scope tree (e.g. `ws_connection.cancel_tasks()`) — this is why the SAVEPOINT must be inside the `try` regardless.

**Nested `try`/`except` on ROLLBACK and RELEASE** so that if the SAVEPOINT was never actually created (e.g. `CancelledError` interrupted `execute` before aiosqlite ran it), the cleanup failure doesn't mask the original exception.

### Testing Notes

The orphan SAVEPOINT was observed on a running node via SQL tracing. A SAVEPOINT was created with no corresponding RELEASE, followed by all subsequent savepoints nesting inside it. Diagnostic logging confirmed `_write_connection.in_transaction` remained `True` after block additions, and reader connections could not see committed data. Many iterations of cancellation protection were tried, and this is the combination that actually was successfully protected me from orphaned savepoints.