### PR TITLE
CHIA-3900 Fix add_dummy_connection_wsc's certificate handling for harvester node type

### DIFF
--- a/chia/_tests/connection_utils.py
+++ b/chia/_tests/connection_utils.py
@@ -66,8 +66,7 @@ async def add_dummy_connection_wsc(
 
     ca_crt_path: Path
     ca_key_path: Path
-    authenticated_client_types: set[NodeType] = {NodeType.HARVESTER}
-    if type in authenticated_client_types:
+    if server._local_type == NodeType.FARMER and type == NodeType.HARVESTER:
         private_ca_crt_path, private_ca_key_path = private_ssl_ca_paths(server.root_path, config)
         ca_crt_path = private_ca_crt_path
         ca_key_path = private_ca_key_path


### PR DESCRIPTION
Fixes a bug in `add_dummy_connection_wsc` where the harvester was using the private CA to authenticate everywhere, instead of reserving it just to its connection to the farmer. This would result in certificate signature failure whenever a harvester connection is attempted to any other node type than farmers.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that narrows when private TLS certs are generated; risk is limited to potentially affecting farmer/harvester-related test setups.
> 
> **Overview**
> Fixes `add_dummy_connection_wsc` test helper certificate selection so a dummy `HARVESTER` connecting to a `FARMER` uses the private farmer/harvester CA instead of the default Chia CA.
> 
> This tightens the conditional from “any harvester” to the specific farmer↔harvester pairing, reducing incorrect cert generation in tests that simulate that connection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1d8ea78b418d8dd39e16e4befbe1d4892390a38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->