### PR TITLE
Add return type annotations to chia/ssl/create_ssl.py

### DIFF
--- a/chia/ssl/create_ssl.py
+++ b/chia/ssl/create_ssl.py
@@ -41,7 +41,9 @@ def get_mozilla_ca_crt() -> str:
     return str(mozilla_path)
 
 
-def write_ssl_cert_and_key(cert_path: Path, cert_data: bytes, key_path: Path, key_data: bytes, overwrite: bool = True):
+def write_ssl_cert_and_key(
+    cert_path: Path, cert_data: bytes, key_path: Path, key_data: bytes, overwrite: bool = True
+) -> None:
     flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
 
     for path, data, mode in [
@@ -58,14 +60,14 @@ def write_ssl_cert_and_key(cert_path: Path, cert_data: bytes, key_path: Path, ke
             f.write(data)  # lgtm [py/clear-text-storage-sensitive-data]
 
 
-def ensure_ssl_dirs(dirs: list[Path]):
+def ensure_ssl_dirs(dirs: list[Path]) -> None:
     """Create SSL dirs with a default 755 mode if necessary"""
     for dir in dirs:
         if not dir.exists():
             dir.mkdir(mode=0o755, parents=True)
 
 
-def generate_ca_signed_cert(ca_crt: bytes, ca_key: bytes, cert_out: Path, key_out: Path):
+def generate_ca_signed_cert(ca_crt: bytes, ca_key: bytes, cert_out: Path, key_out: Path) -> None:
     one_day = datetime.timedelta(1, 0, 0)
     root_cert = x509.load_pem_x509_certificate(ca_crt, default_backend())
     root_key = load_pem_private_key(ca_key, None, default_backend())
@@ -104,7 +106,7 @@ def generate_ca_signed_cert(ca_crt: bytes, ca_key: bytes, cert_out: Path, key_ou
     write_ssl_cert_and_key(cert_out, cert_pem, key_out, key_pem)
 
 
-def make_ca_cert(cert_path: Path, key_path: Path):
+def make_ca_cert(cert_path: Path, key_path: Path) -> None:
     root_key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
     subject = issuer = x509.Name(
         [
@@ -143,7 +145,7 @@ def create_all_ssl(
     private_node_names: list[str] = _all_private_node_names,
     public_node_names: list[str] = _all_public_node_names,
     overwrite: bool = True,
-):
+) -> None:
     # remove old key and crt
     config_dir = root_path / "config"
     old_key_path = config_dir / "trusted.key"
@@ -223,7 +225,7 @@ def generate_ssl_for_nodes(
     nodes: list[str],
     overwrite: bool = True,
     node_certs_and_keys: dict[str, dict] | None = None,
-):
+) -> None:
     for node_name in nodes:
         node_dir = ssl_dir / node_name
         ensure_ssl_dirs([node_dir])
@@ -242,8 +244,8 @@ def generate_ssl_for_nodes(
         generate_ca_signed_cert(ca_crt, ca_key, crt_path, key_path)
 
 
-def main():
-    return make_ca_cert(Path("./chia_ca.crt"), Path("./chia_ca.key"))
+def main() -> None:
+    make_ca_cert(Path("./chia_ca.crt"), Path("./chia_ca.key"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds explicit `-> None` return type annotations to all functions in `chia/ssl/create_ssl.py` that were missing them.

The [CONTRIBUTING.md](https://github.com/Chia-Network/chia-blockchain/blob/main/CONTRIBUTING.md) guide states:

> The Mypy library is very useful for ensuring objects are of the correct type, so try to always add the type of the return value, and the type of local variables.

## Changes

- **`write_ssl_cert_and_key`** — added `-> None`, also reformatted the long signature for readability
- **`ensure_ssl_dirs`** — added `-> None`
- **`generate_ca_signed_cert`** — added `-> None`
- **`make_ca_cert`** — added `-> None`
- **`create_all_ssl`** — added `-> None`
- **`generate_ssl_for_nodes`** — added `-> None`
- **`main`** — added `-> None` and removed the redundant `return` of a `None`-typed function call

## Type of change

- [x] Code quality / type safety improvement (no logic changes)

## Testing

No logic was changed. Existing tests cover this module. The annotations are consistent with how other typed functions in the codebase are declared.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-annotation-only changes in SSL utility code; behavior should be unchanged aside from removing a redundant `return None` in `main()`.
> 
> **Overview**
> Adds explicit `-> None` return type annotations to several functions in `chia/ssl/create_ssl.py`, including `create_all_ssl` and certificate/key generation helpers, and reformats the long `write_ssl_cert_and_key` signature for readability.
> 
> Updates `main()` to no longer `return` the result of `make_ca_cert()` (now explicitly `None`), with no functional behavior changes intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afc0a0c1f0548ef9198716de4fb5e3a5a84f64d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->