### PR TITLE
mypy: remove exclusion for chia._tests.pools.test_wallet_pool_store

### DIFF
--- a/chia/_tests/pools/test_wallet_pool_store.py
+++ b/chia/_tests/pools/test_wallet_pool_store.py
@@ -58,7 +58,7 @@ class DummySpends:
 
 class TestWalletPoolStore:
     @pytest.mark.anyio
-    async def test_store(self, seeded_random: random.Random):
+    async def test_store(self, seeded_random: random.Random) -> None:
         async with DBConnection(1) as db_wrapper:
             store = await WalletPoolStore.create(db_wrapper)
 

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -73,7 +73,6 @@ chia._tests.core.util.test_significant_bits
 chia._tests.plotting.test_plot_manager
 chia._tests.pools.test_pool_config
 chia._tests.pools.test_pool_puzzles_lifecycle
-chia._tests.pools.test_wallet_pool_store
 chia._tests.simulation.test_simulation
 chia._tests.tools.test_run_block
 chia._tests.util.benchmark_cost


### PR DESCRIPTION
### Purpose:

Add missing return type annotation to test_store() in test_wallet_pool_store.py so the module passes mypy strict mode, and remove it from mypy-exclusions.txt.

### Current Behavior:

chia._tests.pools.test_wallet_pool_store is excluded from mypy strict checking. test_store() is missing a return type annotation.

### New Behavior:

The module is now covered by strict type checking. test_store() is annotated with -> None.

### Testing Notes:

- pre-commit run mypy --all-files passes
- No logic changes, annotation-only fix

| Module | Fix |
|--------|-----|
| chia._tests.pools.test_wallet_pool_store | Added -> None return type to test_store() |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit f638f053db59447db7645b918b7a48597dfa1ea9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->