### PR TITLE
remove did wallet duplicate code

### DIFF
--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import json
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from chia_rs import AugSchemeMPL, G1Element, G2Element
@@ -77,7 +78,7 @@ async def test_create_new_did_wallet_insufficient_balance_no_orphan(wallet_envir
     and must not leave an orphaned wallet record in the DB.
     """
     wallet_state_manager = wallet_environments.environments[0].wallet_state_manager
-    initial_wallet_count = len(wallet_state_manager.wallets)
+    initial_wallet_count = len(await wallet_state_manager.user_store.get_all_wallet_info_entries())
     standard_wallet = wallet_state_manager.main_wallet
 
     with pytest.raises(ValueError, match="Not enough balance"):
@@ -99,7 +100,7 @@ async def test_create_new_did_wallet_insufficient_balance_no_orphan(wallet_envir
 async def test_create_new_did_wallet_even_amount_no_orphan(wallet_environments: WalletTestFramework):
     """Even amounts must be rejected before any DB writes."""
     wallet_state_manager = wallet_environments.environments[0].wallet_state_manager
-    initial_wallet_count = len(wallet_state_manager.wallets)
+    initial_wallet_count = len(await wallet_state_manager.user_store.get_all_wallet_info_entries())
     standard_wallet = wallet_state_manager.main_wallet
 
     with pytest.raises(ValueError, match="DID amount must be odd number"):
@@ -112,6 +113,32 @@ async def test_create_new_did_wallet_even_amount_no_orphan(wallet_environments: 
             )
 
     # No wallet record should have been created
+    wallets_after = await wallet_state_manager.user_store.get_all_wallet_info_entries()
+    assert len(wallets_after) == initial_wallet_count
+
+
+@pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
+@pytest.mark.anyio
+async def test_create_new_did_wallet_generate_failure_no_orphan(wallet_environments: WalletTestFramework):
+    """Failures after wallet row creation must clean up and avoid DB orphans."""
+    wallet_state_manager = wallet_environments.environments[0].wallet_state_manager
+    initial_wallet_count = len(await wallet_state_manager.user_store.get_all_wallet_info_entries())
+    standard_wallet = wallet_state_manager.main_wallet
+    error_message = "mocked generate failure"
+
+    with patch.object(
+        DIDWallet, "generate_new_decentralised_id", new=AsyncMock(side_effect=RuntimeError(error_message))
+    ) as mock_generate:
+        with pytest.raises(RuntimeError, match=error_message):
+            async with wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+                await DIDWallet.create_new_did_wallet(
+                    wallet_state_manager=wallet_state_manager,
+                    wallet=standard_wallet,
+                    amount=uint64(1),  # valid odd amount so wallet row creation is attempted
+                    action_scope=action_scope,
+                )
+        assert mock_generate.await_count == 1
+
     wallets_after = await wallet_state_manager.user_store.get_all_wallet_info_entries()
     assert len(wallets_after) == initial_wallet_count
 

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -70,9 +70,7 @@ async def make_did_wallet(
 
 @pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
 @pytest.mark.anyio
-async def test_create_new_did_wallet_insufficient_balance_no_orphan(
-    wallet_environments: WalletTestFramework
-):
+async def test_create_new_did_wallet_insufficient_balance_no_orphan(wallet_environments: WalletTestFramework):
     """
     Regression test for https://github.com/Chia-Network/chia-blockchain/pull/20575
     If balance is insufficient, create_new_did_wallet should raise ValueError
@@ -88,7 +86,7 @@ async def test_create_new_did_wallet_insufficient_balance_no_orphan(
                 wallet_state_manager=wallet_state_manager,
                 wallet=standard_wallet,
                 amount=uint64(2_000_000_000_001),  # more than default mojo 2_000_000_000_000
-                action_scope=action_scope
+                action_scope=action_scope,
             )
 
     # No wallet record should have been created
@@ -98,9 +96,7 @@ async def test_create_new_did_wallet_insufficient_balance_no_orphan(
 
 @pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
 @pytest.mark.anyio
-async def test_create_new_did_wallet_even_amount_no_orphan(
-    wallet_environments: WalletTestFramework
-):
+async def test_create_new_did_wallet_even_amount_no_orphan(wallet_environments: WalletTestFramework):
     """Even amounts must be rejected before any DB writes."""
     wallet_state_manager = wallet_environments.environments[0].wallet_state_manager
     initial_wallet_count = len(wallet_state_manager.wallets)
@@ -112,7 +108,7 @@ async def test_create_new_did_wallet_even_amount_no_orphan(
                 wallet_state_manager=wallet_state_manager,
                 wallet=standard_wallet,
                 amount=uint64(2),  # even, invalid
-                action_scope=action_scope
+                action_scope=action_scope,
             )
 
     # No wallet record should have been created

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -71,18 +71,18 @@ async def make_did_wallet(
 
 @pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
 @pytest.mark.anyio
-async def test_create_new_did_wallet_insufficient_balance_no_orphan(wallet_environments: WalletTestFramework):
+async def test_create_new_did_wallet_failures_no_orphan(wallet_environments: WalletTestFramework):
     """
     Regression test for https://github.com/Chia-Network/chia-blockchain/pull/20575
-    If balance is insufficient, create_new_did_wallet should raise ValueError
-    and must not leave an orphaned wallet record in the DB.
+    create_new_did_wallet should not leave orphaned wallet records in failure paths.
     """
     wallet_state_manager = wallet_environments.environments[0].wallet_state_manager
     initial_wallet_count = len(await wallet_state_manager.user_store.get_all_wallet_info_entries())
     standard_wallet = wallet_state_manager.main_wallet
 
+    # Insufficient balance should fail before DB writes.
     with pytest.raises(ValueError, match="Not enough balance"):
-        async with wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        async with wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
             await DIDWallet.create_new_did_wallet(
                 wallet_state_manager=wallet_state_manager,
                 wallet=standard_wallet,
@@ -90,21 +90,13 @@ async def test_create_new_did_wallet_insufficient_balance_no_orphan(wallet_envir
                 action_scope=action_scope,
             )
 
-    # No wallet record should have been created
+    # No wallet record should have been created.
     wallets_after = await wallet_state_manager.user_store.get_all_wallet_info_entries()
     assert len(wallets_after) == initial_wallet_count
 
-
-@pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
-@pytest.mark.anyio
-async def test_create_new_did_wallet_even_amount_no_orphan(wallet_environments: WalletTestFramework):
-    """Even amounts must be rejected before any DB writes."""
-    wallet_state_manager = wallet_environments.environments[0].wallet_state_manager
-    initial_wallet_count = len(await wallet_state_manager.user_store.get_all_wallet_info_entries())
-    standard_wallet = wallet_state_manager.main_wallet
-
+    # Even amounts should fail before DB writes.
     with pytest.raises(ValueError, match="DID amount must be odd number"):
-        async with wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        async with wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
             await DIDWallet.create_new_did_wallet(
                 wallet_state_manager=wallet_state_manager,
                 wallet=standard_wallet,
@@ -112,25 +104,17 @@ async def test_create_new_did_wallet_even_amount_no_orphan(wallet_environments: 
                 action_scope=action_scope,
             )
 
-    # No wallet record should have been created
+    # No wallet record should have been created.
     wallets_after = await wallet_state_manager.user_store.get_all_wallet_info_entries()
     assert len(wallets_after) == initial_wallet_count
 
-
-@pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
-@pytest.mark.anyio
-async def test_create_new_did_wallet_generate_failure_no_orphan(wallet_environments: WalletTestFramework):
-    """Failures after wallet row creation must clean up and avoid DB orphans."""
-    wallet_state_manager = wallet_environments.environments[0].wallet_state_manager
-    initial_wallet_count = len(await wallet_state_manager.user_store.get_all_wallet_info_entries())
-    standard_wallet = wallet_state_manager.main_wallet
+    # Failures after wallet creation should clean up the DB row.
     error_message = "mocked generate failure"
-
     with patch.object(
         DIDWallet, "generate_new_decentralised_id", new=AsyncMock(side_effect=RuntimeError(error_message))
     ) as mock_generate:
         with pytest.raises(RuntimeError, match=error_message):
-            async with wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            async with wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
                 await DIDWallet.create_new_did_wallet(
                     wallet_state_manager=wallet_state_manager,
                     wallet=standard_wallet,
@@ -139,6 +123,7 @@ async def test_create_new_did_wallet_generate_failure_no_orphan(wallet_environme
                 )
         assert mock_generate.await_count == 1
 
+    # No orphaned wallet record should remain.
     wallets_after = await wallet_state_manager.user_store.get_all_wallet_info_entries()
     assert len(wallets_after) == initial_wallet_count
 

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -68,6 +68,58 @@ async def make_did_wallet(
     return did_wallet
 
 
+@pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
+@pytest.mark.anyio
+async def test_create_new_did_wallet_insufficient_balance_no_orphan(
+    wallet_environments: WalletTestFramework
+):
+    """
+    Regression test for https://github.com/Chia-Network/chia-blockchain/pull/20575
+    If balance is insufficient, create_new_did_wallet should raise ValueError
+    and must not leave an orphaned wallet record in the DB.
+    """
+    wallet_state_manager = wallet_environments.environments[0].wallet_state_manager
+    initial_wallet_count = len(wallet_state_manager.wallets)
+    standard_wallet = wallet_state_manager.main_wallet
+
+    with pytest.raises(ValueError, match="Not enough balance"):
+        async with wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            await DIDWallet.create_new_did_wallet(
+                wallet_state_manager=wallet_state_manager,
+                wallet=standard_wallet,
+                amount=uint64(2_000_000_000_001),  # more than default mojo 2_000_000_000_000
+                action_scope=action_scope
+            )
+
+    # No wallet record should have been created
+    wallets_after = await wallet_state_manager.user_store.get_all_wallet_info_entries()
+    assert len(wallets_after) == initial_wallet_count
+
+
+@pytest.mark.parametrize("wallet_environments", [{"num_environments": 1, "blocks_needed": [1]}], indirect=True)
+@pytest.mark.anyio
+async def test_create_new_did_wallet_even_amount_no_orphan(
+    wallet_environments: WalletTestFramework
+):
+    """Even amounts must be rejected before any DB writes."""
+    wallet_state_manager = wallet_environments.environments[0].wallet_state_manager
+    initial_wallet_count = len(wallet_state_manager.wallets)
+    standard_wallet = wallet_state_manager.main_wallet
+
+    with pytest.raises(ValueError, match="DID amount must be odd number"):
+        async with wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            await DIDWallet.create_new_did_wallet(
+                wallet_state_manager=wallet_state_manager,
+                wallet=standard_wallet,
+                amount=uint64(2),  # even, invalid
+                action_scope=action_scope
+            )
+
+    # No wallet record should have been created
+    wallets_after = await wallet_state_manager.user_store.get_all_wallet_info_entries()
+    assert len(wallets_after) == initial_wallet_count
+
+
 #  TODO: See Issue CHIA-1544
 #  This test should be ported to WalletTestFramework once we can replace keys in the wallet node
 @pytest.mark.parametrize(

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -120,15 +120,17 @@ class DIDWallet:
             metadata=json.dumps(metadata),
         )
         info_as_string = json.dumps(self.did_info.to_json_dict())
-        self.wallet_info = await wallet_state_manager.user_store.create_wallet(
-            name=name, wallet_type=WalletType.DECENTRALIZED_ID.value, data=info_as_string
-        )
-        self.wallet_id = self.wallet_info.id
-
+        wallet_created = False
         try:
+            self.wallet_info = await wallet_state_manager.user_store.create_wallet(
+                name=name, wallet_type=WalletType.DECENTRALIZED_ID.value, data=info_as_string
+            )
+            self.wallet_id = self.wallet_info.id
+            wallet_created = True
             await self.generate_new_decentralised_id(amount, action_scope, fee, extra_conditions)
         except Exception:
-            await wallet_state_manager.delete_wallet(self.id())
+            if wallet_created:
+                await wallet_state_manager.delete_wallet(self.id())
             raise
 
         await self.wallet_state_manager.add_new_wallet(self)

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -124,10 +124,6 @@ class DIDWallet:
             name=name, wallet_type=WalletType.DECENTRALIZED_ID.value, data=info_as_string
         )
         self.wallet_id = self.wallet_info.id
-        std_wallet_id = self.standard_wallet.wallet_id
-        bal = await wallet_state_manager.get_confirmed_balance_for_wallet(std_wallet_id)
-        if amount > bal:
-            raise ValueError("Not enough balance")
 
         try:
             await self.generate_new_decentralised_id(amount, action_scope, fee, extra_conditions)

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -120,17 +120,14 @@ class DIDWallet:
             metadata=json.dumps(metadata),
         )
         info_as_string = json.dumps(self.did_info.to_json_dict())
-        wallet_created = False
+        self.wallet_info = await wallet_state_manager.user_store.create_wallet(
+            name=name, wallet_type=WalletType.DECENTRALIZED_ID.value, data=info_as_string
+        )
+        self.wallet_id = self.wallet_info.id
         try:
-            self.wallet_info = await wallet_state_manager.user_store.create_wallet(
-                name=name, wallet_type=WalletType.DECENTRALIZED_ID.value, data=info_as_string
-            )
-            self.wallet_id = self.wallet_info.id
-            wallet_created = True
             await self.generate_new_decentralised_id(amount, action_scope, fee, extra_conditions)
         except Exception:
-            if wallet_created:
-                await wallet_state_manager.delete_wallet(self.id())
+            await wallet_state_manager.delete_wallet(self.wallet_id)
             raise
 
         await self.wallet_state_manager.add_new_wallet(self)


### PR DESCRIPTION
found duplicated code in DIDWallet.create_new_did_wallet function
check teh balance twice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small DID wallet creation cleanup with targeted tests; no auth or consensus changes.
> 
> **Overview**
> Removes a **second** balance check in `DIDWallet.create_new_did_wallet` that ran after the wallet row was already written to the user store (balance and odd-amount validation stay **before** `create_wallet`). On failure during `generate_new_decentralised_id`, rollback now calls `delete_wallet(self.wallet_id)` instead of `self.id()`.
> 
> Adds **`test_create_new_did_wallet_failures_no_orphan`** to assert insufficient balance, even amount, and mocked generation failures do not increase wallet count—covering regression for PR #20575.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3981aed37cabca19a8b3ecb1b3efca33fa3d489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->