### PR TITLE
Break daemon ↔ plotting cycle: move harvester config helpers to chia.util

### DIFF
--- a/chia/_tests/core/test_farmer_harvester_rpc.py
+++ b/chia/_tests/core/test_farmer_harvester_rpc.py
@@ -32,7 +32,6 @@ from chia.farmer.farmer_rpc_client import FarmerRpcClient
 from chia.farmer.farmer_service import FarmerService
 from chia.harvester.harvester_service import HarvesterService
 from chia.plot_sync.receiver import Receiver, get_list_or_len
-from chia.plotting.util import add_plot_directory
 from chia.protocols import farmer_protocol
 from chia.protocols.harvester_protocol import Plot
 from chia.rpc.rpc_client import ResponseFailureError
@@ -40,6 +39,7 @@ from chia.simulator.block_tools import BlockTools, get_plot_dir
 from chia.solver.solver_service import SolverService
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.config import load_config, lock_and_load_config, save_config
+from chia.util.harvester_config import add_plot_directory
 from chia.util.hash import std_hash
 from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import puzzle_hash_for_pk

--- a/chia/_tests/plot_sync/test_plot_sync.py
+++ b/chia/_tests/plot_sync/test_plot_sync.py
@@ -28,11 +28,11 @@ from chia.plot_sync.receiver import Receiver
 from chia.plot_sync.sender import Sender
 from chia.plot_sync.util import Constants, State
 from chia.plotting.manager import PlotManager
-from chia.plotting.util import add_plot_directory, remove_plot_directory
 from chia.protocols.harvester_protocol import Plot
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.simulator.block_tools import BlockTools
 from chia.util.config import create_default_chia_config, lock_and_load_config, save_config
+from chia.util.harvester_config import add_plot_directory, remove_plot_directory
 from chia.util.streamable import _T_Streamable
 
 

--- a/chia/_tests/plotting/test_plot_manager.py
+++ b/chia/_tests/plotting/test_plot_manager.py
@@ -26,13 +26,11 @@ from chia.plotting.util import (
     PlotInfo,
     PlotRefreshEvents,
     PlotRefreshResult,
-    add_plot_directory,
-    get_plot_directories,
     remove_plot,
-    remove_plot_directory,
 )
 from chia.simulator.block_tools import get_plot_dir
 from chia.util.config import create_default_chia_config, lock_and_load_config, save_config
+from chia.util.harvester_config import add_plot_directory, get_plot_directories, remove_plot_directory
 from chia.util.streamable import VersionedBlob
 
 log = logging.getLogger(__name__)

--- a/chia/cmds/plots.py
+++ b/chia/cmds/plots.py
@@ -8,13 +8,14 @@ from pathlib import Path
 import click
 
 from chia.cmds.cmd_classes import ChiaCliContext
-from chia.plotting.util import add_plot_directory, validate_plot_size
+from chia.plotting.util import validate_plot_size
+from chia.util.harvester_config import add_plot_directory
 
 log = logging.getLogger(__name__)
 
 
 def show_plots(root_path: Path) -> None:
-    from chia.plotting.util import get_plot_directories
+    from chia.util.harvester_config import get_plot_directories
 
     print("Directories where plots are being searched for:")
     print("Note that subdirectories must be added manually")
@@ -199,7 +200,7 @@ def check_cmd(
 )
 @click.pass_context
 def add_cmd(ctx: click.Context, final_dir: str) -> None:
-    from chia.plotting.util import add_plot_directory
+    from chia.util.harvester_config import add_plot_directory
 
     try:
         add_plot_directory(ChiaCliContext.set_default(ctx).root_path, final_dir)
@@ -219,7 +220,7 @@ def add_cmd(ctx: click.Context, final_dir: str) -> None:
 )
 @click.pass_context
 def remove_cmd(ctx: click.Context, final_dir: str) -> None:
-    from chia.plotting.util import remove_plot_directory
+    from chia.util.harvester_config import remove_plot_directory
 
     remove_plot_directory(ChiaCliContext.set_default(ctx).root_path, final_dir)
 

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -30,7 +30,6 @@ from chia.cmds.passphrase_funcs import default_passphrase, using_default_passphr
 from chia.daemon.keychain_server import KeychainServer, keychain_commands
 from chia.daemon.windows_signal import kill
 from chia.plotters.plotters import get_available_plotters
-from chia.plotting.util import add_plot_directory
 from chia.server.server import ssl_context_for_server
 from chia.server.signal_handlers import SignalHandlers
 from chia.util.bech32m import encode_puzzle_hash
@@ -38,6 +37,7 @@ from chia.util.chia_logging import initialize_service_logging
 from chia.util.chia_version import chia_short_version
 from chia.util.config import load_config
 from chia.util.errors import KeychainCurrentPassphraseIsInvalid
+from chia.util.harvester_config import add_plot_directory
 from chia.util.json_util import dict_to_json_str
 from chia.util.keychain import Keychain, KeyData, passphrase_requirements, supports_os_passphrase_storage
 from chia.util.lock import Lockfile, LockfileError

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -28,11 +28,8 @@ from chia.plotting.util import (
     PlotRefreshEvents,
     PlotRefreshResult,
     PlotsRefreshParameter,
-    add_plot_directory,
     get_harvester_config,
-    get_plot_directories,
     remove_plot,
-    remove_plot_directory,
     update_harvester_config,
 )
 from chia.protocols.outbound_message import NodeType
@@ -40,6 +37,7 @@ from chia.rpc.rpc_server import StateChangedProtocol, default_get_connections
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
 from chia.util.cpu import available_logical_cores
+from chia.util.harvester_config import add_plot_directory, get_plot_directories, remove_plot_directory
 
 log = logging.getLogger(__name__)
 

--- a/chia/plotters/chiapos.py
+++ b/chia/plotters/chiapos.py
@@ -13,7 +13,8 @@ from pathlib import Path
 from typing import Any
 
 from chia.plotting.create_plots import create_plots, resolve_plot_keys
-from chia.plotting.util import Params, add_plot_directory, validate_plot_size
+from chia.plotting.util import Params, validate_plot_size
+from chia.util.harvester_config import add_plot_directory
 
 log = logging.getLogger(__name__)
 

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -78,7 +78,6 @@ from chia.plotting.util import (
     PlotRefreshEvents,
     PlotRefreshResult,
     PlotsRefreshParameter,
-    add_plot_directory,
     parse_plot_info,
 )
 from chia.server.server import ssl_context_for_client
@@ -122,6 +121,7 @@ from chia.util.config import (
     save_config,
 )
 from chia.util.default_root import DEFAULT_ROOT_PATH
+from chia.util.harvester_config import add_plot_directory
 from chia.util.hash import std_hash
 from chia.util.keychain import Keychain, bytes_to_mnemonic
 from chia.util.timing import adjusted_timeout, backoff_times

--- a/chia/util/harvester_config.py
+++ b/chia/util/harvester_config.py
@@ -1,0 +1,53 @@
+"""
+Harvester plot directory config helpers.
+Extracted from chia.plotting.util to break the daemon ↔ plotting cycle.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from chia.util.config import load_config, lock_and_load_config, save_config
+
+log = logging.getLogger(__name__)
+
+
+def get_plot_directories(root_path: Path, config: dict | None = None) -> list[str]:
+    if config is None:
+        config = load_config(root_path, "config.yaml")
+    return config["harvester"]["plot_directories"] or []
+
+
+def add_plot_directory(root_path: Path, str_path: str) -> dict:
+    path: Path = Path(str_path).resolve()
+    if not path.exists():
+        raise ValueError(f"Path doesn't exist: {path}")
+    if not path.is_dir():
+        raise ValueError(f"Path is not a directory: {path}")
+    log.debug(f"add_plot_directory {str_path}")
+    with lock_and_load_config(root_path, "config.yaml") as config:
+        if str(Path(str_path).resolve()) in get_plot_directories(root_path, config):
+            raise ValueError(f"Path already added: {path}")
+        if not config["harvester"]["plot_directories"]:
+            config["harvester"]["plot_directories"] = []
+        config["harvester"]["plot_directories"].append(str(Path(str_path).resolve()))
+        save_config(root_path, "config.yaml", config)
+    return config
+
+
+def remove_plot_directory(root_path: Path, str_path: str) -> None:
+    log.debug(f"remove_plot_directory {str_path}")
+    with lock_and_load_config(root_path, "config.yaml") as config:
+        str_paths: list[str] = get_plot_directories(root_path, config)
+        # If path str matches exactly, remove
+        if str_path in str_paths:
+            str_paths.remove(str_path)
+
+        # If path matches full path, remove
+        new_paths = [Path(sp).resolve() for sp in str_paths]
+        if Path(str_path).resolve() in new_paths:
+            new_paths.remove(Path(str_path).resolve())
+
+        config["harvester"]["plot_directories"] = [str(np) for np in new_paths]
+        save_config(root_path, "config.yaml", config)

--- a/chia/util/harvester_config.py
+++ b/chia/util/harvester_config.py
@@ -7,19 +7,20 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 from chia.util.config import load_config, lock_and_load_config, save_config
 
 log = logging.getLogger(__name__)
 
 
-def get_plot_directories(root_path: Path, config: dict | None = None) -> list[str]:
+def get_plot_directories(root_path: Path, config: dict[str, Any] | None = None) -> list[str]:
     if config is None:
         config = load_config(root_path, "config.yaml")
     return config["harvester"]["plot_directories"] or []
 
 
-def add_plot_directory(root_path: Path, str_path: str) -> dict:
+def add_plot_directory(root_path: Path, str_path: str) -> dict[str, Any]:
     path: Path = Path(str_path).resolve()
     if not path.exists():
         raise ValueError(f"Path doesn't exist: {path}")

--- a/tach.toml
+++ b/tach.toml
@@ -214,7 +214,6 @@ depends_on = [
 path = "chia.daemon"
 depends_on = [
     "chia.util",
-    { path = "chia.plotting", deprecated = false },
     { path = "chia.server", deprecated = false },
     { path = "chia.cmds", deprecated = false },
     { path = "chia.wallet", deprecated = false },
@@ -255,8 +254,8 @@ depends_on = [
     "chia.types",
     "chia.util",
     "chia.consensus",
-    { path = "chia.wallet", deprecated = false },
     { path = "chia.daemon", deprecated = false },
+    { path = "chia.wallet", deprecated = false },
 ]
 
 [[modules]]


### PR DESCRIPTION
Extracts `add_plot_directory`, `get_plot_directories`, and `remove_plot_directory` from `chia.plotting.util` into `chia.util.harvester_config`. Daemon and other callers now import from util instead of plotting, breaking the daemon ↔ plotting dependency cycle.

Changes:
- Add `chia/util/harvester_config.py` with the three config helpers
- Update daemon, harvester, plotters, cmds, simulator, and tests to import from `chia.util.harvester_config`
- Remove daemon's dependency on plotting in `tach.toml`

Supersedes #135 (opened in fork).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: behavior should be unchanged, but it touches config read/write helpers used by daemon/CLI/harvester, so any import or path-handling mistake would affect plot directory management.
> 
> **Overview**
> Breaks the daemon↔plotting dependency cycle by moving harvester plot-directory config helpers into a new `chia.util.harvester_config` module.
> 
> Updates the daemon, harvester, CLI/plotter entrypoints, simulator, and related tests to import `add_plot_directory`, `get_plot_directories`, and `remove_plot_directory` from `chia.util.harvester_config` instead of `chia.plotting.util`, and removes the daemon’s `chia.plotting` dependency from `tach.toml`. Also deletes the moved helper implementations from `chia.plotting.util` and has it call the new `get_plot_directories` for plot scanning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6de4a96c955cbac49182d213fc98a7828775fc31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->