### PR TITLE
Add height-based generator switching to analyze-chain.py

### DIFF
--- a/tools/analyze-chain.py
+++ b/tools/analyze-chain.py
@@ -21,6 +21,7 @@ from chia_rs import (
     G2Element,
     SpendBundleConditions,
     run_block_generator,
+    run_block_generator2,
 )
 from chia_rs.sized_bytes import bytes32
 
@@ -35,19 +36,31 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 # exactly one of those will hold a value and the number of seconds it took to
 # run
 def run_gen(
-    generator_program: SerializedProgram, block_program_args: list[bytes], flags: int
+    generator_program: SerializedProgram, block_program_args: list[bytes], flags: int, height: int
 ) -> tuple[int | None, SpendBundleConditions | None, float]:
     try:
         start_time = time()
-        err, result = run_block_generator(
-            bytes(generator_program),
-            block_program_args,
-            DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
-            flags | DONT_VALIDATE_SIGNATURE,
-            G2Element(),
-            None,
-            DEFAULT_CONSTANTS,
-        )
+        # Use run_block_generator2 for blocks at or after the hard fork height
+        if height >= DEFAULT_CONSTANTS.HARD_FORK_HEIGHT:
+            err, result = run_block_generator2(
+                bytes(generator_program),
+                block_program_args,
+                DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
+                flags | DONT_VALIDATE_SIGNATURE,
+                G2Element(),
+                None,
+                DEFAULT_CONSTANTS,
+            )
+        else:
+            err, result = run_block_generator(
+                bytes(generator_program),
+                block_program_args,
+                DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
+                flags | DONT_VALIDATE_SIGNATURE,
+                G2Element(),
+                None,
+                DEFAULT_CONSTANTS,
+            )
         run_time = time() - start_time
         return err, result, run_time
     except Exception as e:
@@ -140,7 +153,7 @@ def default_call(
 
     # add the block program arguments
     assert block.transactions_generator is not None
-    err, result, run_time = run_gen(block.transactions_generator, generator_blobs, flags)
+    err, result, run_time = run_gen(block.transactions_generator, generator_blobs, flags, height)
     if err is not None:
         sys.stderr.write(f"ERROR: {hh.hex()} {height} {err}\n")
         return


### PR DESCRIPTION
## Summary

Update `tools/analyze-chain.py` to use the appropriate block generator function based on block height, matching the pattern already used throughout the consensus code.

## Changes

- Import `run_block_generator2` from chia_rs
- Add `height` parameter to `run_gen()` function
- Use `run_block_generator2` for blocks at or after `HARD_FORK_HEIGHT`  
- Use `run_block_generator` for pre-fork blocks
- Pass height from `default_call()` to `run_gen()`

## Context

This tool is currently the only place in the codebase that doesn't implement height-based switching. After chia_rs changes land (PR #1367, #1356), analyze-chain.py needs to handle both pre and post-fork blocks correctly.

## Test plan

- [x] Code compiles
- [x] Rebased on green upstream commit (0a2536f)
- [ ] Test with blockchain database containing both pre and post-fork blocks

## Note

This is a tool created and primarily maintained by @arvidn for blockchain analysis. The fix ensures it won't break when upcoming chia_rs generator identity hard fork changes land.

## Related

- Chia-Network/chia_rs#1367 - Remove allocator argument from run_block_generator
- Chia-Network/chia_rs#1356 - Generator identity hard fork implementation
- Part of March 6, 2026 hard fork preparation

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are isolated to the `tools/analyze-chain.py` analysis script; main impact is correctness of generator execution around the hard-fork boundary if the height check or chia_rs API expectations are wrong.
> 
> **Overview**
> `tools/analyze-chain.py` now selects the block generator runner based on height: `run_gen()` takes a `height` parameter and uses `chia_rs.run_block_generator2` for blocks at/after `DEFAULT_CONSTANTS.HARD_FORK_HEIGHT`, falling back to `run_block_generator` for earlier blocks.
> 
> The default analysis path (`default_call`) is updated to pass `height` through so post-fork blocks are executed with the correct generator semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0982da901185ebac68c2e14fd44ac27d1986e99d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->