### PR TITLE
replace .dev with -dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ format-jinja = """
         {%- if stage is none -%}
             {{ base }}-dev{{ distance }}
         {%- else -%}
-            {{ base }}-{{stage}}{{revision}}.dev{{ distance }}
+            {{ base }}-{{stage}}{{revision}}-dev{{ distance }}
         {%- endif -%}
     {%- endif -%}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,9 +129,9 @@ format-jinja = """
         {%- endif -%}
     {%- else -%}
         {%- if stage is none -%}
-            {{ base }}-dev{{ distance }}
+            {{ base }}+dev{{ distance }}
         {%- else -%}
-            {{ base }}-{{stage}}{{revision}}-dev{{ distance }}
+            {{ base }}-{{stage}}{{revision}}+dev{{ distance }}
         {%- endif -%}
     {%- endif -%}
 """


### PR DESCRIPTION
Make an attempt to create more semver friendly "dev" versions by using `-dev` instead of `.dev` in pyproject.toml. Not sure if this has downstream implications, but I believe this is what we use to set the version (see `reflow-version.yml`)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes package version semantics/format, which can impact build/publish pipelines and dependency comparisons in downstream tooling.
> 
> **Overview**
> Switches Poetry dynamic versioning’s `format-jinja` to emit SemVer-style development versions using `+dev<distance>` instead of pre-release/dev separators (e.g., `-dev`/`.dev`).
> 
> This changes the generated version string for non-tagged commits (both with and without an existing pre-release `stage`), which may affect downstream tooling that expects PEP 440 dev versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2f79c9a470ae8e98ea00b9bbe4975ebc3b9ee47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->