### PR TITLE
move savepoint

### DIFF
--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -275,8 +275,8 @@ class DBWrapper2:
     @contextlib.asynccontextmanager
     async def _savepoint_ctx(self) -> AsyncIterator[None]:
         name = self._next_savepoint()
-        await self._write_connection.execute(f"SAVEPOINT {name}")
         try:
+            await self._write_connection.execute(f"SAVEPOINT {name}")
             yield
         except:
             await self._write_connection.execute(f"ROLLBACK TO {name}")

--- a/chia/util/db_wrapper.py
+++ b/chia/util/db_wrapper.py
@@ -277,8 +277,9 @@ class DBWrapper2:
         savepointOK = False
         name = self._next_savepoint()
         try:
-            await self._write_connection.execute(f"SAVEPOINT {name}")
-            savepointOK = True
+            with anyio.CancelScope(shield=True):
+                await self._write_connection.execute(f"SAVEPOINT {name}")
+                savepointOK = True
             yield
         except:
             if savepointOK:


### PR DESCRIPTION
DO NOT MERGE

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core transaction/savepoint logic used by all DB writes; while small, it can affect rollback/cleanup behavior under cancellation and error paths.
> 
> **Overview**
> Hardens `DBWrapper2._savepoint_ctx()` by shielding the `SAVEPOINT` creation from cancellation and tracking whether it actually succeeded.
> 
> If the task is cancelled or errors before the savepoint is established, the context manager now skips `ROLLBACK TO`/`RELEASE` to avoid issuing invalid savepoint commands; otherwise behavior is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9f2eab49546b96ba916fadc9390901b7d8423d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->