### PR TITLE
refactor connection handshake

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -242,17 +242,17 @@ class WSChiaConnection:
         if inbound_handshake.network_id != network_id:
             raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
 
-        if self.is_outbound:
-            if (
-                local_type in {NodeType.FARMER, NodeType.HARVESTER}
-                and inbound_handshake.protocol_version != protocol_version[local_type]
-            ):
-                self.log.warning(
-                    f"protocol version mismatch: "
-                    f"local_type={local_type} "
-                    f"incoming={inbound_handshake.protocol_version} "
-                    f"our={protocol_version[local_type]}"
-                )
+        if (
+            self.is_outbound
+            and local_type in {NodeType.FARMER, NodeType.HARVESTER}
+            and inbound_handshake.protocol_version != protocol_version[local_type]
+        ):
+            self.log.warning(
+                f"protocol version mismatch: "
+                f"local_type={local_type} "
+                f"incoming={inbound_handshake.protocol_version} "
+                f"our={protocol_version[local_type]}"
+            )
 
         self.version = inbound_handshake.software_version
         self.protocol_version = Version(inbound_handshake.protocol_version)

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -254,15 +254,9 @@ class WSChiaConnection:
                 f"our={protocol_version[local_type]}"
             )
 
-        self.version = inbound_handshake.software_version
-        self.protocol_version = Version(inbound_handshake.protocol_version)
-        self.peer_server_port = inbound_handshake.server_port
         remote_node_type = NodeType(inbound_handshake.node_type)
-        self.connection_type = remote_node_type
-        # "1" means capability is enabled
-        self.peer_capabilities = known_active_capabilities(inbound_handshake.capabilities)
 
-        if len(self.version.encode("utf-8")) > MAX_VERSION_STRING_BYTES:
+        if len(inbound_handshake.software_version.encode("utf-8")) > MAX_VERSION_STRING_BYTES:
             self.log.debug("version string too long")
             raise ProtocolError(Err.INVALID_HANDSHAKE)
 
@@ -290,6 +284,13 @@ class WSChiaConnection:
                 ),
             )
             await self._send_message(outbound_handshake)
+
+        self.version = inbound_handshake.software_version
+        self.protocol_version = Version(inbound_handshake.protocol_version)
+        self.peer_server_port = inbound_handshake.server_port
+        self.connection_type = remote_node_type
+        # "1" means capability is enabled
+        self.peer_capabilities = known_active_capabilities(inbound_handshake.capabilities)
 
         self.outbound_task = create_referenced_task(self.outbound_handler())
         self.inbound_task = create_referenced_task(self.inbound_handler())

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -44,6 +44,9 @@ from chia.util.task_referencer import create_referenced_task
 # Max size 2^(8*4) which is around 4GiB
 LENGTH_BYTES: int = 4
 
+# Max length of peer version string in bytes (UTF-8)
+MAX_VERSION_STRING_BYTES: int = 128
+
 WebSocket = WebSocketResponse | ClientWebSocketResponse
 ConnectionCallback = Callable[["WSChiaConnection"], Awaitable[None]]
 
@@ -217,23 +220,29 @@ class WSChiaConnection:
                 ),
             )
             await self._send_message(outbound_handshake)
-            inbound_handshake_msg = await self._read_one_message()
-            if inbound_handshake_msg is None:
-                raise ProtocolError(Err.INVALID_HANDSHAKE)
-            inbound_handshake = Handshake.from_bytes(inbound_handshake_msg.data)
 
-            # Handle case of invalid ProtocolMessageType
-            try:
-                message_type: ProtocolMessageTypes = ProtocolMessageTypes(inbound_handshake_msg.type)
-            except Exception:
-                raise ProtocolError(Err.INVALID_HANDSHAKE)
+        try:
+            message = await self._read_one_message()
+        except Exception:
+            raise ProtocolError(Err.INVALID_HANDSHAKE)
 
-            if message_type != ProtocolMessageTypes.handshake:
-                raise ProtocolError(Err.INVALID_HANDSHAKE)
+        if message is None:
+            raise ProtocolError(Err.INVALID_HANDSHAKE)
 
-            if inbound_handshake.network_id != network_id:
-                raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
+        # Handle case of invalid ProtocolMessageType
+        try:
+            inbound_handshake = Handshake.from_bytes(message.data)
+            message_type = ProtocolMessageTypes(message.type)
+        except Exception:
+            raise ProtocolError(Err.INVALID_HANDSHAKE)
 
+        if message_type != ProtocolMessageTypes.handshake:
+            raise ProtocolError(Err.INVALID_HANDSHAKE)
+
+        if inbound_handshake.network_id != network_id:
+            raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
+
+        if self.is_outbound:
             if (
                 local_type in {NodeType.FARMER, NodeType.HARVESTER}
                 and inbound_handshake.protocol_version != protocol_version[local_type]
@@ -245,36 +254,19 @@ class WSChiaConnection:
                     f"our={protocol_version[local_type]}"
                 )
 
-            self.version = inbound_handshake.software_version
-            self.protocol_version = Version(inbound_handshake.protocol_version)
-            self.peer_server_port = inbound_handshake.server_port
-            self.connection_type = NodeType(inbound_handshake.node_type)
-            # "1" means capability is enabled
-            self.peer_capabilities = known_active_capabilities(inbound_handshake.capabilities)
-        else:
-            try:
-                message = await self._read_one_message()
-            except Exception:
-                raise ProtocolError(Err.INVALID_HANDSHAKE)
+        self.version = inbound_handshake.software_version
+        self.protocol_version = Version(inbound_handshake.protocol_version)
+        self.peer_server_port = inbound_handshake.server_port
+        remote_node_type = NodeType(inbound_handshake.node_type)
+        self.connection_type = remote_node_type
+        # "1" means capability is enabled
+        self.peer_capabilities = known_active_capabilities(inbound_handshake.capabilities)
 
-            if message is None:
-                raise ProtocolError(Err.INVALID_HANDSHAKE)
+        if len(self.version.encode("utf-8")) > MAX_VERSION_STRING_BYTES:
+            self.log.debug("version string too long")
+            raise ProtocolError(Err.INVALID_HANDSHAKE)
 
-            # Handle case of invalid ProtocolMessageType
-            try:
-                message_type = ProtocolMessageTypes(message.type)
-            except Exception:
-                raise ProtocolError(Err.INVALID_HANDSHAKE)
-
-            if message_type != ProtocolMessageTypes.handshake:
-                raise ProtocolError(Err.INVALID_HANDSHAKE)
-
-            inbound_handshake = Handshake.from_bytes(message.data)
-            if inbound_handshake.network_id != network_id:
-                raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
-
-            remote_node_type = NodeType(inbound_handshake.node_type)
-
+        if not self.is_outbound:
             if (
                 remote_node_type in {NodeType.FARMER, NodeType.HARVESTER}
                 and inbound_handshake.protocol_version != protocol_version[remote_node_type]
@@ -298,12 +290,6 @@ class WSChiaConnection:
                 ),
             )
             await self._send_message(outbound_handshake)
-            self.version = inbound_handshake.software_version
-            self.protocol_version = Version(inbound_handshake.protocol_version)
-            self.peer_server_port = inbound_handshake.server_port
-            self.connection_type = remote_node_type
-            # "1" means capability is enabled
-            self.peer_capabilities = known_active_capabilities(inbound_handshake.capabilities)
 
         self.outbound_task = create_referenced_task(self.outbound_handler())
         self.inbound_task = create_referenced_task(self.inbound_handler())


### PR DESCRIPTION
### Purpose:

Unify the incoming and outgoing case. In one we receive the handshake first, then send our own handshake, in the other case we first send our handshake and then receive the handshake from the peer.

In this flow sending our handshake happens, conditionally, at the start or at the end. This lets us share the code to handle the incoming handshake message.

Also add some more sanity checks.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core peer handshake logic and adds new rejection conditions, which could affect node interoperability if edge cases differ from prior behavior. Test coverage is improved but handshake/connection establishment is a high-traffic path.
> 
> **Overview**
> Refactors `WSChiaConnection.perform_handshake()` to use a single inbound-handshake parsing/validation path for both outbound and inbound connections, with more explicit handling of invalid message types/parse failures and centralized assignment of peer connection properties.
> 
> Adds a new `MAX_VERSION_STRING_BYTES` limit (128 bytes UTF-8) and rejects handshakes with overly long `software_version` values. Updates DoS tests by extracting a shared websocket helper and adding coverage for wrong message type, wrong network id, and version-too-long handshake disconnects (asserting specific close reasons/errors).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 477c6b6d51f4060fca42415681e19f3185bfa498. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->