### PR TITLE
mypy: remove exclusion for chia._tests.build-init-files

### DIFF
--- a/chia/_tests/build-init-files.py
+++ b/chia/_tests/build-init-files.py
@@ -56,7 +56,7 @@ def traverse_directory(path: pathlib.Path) -> list[pathlib.Path]:
     "-r", "--root", "root_str", type=click.Path(dir_okay=True, file_okay=False, resolve_path=True), default="."
 )
 @click.option("-v", "--verbose", count=True, help=f"Increase verbosity up to {len(log_levels) - 1} times")
-def command(verbose, root_str):
+def command(verbose: int, root_str: str) -> None:
     logger = logging.getLogger()
     log_level = log_levels.get(verbose, min(log_levels.values()))
     logger.setLevel(log_level)

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -38,7 +38,6 @@ chia.wallet.wallet_transaction_store
 chia.wallet.wallet_user_store
 installhelper
 chia._tests.blockchain.blockchain_test_utils
-chia._tests.build-init-files
 chia._tests.clvm.coin_store
 chia._tests.clvm.test_chialisp_deserialization
 chia._tests.clvm.test_program


### PR DESCRIPTION
### Purpose:

Add missing type annotations to `chia/_tests/build-init-files.py` so the module passes mypy strict mode, and remove it from `mypy-exclusions.txt` (71 → 70 excluded modules).

### Current Behavior:

`chia._tests.build-init-files` is excluded from mypy strict checking. The `command()` function (click entrypoint) has no type annotations on its parameters or return type.

### New Behavior:

The module is now covered by strict type checking. `command(verbose: int, root_str: str) -> None` is fully annotated.

### Testing Notes:

- `pre-commit run mypy --all-files` passes
- No logic changes — annotation-only fix

| Module | Fix |
|--------|-----|
| `chia._tests.build-init-files` | Added `verbose: int, root_str: str` param types + `-> None` return to `command()` |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only change plus mypy config update; runtime behavior is unchanged and the impact is limited to static type checking/CI.
> 
> **Overview**
> Removes `chia._tests.build-init-files` from `mypy-exclusions.txt`, bringing the script under strict mypy checking.
> 
> Adds type annotations to the click entrypoint `command()` (parameter types and `-> None`) with no functional changes to the script’s behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b69abe7aab130323ee8ec717d037c0fa892070d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->