### PR TITLE
Disable git text conversion via .gitattributes, remove CI workarounds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 .git_archival.txt  export-subst
 **/*.lock  linguist-generated=false
+* -text

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -62,10 +62,6 @@ jobs:
 
       - uses: Chia-Network/actions/git-mark-workspace-safe@main
 
-      - name: disable git autocrlf
-        run: |
-          git config --global core.autocrlf false
-
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -133,10 +133,6 @@ jobs:
       BLOCKS_AND_PLOTS_VERSION: 0.44.0
 
     steps:
-      - name: Configure git
-        run: |
-          git config --global core.autocrlf false
-
       - name: Checkout code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- Add `* -text` to `.gitattributes` to disable git's automatic line-ending conversion for all files in the repository
- Remove the now-redundant `git config --global core.autocrlf false` CI steps from `test-single.yml` and `pre-commit.yml`

## Context

cc @quexington @cmmarslender

I came across the `* -text` gitattributes option while working on other projects and thought I'd share it here in case you're interested. It tells git to never perform any text/line-ending conversion (LF ↔ CRLF) on any file, regardless of platform or user config.

Previously, the CI workflows needed explicit `git config --global core.autocrlf false` steps before checkout to prevent Windows runners (which default to `core.autocrlf=true`) from converting line endings. With `* -text` in `.gitattributes`, the attribute takes precedence over `core.autocrlf`, so those steps are no longer needed — and the protection extends to all contributors' local environments too, not just CI.

I understand this might not be wanted for various reasons — just sharing in case it's useful.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes affecting checkout behavior and CI setup; low risk, with the main impact being how line endings are handled across platforms.
> 
> **Overview**
> Disables Git’s automatic text/line-ending conversion for the entire repo by adding `* -text` to `.gitattributes`.
> 
> Cleans up CI by removing the explicit `git config --global core.autocrlf false` steps from the `pre-commit` and `test-single` GitHub Actions workflows, relying on the attributes rule instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3437a627484d9a96e3438e71fa3080cae8e43341. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->