### PR TITLE
General electron builder cleanup

### DIFF
--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -89,7 +89,8 @@ if [ "$PLATFORM" = "arm64" ]; then
   # https://github.com/Chia-Network/build-images/blob/7c74d2f20739543c486c2522032cf09d96396d24/ubuntu-22.04/Dockerfile#L48-L61
   echo USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux deb --arm64 \
     --config.extraMetadata.name=chia-blockchain \
-    --config ../../../build_scripts/electron-builder.json
+    --config ../../../build_scripts/electron-builder.json \
+    --publish always
   USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux deb --arm64 \
     --config.extraMetadata.name=chia-blockchain \
     --config ../../../build_scripts/electron-builder.json \
@@ -98,7 +99,8 @@ if [ "$PLATFORM" = "arm64" ]; then
 else
   echo "${NPM_PATH}/electron-builder" build --linux deb --x64 \
     --config.extraMetadata.name=chia-blockchain \
-    --config ../../../build_scripts/electron-builder.json
+    --config ../../../build_scripts/electron-builder.json \
+    --publish always
   "${NPM_PATH}/electron-builder" build --linux deb --x64 \
     --config.extraMetadata.name=chia-blockchain \
     --config ../../../build_scripts/electron-builder.json \

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -82,7 +82,6 @@ cp package.json package.json.orig
 jq --arg VER "$CHIA_SEMVER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
 
 echo "Building Linux(deb) Electron app"
-PRODUCT_NAME="chia"
 if [ "$PLATFORM" = "arm64" ]; then
   # https://github.com/jordansissel/fpm/issues/1801#issuecomment-919877499
   # workaround for above now implemented in the image build at
@@ -90,21 +89,21 @@ if [ "$PLATFORM" = "arm64" ]; then
   echo USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux deb --arm64 \
     --config.extraMetadata.name=chia-blockchain \
     --config ../../../build_scripts/electron-builder.json \
-    --publish always
+    --publish never
   USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux deb --arm64 \
     --config.extraMetadata.name=chia-blockchain \
     --config ../../../build_scripts/electron-builder.json \
-    --publish always
+    --publish never
   LAST_EXIT_CODE=$?
 else
   echo "${NPM_PATH}/electron-builder" build --linux deb --x64 \
     --config.extraMetadata.name=chia-blockchain \
     --config ../../../build_scripts/electron-builder.json \
-    --publish always
+    --publish never
   "${NPM_PATH}/electron-builder" build --linux deb --x64 \
     --config.extraMetadata.name=chia-blockchain \
     --config ../../../build_scripts/electron-builder.json \
-    --publish always
+    --publish never
   LAST_EXIT_CODE=$?
 fi
 ls -l dist/linux*-unpacked/resources
@@ -118,7 +117,7 @@ if [ "$LAST_EXIT_CODE" -ne 0 ]; then
 fi
 
 GUI_DEB_NAME=chia-blockchain_${CHIA_INSTALLER_VERSION}_${PLATFORM}.deb
-mv "dist/${PRODUCT_NAME}-${CHIA_INSTALLER_VERSION}.deb" "../../../build_scripts/dist/${GUI_DEB_NAME}"
+mv "dist/chia-${CHIA_INSTALLER_VERSION}.deb" "../../../build_scripts/dist/${GUI_DEB_NAME}"
 cd ../../../build_scripts || exit 1
 
 echo "Create final installer"

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -82,32 +82,20 @@ cp package.json package.json.orig
 jq --arg VER "$CHIA_SEMVER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
 
 echo "Building Linux(deb) Electron app"
-PRODUCT_NAME="chia"
+PRODUCT_NAME="Chia"
 if [ "$PLATFORM" = "arm64" ]; then
   # https://github.com/jordansissel/fpm/issues/1801#issuecomment-919877499
   # workaround for above now implemented in the image build at
   # https://github.com/Chia-Network/build-images/blob/7c74d2f20739543c486c2522032cf09d96396d24/ubuntu-22.04/Dockerfile#L48-L61
   echo USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux deb --arm64 \
-    --config.extraMetadata.name=chia-blockchain \
-    --config.productName="$PRODUCT_NAME" \
-    --config.deb.packageName="chia-blockchain" \
     --config ../../../build_scripts/electron-builder.json
   USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux deb --arm64 \
-    --config.extraMetadata.name=chia-blockchain \
-    --config.productName="$PRODUCT_NAME" \
-    --config.deb.packageName="chia-blockchain" \
     --config ../../../build_scripts/electron-builder.json
   LAST_EXIT_CODE=$?
 else
   echo "${NPM_PATH}/electron-builder" build --linux deb --x64 \
-    --config.extraMetadata.name=chia-blockchain \
-    --config.productName="$PRODUCT_NAME" \
-    --config.deb.packageName="chia-blockchain" \
     --config ../../../build_scripts/electron-builder.json
   "${NPM_PATH}/electron-builder" build --linux deb --x64 \
-    --config.extraMetadata.name=chia-blockchain \
-    --config.productName="$PRODUCT_NAME" \
-    --config.deb.packageName="chia-blockchain" \
     --config ../../../build_scripts/electron-builder.json
   LAST_EXIT_CODE=$?
 fi

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -88,15 +88,21 @@ if [ "$PLATFORM" = "arm64" ]; then
   # workaround for above now implemented in the image build at
   # https://github.com/Chia-Network/build-images/blob/7c74d2f20739543c486c2522032cf09d96396d24/ubuntu-22.04/Dockerfile#L48-L61
   echo USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux deb --arm64 \
+    --config.extraMetadata.name=chia-blockchain \
     --config ../../../build_scripts/electron-builder.json
   USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux deb --arm64 \
-    --config ../../../build_scripts/electron-builder.json
+    --config.extraMetadata.name=chia-blockchain \
+    --config ../../../build_scripts/electron-builder.json \
+    --publish always
   LAST_EXIT_CODE=$?
 else
   echo "${NPM_PATH}/electron-builder" build --linux deb --x64 \
+    --config.extraMetadata.name=chia-blockchain \
     --config ../../../build_scripts/electron-builder.json
   "${NPM_PATH}/electron-builder" build --linux deb --x64 \
-    --config ../../../build_scripts/electron-builder.json
+    --config.extraMetadata.name=chia-blockchain \
+    --config ../../../build_scripts/electron-builder.json \
+    --publish always
   LAST_EXIT_CODE=$?
 fi
 ls -l dist/linux*-unpacked/resources

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -82,7 +82,7 @@ cp package.json package.json.orig
 jq --arg VER "$CHIA_SEMVER_VERSION" '.version=$VER' package.json >temp.json && mv temp.json package.json
 
 echo "Building Linux(deb) Electron app"
-PRODUCT_NAME="Chia"
+PRODUCT_NAME="chia"
 if [ "$PLATFORM" = "arm64" ]; then
   # https://github.com/jordansissel/fpm/issues/1801#issuecomment-919877499
   # workaround for above now implemented in the image build at

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -107,15 +107,14 @@ OPT_ARCH="--x64"
 if [ "$REDHAT_PLATFORM" = "arm64" ]; then
   OPT_ARCH="--arm64"
 fi
-PRODUCT_NAME="chia"
 echo USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux rpm "${OPT_ARCH}" \
   --config.extraMetadata.name=chia-blockchain \
   --config ../../../build_scripts/electron-builder.json \
-  --publish always
+  --publish never
 USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux rpm "${OPT_ARCH}" \
   --config.extraMetadata.name=chia-blockchain \
   --config ../../../build_scripts/electron-builder.json \
-  --publish always
+  --publish never
 LAST_EXIT_CODE=$?
 ls -l dist/linux*-unpacked/resources
 
@@ -128,7 +127,7 @@ if [ "$LAST_EXIT_CODE" -ne 0 ]; then
 fi
 
 GUI_RPM_NAME="chia-blockchain-${CHIA_INSTALLER_VERSION}-1.${REDHAT_PLATFORM}.rpm"
-mv "dist/${PRODUCT_NAME}-${CHIA_INSTALLER_VERSION}.rpm" "../../../build_scripts/dist/${GUI_RPM_NAME}"
+mv "dist/chia-${CHIA_INSTALLER_VERSION}.rpm" "../../../build_scripts/dist/${GUI_RPM_NAME}"
 cd ../../../build_scripts || exit 1
 
 echo "Create final installer"

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -109,9 +109,13 @@ if [ "$REDHAT_PLATFORM" = "arm64" ]; then
 fi
 PRODUCT_NAME="Chia"
 echo USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux rpm "${OPT_ARCH}" \
-  --config ../../../build_scripts/electron-builder.json
+  --config.extraMetadata.name=chia-blockchain \
+  --config ../../../build_scripts/electron-builder.json \
+  --publish always
 USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux rpm "${OPT_ARCH}" \
-  --config ../../../build_scripts/electron-builder.json
+  --config.extraMetadata.name=chia-blockchain \
+  --config ../../../build_scripts/electron-builder.json \
+  --publish always
 LAST_EXIT_CODE=$?
 ls -l dist/linux*-unpacked/resources
 

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -107,16 +107,10 @@ OPT_ARCH="--x64"
 if [ "$REDHAT_PLATFORM" = "arm64" ]; then
   OPT_ARCH="--arm64"
 fi
-PRODUCT_NAME="chia"
+PRODUCT_NAME="Chia"
 echo USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux rpm "${OPT_ARCH}" \
-  --config.extraMetadata.name=chia-blockchain \
-  --config.productName="${PRODUCT_NAME}" \
-  --config.rpm.packageName="chia-blockchain" \
   --config ../../../build_scripts/electron-builder.json
 USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux rpm "${OPT_ARCH}" \
-  --config.extraMetadata.name=chia-blockchain \
-  --config.productName="${PRODUCT_NAME}" \
-  --config.rpm.packageName="chia-blockchain" \
   --config ../../../build_scripts/electron-builder.json
 LAST_EXIT_CODE=$?
 ls -l dist/linux*-unpacked/resources

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -107,7 +107,7 @@ OPT_ARCH="--x64"
 if [ "$REDHAT_PLATFORM" = "arm64" ]; then
   OPT_ARCH="--arm64"
 fi
-PRODUCT_NAME="Chia"
+PRODUCT_NAME="chia"
 echo USE_SYSTEM_FPM=true "${NPM_PATH}/electron-builder" build --linux rpm "${OPT_ARCH}" \
   --config.extraMetadata.name=chia-blockchain \
   --config ../../../build_scripts/electron-builder.json \

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -72,9 +72,11 @@ else
   export CSC_IDENTITY_AUTO_DISCOVERY=false
 fi
 echo "${NPM_PATH}/electron-builder" build --mac "${OPT_ARCH}" \
+  --config.productName="Chia" \
   --config ../../../build_scripts/electron-builder.json \
   --publish always
 "${NPM_PATH}/electron-builder" build --mac "${OPT_ARCH}" \
+  --config.productName="Chia" \
   --config ../../../build_scripts/electron-builder.json \
   --publish always
 LAST_EXIT_CODE=$?

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -62,7 +62,6 @@ OPT_ARCH="--x64"
 if [ "$(arch)" = "arm64" ]; then
   OPT_ARCH="--arm64"
 fi
-PRODUCT_NAME="Chia"
 if [ "$NOTARIZE" == true ]; then
   echo "Setting credentials for signing"
   export CSC_LINK=$APPLE_DEV_ID_APP
@@ -74,15 +73,11 @@ else
   export CSC_IDENTITY_AUTO_DISCOVERY=false
 fi
 echo "${NPM_PATH}/electron-builder" build --mac "${OPT_ARCH}" \
-  --config.productName="$PRODUCT_NAME" \
-  --config.mac.minimumSystemVersion="13" \
   --config ../../../build_scripts/electron-builder.json
 "${NPM_PATH}/electron-builder" build --mac "${OPT_ARCH}" \
-  --config.productName="$PRODUCT_NAME" \
-  --config.mac.minimumSystemVersion="13" \
   --config ../../../build_scripts/electron-builder.json
 LAST_EXIT_CODE=$?
-ls -l dist/mac*/chia.app/Contents/Resources/app.asar
+ls -l dist/mac*/Chia.app/Contents/Resources/app.asar
 
 # reset the package.json to the original
 mv package.json.orig package.json
@@ -96,11 +91,10 @@ mv dist/* ../../../build_scripts/dist/
 cd ../../../build_scripts || exit 1
 
 mkdir final_installer
-ORIGINAL_DMG_NAME="chia-${CHIA_INSTALLER_VERSION}.dmg"
+ORIGINAL_DMG_NAME="Chia-${CHIA_INSTALLER_VERSION}.dmg"
 if [ "$(arch)" = "arm64" ]; then
   DMG_NAME=Chia-${CHIA_INSTALLER_VERSION}-arm64.dmg
 else
-  # NOTE: when coded, this changes the case to Chia
   DMG_NAME=Chia-${CHIA_INSTALLER_VERSION}.dmg
 fi
 mv dist/"$ORIGINAL_DMG_NAME" final_installer/"$DMG_NAME"

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -74,11 +74,11 @@ fi
 echo "${NPM_PATH}/electron-builder" build --mac "${OPT_ARCH}" \
   --config.productName="Chia" \
   --config ../../../build_scripts/electron-builder.json \
-  --publish always
+  --publish never
 "${NPM_PATH}/electron-builder" build --mac "${OPT_ARCH}" \
   --config.productName="Chia" \
   --config ../../../build_scripts/electron-builder.json \
-  --publish always
+  --publish never
 LAST_EXIT_CODE=$?
 ls -l dist/mac*/Chia.app/Contents/Resources/app.asar
 

--- a/build_scripts/build_macos-2-installer.sh
+++ b/build_scripts/build_macos-2-installer.sh
@@ -66,16 +66,17 @@ if [ "$NOTARIZE" == true ]; then
   echo "Setting credentials for signing"
   export CSC_LINK=$APPLE_DEV_ID_APP
   export CSC_KEY_PASSWORD=$APPLE_DEV_ID_APP_PASS
-  export PUBLISH_FOR_PULL_REQUEST=true
   export CSC_FOR_PULL_REQUEST=true
 else
   echo "Not on ci or no secrets so not signing"
   export CSC_IDENTITY_AUTO_DISCOVERY=false
 fi
 echo "${NPM_PATH}/electron-builder" build --mac "${OPT_ARCH}" \
-  --config ../../../build_scripts/electron-builder.json
+  --config ../../../build_scripts/electron-builder.json \
+  --publish always
 "${NPM_PATH}/electron-builder" build --mac "${OPT_ARCH}" \
-  --config ../../../build_scripts/electron-builder.json
+  --config ../../../build_scripts/electron-builder.json \
+  --publish always
 LAST_EXIT_CODE=$?
 ls -l dist/mac*/Chia.app/Contents/Resources/app.asar
 

--- a/build_scripts/build_windows-2-installer.ps1
+++ b/build_scripts/build_windows-2-installer.ps1
@@ -76,7 +76,7 @@ Write-Output "   ---"
 Write-Output "   ---"
 Write-Output "electron-builder create package directory"
 & "$NPM_PATH/electron-builder.ps1" --version
-& "$NPM_PATH/electron-builder.ps1" build --win --x64 --dir --config ../../../build_scripts/electron-builder.json
+& "$NPM_PATH/electron-builder.ps1" build --win --x64 --config.productName="Chia" --dir --config ../../../build_scripts/electron-builder.json
 Get-ChildItem dist\win-unpacked\resources
 Write-Output "   ---"
 
@@ -96,7 +96,7 @@ If ($env:HAS_SIGNING_SECRET) {
 
 Write-Output "   ---"
 Write-Output "electron-builder create installer"
-& "$NPM_PATH/electron-builder.ps1" build --win --x64 --pd ".\dist\win-unpacked" --config ../../../build_scripts/electron-builder.json --publish always
+& "$NPM_PATH/electron-builder.ps1" build --win --x64 --config.productName="Chia" --pd ".\dist\win-unpacked" --config ../../../build_scripts/electron-builder.json --publish always
 Write-Output "   ---"
 
 If ($env:HAS_SIGNING_SECRET) {

--- a/build_scripts/build_windows-2-installer.ps1
+++ b/build_scripts/build_windows-2-installer.ps1
@@ -96,7 +96,7 @@ If ($env:HAS_SIGNING_SECRET) {
 
 Write-Output "   ---"
 Write-Output "electron-builder create installer"
-& "$NPM_PATH/electron-builder.ps1" build --win --x64 --config.productName="Chia" --pd ".\dist\win-unpacked" --config ../../../build_scripts/electron-builder.json --publish always
+& "$NPM_PATH/electron-builder.ps1" build --win --x64 --config.productName="Chia" --pd ".\dist\win-unpacked" --config ../../../build_scripts/electron-builder.json --publish never
 Write-Output "   ---"
 
 If ($env:HAS_SIGNING_SECRET) {

--- a/build_scripts/build_windows-2-installer.ps1
+++ b/build_scripts/build_windows-2-installer.ps1
@@ -76,7 +76,7 @@ Write-Output "   ---"
 Write-Output "   ---"
 Write-Output "electron-builder create package directory"
 & "$NPM_PATH/electron-builder.ps1" --version
-& "$NPM_PATH/electron-builder.ps1" build --win --x64 --config.productName="Chia" --dir --config ../../../build_scripts/electron-builder.json
+& "$NPM_PATH/electron-builder.ps1" build --win --x64 --dir --config ../../../build_scripts/electron-builder.json
 Get-ChildItem dist\win-unpacked\resources
 Write-Output "   ---"
 
@@ -96,7 +96,7 @@ If ($env:HAS_SIGNING_SECRET) {
 
 Write-Output "   ---"
 Write-Output "electron-builder create installer"
-& "$NPM_PATH/electron-builder.ps1" build --win --x64 --config.productName="Chia" --pd ".\dist\win-unpacked" --config ../../../build_scripts/electron-builder.json
+& "$NPM_PATH/electron-builder.ps1" build --win --x64 --pd ".\dist\win-unpacked" --config ../../../build_scripts/electron-builder.json
 Write-Output "   ---"
 
 If ($env:HAS_SIGNING_SECRET) {

--- a/build_scripts/build_windows-2-installer.ps1
+++ b/build_scripts/build_windows-2-installer.ps1
@@ -96,7 +96,7 @@ If ($env:HAS_SIGNING_SECRET) {
 
 Write-Output "   ---"
 Write-Output "electron-builder create installer"
-& "$NPM_PATH/electron-builder.ps1" build --win --x64 --pd ".\dist\win-unpacked" --config ../../../build_scripts/electron-builder.json
+& "$NPM_PATH/electron-builder.ps1" build --win --x64 --pd ".\dist\win-unpacked" --config ../../../build_scripts/electron-builder.json --publish always
 Write-Output "   ---"
 
 If ($env:HAS_SIGNING_SECRET) {

--- a/build_scripts/electron-builder.json
+++ b/build_scripts/electron-builder.json
@@ -1,5 +1,5 @@
 {
-  "productName": "Chia",
+  "productName": "chia",
   "appId": "net.chia.blockchain",
   "asar": true,
   "asarUnpack": "**/daemon/**",

--- a/build_scripts/electron-builder.json
+++ b/build_scripts/electron-builder.json
@@ -1,9 +1,6 @@
 {
   "productName": "Chia",
   "appId": "net.chia.blockchain",
-  "extraMetadata": {
-    "name": "chia-blockchain"
-  },
   "asar": true,
   "asarUnpack": "**/daemon/**",
   "npmRebuild": false,

--- a/build_scripts/electron-builder.json
+++ b/build_scripts/electron-builder.json
@@ -1,6 +1,9 @@
 {
-  "productName": "chia",
+  "productName": "Chia",
   "appId": "net.chia.blockchain",
+  "extraMetadata": {
+    "name": "chia-blockchain"
+  },
   "asar": true,
   "asarUnpack": "**/daemon/**",
   "npmRebuild": false,
@@ -38,6 +41,7 @@
     "artifactName": "${productName}-${env.CHIA_INSTALLER_VERSION}.${ext}",
     "category": "public.app-category.finance",
     "target": "dmg",
+    "minimumSystemVersion": "13",
     "icon": "src/assets/img/chia.icns",
     "entitlements": "entitlements.mac.plist",
     "provisioningProfile": "chiablockchain.provisionprofile",
@@ -76,6 +80,7 @@
     "icon": "src/assets/img/chia.icns"
   },
   "deb": {
+    "packageName": "chia-blockchain",
     "afterInstall": "../../../build_scripts/assets/deb/postinst.sh",
     "afterRemove": "../../../build_scripts/assets/deb/prerm.sh",
     "depends": [
@@ -92,6 +97,7 @@
     ]
   },
   "rpm": {
+    "packageName": "chia-blockchain",
     "afterInstall": "../../../build_scripts/assets/rpm/postinst.sh",
     "afterRemove": "../../../build_scripts/assets/rpm/prerm.sh",
     "fpm": [


### PR DESCRIPTION
Move options to electron-builder.json and general cleanup of the shell scripts to remove unused or redundant CLI options

Also updated to add `--publish never` . We use separate publish steps and don't rely on electron-builder to do it's own publishing. 

- [x] Need to verify the signing steps still done with publish=never



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect every platform’s release packaging and artifact naming; `--publish never` may interact with signing/notarization and should be verified in CI as noted in the PR.
> 
> **Overview**
> Centralizes **electron-builder** settings in `electron-builder.json` and trims duplicate flags from the Linux, macOS, and Windows installer scripts.
> 
> **`deb`/`rpm` `packageName`** (`chia-blockchain`) and **macOS `minimumSystemVersion`** (`15`) now live in the shared config instead of per-platform CLI overrides. Linux GUI build steps drop inline `productName` / package overrides and rely on the default **`productName`** `chia` for intermediate artifacts (`chia-${CHIA_INSTALLER_VERSION}.deb`/`.rpm`), then rename to the existing **`chia-blockchain_*`** release names. macOS keeps display **`productName`** `Chia` on the command line, drops **`PUBLISH_FOR_PULL_REQUEST`**, and updates post-build paths/DMG names to **`Chia.app`** / **`Chia-*.dmg`**.
> 
> All **`electron-builder build`** invocations that produce installers add **`--publish never`**, so publishing stays in separate CI steps rather than electron-builder’s publish flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 069802d29dc173e4d5ee4fb6da16c49f10c5593b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->