### PR TITLE
mypy: remove exclusions for test_spend_bundle and build-init-files

### DIFF
--- a/chia/_tests/build-init-files.py
+++ b/chia/_tests/build-init-files.py
@@ -56,7 +56,7 @@ def traverse_directory(path: pathlib.Path) -> list[pathlib.Path]:
     "-r", "--root", "root_str", type=click.Path(dir_okay=True, file_okay=False, resolve_path=True), default="."
 )
 @click.option("-v", "--verbose", count=True, help=f"Increase verbosity up to {len(log_levels) - 1} times")
-def command(verbose, root_str):
+def command(verbose: int, root_str: str) -> None:
     logger = logging.getLogger()
     log_level = log_levels.get(verbose, min(log_levels.values()))
     logger.setLevel(log_level)

--- a/chia/_tests/core/custom_types/test_spend_bundle.py
+++ b/chia/_tests/core/custom_types/test_spend_bundle.py
@@ -18,7 +18,7 @@ NULL_SIGNATURE = "0xc" + "0" * 191
 
 
 class TestStructStream(unittest.TestCase):
-    def test_round_trip(self):
+    def test_round_trip(self) -> None:
         spend_bundle = BLANK_SPEND_BUNDLE
         json_dict = spend_bundle.to_json_dict()
 

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -38,7 +38,6 @@ chia.wallet.wallet_transaction_store
 chia.wallet.wallet_user_store
 installhelper
 chia._tests.blockchain.blockchain_test_utils
-chia._tests.build-init-files
 chia._tests.clvm.coin_store
 chia._tests.clvm.test_chialisp_deserialization
 chia._tests.clvm.test_program
@@ -51,7 +50,6 @@ chia._tests.connection_utils
 chia._tests.core.cmds.test_keys
 chia._tests.core.consensus.test_pot_iterations
 chia._tests.core.custom_types.test_coin
-chia._tests.core.custom_types.test_spend_bundle
 chia._tests.core.daemon.test_daemon
 chia._tests.core.full_node.stores.test_sync_store
 chia._tests.core.full_node.test_address_manager


### PR DESCRIPTION
### Purpose:

Add missing type annotations to two modules and remove them from mypy-exclusions.txt (79 to 77 excluded modules).

### Current Behavior:

- chia._tests.core.custom_types.test_spend_bundle is excluded from mypy strict checking. test_round_trip() is missing a return type.
- chia._tests.build-init-files has an exclusion entry in mypy-exclusions.txt, but the exclusion never worked because hyphens in the filename (build-init-files.py) are not valid Python module identifiers. mypy cannot match the pattern chia._tests.build-init-files to the file. This causes a pre-existing mypy failure on main.

### New Behavior:

Both modules are now fully annotated and covered by strict type checking.

### Testing Notes:

- pre-commit run mypy --all-files passes
- No logic changes, annotation-only fixes

Modules fixed:

| Module | Fix |
|--------|-----|
| chia._tests.core.custom_types.test_spend_bundle | Added -> None return type to test_round_trip() |
| chia._tests.build-init-files | Added verbose: int, root_str: str param types + -> None return to command(); removed broken exclusion entry |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only changes plus removal of `mypy` exclusions; runtime behavior should be unchanged aside from stricter CI type-checking.
> 
> **Overview**
> Removes `mypy` exclusions for `chia/_tests/build-init-files.py` and `chia/_tests/core/custom_types/test_spend_bundle.py`, bringing them under strict type checking.
> 
> Adds missing type annotations (`-> None` and parameter types) to `build-init-files.command()` and `TestStructStream.test_round_trip()` to satisfy `mypy`, with no behavioral changes intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8868aa1f0231783d79a4f36b304773bff9af569b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->