### PR TITLE
[CHIA-3936] improve the test that keep failing with TIMESTAMP_TOO_FAR_IN_PAST

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -1637,70 +1637,66 @@ class TestBlockHeaderValidation:
             await _validate_and_add_block(b, blocks[0])
             while True:
                 blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
-                if blocks[-1].foliage_transaction_block is not None:
-                    assert blocks[0].foliage_transaction_block is not None
-                    block_bad: FullBlock = recursive_replace(
-                        blocks[-1],
-                        "foliage_transaction_block.timestamp",
-                        blocks[0].foliage_transaction_block.timestamp - 10,
-                    )
-                    assert block_bad.foliage_transaction_block is not None
-                    block_bad = recursive_replace(
-                        block_bad,
-                        "foliage.foliage_transaction_block_hash",
-                        block_bad.foliage_transaction_block.get_hash(),
-                    )
-                    new_m = block_bad.foliage.foliage_transaction_block_hash
-                    assert new_m is not None
-                    new_fbh_sig = bt.get_plot_signature(
-                        new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key
-                    )
-                    block_bad = recursive_replace(block_bad, "foliage.foliage_transaction_block_signature", new_fbh_sig)
-                    await _validate_and_add_block(b, block_bad, expected_error=Err.TIMESTAMP_TOO_FAR_IN_PAST)
+                if blocks[-1].foliage_transaction_block is None:
+                    await _validate_and_add_block(b, blocks[-1])
+                    continue
 
-                    assert blocks[0].foliage_transaction_block is not None
-                    block_bad = recursive_replace(
-                        blocks[-1],
-                        "foliage_transaction_block.timestamp",
-                        blocks[0].foliage_transaction_block.timestamp,
-                    )
-                    assert block_bad.foliage_transaction_block is not None
-                    block_bad = recursive_replace(
-                        block_bad,
-                        "foliage.foliage_transaction_block_hash",
-                        block_bad.foliage_transaction_block.get_hash(),
-                    )
-                    new_m = block_bad.foliage.foliage_transaction_block_hash
-                    assert new_m is not None
-                    new_fbh_sig = bt.get_plot_signature(
-                        new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key
-                    )
-                    block_bad = recursive_replace(block_bad, "foliage.foliage_transaction_block_signature", new_fbh_sig)
-                    await _validate_and_add_block(b, block_bad, expected_error=Err.TIMESTAMP_TOO_FAR_IN_PAST)
+                assert blocks[0].foliage_transaction_block is not None
+                block_bad: FullBlock = recursive_replace(
+                    blocks[-1],
+                    "foliage_transaction_block.timestamp",
+                    blocks[0].foliage_transaction_block.timestamp - 10,
+                )
+                assert block_bad.foliage_transaction_block is not None
+                block_bad = recursive_replace(
+                    block_bad,
+                    "foliage.foliage_transaction_block_hash",
+                    block_bad.foliage_transaction_block.get_hash(),
+                )
+                new_m = block_bad.foliage.foliage_transaction_block_hash
+                assert new_m is not None
+                new_fbh_sig = bt.get_plot_signature(new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key)
+                block_bad = recursive_replace(block_bad, "foliage.foliage_transaction_block_signature", new_fbh_sig)
+                await _validate_and_add_block(b, block_bad, expected_error=Err.TIMESTAMP_TOO_FAR_IN_PAST)
 
-                    # since tests can run slow sometimes, and since we're using
-                    # the system clock, add some extra slack
-                    slack = 30
-                    block_bad = recursive_replace(
-                        blocks[-1],
-                        "foliage_transaction_block.timestamp",
-                        blocks[0].foliage_transaction_block.timestamp + time_delta + slack,
-                    )
-                    assert block_bad.foliage_transaction_block is not None
-                    block_bad = recursive_replace(
-                        block_bad,
-                        "foliage.foliage_transaction_block_hash",
-                        block_bad.foliage_transaction_block.get_hash(),
-                    )
-                    new_m = block_bad.foliage.foliage_transaction_block_hash
-                    assert new_m is not None
-                    new_fbh_sig = bt.get_plot_signature(
-                        new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key
-                    )
-                    block_bad = recursive_replace(block_bad, "foliage.foliage_transaction_block_signature", new_fbh_sig)
-                    await _validate_and_add_block(b, block_bad, expected_error=Err.TIMESTAMP_TOO_FAR_IN_FUTURE)
-                    return None
-                await _validate_and_add_block(b, blocks[-1])
+                assert blocks[0].foliage_transaction_block is not None
+                block_bad = recursive_replace(
+                    blocks[-1],
+                    "foliage_transaction_block.timestamp",
+                    blocks[0].foliage_transaction_block.timestamp,
+                )
+                assert block_bad.foliage_transaction_block is not None
+                block_bad = recursive_replace(
+                    block_bad,
+                    "foliage.foliage_transaction_block_hash",
+                    block_bad.foliage_transaction_block.get_hash(),
+                )
+                new_m = block_bad.foliage.foliage_transaction_block_hash
+                assert new_m is not None
+                new_fbh_sig = bt.get_plot_signature(new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key)
+                block_bad = recursive_replace(block_bad, "foliage.foliage_transaction_block_signature", new_fbh_sig)
+                await _validate_and_add_block(b, block_bad, expected_error=Err.TIMESTAMP_TOO_FAR_IN_PAST)
+
+                # Set the timestamp on the block to be too far out in the
+                # future from now
+                slack = 5
+                block_bad = recursive_replace(
+                    blocks[-1],
+                    "foliage_transaction_block.timestamp",
+                    uint64(time.time()) + time_delta + slack,
+                )
+                assert block_bad.foliage_transaction_block is not None
+                block_bad = recursive_replace(
+                    block_bad,
+                    "foliage.foliage_transaction_block_hash",
+                    block_bad.foliage_transaction_block.get_hash(),
+                )
+                new_m = block_bad.foliage.foliage_transaction_block_hash
+                assert new_m is not None
+                new_fbh_sig = bt.get_plot_signature(new_m, blocks[-1].reward_chain_block.proof_of_space.plot_public_key)
+                block_bad = recursive_replace(block_bad, "foliage.foliage_transaction_block_signature", new_fbh_sig)
+                await _validate_and_add_block(b, block_bad, expected_error=Err.TIMESTAMP_TOO_FAR_IN_FUTURE)
+                return None
 
     @pytest.mark.anyio
     async def test_height(self, empty_blockchain: Blockchain, bt: BlockTools) -> None:


### PR DESCRIPTION
### Purpose:

If it takes more than 30 seconds to farm blocks until we find the next transaction block, the test will fail. This is especially likely with v2 plots, as `chia-pos2` is not optimized yet.

I also reduced an indentation level. This patch is best viewed ignoring whitespace for this reason.

### Current Behavior:

The "slack" is 30 seconds, relying un the test taking less than 30 seconds from the first farmed block to the one whose time we update.

### New Behavior:

The block we set the timestamp to be wrong, we base on the *current* time, not the time the test started running. The slack now is just the time from updating the block to validating it, which should be negligable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a unit test to reduce flakiness by changing how the future timestamp is computed and simplifying control flow.
> 
> **Overview**
> Updates `test_bad_timestamp` to avoid flaky failures when finding the next transaction block is slow by computing the *too-far-in-future* timestamp relative to the current wall clock (`time.time()`) instead of the first block’s timestamp, and reducing the slack.
> 
> Also simplifies the loop by early-continuing on non-transaction blocks (reducing indentation) while keeping the same `TIMESTAMP_TOO_FAR_IN_PAST`/`TIMESTAMP_TOO_FAR_IN_FUTURE` assertions for transaction blocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 498a16e912ca628c6448d03d4ebfc5a1d9cfffe8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->