### PR TITLE
Correct accounting of cost limits in offer summary computation

### DIFF
--- a/chia/types/blockchain_format/program.py
+++ b/chia/types/blockchain_format/program.py
@@ -18,7 +18,7 @@ from chia.util.byte_types import hexstr_to_bytes
 from chia.util.casts import int_from_bytes
 from chia.util.hash import std_hash
 
-INFINITE_COST = 11000000000
+INFINITE_COST = 11_000_000_000
 
 DEFAULT_FLAGS = MEMPOOL_MODE
 

--- a/chia/wallet/trading/offer.py
+++ b/chia/wallet/trading/offer.py
@@ -238,6 +238,7 @@ class Offer:
     def _get_offered_coins(self) -> dict[bytes32 | None, list[Coin]]:
         offered_coins: dict[bytes32 | None, list[Coin]] = {}
 
+        cost_left = INFINITE_COST
         for parent_spend in self._bundle.coin_spends:
             coins_for_this_spend: list[Coin] = []
 
@@ -253,7 +254,9 @@ class Offer:
                 assert inner_puzzle is not None and inner_solution is not None
 
                 # We're going to look at the conditions created by the inner puzzle
-                conditions: Program = inner_puzzle.run(inner_solution)
+                puzzle_cost, conditions = inner_puzzle.run_with_cost(cost_left, inner_solution)
+                assert cost_left >= puzzle_cost
+                cost_left -= puzzle_cost
                 expected_num_matches: int = 0
                 offered_amounts: list[int] = []
                 for condition in conditions.as_iter():


### PR DESCRIPTION
### Purpose:

We were not restricting the cost correctly in `Offer.summary()`.

### Current Behavior:

If you look at an offer that's too costly, it may show up as valid until later validation.

### New Behavior:

Exceeding cost triggers a failure in the `summary()` function.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how offer summaries execute puzzles by enforcing cumulative cost limits; may cause previously “working” summaries to raise errors for high-cost offers, but is localized to wallet offer inspection logic.
> 
> **Overview**
> `Offer._get_offered_coins()` now tracks a remaining CLVM budget and uses `run_with_cost()` when executing inner puzzles, decrementing the budget per spend; this makes `Offer.summary()` fail early when the offer exceeds allowed cost instead of appearing valid.
> 
> Also formats `INFINITE_COST` as `11_000_000_000` (no functional change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0c8604553a0802ff6aeca952c244fbd688ad66e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->