### PR TITLE
Validate QR bit in DNS seeder to only process queries

### DIFF
--- a/chia/seeder/dns_server.py
+++ b/chia/seeder/dns_server.py
@@ -248,6 +248,8 @@ def parse_dns_request(data: bytes) -> DNSRecord | None:
     dns_request: DNSRecord | None = None
     try:
         dns_request = DNSRecord.parse(data)
+        if dns_request.header.qr != 0:
+            return None
     except DNSError as e:
         log.warning(f"Received invalid DNS request: {e}. Traceback: {traceback.format_exc()}.")
     return dns_request


### PR DESCRIPTION
### Purpose:

Conform DNS seeder to standard RFC behavior by validating the QR bit in incoming packets.

### Current Behavior:

`parse_dns_request()` accepts all parseable DNS packets

### New Behavior:

`parse_dns_request()` validates the QR bit and silently drops any packet that is not a query

### Testing Notes:

Verified proper behavior using with sending different types of DNS packets to the seeder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized validation change that only affects handling of malformed/unexpected DNS packets; low risk to normal query traffic.
> 
> **Overview**
> Updates `parse_dns_request()` in `chia/seeder/dns_server.py` to **validate the DNS header QR bit** and return `None` for any packet that isn’t a query.
> 
> As a result, the seeder will silently drop response/non-query DNS packets (UDP) and close the connection for such packets over TCP, aligning behavior with expected DNS semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1449cd2c0f494f9ba90ed8f32141bdf2da4a8352. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->