### PR TITLE
New PR original reference

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -70,6 +70,7 @@ from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.shared_protocol import Capability, default_capabilities
 from chia.protocols.wallet_protocol import RespondHeaderBlocks, SendTransaction, TransactionAck
 from chia.server.address_manager import AddressManager
+from chia.server.config_defaults import INBOUND_LIMIT_DEFAULTS
 from chia.server.node_discovery import FullNodePeers
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
@@ -3655,3 +3656,20 @@ async def test_request_header_blocks_non_tx_block(
     assert msg is not None
     response = RespondHeaderBlocks.from_bytes(msg.data)
     assert len(response.header_blocks) == 2
+
+
+def test_inbound_limit_defaults_covers_all_non_full_node_types() -> None:
+    assert set(INBOUND_LIMIT_DEFAULTS) == set(NodeType) - {NodeType.FULL_NODE}
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_node_types_inbound_connections_limit(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools], self_hostname: str
+) -> None:
+    _, server, _ = one_node_one_block
+    for node_type, (config_key, _) in INBOUND_LIMIT_DEFAULTS.items():
+        assert server.accept_inbound_connections(node_type) is True
+        server.config[config_key] = 1
+        await add_dummy_connection(server, self_hostname, 1337, node_type)
+        assert server.accept_inbound_connections(node_type) is False

--- a/chia/server/config_defaults.py
+++ b/chia/server/config_defaults.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from chia.protocols.outbound_message import NodeType
+
+INBOUND_LIMIT_DEFAULTS: dict[NodeType, tuple[str, int]] = {
+    NodeType.HARVESTER: ("max_inbound_harvester", 5),
+    NodeType.FARMER: ("max_inbound_farmer", 10),
+    NodeType.TIMELORD: ("max_inbound_timelord", 5),
+    NodeType.INTRODUCER: ("max_inbound_introducer", 5),
+    NodeType.WALLET: ("max_inbound_wallet", 20),
+    NodeType.DATA_LAYER: ("max_inbound_data_layer", 5),
+    NodeType.SOLVER: ("max_inbound_solver", 1),
+}
+
+_EXPECTED_TYPES = set(NodeType) - {NodeType.FULL_NODE}
+assert set(INBOUND_LIMIT_DEFAULTS) == _EXPECTED_TYPES, (
+    f"INBOUND_LIMIT_DEFAULTS is missing or has extra entries: "
+    f"missing={_EXPECTED_TYPES - set(INBOUND_LIMIT_DEFAULTS)}, "
+    f"extra={set(INBOUND_LIMIT_DEFAULTS) - _EXPECTED_TYPES}"
+)

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -32,6 +32,7 @@ from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.protocol_state_machine import message_requires_reply
 from chia.protocols.protocol_timing import INVALID_PROTOCOL_BAN_SECONDS
 from chia.server.api_protocol import ApiMetadata, ApiProtocol
+from chia.server.config_defaults import INBOUND_LIMIT_DEFAULTS
 from chia.server.introducer_peers import IntroducerPeers
 from chia.server.ssl_context import private_ssl_paths, public_ssl_paths
 from chia.server.ws_connection import ConnectionCallback, WSChiaConnection
@@ -131,6 +132,9 @@ class ChiaServer:
     received_message_callback: ConnectionCallback | None = None
     banned_peers: dict[str, float] = field(default_factory=dict)
     invalid_protocol_ban_seconds: int = INVALID_PROTOCOL_BAN_SECONDS
+    inbound_limit_defaults: dict[NodeType, tuple[str, int]] = field(
+        default_factory=lambda: dict(INBOUND_LIMIT_DEFAULTS)
+    )
 
     @classmethod
     def create(
@@ -719,13 +723,9 @@ class ChiaServer:
             return inbound_count < cast(int, self.config.get("target_peer_count", 40)) - cast(
                 int, self.config.get("target_outbound_peer_count", 8)
             )
-        if node_type == NodeType.WALLET:
-            return inbound_count < cast(int, self.config.get("max_inbound_wallet", 20))
-        if node_type == NodeType.FARMER:
-            return inbound_count < cast(int, self.config.get("max_inbound_farmer", 10))
-        if node_type == NodeType.TIMELORD:
-            return inbound_count < cast(int, self.config.get("max_inbound_timelord", 5))
-        return True
+        config_key, default_limit = self.inbound_limit_defaults[node_type]
+        limit: int = self.config.get(config_key, default_limit)
+        return inbound_count < limit
 
     def is_trusted_peer(self, peer: WSChiaConnection, trusted_peers: dict[str, Any]) -> bool:
         return is_trusted_peer(

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -389,8 +389,12 @@ full_node:
   exempt_peer_networks: []
   # Accept at most # of inbound connections for different node types.
   max_inbound_wallet: 20
+  max_inbound_harvester: 5
   max_inbound_farmer: 10
   max_inbound_timelord: 5
+  max_inbound_introducer: 5
+  max_inbound_data_layer: 5
+  max_inbound_solver: 1
   # Only connect to peers who we have heard about in the last recent_peer_threshold seconds
   recent_peer_threshold: 6000
 


### PR DESCRIPTION
### Purpose:
This PR re-introduces and references the changes from PR #20562, which centralizes the configuration of inbound connection limit defaults into a dedicated module.

### Current Behavior:
Inbound connection limit defaults are managed through an if-else chain in `chia/server/server.py` and partially defined in `initial-config.yaml`.

### New Behavior:
A new `chia/server/config_defaults.py` module is introduced with a `INBOUND_LIMIT_DEFAULTS` mapping. `chia/server/server.py` now uses a table-driven lookup for these defaults, and `initial-config.yaml` is updated to include all `max_inbound_*` keys.

### Testing Notes:
Unit tests from the original PR #20562 are included in `test_full_node.py` to ensure the correct application of the new default values.

### Reference to original PR:
This PR is based on the work from the original PR #20562. See https://github.com/Chia-Network/chia-blockchain/pull/20562 for the initial implementation and discussion.

---
<p><a href="https://cursor.com/agents/bc-e48d2e86-0b90-46e9-a906-ebcb743eec0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e48d2e86-0b90-46e9-a906-ebcb743eec0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

