### PR TITLE
grep for and remove `altendky`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 *	@Chia-Network/required-reviewers
 /.github/**/* @Chia-Network/actions-reviewers
-/PRETTY_GOOD_PRACTICES.md	@altendky @Chia-Network/required-reviewers
-/tests/ether.py @altendky @Chia-Network/required-reviewers
-/pyproject.toml @altendky @Chia-Network/required-reviewers
+/PRETTY_GOOD_PRACTICES.md	@Chia-Network/required-reviewers
+/tests/ether.py @Chia-Network/required-reviewers
+/pyproject.toml @Chia-Network/required-reviewers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,7 @@ updates:
       - dependencies
       - python
       - "Changed"
-    reviewers: ["emlowe", "altendky"]
+    reviewers: ["emlowe"]
 
   - package-ecosystem: "github-actions"
     directories: ["/", ".github/actions/*"]
@@ -50,7 +50,7 @@ updates:
       - dependencies
       - github_actions
       - "Changed"
-    reviewers: ["cmmarslender", "altendky"]
+    reviewers: ["cmmarslender"]
 
   - package-ecosystem: "npm"
     directory: /

--- a/.repo-content-updater.yml
+++ b/.repo-content-updater.yml
@@ -1,4 +1,4 @@
 var_overrides:
-  DEPENDABOT_ACTIONS_REVIEWERS: '["cmmarslender", "altendky"]'
+  DEPENDABOT_ACTIONS_REVIEWERS: '["cmmarslender"]'
   DEPENDENCY_REVIEW_ALLOW_DEPENDENCIES_LICENSES: pkg:pypi/pyinstaller, pkg:pypi/mypy
   DEPENDABOT_PIP_PULL_REQUEST_LIMIT: "30"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Configuration-only changes affecting PR review routing/automation; no runtime or production code paths are modified.
> 
> **Overview**
> Removes `altendky` from `.github/CODEOWNERS` entries for `/PRETTY_GOOD_PRACTICES.md`, `/tests/ether.py`, and `/pyproject.toml`, leaving ownership to `@Chia-Network/required-reviewers`.
> 
> Updates Dependabot configuration to drop `altendky` from the reviewer lists for `pip` and `github-actions` updates, and aligns `.repo-content-updater.yml` override `DEPENDABOT_ACTIONS_REVIEWERS` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f37c8a99d798883d893a431d88216535ac49be7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->