### PR TITLE
Fix timelord to skip processing after failed VDF proof validation

### DIFF
--- a/chia/_tests/timelord/test_timelord.py
+++ b/chia/_tests/timelord/test_timelord.py
@@ -62,7 +62,9 @@ async def test_invalid_vdf_proof_is_ignored_in_process_communication(
     reader.feed_eof()
 
     writer = _DummyStreamWriter()
-    await timelord._do_process_communication(chain, challenge, initial_form, "127.0.0.1", reader, writer, proof_label=1)
+    await timelord._do_process_communication(
+        chain, challenge, initial_form, "127.0.0.1", reader, writer, proof_label=1  # type: ignore[arg-type]
+    )
 
     assert timelord.proofs_finished == []
     assert state_changed_calls == []

--- a/chia/_tests/timelord/test_timelord.py
+++ b/chia/_tests/timelord/test_timelord.py
@@ -19,12 +19,19 @@ async def test_timelord_has_no_server(timelord_service: TimelordService) -> None
     assert timelord_server.webserver is None
 
 
-class _DummyStreamWriter:
+class _NullTransport(asyncio.Transport):
     def write(self, data: bytes) -> None:
         pass
 
-    async def drain(self) -> None:
-        pass
+    def is_closing(self) -> bool:
+        return False
+
+
+def _make_null_writer() -> asyncio.StreamWriter:
+    loop = asyncio.get_running_loop()
+    reader = asyncio.StreamReader()
+    protocol = asyncio.StreamReaderProtocol(reader, loop=loop)
+    return asyncio.StreamWriter(_NullTransport(), protocol, reader, loop)
 
 
 @pytest.mark.anyio
@@ -61,10 +68,8 @@ async def test_invalid_vdf_proof_is_ignored_in_process_communication(
     reader.feed_data(b"STOP")
     reader.feed_eof()
 
-    writer = _DummyStreamWriter()
-    await timelord._do_process_communication(
-        chain, challenge, initial_form, "127.0.0.1", reader, writer, proof_label=1  # type: ignore[arg-type]
-    )
+    writer = _make_null_writer()
+    await timelord._do_process_communication(chain, challenge, initial_form, "127.0.0.1", reader, writer, proof_label=1)
 
     assert timelord.proofs_finished == []
     assert state_changed_calls == []

--- a/chia/_tests/timelord/test_timelord.py
+++ b/chia/_tests/timelord/test_timelord.py
@@ -8,9 +8,9 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint64
 
 from chia.timelord import timelord as timelord_module
+from chia.timelord.timelord_service import TimelordService
 from chia.timelord.types import Chain
 from chia.types.blockchain_format.classgroup import ClassgroupElement
-from chia.timelord.timelord_service import TimelordService
 
 
 @pytest.mark.anyio

--- a/chia/_tests/timelord/test_timelord.py
+++ b/chia/_tests/timelord/test_timelord.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
-import pytest
+import asyncio
+import time
 
+import pytest
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint64
+
+from chia.timelord import timelord as timelord_module
+from chia.timelord.types import Chain
+from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.timelord.timelord_service import TimelordService
 
 
@@ -9,3 +17,52 @@ from chia.timelord.timelord_service import TimelordService
 async def test_timelord_has_no_server(timelord_service: TimelordService) -> None:
     timelord_server = timelord_service._node.server
     assert timelord_server.webserver is None
+
+
+class _DummyStreamWriter:
+    def write(self, data: bytes) -> None:
+        pass
+
+    async def drain(self) -> None:
+        pass
+
+
+@pytest.mark.anyio
+async def test_invalid_vdf_proof_is_ignored_in_process_communication(
+    timelord_service: TimelordService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    timelord = timelord_service._node
+    chain = Chain.CHALLENGE_CHAIN
+    challenge = bytes32.zeros
+    initial_form = ClassgroupElement.get_default_element()
+    timelord.chain_start_time[chain] = time.time()
+
+    state_changed_calls: list[object] = []
+    monkeypatch.setattr(timelord_module, "validate_vdf", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(timelord, "state_changed", lambda *args, **kwargs: state_changed_calls.append((args, kwargs)))
+
+    iterations_needed = uint64(10)
+    y_bytes = initial_form.data
+    witness_type = 0
+    proof_bytes = b"\x01\x02"
+    proof_payload = (
+        int(iterations_needed).to_bytes(8, "big", signed=True)
+        + len(y_bytes).to_bytes(8, "big", signed=True)
+        + y_bytes
+        + bytes([witness_type])
+        + proof_bytes
+    )
+    encoded_payload = proof_payload.hex().encode()
+
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"OK")
+    reader.feed_data(len(encoded_payload).to_bytes(4, "big"))
+    reader.feed_data(encoded_payload)
+    reader.feed_data(b"STOP")
+    reader.feed_eof()
+
+    writer = _DummyStreamWriter()
+    await timelord._do_process_communication(chain, challenge, initial_form, "127.0.0.1", reader, writer, proof_label=1)
+
+    assert timelord.proofs_finished == []
+    assert state_changed_calls == []

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -1066,6 +1066,7 @@ class Timelord:
 
                 if not validate_vdf(vdf_proof, self.constants, initial_form, vdf_info):
                     log.error("Invalid proof of time!")
+                    continue
                 if not self.bluebox_mode:
                     async with self.lock:
                         assert proof_label is not None


### PR DESCRIPTION
### Purpose:

`_do_process_communication()` in the timelord logs an error when `validate_vdf()` fails but then falls through to process the invalid proof anyway — either appending it to `proofs_finished` (normal mode) or sending it as a `RespondCompactProofOfTime` (bluebox mode). This adds the missing `continue` so invalid proofs are discarded immediately, matching the behavior of the sibling code path in `_manage_discriminant_queue_sanitizer_slow()` which already returns on validation failure.

### Current Behavior:

When `validate_vdf()` returns `False` inside `_do_process_communication()`, the code logs `"Invalid proof of time!"` but execution falls through to the subsequent `if not self.bluebox_mode:` / `else:` block. The invalid proof is then either:
- Appended to `self.proofs_finished` and later sent to the full node as a signage/infusion point (normal mode), or
- Sent directly via `RespondCompactProofOfTime` to the full node (bluebox mode).

The full node independently validates all incoming VDF proofs and correctly rejects them, so there is no downstream propagation — but the timelord wastes work constructing and sending proofs that will always be rejected.

### New Behavior:

A `continue` statement after the error log causes the timelord to skip the invalid proof and immediately read the next proof from the VDF client process. This avoids unnecessary processing and network round-trips for proofs that would be rejected anyway.

### Testing Notes:

- Added `test_invalid_vdf_proof_is_ignored_in_process_communication` which monkeypatches `validate_vdf` to always return `False`, feeds a crafted proof payload into `_do_process_communication()` via an in-memory `asyncio.StreamReader`, and asserts that:
  - `timelord.proofs_finished` remains empty
  - `state_changed` is never called
- Verified that the sibling path `_manage_discriminant_queue_sanitizer_slow()` (line ~1211) already handles this correctly with an early `return`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change gated by `validate_vdf()` with a targeted regression test; limited to timelord proof handling and should only reduce propagation of invalid data.
> 
> **Overview**
> Fixes `Timelord._do_process_communication()` to **stop processing invalid VDF proofs** by `continue`-ing immediately after a failed `validate_vdf()` check, preventing bad proofs from being appended to `proofs_finished` or sent in bluebox mode.
> 
> Adds a focused test (`test_invalid_vdf_proof_is_ignored_in_process_communication`) that feeds a crafted proof through an in-memory stream with `validate_vdf` monkeypatched to fail, asserting no finished-proof/state-changed side effects occur.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf1dbb4dc977356acc6830bd485f8cd64fdb01fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->