### PR TITLE
[CHIA-3934] default to block creation 1

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -916,9 +916,7 @@ class FullNodeAPI:
                     while not curr_l_tb.is_transaction_block:
                         curr_l_tb = self.full_node.blockchain.block_record(curr_l_tb.prev_hash)
                     try:
-                        # TODO: once we're confident in the new block creation,
-                        # make it default to 1
-                        block_version = self.full_node.config.get("block_creation", 0)
+                        block_version = self.full_node.config.get("block_creation", 1)
                         block_timeout = self.full_node.config.get("block_creation_timeout", 2.0)
                         if block_version == 0:
                             create_block = self.full_node.mempool_manager.create_block_generator

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -320,7 +320,7 @@ full_node:
   #    are added. Use the new, optimized, compression function. This produces
   #    blocks that fill up the allowed block cost.
 
-  # block_creation: 0
+  # block_creation: 1
 
   # If we spend more than this many seconds forming the new transactions block
   # generator, stop and just go with what we have so far. This is a safety


### PR DESCRIPTION
This improves performance of creating large blocks.

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default block generator construction path used when farming, which can affect block assembly performance and correctness if the newer generator has edge-case bugs; impact is mitigated by retaining the config switch and fallback behavior.
> 
> **Overview**
> Defaults full-node farming to `block_creation=1`, making `declare_proof_of_space` use `create_block_generator2` unless explicitly configured otherwise.
> 
> Updates `initial-config.yaml` to document `block_creation` as `1` by default (commented), aligning new installs with the optimized block creation path while keeping the version switch and unknown-value fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66676307cef8470a7d5fe21c1fab7d3669c55508. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->