### PR TITLE
timeout

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -735,7 +735,7 @@ class Mempool:
                 # if adding item would make us exceed the block cost, commit the
                 # batch we've built up first, to see if more space may be freed
                 # up by the compression
-                if block_cost + item.conds.cost - cost_saving > constants.MAX_BLOCK_COST_CLVM:
+                if len(batch_transactions) > 0:
                     added, done = builder.add_spend_bundles(batch_transactions, uint64(batch_cost), constants)
 
                     block_cost = builder.cost()


### PR DESCRIPTION
DO NOT MERGE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches block-construction batching logic, which can change which transactions are included and affect performance under mempool load.
> 
> **Overview**
> Adjusts `create_block_generator2()` batching logic in `mempool.py` to **always flush the current transaction batch whenever it’s non-empty**, instead of only flushing when the next item would exceed `MAX_BLOCK_COST_CLVM`.
> 
> This changes when `BlockBuilder.add_spend_bundles()` is invoked during block assembly, which may affect block packing efficiency/throughput and the set of mempool items selected under time/cost pressure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a98d9880d23469859c90ca59e7e3df396491e7ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->