### PR TITLE
CHIA-3901 Add missing request decorator to reject_removals_request

### DIFF
--- a/chia/apis/wallet_stub.py
+++ b/chia/apis/wallet_stub.py
@@ -49,6 +49,7 @@ class WalletNodeApiStub(ApiProtocol, Protocol):
         """Handle removals response from full node."""
         ...
 
+    @metadata.request(peer_required=True)
     async def reject_removals_request(self, response: RejectRemovalsRequest, peer: WSChiaConnection) -> None:
         """Handle reject removals request from full node."""
         ...

--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -37,6 +37,7 @@ class WalletNodeAPI:
     async def respond_removals(self, response: wallet_protocol.RespondRemovals, peer: WSChiaConnection):
         pass
 
+    @metadata.request(peer_required=True)
     async def reject_removals_request(self, response: wallet_protocol.RejectRemovalsRequest, peer: WSChiaConnection):
         """
         The full node has rejected our request for removals.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small metadata/decorator-only change that affects request registration/validation but not core wallet logic.
> 
> **Overview**
> Adds the missing `@metadata.request(peer_required=True)` decorator to `reject_removals_request` in both `WalletNodeAPI` and the `WalletNodeApiStub` protocol, aligning it with other peer-originated wallet messages.
> 
> This ensures the handler is registered/validated as a peer-required API request in the wallet API metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb3bb81ea279ea6f376cc33ea9de8b99cd5b7de7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->