### PR TITLE
mypy: remove exclusion for chia._tests.tools.test_run_block

### DIFF
--- a/chia/_tests/tools/test_run_block.py
+++ b/chia/_tests/tools/test_run_block.py
@@ -53,7 +53,7 @@ def find_retirement(tocheck: list[ConditionWithArgs]) -> bool:
     return False
 
 
-def test_block_no_generator():
+def test_block_no_generator() -> None:
     dirname = Path(__file__).parent
     with open(dirname / "300000.json") as f:
         full_block = json.load(f)
@@ -63,7 +63,7 @@ def test_block_no_generator():
     assert not cat_list
 
 
-def test_block_retired_cat_with_memo():
+def test_block_retired_cat_with_memo() -> None:
     dirname = Path(__file__).parent
     with open(dirname / "1315630.json") as f:
         full_block = json.load(f)
@@ -83,7 +83,7 @@ def test_block_retired_cat_with_memo():
     assert found
 
 
-def test_block_retired_cat_no_memo():
+def test_block_retired_cat_no_memo() -> None:
     dirname = Path(__file__).parent
     with open(dirname / "1315544.json") as f:
         full_block = json.load(f)
@@ -104,7 +104,7 @@ def test_block_retired_cat_no_memo():
     assert found
 
 
-def test_block_cat():
+def test_block_cat() -> None:
     dirname = Path(__file__).parent
     with open(dirname / "1315537.json") as f:
         full_block = json.load(f)
@@ -118,7 +118,7 @@ def test_block_cat():
     assert cat_list[0].npc.puzzle_hash.hex() == "20a2284ec41cdcc3c54e6b44f8801db2dc28f3aa01c115674b598757d62f09a6"
 
 
-def test_generator_ref():
+def test_generator_ref() -> None:
     """Run a block containing a back reference without error"""
     dirname = Path(__file__).parent
     with open(dirname / "466212.json") as f:

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -62,7 +62,6 @@ chia._tests.core.util.test_keyring_wrapper
 chia._tests.plotting.test_plot_manager
 chia._tests.pools.test_pool_puzzles_lifecycle
 chia._tests.simulation.test_simulation
-chia._tests.tools.test_run_block
 chia._tests.util.benchmark_cost
 chia._tests.util.test_misc
 chia._tests.wallet.did_wallet.test_did


### PR DESCRIPTION
### Purpose:

Add missing return type annotations to all five test functions in `test_run_block.py` so the module passes mypy strict mode, and remove it from `mypy-exclusions.txt`.

### Current Behavior:

`chia._tests.tools.test_run_block` is excluded from mypy strict checking. The five test functions are missing `-> None` return type annotations.

### New Behavior:

The module is now covered by strict type checking. All five test functions have explicit `-> None` return types.

### Changes:

- `chia/_tests/tools/test_run_block.py` — added `-> None` to `test_block_no_generator`, `test_block_retired_cat_with_memo`, `test_block_retired_cat_no_memo`, `test_block_cat`, `test_generator_ref`
- `mypy-exclusions.txt` — removed `chia._tests.tools.test_run_block`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 60af118e279f9a73194a9d35c20933d6766232e3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->