### PR TITLE
Add missing type annotations and remove 10 mypy exclusions

### DIFF
--- a/chia/_tests/blockchain/blockchain_test_utils.py
+++ b/chia/_tests/blockchain/blockchain_test_utils.py
@@ -12,7 +12,7 @@ from chia.types.validation_state import ValidationState
 from chia.util.errors import Err
 
 
-async def check_block_store_invariant(bc: Blockchain):
+async def check_block_store_invariant(bc: Blockchain) -> None:
     db_wrapper = bc.block_store.db_wrapper
 
     if db_wrapper.db_version == 1:

--- a/chia/_tests/core/custom_types/test_coin.py
+++ b/chia/_tests/core/custom_types/test_coin.py
@@ -8,7 +8,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.util.hash import std_hash
 
 
-def coin_serialize(amount: uint64, clvm_serialize: bytes, full_serialize: bytes):
+def coin_serialize(amount: uint64, clvm_serialize: bytes, full_serialize: bytes) -> None:
     c = Coin(bytes32(b"a" * 32), bytes32(b"b" * 32), amount)
     expected_hash = (b"a" * 32) + (b"b" * 32) + clvm_serialize
 
@@ -23,7 +23,7 @@ def coin_serialize(amount: uint64, clvm_serialize: bytes, full_serialize: bytes)
     assert c2 == c
 
 
-def test_serialization():
+def test_serialization() -> None:
     coin_serialize(uint64(0xFFFF), bytes([0, 0xFF, 0xFF]), bytes([0, 0, 0, 0, 0, 0, 0xFF, 0xFF]))
     coin_serialize(uint64(1337000000), bytes([0x4F, 0xB1, 0x00, 0x40]), bytes([0, 0, 0, 0, 0x4F, 0xB1, 0x00, 0x40]))
 

--- a/chia/_tests/core/test_daemon_rpc.py
+++ b/chia/_tests/core/test_daemon_rpc.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from chia import __version__
@@ -7,7 +9,7 @@ from chia.daemon.client import connect_to_daemon
 
 
 @pytest.mark.anyio
-async def test_get_version_rpc(get_daemon, bt):
+async def test_get_version_rpc(get_daemon: Any, bt: Any) -> None:
     ws_server = get_daemon
     config = bt.config
     client = await connect_to_daemon(

--- a/chia/_tests/core/test_daemon_rpc.py
+++ b/chia/_tests/core/test_daemon_rpc.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 from chia import __version__
 from chia.daemon.client import connect_to_daemon
+from chia.daemon.server import WebSocketServer
+from chia.simulator.block_tools import BlockTools
 
 
 @pytest.mark.anyio
-async def test_get_version_rpc(get_daemon: Any, bt: Any) -> None:
+async def test_get_version_rpc(get_daemon: WebSocketServer, bt: BlockTools) -> None:
     ws_server = get_daemon
     config = bt.config
     client = await connect_to_daemon(
@@ -23,4 +23,4 @@ async def test_get_version_rpc(get_daemon: Any, bt: Any) -> None:
 
     assert response["data"]["success"]
     assert response["data"]["version"] == __version__
-    ws_server.stop()
+    await ws_server.stop()

--- a/chia/_tests/core/test_filter.py
+++ b/chia/_tests/core/test_filter.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 from chiabip158 import PyBIP158
 
+from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 
 
 @pytest.mark.anyio
-async def test_basic_filter_test(simulator_and_wallet: Any) -> None:
+async def test_basic_filter_test(simulator_and_wallet: OldSimulatorsAndWallets) -> None:
     _full_nodes, wallets, bt = simulator_and_wallet
     wallet_node, _server_2 = wallets[0]
     wallet = wallet_node.wallet_state_manager.main_wallet

--- a/chia/_tests/core/test_filter.py
+++ b/chia/_tests/core/test_filter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from chiabip158 import PyBIP158
 
@@ -7,7 +9,7 @@ from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 
 
 @pytest.mark.anyio
-async def test_basic_filter_test(simulator_and_wallet):
+async def test_basic_filter_test(simulator_and_wallet: Any) -> None:
     _full_nodes, wallets, bt = simulator_and_wallet
     wallet_node, _server_2 = wallets[0]
     wallet = wallet_node.wallet_state_manager.main_wallet

--- a/chia/_tests/core/util/test_lru_cache.py
+++ b/chia/_tests/core/util/test_lru_cache.py
@@ -8,8 +8,8 @@ from chia.util.lru_cache import LRUCache, LRUSet
 
 
 class TestLRUCache(unittest.TestCase):
-    def test_lru_cache(self):
-        cache = LRUCache(5)
+    def test_lru_cache(self) -> None:
+        cache: LRUCache[bytes, int] = LRUCache(5)
 
         assert cache.get(b"0") is None
 

--- a/chia/_tests/core/util/test_significant_bits.py
+++ b/chia/_tests/core/util/test_significant_bits.py
@@ -6,7 +6,7 @@ from chia.util.significant_bits import count_significant_bits, truncate_to_signi
 
 
 class TestSignificantBits(unittest.TestCase):
-    def test_truncate_to_significant_bits(self):
+    def test_truncate_to_significant_bits(self) -> None:
         a = -0b001101
         assert truncate_to_significant_bits(a, 2) == -0b1100
         a = -0b001111
@@ -26,7 +26,7 @@ class TestSignificantBits(unittest.TestCase):
         a = 0b10101
         assert truncate_to_significant_bits(a, 4) == 0b10100
 
-    def test_count_significant_bits(self):
+    def test_count_significant_bits(self) -> None:
         assert count_significant_bits(0b0001) == 1
         assert count_significant_bits(0b00010) == 1
         assert count_significant_bits(0b01010) == 3

--- a/chia/_tests/pools/test_pool_config.py
+++ b/chia/_tests/pools/test_pool_config.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from chia.pools.pool_config import PoolWalletConfig
 from chia.util.config import create_default_chia_config, load_config, lock_config, save_config
 
 
-def test_pool_config(tmp_path):
+def test_pool_config(tmp_path: Path) -> None:
     test_root = tmp_path
     test_path = test_root / "config"
     eg_config = test_path / "config.yaml"

--- a/chia/_tests/pools/test_wallet_pool_store.py
+++ b/chia/_tests/pools/test_wallet_pool_store.py
@@ -79,15 +79,15 @@ class TestWalletPoolStore:
                     assert await store.get_spends_for_wallet(0) == []
                     assert await store.get_spends_for_wallet(1) == []
 
-                    await store.add_spend(1, solution_1, 100)
+                    await store.add_spend(1, solution_1, uint32(100))
                     assert await store.get_spends_for_wallet(1) == [(100, solution_1)]
 
                     # Idempotent
-                    await store.add_spend(1, solution_1, 100)
+                    await store.add_spend(1, solution_1, uint32(100))
                     assert await store.get_spends_for_wallet(1) == [(100, solution_1)]
 
                     with pytest.raises(ValueError):
-                        await store.add_spend(1, solution_1, 101)
+                        await store.add_spend(1, solution_1, uint32(101))
 
                     # Rebuild cache, no longer present
                     raise RuntimeError("abandon transaction")
@@ -96,26 +96,26 @@ class TestWalletPoolStore:
 
             assert await store.get_spends_for_wallet(1) == []
 
-            await store.add_spend(1, solution_1, 100)
+            await store.add_spend(1, solution_1, uint32(100))
             assert await store.get_spends_for_wallet(1) == [(100, solution_1)]
 
             solution_1_alt: CoinSpend = make_child_solution(solution_0_alt, new_coin=None, seeded_random=seeded_random)
 
             with pytest.raises(ValueError):
-                await store.add_spend(1, solution_1_alt, 100)
+                await store.add_spend(1, solution_1_alt, uint32(100))
 
             assert await store.get_spends_for_wallet(1) == [(100, solution_1)]
 
             solution_2: CoinSpend = make_child_solution(solution_1, new_coin=None, seeded_random=seeded_random)
-            await store.add_spend(1, solution_2, 100)
+            await store.add_spend(1, solution_2, uint32(100))
             solution_3: CoinSpend = make_child_solution(solution_2, new_coin=None, seeded_random=seeded_random)
-            await store.add_spend(1, solution_3, 100)
+            await store.add_spend(1, solution_3, uint32(100))
             solution_4: CoinSpend = make_child_solution(solution_3, new_coin=None, seeded_random=seeded_random)
 
             with pytest.raises(ValueError):
-                await store.add_spend(1, solution_4, 99)
+                await store.add_spend(1, solution_4, uint32(99))
 
-            await store.add_spend(1, solution_4, 101)
+            await store.add_spend(1, solution_4, uint32(101))
             await store.rollback(101, 1)
             assert await store.get_spends_for_wallet(1) == [
                 (100, solution_1),
@@ -130,11 +130,11 @@ class TestWalletPoolStore:
                 (100, solution_3),
             ]
             with pytest.raises(ValueError):
-                await store.add_spend(1, solution_1, 105)
+                await store.add_spend(1, solution_1, uint32(105))
 
-            await store.add_spend(1, solution_4, 105)
+            await store.add_spend(1, solution_4, uint32(105))
             solution_5: CoinSpend = make_child_solution(solution_4, new_coin=None, seeded_random=seeded_random)
-            await store.add_spend(1, solution_5, 105)
+            await store.add_spend(1, solution_5, uint32(105))
             await store.rollback(99, 1)
             assert await store.get_spends_for_wallet(1) == []
 
@@ -155,5 +155,5 @@ async def test_delete_wallet(seeded_random: random.Random) -> None:
         for wallet_id, spends in dummy_spends.spends_per_wallet.items():
             # Assert the existence again here to make sure the previous removals did not affect other wallet_ids
             await assert_db_spends(store, wallet_id, spends)
-            await store.delete_wallet(wallet_id)
+            await store.delete_wallet(uint32(wallet_id))
             await assert_db_spends(store, wallet_id, [])

--- a/chia/cmds/start_funcs.py
+++ b/chia/cmds/start_funcs.py
@@ -16,7 +16,7 @@ from chia.util.keychain import Keychain
 from chia.util.service_groups import services_for_groups
 
 
-def launch_start_daemon(root_path: Path) -> subprocess.Popen:
+def launch_start_daemon(root_path: Path) -> subprocess.Popen[bytes]:
     os.environ["CHIA_ROOT"] = str(root_path)
     creationflags = 0
     if sys.platform == "win32":

--- a/chia/wallet/wallet_pool_store.py
+++ b/chia/wallet/wallet_pool_store.py
@@ -14,7 +14,7 @@ class WalletPoolStore:
     db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, wrapper: DBWrapper2):
+    async def create(cls, wrapper: DBWrapper2) -> WalletPoolStore:
         self = cls()
         self.db_wrapper = wrapper
 

--- a/installhelper.py
+++ b/installhelper.py
@@ -61,7 +61,7 @@ def get_chia_version() -> str:
     return make_semver(version)
 
 
-def update_version(package_json_path: str):
+def update_version(package_json_path: str) -> None:
     if not exists(package_json_path):
         return
 

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -1,5 +1,4 @@
 # File created by: python manage-mypy.py build-exclusions
-chia.cmds.start_funcs
 chia.daemon.server
 chia.introducer.introducer
 chia.introducer.introducer_api
@@ -32,12 +31,9 @@ chia.wallet.util.new_peak_queue
 chia.wallet.wallet_coin_store
 chia.wallet.wallet_interested_store
 chia.wallet.wallet_node_api
-chia.wallet.wallet_pool_store
 chia.wallet.wallet_puzzle_store
 chia.wallet.wallet_transaction_store
 chia.wallet.wallet_user_store
-installhelper
-chia._tests.blockchain.blockchain_test_utils
 chia._tests.build-init-files
 chia._tests.clvm.coin_store
 chia._tests.clvm.test_chialisp_deserialization
@@ -50,7 +46,6 @@ chia._tests.conftest
 chia._tests.connection_utils
 chia._tests.core.cmds.test_keys
 chia._tests.core.consensus.test_pot_iterations
-chia._tests.core.custom_types.test_coin
 chia._tests.core.custom_types.test_spend_bundle
 chia._tests.core.daemon.test_daemon
 chia._tests.core.full_node.stores.test_sync_store
@@ -60,18 +55,13 @@ chia._tests.core.full_node.test_performance
 chia._tests.core.full_node.test_transactions
 chia._tests.core.ssl.test_ssl
 chia._tests.core.test_crawler_rpc
-chia._tests.core.test_daemon_rpc
 chia._tests.core.test_db_conversion
-chia._tests.core.test_filter
 chia._tests.core.util.test_config
 chia._tests.core.util.test_file_keyring_synchronization
 chia._tests.core.util.test_files
 chia._tests.core.util.test_keychain
 chia._tests.core.util.test_keyring_wrapper
-chia._tests.core.util.test_lru_cache
-chia._tests.core.util.test_significant_bits
 chia._tests.plotting.test_plot_manager
-chia._tests.pools.test_pool_config
 chia._tests.pools.test_pool_puzzles_lifecycle
 chia._tests.pools.test_wallet_pool_store
 chia._tests.simulation.test_simulation


### PR DESCRIPTION
### Purpose:

Adds missing type annotations (return types, parameter types, generic type parameters) to 10 modules that had trivial mypy strict-mode violations. Removes those modules from `mypy-exclusions.txt` so they are now covered by strict type checking. Fixes downstream `int`→`uint32` arg-type errors in `test_wallet_pool_store.py` that surfaced once `wallet_pool_store.py` became strictly typed.

### Current Behavior:

10 modules are excluded from mypy strict checking (82 excluded modules total). Some test code passes plain `int` where `uint32` is expected.

### New Behavior:

Those 10 modules are now type-checked (72 excluded modules). `test_wallet_pool_store.py` uses correct `uint32` types.

### Testing Notes:

- `pre-commit run mypy --all-files` passes
- Affected test modules pass: `blockchain_test_utils`, `test_coin`, `test_daemon_rpc`, `test_filter`, `test_lru_cache`, `test_significant_bits`, `test_pool_config`, `test_wallet_pool_store`

**Modules removed from exclusions:**

| Module | Fix |
|--------|-----|
| `chia.cmds.start_funcs` | `Popen` → `Popen[bytes]` |
| `chia.wallet.wallet_pool_store` | Added `-> WalletPoolStore` return type to `create()` |
| `installhelper` | Added `-> None` return type to `update_version()` |
| `chia._tests.blockchain.blockchain_test_utils` | Added `-> None` return type |
| `chia._tests.core.test_daemon_rpc` | Added parameter + return types |
| `chia._tests.core.test_filter` | Added parameter + return types |
| `chia._tests.pools.test_pool_config` | Added `tmp_path: Path` + `-> None` |
| `chia._tests.core.custom_types.test_coin` | Added `-> None` return types |
| `chia._tests.core.util.test_lru_cache` | Added `-> None` + `LRUCache[bytes, int]` var annotation |
| `chia._tests.core.util.test_significant_bits` | Added `-> None` return types |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 8b83b772ed62b5041c4b23323a45613c5332acc2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->