### PR TITLE
Increate job timeout to 60

### DIFF
--- a/chia/_tests/wallet/nft_wallet/config.py
+++ b/chia/_tests/wallet/nft_wallet/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 45
+job_timeout = 60
 checkout_blocks_and_plots = True


### PR DESCRIPTION
Increase nft_wallet tests job timeout to 60 minutes