### PR TITLE
CHIA-3925 Ensure the connection is established in test_node_type_message_typechecking

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3665,6 +3665,7 @@ async def test_node_type_message_typechecking(
 ) -> None:
     _, server, _ = one_node_one_block
     wsc, peer_id = await add_dummy_connection_wsc(server, self_hostname, 1337, node_type)
+    await time_out_assert(5, lambda: peer_id in server.all_connections)
     server.all_connections[peer_id].peer_info = PeerInfo("1.3.3.7", 42)
     await wsc._send_message(make_msg(ProtocolMessageTypes.request_peers, b""))
     type_mismatch = node_type not in {NodeType.WALLET, NodeType.FULL_NODE}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds a synchronization wait to reduce flakiness from connection setup timing.
> 
> **Overview**
> Stabilizes `test_node_type_message_typechecking` by waiting until the dummy peer is registered in `server.all_connections` before mutating `peer_info` and sending protocol messages, preventing race-related test failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d9e6c2d41561d54a85d9b8b5fb25584b5605a57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->