### PR TITLE
[CHIA-3928] Drop support for macos-13 and macos-14

### DIFF
--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -53,11 +53,11 @@ jobs:
       matrix:
         python-version: ["3.12"]
         os:
-          - runs-on: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-intel' || 'macos-15-intel' }}
+          - runs-on: "macos-15-intel"
             name: intel
             bladebit-suffix: macos-x86-64.tar.gz
             arch-artifact-name: intel
-          - runs-on: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-arm64' || 'macos-15' }}
+          - runs-on: "macos-15"
             name: m1
             bladebit-suffix: macos-arm64.tar.gz
             arch-artifact-name: arm
@@ -86,7 +86,7 @@ jobs:
         uses: Chia-Network/actions/setjobenv@main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MACOSX_DEPLOYMENT_TARGET: 13
+          MACOSX_DEPLOYMENT_TARGET: 15
 
       - name: Test for secrets access
         id: check_secrets
@@ -294,14 +294,11 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - name: 13
-            matrix: 13
+          - name: 15
+            matrix: 15
             runs-on:
-              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-intel' || 'macos-15-intel' }}
-          - name: 14
-            matrix: 14
-            runs-on:
-              arm: macos-14
+              intel: "macos-15-intel"
+              arm: "macos-15"
         arch:
           - name: ARM64
             matrix: arm
@@ -309,15 +306,6 @@ jobs:
           - name: Intel
             matrix: intel
             artifact-name: intel
-        exclude:
-          - os:
-              matrix: 13
-            arch:
-              matrix: arm
-          - os:
-              matrix: 14
-            arch:
-              matrix: intel
 
     steps:
       - uses: Chia-Network/actions/clean-workspace@main

--- a/.github/workflows/build-macos-installers.yml
+++ b/.github/workflows/build-macos-installers.yml
@@ -53,11 +53,11 @@ jobs:
       matrix:
         python-version: ["3.12"]
         os:
-          - runs-on: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-15-intel' }}
+          - runs-on: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-intel' || 'macos-15-intel' }}
             name: intel
             bladebit-suffix: macos-x86-64.tar.gz
             arch-artifact-name: intel
-          - runs-on: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-arm64' || 'macos-15' }}
+          - runs-on: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-arm64' || 'macos-15' }}
             name: m1
             bladebit-suffix: macos-arm64.tar.gz
             arch-artifact-name: arm
@@ -297,7 +297,7 @@ jobs:
           - name: 13
             matrix: 13
             runs-on:
-              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-15-intel' }}
+              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-intel' || 'macos-15-intel' }}
           - name: 14
             matrix: 14
             runs-on:

--- a/.github/workflows/check_wheel_availability.yaml
+++ b/.github/workflows/check_wheel_availability.yaml
@@ -32,8 +32,8 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-15-intel' }}
-              arm: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-arm64' || 'macos-15' }}
+              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-intel' || 'macos-15-intel' }}
+              arm: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-arm64' || 'macos-15' }}
           - name: Windows
             matrix: windows
             runs-on:

--- a/.github/workflows/check_wheel_availability.yaml
+++ b/.github/workflows/check_wheel_availability.yaml
@@ -32,8 +32,8 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-intel' || 'macos-15-intel' }}
-              arm: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-arm64' || 'macos-15' }}
+              intel: "macos-15-intel"
+              arm: "macos-15"
           - name: Windows
             matrix: windows
             runs-on:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,7 +29,7 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-15-intel' }}
+              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-intel' || 'macos-15-intel' }}
               arm: macos-latest
           - name: Windows
             matrix: windows

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,7 +29,7 @@ jobs:
           - name: macOS
             matrix: macos
             runs-on:
-              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-intel' || 'macos-15-intel' }}
+              intel: "macos-15-intel"
               arm: macos-latest
           - name: Windows
             matrix: windows

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -44,7 +44,7 @@ jobs:
             emoji: 🍎
             runs-on:
               arm: macos-15
-              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-13-intel' || 'macos-15-intel' }}
+              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-intel' || 'macos-15-intel' }}
             matrix: macos
           - name: Windows
             emoji: 🪟

--- a/.github/workflows/test-install-scripts.yml
+++ b/.github/workflows/test-install-scripts.yml
@@ -44,7 +44,7 @@ jobs:
             emoji: 🍎
             runs-on:
               arm: macos-15
-              intel: ${{ github.repository_owner == 'Chia-Network' && 'macos-14-intel' || 'macos-15-intel' }}
+              intel: "macos-15-intel"
             matrix: macos
           - name: Windows
             emoji: 🪟

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
       concurrency-name: macos-arm
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
-      runs-on: macos-14
+      runs-on: macos-15
       arch: arm
       arch-emoji: 💪
       collect-junit: false

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -44,8 +44,8 @@ jobs:
             matrix: macos
             emoji: 🍎
             runs-on:
-              intel: macos-13-intel
-              arm: macos-13-arm64
+              intel: macos-14-intel
+              arm: macos-14-arm64
           - name: Windows
             matrix: windows
             emoji: 🪟

--- a/.github/workflows/upload-pypi-source.yml
+++ b/.github/workflows/upload-pypi-source.yml
@@ -44,8 +44,8 @@ jobs:
             matrix: macos
             emoji: 🍎
             runs-on:
-              intel: macos-14-intel
-              arm: macos-14-arm64
+              intel: macos-15-intel
+              arm: macos-15
           - name: Windows
             matrix: windows
             emoji: 🪟

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -48,7 +48,7 @@ bash ./build_license_directory.sh
 # appears sometimes m-series chips (prefer bundled from @loader_path/..)
 bash ./remove_brew_rpaths.sh
 
-cp -r dist/daemon ../chia-blockchain-gui/packages/gui
+cp -a dist/daemon ../chia-blockchain-gui/packages/gui
 # Change to the gui package
 cd ../chia-blockchain-gui/packages/gui || exit 1
 

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -75,11 +75,11 @@ else
 fi
 echo "${NPM_PATH}/electron-builder" build --mac "${OPT_ARCH}" \
   --config.productName="$PRODUCT_NAME" \
-  --config.mac.minimumSystemVersion="13" \
+  --config.mac.minimumSystemVersion="15" \
   --config ../../../build_scripts/electron-builder.json
 "${NPM_PATH}/electron-builder" build --mac "${OPT_ARCH}" \
   --config.productName="$PRODUCT_NAME" \
-  --config.mac.minimumSystemVersion="13" \
+  --config.mac.minimumSystemVersion="15" \
   --config ../../../build_scripts/electron-builder.json
 LAST_EXIT_CODE=$?
 ls -l dist/mac*/chia.app/Contents/Resources/app.asar

--- a/build_scripts/electron-builder.json
+++ b/build_scripts/electron-builder.json
@@ -43,8 +43,7 @@
     "provisioningProfile": "chiablockchain.provisionprofile",
     "darkModeSupport": true,
     "hardenedRuntime": true,
-    "gatekeeperAssess": false,
-    "signIgnore": ["Python.framework"]
+    "gatekeeperAssess": false
   },
   "dmg": {
     "background": "../../../build_scripts/assets/dmg/background.tiff",

--- a/build_scripts/electron-builder.json
+++ b/build_scripts/electron-builder.json
@@ -43,8 +43,7 @@
     "provisioningProfile": "chiablockchain.provisionprofile",
     "darkModeSupport": true,
     "hardenedRuntime": true,
-    "gatekeeperAssess": false,
-    "additionalArguments": ["--deep"]
+    "gatekeeperAssess": false
   },
   "dmg": {
     "background": "../../../build_scripts/assets/dmg/background.tiff",

--- a/build_scripts/electron-builder.json
+++ b/build_scripts/electron-builder.json
@@ -43,7 +43,8 @@
     "provisioningProfile": "chiablockchain.provisionprofile",
     "darkModeSupport": true,
     "hardenedRuntime": true,
-    "gatekeeperAssess": false
+    "gatekeeperAssess": false,
+    "additionalArguments": ["--deep"]
   },
   "dmg": {
     "background": "../../../build_scripts/assets/dmg/background.tiff",

--- a/build_scripts/electron-builder.json
+++ b/build_scripts/electron-builder.json
@@ -43,7 +43,8 @@
     "provisioningProfile": "chiablockchain.provisionprofile",
     "darkModeSupport": true,
     "hardenedRuntime": true,
-    "gatekeeperAssess": false
+    "gatekeeperAssess": false,
+    "signIgnore": ["Python.framework"]
   },
   "dmg": {
     "background": "../../../build_scripts/assets/dmg/background.tiff",


### PR DESCRIPTION
Drop support for macOS 13 (Ventura) and macOS 14 (Sonoma).

Use macos-15 and macos-15-intel as base OS runners instead of 13 or 14. This allows us to use GH runners. This does mean that the pacakged DMG will only work on macOS 15 and up.

macOS 14 is able to be run from source but won't be supported by the DMG
macOS 13 is fullly deprecated and is unable to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the CI build/test environment and raises the installer deployment target to macOS 15, which will break DMG installs for users on older macOS versions if still expected.
> 
> **Overview**
> **Drops macOS 13/14 support in CI and installers.** All macOS GitHub Actions jobs (installer build/test, wheel availability checks, pre-commit, install-script tests, and main test matrix) are moved to `macos-15`/`macos-15-intel`, removing conditional runner selection and older OS matrix entries.
> 
> **Raises the minimum supported macOS for the packaged DMG to 15.** The installer workflow sets `MACOSX_DEPLOYMENT_TARGET=15`, and `build_macos-2-installer.sh` updates Electron `minimumSystemVersion` from 13 to 15; it also switches `cp` to `cp -a` when staging the `daemon` into the GUI package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3dc712f5e7a0fcab9ca8da7067617eb353f15a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->