### PR TITLE
reject unsolicited RespondCompactVDF messages

### DIFF
--- a/chia/_tests/core/full_node/stores/test_full_node_store.py
+++ b/chia/_tests/core/full_node/stores/test_full_node_store.py
@@ -208,7 +208,7 @@ async def test_basic_store(
     assert not store.seen_unfinished_block(h_hash_1)
     assert store.seen_unfinished_block(h_hash_1)
     # this will crowd out h_hash_1
-    for _ in range(store.max_seen_unfinished_blocks):
+    for _ in range(store.seen_unfinished_blocks.get_capacity()):
         store.seen_unfinished_block(bytes32.random(seeded_random))
     assert not store.seen_unfinished_block(h_hash_1)
 

--- a/chia/_tests/core/util/test_lru_cache.py
+++ b/chia/_tests/core/util/test_lru_cache.py
@@ -4,7 +4,7 @@ import unittest
 
 import pytest
 
-from chia.util.lru_cache import LRUCache
+from chia.util.lru_cache import LRUCache, LRUSet
 
 
 class TestLRUCache(unittest.TestCase):
@@ -70,3 +70,114 @@ def test_with_zero_capacity(capacity: int) -> None:
 def test_get_capacity(capacity: int) -> None:
     cache: LRUCache[object, object] = LRUCache(capacity=capacity)
     assert cache.get_capacity() == capacity
+
+
+class TestLRUSet:
+    def test_put_and_contains(self) -> None:
+        s: LRUSet[str] = LRUSet(5)
+        assert "a" not in s
+        assert len(s) == 0
+
+        s.put("a")
+        assert "a" in s
+        assert len(s) == 1
+
+        s.put("b")
+        s.put("c")
+        assert len(s) == 3
+        assert "a" in s
+        assert "b" in s
+        assert "c" in s
+
+    def test_duplicate_put(self) -> None:
+        s: LRUSet[str] = LRUSet(5)
+        s.put("a")
+        s.put("a")
+        s.put("a")
+        assert len(s) == 1
+        assert "a" in s
+
+    def test_remove(self) -> None:
+        s: LRUSet[str] = LRUSet(5)
+        s.put("a")
+        s.put("b")
+        s.remove("a")
+        assert "a" not in s
+        assert "b" in s
+        assert len(s) == 1
+
+    def test_remove_missing_key(self) -> None:
+        s: LRUSet[str] = LRUSet(5)
+        s.remove("nonexistent")
+        assert len(s) == 0
+
+    def test_eviction_order(self) -> None:
+        s: LRUSet[str] = LRUSet(3)
+        s.put("a")
+        s.put("b")
+        s.put("c")
+        assert len(s) == 3
+
+        # adding a 4th element evicts the oldest ("a")
+        s.put("d")
+        assert len(s) == 3
+        assert "a" not in s
+        assert "b" in s
+        assert "c" in s
+        assert "d" in s
+
+        # adding a 5th evicts "b"
+        s.put("e")
+        assert len(s) == 3
+        assert "b" not in s
+        assert "c" in s
+        assert "d" in s
+        assert "e" in s
+
+    def test_duplicate_does_not_reset_insertion_order(self) -> None:
+        s: LRUSet[str] = LRUSet(3)
+        s.put("a")
+        s.put("b")
+        s.put("c")
+
+        # re-adding "a" should NOT move it to the end
+        s.put("a")
+        assert len(s) == 3
+
+        # so adding a new element should still evict "a" (the oldest)
+        s.put("d")
+        assert "a" not in s
+        assert "b" in s
+        assert "c" in s
+        assert "d" in s
+
+    def test_remove_frees_slot(self) -> None:
+        s: LRUSet[str] = LRUSet(3)
+        s.put("a")
+        s.put("b")
+        s.put("c")
+        s.remove("b")
+        assert len(s) == 2
+
+        # adding after remove should not trigger eviction
+        s.put("d")
+        assert len(s) == 3
+        assert "a" in s
+        assert "c" in s
+        assert "d" in s
+
+    def test_capacity_one(self) -> None:
+        s: LRUSet[str] = LRUSet(1)
+        s.put("a")
+        assert "a" in s
+        assert len(s) == 1
+
+        s.put("b")
+        assert "a" not in s
+        assert "b" in s
+        assert len(s) == 1
+
+    def test_get_capacity(self) -> None:
+        for cap in [1, 5, 100]:
+            s: LRUSet[str] = LRUSet(cap)
+            assert s.get_capacity() == cap

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -3150,8 +3150,13 @@ class FullNode:
             peer_request = full_node_protocol.RequestCompactVDF(
                 request.height, request.header_hash, request.field_vdf, request.vdf_info
             )
+            peer.pending_compact_vdfs.put(peer_request.get_hash())
             response = await peer.call_api(FullNodeAPI.request_compact_vdf, peer_request, timeout=10)
             if response is not None and isinstance(response, full_node_protocol.RespondCompactVDF):
+                # if we fail to receive a response within 10 seconds, we give up
+                # here, but it's stil possible it will arrive later. We leave it
+                # in pending_compact_vdfs
+                peer.pending_compact_vdfs.remove(peer_request.get_hash())
                 await self.add_compact_vdf(response, peer)
 
     async def request_compact_vdf(self, request: full_node_protocol.RequestCompactVDF, peer: WSChiaConnection) -> None:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -3150,13 +3150,14 @@ class FullNode:
             peer_request = full_node_protocol.RequestCompactVDF(
                 request.height, request.header_hash, request.field_vdf, request.vdf_info
             )
-            peer.pending_compact_vdfs.put(peer_request.get_hash())
+            vdf_req_key = peer_request.get_hash()
+            peer.pending_compact_vdfs.put(vdf_req_key)
             response = await peer.call_api(FullNodeAPI.request_compact_vdf, peer_request, timeout=10)
             if response is not None and isinstance(response, full_node_protocol.RespondCompactVDF):
                 # if we fail to receive a response within 10 seconds, we give up
                 # here, but it's stil possible it will arrive later. We leave it
                 # in pending_compact_vdfs
-                peer.pending_compact_vdfs.remove(peer_request.get_hash())
+                peer.pending_compact_vdfs.remove(vdf_req_key)
                 await self.add_compact_vdf(response, peer)
 
     async def request_compact_vdf(self, request: full_node_protocol.RequestCompactVDF, peer: WSChiaConnection) -> None:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -76,7 +76,6 @@ from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER
 from chia.util.errors import Err, ValidationError
 from chia.util.hash import std_hash
 from chia.util.limited_semaphore import LimitedSemaphoreFullError
-from chia.util.network import is_localhost
 from chia.util.task_referencer import create_referenced_task
 
 if TYPE_CHECKING:
@@ -1660,7 +1659,7 @@ class FullNodeAPI:
             request.height, request.header_hash, request.field_vdf, request.vdf_info
         ).get_hash()
         if request_key not in peer.pending_compact_vdfs:
-            if not self.is_trusted(peer) and not is_localhost(peer.peer_info.host):
+            if not self.is_trusted(peer):
                 await peer.ban_peer_bad_protocol("Received unsolicited RespondCompactVDF")
                 return None
         else:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -76,6 +76,7 @@ from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER
 from chia.util.errors import Err, ValidationError
 from chia.util.hash import std_hash
 from chia.util.limited_semaphore import LimitedSemaphoreFullError
+from chia.util.network import is_localhost
 from chia.util.task_referencer import create_referenced_task
 
 if TYPE_CHECKING:
@@ -1655,6 +1656,16 @@ class FullNodeAPI:
 
     @metadata.request(peer_required=True)
     async def respond_compact_vdf(self, request: full_node_protocol.RespondCompactVDF, peer: WSChiaConnection) -> None:
+        request_key = full_node_protocol.RequestCompactVDF(
+            request.height, request.header_hash, request.field_vdf, request.vdf_info
+        ).get_hash()
+        if request_key not in peer.pending_compact_vdfs:
+            if not self.is_trusted(peer) and not is_localhost(peer.peer_info.host):
+                await peer.ban_peer_bad_protocol("Received unsolicited RespondCompactVDF")
+                return None
+        else:
+            peer.pending_compact_vdfs.remove(request_key)
+
         if self.full_node.sync_store.get_sync_mode():
             return None
         await self.full_node.add_compact_vdf(request, peer)

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -35,11 +35,14 @@ from chia.server.rate_limits import RateLimiter
 from chia.types.peer_info import PeerInfo
 from chia.util.errors import ApiError, ConsensusError, Err, ProtocolError, TimestampError
 from chia.util.log_exceptions import log_exceptions
+from chia.util.lru_cache import LRUSet
 
 # Each message is prepended with LENGTH_BYTES bytes specifying the length
 from chia.util.network import is_in_network, is_localhost
 from chia.util.streamable import Streamable
 from chia.util.task_referencer import create_referenced_task
+
+MAX_PENDING_COMPACT_VDFS = 100
 
 # Max size 2^(8*4) which is around 4GiB
 LENGTH_BYTES: int = 4
@@ -125,6 +128,10 @@ class WSChiaConnection:
         default_factory=create_default_last_message_time_dict,
         repr=False,
     )
+
+    # Tracks compact VDF requests we've sent to this peer (hashed RequestCompactVDF).
+    # Used to reject unsolicited RespondCompactVDF messages.
+    pending_compact_vdfs: LRUSet[bytes32] = field(default_factory=lambda: LRUSet(MAX_PENDING_COMPACT_VDFS), repr=False)
 
     exempt_peer_networks: list[IPv4Network | IPv6Network] = field(
         default_factory=list,

--- a/chia/util/lru_cache.py
+++ b/chia/util/lru_cache.py
@@ -39,24 +39,24 @@ class LRUSet(Generic[K]):
     """A bounded set that preserves insertion order and evicts the oldest entry when full."""
 
     def __init__(self, capacity: int) -> None:
-        self.capacity = capacity
-        self.cache: dict[K, None] = {}
+        self._capacity = capacity
+        self._cache: dict[K, None] = {}
 
     def put(self, key: K) -> None:
-        if key in self.cache:
+        if key in self._cache:
             return
-        if len(self.cache) >= self.capacity:
-            self.cache.pop(next(iter(self.cache)))
-        self.cache[key] = None
+        if len(self._cache) >= self._capacity:
+            self._cache.pop(next(iter(self._cache)))
+        self._cache[key] = None
 
     def remove(self, key: K) -> None:
-        self.cache.pop(key, None)
+        self._cache.pop(key, None)
 
     def get_capacity(self) -> int:
-        return self.capacity
+        return self._capacity
 
     def __contains__(self, key: K) -> bool:
-        return key in self.cache
+        return key in self._cache
 
     def __len__(self) -> int:
-        return len(self.cache)
+        return len(self._cache)

--- a/chia/util/lru_cache.py
+++ b/chia/util/lru_cache.py
@@ -33,3 +33,30 @@ class LRUCache(Generic[K, V]):
 
     def get_capacity(self) -> int:
         return self.capacity
+
+
+class LRUSet(Generic[K]):
+    """A bounded set that preserves insertion order and evicts the oldest entry when full."""
+
+    def __init__(self, capacity: int) -> None:
+        self.capacity = capacity
+        self.cache: dict[K, None] = {}
+
+    def put(self, key: K) -> None:
+        if key in self.cache:
+            return
+        if len(self.cache) >= self.capacity:
+            self.cache.pop(next(iter(self.cache)))
+        self.cache[key] = None
+
+    def remove(self, key: K) -> None:
+        self.cache.pop(key, None)
+
+    def get_capacity(self) -> int:
+        return self.capacity
+
+    def __contains__(self, key: K) -> bool:
+        return key in self.cache
+
+    def __len__(self) -> int:
+        return len(self.cache)


### PR DESCRIPTION
### Purpose:

be stricter about receiving `RespondCompactVDF`.

This was a bit more involved than I first thought.

Like many other messages, the normal request-response path happens via a `call_api()` on the peer. This is an async call which will put the task to sleep until we get the response and we handle it directly below the call.

This means that all calls to the message handler for `RespondCompactVDF` are "unsolicited". However, it can also mean that the peer was just too slow to respond within our 10 seconds timeout and we gave up in the normal `call_api()` flow. Once the respond arrives, it would be a bit harsh (and counter-productive) to disconnect the peer.

Instead, we track all requests we've made, and we accept stragglers, as long as they were legitimately requested by us.

This opens up the risk of DoS. We don't want the tracking of requested compact VDFs to be unbounded, so we need an LRU.

It turns out that this is not the first time we need something like this, so I factored out the same facility from `full_node_store` and called it `LRUSet`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches peer-protocol handling and introduces banning behavior; a mistake could disconnect honest peers or weaken DoS protections despite bounded tracking.
> 
> **Overview**
> **Rejects unsolicited `RespondCompactVDF` messages from untrusted peers.** The node now tracks outbound `RequestCompactVDF` requests per-peer (bounded `LRUSet`) and bans untrusted peers that send a `RespondCompactVDF` without a matching pending request, while still accepting late responses.
> 
> Introduces a reusable `LRUSet` utility and migrates `FullNodeStore.seen_unfinished_blocks` to it; adds targeted unit tests (including a new full-node test covering trusted vs untrusted unsolicited compact VDF behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef2e1eb13175d71439019ea48fd20eda4b4e00c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->