### PR TITLE
Include timezone offset in debug.log timestamps

### DIFF
--- a/chia/_tests/util/test_chia_logging.py
+++ b/chia/_tests/util/test_chia_logging.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import contextlib
+import logging
+import re
+from pathlib import Path
+
+from chia.util.chia_logging import initialize_logging
+
+
+def test_initialize_logging_timestamp_includes_timezone_offset(tmp_path: Path) -> None:
+    # Regression coverage for issue #8802.
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_level = root_logger.level
+
+    for handler in original_handlers:
+        root_logger.removeHandler(handler)
+
+    try:
+        initialize_logging(
+            service_name="test-service",
+            logging_config={
+                "log_stdout": False,
+                "log_filename": "log/debug.log",
+                "log_level": "WARNING",
+            },
+            root_path=tmp_path,
+        )
+
+        [handler] = root_logger.handlers
+        record = logging.LogRecord(
+            name="chia.test",
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=1,
+            msg="timezone test",
+            args=(),
+            exc_info=None,
+        )
+        timestamp = handler.format(record).split(" ", maxsplit=1)[0]
+        assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{4})\.\d{3}$", timestamp) is not None
+    finally:
+        for handler in list(root_logger.handlers):
+            root_logger.removeHandler(handler)
+            with contextlib.suppress(Exception):
+                handler.close()
+        for handler in original_handlers:
+            root_logger.addHandler(handler)
+        root_logger.setLevel(original_level)

--- a/chia/util/chia_logging.py
+++ b/chia/util/chia_logging.py
@@ -51,7 +51,7 @@ def initialize_logging(
     log_backcompat = logging_config.get("log_backcompat", False)
     log_level = logging_config.get("log_level", default_log_level)
     file_name_length = 33 - len(service_name)
-    log_date_format = "%Y-%m-%dT%H:%M:%S"
+    log_date_format = "%Y-%m-%dT%H:%M:%S%z"
     file_log_formatter = logging.Formatter(
         fmt=(
             f"%(asctime)s.%(msecs)03d {service_name} %(name)-{file_name_length}s: %(levelname)-8s %(message)s"


### PR DESCRIPTION
Fixes #8802

### Summary
- Adds timezone offset to the `%(asctime)s` portion of the file log formatter (e.g. `+0100`, `+0000`).
- Adds a small unit test ensuring the formatted timestamp includes a timezone offset.

This makes log timestamps unambiguous for external log ingestion/parsing tools.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to log formatting plus a unit test; main risk is downstream tools expecting the old timestamp format.
> 
> **Overview**
> Log timestamps written by `initialize_logging` now include a numeric timezone offset by adding `%z` to the formatter date format, making `debug.log` timestamps unambiguous for ingestion/parsing.
> 
> Adds a regression test (`test_initialize_logging_timestamp_includes_timezone_offset`) that initializes file logging and asserts the formatted `%(asctime)s` matches an ISO-like timestamp including `Z` or `+/-HHMM` plus milliseconds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7618c3f5ab73bff32277fe0bb7a73018a1f3173. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->