### PR TITLE
Minor pyinstaller.spec cleanup: remove unused and deprecated cipher flag

### DIFF
--- a/build_scripts/pyinstaller.spec
+++ b/build_scripts/pyinstaller.spec
@@ -23,8 +23,6 @@ version_data = [
     for name in ["chia-blockchain", "chiapos"]
 ]
 
-block_cipher = None
-
 SERVERS = [
     "data_layer",
     "wallet",
@@ -140,11 +138,10 @@ def add_binary(name, path_to_script, collect_args):
         excludes=[],
         win_no_prefer_redirects=False,
         win_private_assemblies=False,
-        cipher=block_cipher,
         noarchive=False,
     )
 
-    binary_pyz = PYZ(analysis.pure, analysis.zipped_data, cipher=block_cipher)
+    binary_pyz = PYZ(analysis.pure, analysis.zipped_data)
 
     binary_exe = EXE(
         binary_pyz,


### PR DESCRIPTION
Minor cleanup of spec file - remove `cipher=` and related lines

We never used this `cipher` option, and it has been deprecated by pyinstaller, so you can't use it anymore, even if you wanted to

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only cleanup with no runtime or security impact.
> 
> **Overview**
> Removes the unused `block_cipher = None` variable and all `cipher=` arguments from the PyInstaller spec in `build_scripts/pyinstaller.spec`. **`Analysis`** no longer passes `cipher`, and **`PYZ`** is constructed without a cipher argument.
> 
> This aligns the build with current PyInstaller, where the cipher option is deprecated and no longer accepted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 656f1dbda869b37fc1922614caf05b82c6b34166. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->