### PR TITLE
made log less chatty for compact proofs

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -3186,7 +3186,7 @@ class FullNode:
         ):
             vdf_proof = header_block.challenge_chain_ip_proof
         if vdf_proof is None or vdf_proof.witness_type > 0 or not vdf_proof.normalized_to_identity:
-            self.log.error(f"{peer} requested compact vdf we don't have, height: {request.height}.")
+            self.log.info(f"{peer.peer_node_id} requested compact vdf we don't have, height: {request.height}.")
             return None
         compact_vdf = full_node_protocol.RespondCompactVDF(
             request.height,


### PR DESCRIPTION
### Purpose:

Adjusted logging info and level

### Current Behavior:

2026-02-19T00:48:32.493 2.6.0 full_node chia.full_node.full_node: ERROR    WSChiaConnection(local_type=<NodeType.FULL_NODE: 1>, local_port=8444, local_capabilities=[<Capability.BASE: 1>, <Capability.BLOCK_HEADERS: 2>, <Capability.RATE_LIMITS_V2: 3>, <Capability.MEMPOOL_UPDATES: 5>], peer_info=PeerInfo(_ip=IPv6Address('2001:9e8:f9aa:2200:1d:5907:79d1:9a72'), _port=55823), peer_node_id=<bytes32: 38e98660fa45e5978ab7359fe0ec66f4178c6e3407d59400f5056bc18dc3f3c5>, outbound_rate_limiter=<chia.server.rate_limits.RateLimiter object at 0x743e6cebac30>, inbound_rate_limiter=<chia.server.rate_limits.RateLimiter object at 0x743e6ceb9190>, is_outbound=False, creation_time=1771384664.2813828, bytes_read=6181930, bytes_written=96448469, last_message_time=1771458512.493029, peer_server_port=8444, closed=False, connection_type=<NodeType.FULL_NODE: 1>, request_nonce=32786, peer_capabilities=[<Capability.BASE: 1>, <Capability.BLOCK_HEADERS: 2>, <Capability.RATE_LIMITS_V2: 3>, <Capability.MEMPOOL_UPDATES: 5>], version='2.6.0', protocol_version=<Version('0.0.36')>) requested compact vdf we don't have, height: 3137078.

### New Behavior:

2026-02-19T00:48:32.493 2.6.0 full_node chia.full_node.full_node: INFO 38e98660fa45e5978ab7359fe0ec66f4178c6e3407d59400f5056bc18dc3f3c5 requested compact vdf we don't have, height: 3137078.

### Testing Notes:

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change (severity and message content) with no impact on consensus, networking behavior, or data handling.
> 
> **Overview**
> Reduces log noise when peers request compact VDF proofs the node can’t serve by changing the message from `ERROR` to `INFO` and logging only `peer.peer_node_id` instead of the full peer connection object.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93cb4c983c564a23cab09d12425f90bbe06e2f05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->