### PR TITLE
timeout

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -735,28 +735,28 @@ class Mempool:
                 # if adding item would make us exceed the block cost, commit the
                 # batch we've built up first, to see if more space may be freed
                 # up by the compression
-                if block_cost + item.conds.cost - cost_saving > constants.MAX_BLOCK_COST_CLVM:
-                    added, done = builder.add_spend_bundles(batch_transactions, uint64(batch_cost), constants)
+                # if block_cost + item.conds.cost - cost_saving > constants.MAX_BLOCK_COST_CLVM:
+                added, done = builder.add_spend_bundles(batch_transactions, uint64(batch_cost), constants)
 
-                    block_cost = builder.cost()
-                    if added:
-                        added_spends += batch_spends
-                        additions.extend(batch_additions)
-                        removals.extend([cs.coin for sb in batch_transactions for cs in sb.coin_spends])
-                        log.info(
-                            f"adding TX batch, additions: {len(batch_additions)} removals: {batch_spends} "
-                            f"cost: {batch_cost} total cost: {block_cost}"
-                        )
-                    else:
-                        log.info(f"Skipping transaction batch cumulative cost: {block_cost} batch cost: {batch_cost}")
-                        skipped_items += 1
+                block_cost = builder.cost()
+                if added:
+                    added_spends += batch_spends
+                    additions.extend(batch_additions)
+                    removals.extend([cs.coin for sb in batch_transactions for cs in sb.coin_spends])
+                    log.info(
+                        f"adding TX batch, additions: {len(batch_additions)} removals: {batch_spends} "
+                        f"cost: {batch_cost} total cost: {block_cost}"
+                    )
+                else:
+                    log.info(f"Skipping transaction batch cumulative cost: {block_cost} batch cost: {batch_cost}")
+                    skipped_items += 1
 
-                    batch_cost = 0
-                    batch_transactions = []
-                    batch_additions = []
-                    batch_spends = 0
-                    if done:
-                        break
+                batch_cost = 0
+                batch_transactions = []
+                batch_additions = []
+                batch_spends = 0
+                if done:
+                    break
 
                 batch_cost += cost - cost_saving
                 batch_transactions.append(SpendBundle(unique_coin_spends, item.aggregated_signature))


### PR DESCRIPTION
DO NOT MERGE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core block-construction batching logic; it can alter transaction inclusion/ordering and performance characteristics during block creation.
> 
> **Overview**
> In `create_block_generator2()` (mempool block assembly), the batch-flush logic has been changed from *conditional on exceeding* `MAX_BLOCK_COST_CLVM` to running **unconditionally each iteration** by commenting out the `if block_cost + item.conds.cost - cost_saving > ...` guard.
> 
> This means the builder now attempts to `add_spend_bundles()` and resets the batch for every mempool item, potentially changing which transactions get included and increasing the chance of skipping items or stopping early (`done`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b9bfa76079f35d7a2f0fe04c09b8c552edbfc79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->