### PR TITLE
Use new CHIA_SEMVER_VERSION envvar for version in package.json 

### DIFF
--- a/.github/workflows/build-linux-installer-deb.yml
+++ b/.github/workflows/build-linux-installer-deb.yml
@@ -67,6 +67,7 @@ jobs:
 
     env:
       CHIA_INSTALLER_VERSION: ${{ needs.version.outputs.chia-installer-version }}
+      CHIA_SEMVER_VERSION: ${{ needs.version.outputs.chia-semver-version }}
       POETRY_DYNAMIC_VERSIONING_OVERRIDE: "chia-blockchain=${{ needs.version.outputs.chia-installer-version }}"
       TAG_TYPE: ${{ needs.version.outputs.tag-type }}
 

--- a/.github/workflows/build-linux-installer-rpm.yml
+++ b/.github/workflows/build-linux-installer-rpm.yml
@@ -59,6 +59,7 @@ jobs:
 
     env:
       CHIA_INSTALLER_VERSION: ${{ needs.version.outputs.chia-installer-version }}
+      CHIA_SEMVER_VERSION: ${{ needs.version.outputs.chia-semver-version }}
       POETRY_DYNAMIC_VERSIONING_OVERRIDE: "chia-blockchain=${{ needs.version.outputs.chia-installer-version }}"
       TAG_TYPE: ${{ needs.version.outputs.tag-type }}
 

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -64,6 +64,7 @@ jobs:
 
     env:
       CHIA_INSTALLER_VERSION: ${{ needs.version.outputs.chia-installer-version }}
+      CHIA_SEMVER_VERSION: ${{ needs.version.outputs.chia-semver-version }}
       POETRY_DYNAMIC_VERSIONING_OVERRIDE: "chia-blockchain=${{ needs.version.outputs.chia-installer-version }}"
       TAG_TYPE: ${{ needs.version.outputs.tag-type }}
 

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -55,6 +55,7 @@ jobs:
 
     env:
       CHIA_INSTALLER_VERSION: ${{ needs.version.outputs.chia-installer-version }}
+      CHIA_SEMVER_VERSION: ${{ needs.version.outputs.chia-semver-version }}
       POETRY_DYNAMIC_VERSIONING_OVERRIDE: "chia-blockchain=${{ needs.version.outputs.chia-installer-version }}"
       TAG_TYPE: ${{ needs.version.outputs.tag-type }}
 

--- a/.github/workflows/reflow-version.yml
+++ b/.github/workflows/reflow-version.yml
@@ -13,6 +13,8 @@ on:
         value: ${{ jobs.version.outputs.chia-dev-version }}
       chia-installer-version:
         value: ${{ jobs.version.outputs.chia-installer-version }}
+      chia-semver-version:
+        value: ${{ jobs.version.outputs.chia-semver-version }}
       tag-type:
         value: ${{ jobs.version.outputs.tag-type }}
 
@@ -24,7 +26,7 @@ jobs:
     outputs:
       chia-dev-version: ${{ steps.version-number.outputs.chia-dev-version }}
       chia-installer-version: ${{ steps.version-number.outputs.chia-installer-version }}
-      tag-type: ${{ steps.tag-type.outputs.tag-type }}
+      chia-semver-version: ${{ steps.version-number.outputs.chia-semver-version }}
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/reflow-version.yml
+++ b/.github/workflows/reflow-version.yml
@@ -27,6 +27,7 @@ jobs:
       chia-dev-version: ${{ steps.version-number.outputs.chia-dev-version }}
       chia-installer-version: ${{ steps.version-number.outputs.chia-installer-version }}
       chia-semver-version: ${{ steps.version-number.outputs.chia-semver-version }}
+      tag-type: ${{ steps.tag-type.outputs.tag-type }}
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/reflow-version.yml
+++ b/.github/workflows/reflow-version.yml
@@ -60,5 +60,7 @@ jobs:
           echo "chia-installer-version=${VERSION}" >> "$GITHUB_OUTPUT"
           GIT_SHORT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-8)
           echo "chia-dev-version=${VERSION}-${GIT_SHORT_HASH}" >> "$GITHUB_OUTPUT"
+          SEMVER_VERSION=$(echo "${VERSION}" | sed -E 's/([0-9])(rc|beta)/\1-\2/g; s/\.dev/-dev/g')
+          echo "chia-semver-version=${SEMVER_VERSION}" >> "$GITHUB_OUTPUT"
 
           deactivate

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -21,9 +21,12 @@ git submodule
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
   echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
   CHIA_INSTALLER_VERSION="0.0.0"
+  CHIA_SEMVER_VERSION="0.0.0"
 fi
 echo "Chia Installer Version is: $CHIA_INSTALLER_VERSION"
+echo "Chia Semver Version is: $CHIA_SEMVER_VERSION"
 export CHIA_INSTALLER_VERSION
+export CHIA_SEMVER_VERSION
 
 echo "Installing npm and electron packagers"
 cd npm_linux || exit 1
@@ -49,22 +52,13 @@ echo "Building pip and NPM license directory"
 pwd
 bash ./build_license_directory.sh
 
-# Builds CLI only .deb
-# need j2 for templating the control file
-format_deb_version_string() {
-  version_str=$1
-  # Use sed to conform to expected apt versioning conventions:
-  # - conditionally insert a hyphen before 'rc' or 'beta' if not already present
-  # - replace '.dev' with '-dev'
-  echo "$version_str" | sed -E 's/([0-9])(rc|beta)/\1-\2/g; s/\.dev/-dev/g'
-}
 pip install jinjanator
 CLI_DEB_BASE="chia-blockchain-cli_$CHIA_INSTALLER_VERSION-1_$PLATFORM"
 mkdir -p "dist/$CLI_DEB_BASE/opt/chia"
 mkdir -p "dist/$CLI_DEB_BASE/usr/bin"
 mkdir -p "dist/$CLI_DEB_BASE/DEBIAN"
 mkdir -p "dist/$CLI_DEB_BASE/etc/systemd/system"
-CHIA_DEB_CONTROL_VERSION=$(format_deb_version_string "$CHIA_INSTALLER_VERSION")
+CHIA_DEB_CONTROL_VERSION=$CHIA_SEMVER_VERSION
 export CHIA_DEB_CONTROL_VERSION
 j2 -o "dist/$CLI_DEB_BASE/DEBIAN/control" assets/deb/control.j2
 cp assets/systemd/*.service "dist/$CLI_DEB_BASE/etc/systemd/system/"
@@ -81,7 +75,7 @@ cd ../chia-blockchain-gui/packages/gui || exit 1
 
 # sets the version for chia-blockchain in package.json
 cp package.json package.json.orig
-jq --arg VER "$CHIA_DEB_CONTROL_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
+jq --arg VER "$CHIA_SEMVER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
 
 echo "Building Linux(deb) Electron app"
 PRODUCT_NAME="chia"

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -81,7 +81,7 @@ cd ../chia-blockchain-gui/packages/gui || exit 1
 
 # sets the version for chia-blockchain in package.json
 cp package.json package.json.orig
-jq --arg VER "$CHIA_INSTALLER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
+jq --arg VER "$CHIA_DEB_CONTROL_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
 
 echo "Building Linux(deb) Electron app"
 PRODUCT_NAME="chia"

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -21,8 +21,12 @@ git submodule
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
   echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
   CHIA_INSTALLER_VERSION="0.0.0"
-  CHIA_SEMVER_VERSION="0.0.0"
 fi
+if [ ! "$CHIA_SEMVER_VERSION" ]; then
+  echo "WARNING: No environment variable CHIA_SEMVER_VERSION set. Using $CHIA_INSTALLER_VERSION."
+  CHIA_SEMVER_VERSION="$CHIA_INSTALLER_VERSION"
+fi
+
 echo "Chia Installer Version is: $CHIA_INSTALLER_VERSION"
 echo "Chia Semver Version is: $CHIA_SEMVER_VERSION"
 export CHIA_INSTALLER_VERSION

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -20,8 +20,10 @@ fi
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
   echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
   CHIA_INSTALLER_VERSION="0.0.0"
+  CHIA_SEMVER_VERSION="0.0.0"
 fi
 echo "Chia Installer Version is: $CHIA_INSTALLER_VERSION"
+echo "Chia Semver Version is: $CHIA_SEMVER_VERSION"
 
 echo "Installing npm and electron packagers"
 cd npm_linux || exit 1
@@ -91,7 +93,7 @@ cd ../chia-blockchain-gui/packages/gui || exit 1
 
 # sets the version for chia-blockchain in package.json
 cp package.json package.json.orig
-jq --arg VER "$CHIA_INSTALLER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
+jq --arg VER "$CHIA_SEMVER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
 
 export FPM_EDITOR="cat >../../../build_scripts/dist/gui.spec <"
 jq '.rpm.fpm |= . + ["--edit"]' ../../../build_scripts/electron-builder.json >temp.json && mv temp.json ../../../build_scripts/electron-builder.json

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -20,8 +20,12 @@ fi
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
   echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
   CHIA_INSTALLER_VERSION="0.0.0"
-  CHIA_SEMVER_VERSION="0.0.0"
 fi
+if [ ! "$CHIA_SEMVER_VERSION" ]; then
+  echo "WARNING: No environment variable CHIA_SEMVER_VERSION set. Using $CHIA_INSTALLER_VERSION."
+  CHIA_SEMVER_VERSION="$CHIA_INSTALLER_VERSION"
+fi
+
 echo "Chia Installer Version is: $CHIA_INSTALLER_VERSION"
 echo "Chia Semver Version is: $CHIA_SEMVER_VERSION"
 

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -11,8 +11,10 @@ git submodule
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
   echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
   CHIA_INSTALLER_VERSION="0.0.0"
+  CHIA_SEMVER_VERSION="0.0.0"
 fi
 echo "Chia Installer Version is: $CHIA_INSTALLER_VERSION"
+echo "Chia Semver Version is: $CHIA_SEMVER_VERSION"
 
 echo "Installing npm utilities"
 cd npm_macos || exit 1
@@ -49,7 +51,7 @@ cd ../chia-blockchain-gui/packages/gui || exit 1
 # sets the version for chia-blockchain in package.json
 brew install jq
 cp package.json package.json.orig
-jq --arg VER "$CHIA_INSTALLER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
+jq --arg VER "$CHIA_SEMVER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
 
 echo "Building macOS Electron app"
 OPT_ARCH="--x64"

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -11,8 +11,12 @@ git submodule
 if [ ! "$CHIA_INSTALLER_VERSION" ]; then
   echo "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0."
   CHIA_INSTALLER_VERSION="0.0.0"
-  CHIA_SEMVER_VERSION="0.0.0"
 fi
+if [ ! "$CHIA_SEMVER_VERSION" ]; then
+  echo "WARNING: No environment variable CHIA_SEMVER_VERSION set. Using $CHIA_INSTALLER_VERSION."
+  CHIA_SEMVER_VERSION="$CHIA_INSTALLER_VERSION"
+fi
+
 echo "Chia Installer Version is: $CHIA_INSTALLER_VERSION"
 echo "Chia Semver Version is: $CHIA_SEMVER_VERSION"
 

--- a/build_scripts/build_windows-2-installer.ps1
+++ b/build_scripts/build_windows-2-installer.ps1
@@ -9,9 +9,13 @@ git submodule
 
 if (-not (Test-Path env:CHIA_INSTALLER_VERSION)) {
   $env:CHIA_INSTALLER_VERSION = '0.0.0'
-  $env:CHIA_SEMVER_VERSION = '0.0.0'
   Write-Output "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0"
 }
+if (-not (Test-Path env:CHIA_SEMVER_VERSION)) {
+  $env:CHIA_SEMVER_VERSION = $env:CHIA_INSTALLER_VERSION
+  Write-Output "WARNING: No environment variable CHIA_SEMVER_VERSION set. Using $env:CHIA_INSTALLER_VERSION"
+}
+
 Write-Output "Chia Version is: $env:CHIA_INSTALLER_VERSION"
 Write-Output "Chia Semver Version is: $env:CHIA_SEMVER_VERSION"
 Write-Output "   ---"

--- a/build_scripts/build_windows-2-installer.ps1
+++ b/build_scripts/build_windows-2-installer.ps1
@@ -9,9 +9,11 @@ git submodule
 
 if (-not (Test-Path env:CHIA_INSTALLER_VERSION)) {
   $env:CHIA_INSTALLER_VERSION = '0.0.0'
+  $env:CHIA_SEMVER_VERSION = '0.0.0'
   Write-Output "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0"
 }
 Write-Output "Chia Version is: $env:CHIA_INSTALLER_VERSION"
+Write-Output "Chia Semver Version is: $env:CHIA_SEMVER_VERSION"
 Write-Output "   ---"
 
 Write-Output "   ---"
@@ -62,7 +64,7 @@ Write-Output "   ---"
 Write-Output "fix version in package.json"
 choco install jq
 cp package.json package.json.orig
-jq --arg VER "$env:CHIA_INSTALLER_VERSION" '.version=$VER' package.json > temp.json
+jq --arg VER "$env:CHIA_SEMVER_VERSION" '.version=$VER' package.json > temp.json
 rm package.json
 mv temp.json package.json
 Write-Output "   ---"


### PR DESCRIPTION
Add new semver-specific version for use in the package.json as electron-builder/node/npm is rather specific on versioning there. And PEP440 (python) and SEMVER (npm) don't always agree

Use an existing SED script to adjust the PEP440 output of poetry version into a semver friendly format

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI/build-only changes that adjust how version strings are formatted for packaging; risk is limited to installer versioning/upgrade behavior if the normalized string is incorrect.
> 
> **Overview**
> Adds a new `chia-semver-version` output in `reflow-version.yml` that normalizes Poetry versions (e.g., inserting `-rc`/`-beta` and converting `.dev` to `-dev`).
> 
> Propagates this as `CHIA_SEMVER_VERSION` through the Linux/macOS/Windows installer workflows and updates installer build scripts to use it when writing GUI `package.json` versions and the Debian control version, while keeping artifact filenames based on `CHIA_INSTALLER_VERSION` (with a fallback to installer version if semver isn’t set).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4d011fa4eafbb2be0d30052a8f6ac4593929206. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->