### PR TITLE
Use tree_hash for generator_root after hard fork 2

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -2664,9 +2664,7 @@ class TestBodyValidation:
 
     @pytest.mark.anyio
     @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0])
-    async def test_generator_root_is_std_hash_pre_hf2(
-        self, empty_blockchain: Blockchain, bt: BlockTools
-    ) -> None:
+    async def test_generator_root_is_std_hash_pre_hf2(self, empty_blockchain: Blockchain, bt: BlockTools) -> None:
         """Pre-HF2 transaction blocks must use std_hash for generator_root."""
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
@@ -2681,9 +2679,7 @@ class TestBodyValidation:
     @pytest.mark.limit_consensus_modes(
         allowed=[ConsensusMode.HARD_FORK_3_0, ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT]
     )
-    async def test_generator_root_is_tree_hash_post_hf2(
-        self, empty_blockchain: Blockchain, bt: BlockTools
-    ) -> None:
+    async def test_generator_root_is_tree_hash_post_hf2(self, empty_blockchain: Blockchain, bt: BlockTools) -> None:
         """Post-HF2 transaction blocks must use tree_hash for generator_root."""
         b = empty_blockchain
         blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -27,6 +27,7 @@ from chia_rs import (
     TransactionsInfo,
     UnfinishedBlock,
     is_canonical_serialization,
+    tree_hash,
 )
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
@@ -2583,6 +2584,67 @@ class TestBodyValidation:
         new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
         block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
         await _validate_and_add_block(b, block_2, expected_error=Err.INVALID_TRANSACTIONS_GENERATOR_HASH)
+
+    @pytest.mark.anyio
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN, ConsensusMode.HARD_FORK_2_0])
+    async def test_generator_root_is_std_hash_pre_hf2(
+        self, empty_blockchain: Blockchain, bt: BlockTools
+    ) -> None:
+        """Pre-HF2 transaction blocks must use std_hash for generator_root."""
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
+        await _validate_and_add_block(b, blocks[0])
+        await _validate_and_add_block(b, blocks[1])
+        block = blocks[1]
+        assert block.transactions_generator is not None
+        assert block.transactions_info is not None
+        assert block.transactions_info.generator_root == std_hash(bytes(block.transactions_generator))
+
+    @pytest.mark.anyio
+    @pytest.mark.limit_consensus_modes(
+        allowed=[ConsensusMode.HARD_FORK_3_0, ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT]
+    )
+    async def test_generator_root_is_tree_hash_post_hf2(
+        self, empty_blockchain: Blockchain, bt: BlockTools
+    ) -> None:
+        """Post-HF2 transaction blocks must use tree_hash for generator_root."""
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
+        await _validate_and_add_block(b, blocks[0])
+        await _validate_and_add_block(b, blocks[1])
+        block = blocks[1]
+        assert block.transactions_generator is not None
+        assert block.transactions_info is not None
+        assert block.transactions_info.generator_root == bytes32(tree_hash(bytes(block.transactions_generator)))
+
+    @pytest.mark.anyio
+    @pytest.mark.limit_consensus_modes(
+        allowed=[ConsensusMode.HARD_FORK_3_0, ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT]
+    )
+    async def test_generator_root_std_hash_rejected_post_hf2(
+        self, empty_blockchain: Blockchain, bt: BlockTools
+    ) -> None:
+        """Post-HF2, a block whose generator_root is std_hash (old format) must be rejected."""
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
+        await _validate_and_add_block(b, blocks[0])
+        block = blocks[1]
+        assert block.transactions_generator is not None
+        wrong_root = std_hash(bytes(block.transactions_generator))
+        block_2 = recursive_replace(block, "transactions_info.generator_root", wrong_root)
+        block_2 = recursive_replace(
+            block_2, "foliage_transaction_block.transactions_info_hash", block_2.transactions_info.get_hash()
+        )
+        block_2 = recursive_replace(
+            block_2, "foliage.foliage_transaction_block_hash", block_2.foliage_transaction_block.get_hash()
+        )
+        new_m = block_2.foliage.foliage_transaction_block_hash
+        assert new_m is not None
+        new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
+        block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
+        await _validate_and_add_block(
+            b, block_2, expected_error=Err.INVALID_TRANSACTIONS_GENERATOR_HASH, skip_prevalidation=True
+        )
 
     @pytest.mark.anyio
     async def test_invalid_transactions_ref_list(

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -375,6 +375,83 @@ class TestBlockHeaderValidation:
         assert validate_res.error is None
 
     @pytest.mark.anyio
+    @pytest.mark.limit_consensus_modes(
+        allowed=[ConsensusMode.HARD_FORK_3_0, ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT]
+    )
+    async def test_unfinished_block_generator_root_tree_hash_post_hf2(
+        self, empty_blockchain: Blockchain, bt: BlockTools
+    ) -> None:
+        """Post-HF2 unfinished transaction blocks with tree_hash generator_root must be accepted."""
+        blockchain = empty_blockchain
+        blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
+        await _validate_and_add_block(blockchain, blocks[0])
+        block = blocks[1]
+        assert block.transactions_generator is not None
+        assert block.transactions_info is not None
+        assert block.transactions_info.generator_root == bytes32(tree_hash(bytes(block.transactions_generator)))
+        unf = UnfinishedBlock(
+            block.finished_sub_slots,
+            block.reward_chain_block.get_unfinished(),
+            block.challenge_chain_sp_proof,
+            block.reward_chain_sp_proof,
+            block.foliage,
+            block.foliage_transaction_block,
+            block.transactions_info,
+            block.transactions_generator,
+            [],
+        )
+        block_generator = await get_block_generator(blockchain.lookup_block_generators, unf)
+        assert block_generator is not None
+        npc_result = get_name_puzzle_conditions(
+            block_generator,
+            block.transactions_info.cost,
+            mempool_mode=False,
+            height=block.height,
+            constants=bt.constants,
+        )
+        validate_res = await blockchain.validate_unfinished_block(unf, npc_result, False)
+        assert validate_res.error is None
+
+    @pytest.mark.anyio
+    @pytest.mark.limit_consensus_modes(
+        allowed=[ConsensusMode.HARD_FORK_3_0, ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT]
+    )
+    async def test_unfinished_block_std_hash_root_rejected_post_hf2(
+        self, empty_blockchain: Blockchain, bt: BlockTools
+    ) -> None:
+        """Post-HF2 unfinished blocks with std_hash (old) generator_root must be rejected."""
+        blockchain = empty_blockchain
+        blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
+        await _validate_and_add_block(blockchain, blocks[0])
+        block = blocks[1]
+        assert block.transactions_generator is not None
+        wrong_root = std_hash(bytes(block.transactions_generator))
+        block_2 = recursive_replace(block, "transactions_info.generator_root", wrong_root)
+        block_2 = recursive_replace(
+            block_2, "foliage_transaction_block.transactions_info_hash", block_2.transactions_info.get_hash()
+        )
+        block_2 = recursive_replace(
+            block_2, "foliage.foliage_transaction_block_hash", block_2.foliage_transaction_block.get_hash()
+        )
+        new_m = block_2.foliage.foliage_transaction_block_hash
+        assert new_m is not None
+        new_fsb_sig = bt.get_plot_signature(new_m, block.reward_chain_block.proof_of_space.plot_public_key)
+        block_2 = recursive_replace(block_2, "foliage.foliage_transaction_block_signature", new_fsb_sig)
+        unf = UnfinishedBlock(
+            block_2.finished_sub_slots,
+            block_2.reward_chain_block.get_unfinished(),
+            block_2.challenge_chain_sp_proof,
+            block_2.reward_chain_sp_proof,
+            block_2.foliage,
+            block_2.foliage_transaction_block,
+            block_2.transactions_info,
+            block_2.transactions_generator,
+            [],
+        )
+        validate_res = await blockchain.validate_unfinished_block(unf, None, False)
+        assert validate_res.error == Err.INVALID_TRANSACTIONS_GENERATOR_HASH.value
+
+    @pytest.mark.anyio
     async def test_empty_genesis(self, empty_blockchain: Blockchain, bt: BlockTools) -> None:
         for block in bt.get_consecutive_blocks(2, skip_slots=3):
             await _validate_and_add_block(empty_blockchain, block)

--- a/chia/_tests/core/consensus/test_block_creation.py
+++ b/chia/_tests/core/consensus/test_block_creation.py
@@ -1,11 +1,24 @@
 from __future__ import annotations
 
-import pytest
-from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint64
+from collections.abc import Sequence
 
-from chia.consensus.block_creation import compute_block_fee
+import pytest
+from chia_rs import (
+    G1Element,
+    G2Element,
+    PoolTarget,
+    ProofOfSpace,
+    RewardChainBlockUnfinished,
+    tree_hash,
+)
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
+
+from chia.consensus.block_creation import compute_block_fee, create_foliage
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
+from chia.types.generator_types import NewBlockGenerator
+from chia.util.hash import std_hash
 
 
 @pytest.mark.parametrize("add_amount", [[0], [1, 2, 3], []])
@@ -23,3 +36,119 @@ def test_compute_block_fee(add_amount: list[int], rem_amount: list[int]) -> None
             compute_block_fee(additions, removals)
     else:
         assert compute_block_fee(additions, removals) == expected
+
+
+def _make_proof_of_space() -> ProofOfSpace:
+    return ProofOfSpace(
+        bytes32.zeros,
+        G1Element(),
+        None,
+        G1Element(),
+        uint8(0),
+        uint16(0),
+        uint8(0),
+        uint8(0),
+        uint8(20),
+        bytes(32 * 5),
+    )
+
+
+def _make_rc_block_unfinished() -> RewardChainBlockUnfinished:
+    return RewardChainBlockUnfinished(
+        uint128(1),
+        uint8(1),
+        bytes32.zeros,
+        _make_proof_of_space(),
+        None,
+        G2Element(),
+        None,
+        G2Element(),
+    )
+
+
+def _dummy_plot_sig(_msg: bytes32, _pk: G1Element) -> G2Element:
+    return G2Element()
+
+
+def _dummy_pool_sig(_target: PoolTarget, _pk: G1Element | None) -> G2Element | None:
+    return G2Element()
+
+
+def _zero_fees(_additions: Sequence[Coin], _removals: Sequence[Coin]) -> uint64:
+    return uint64(0)
+
+
+def _call_create_foliage_genesis(constants, program_bytes: bytes) -> bytes32:
+    """Call create_foliage for a genesis block and return the generator_root."""
+    from chia_rs import Program
+
+    program = Program.from_bytes(program_bytes)
+    gen = NewBlockGenerator(
+        program=program,
+        block_refs=[],
+        signature=G2Element(),
+        additions=[],
+        removals=[],
+        cost=uint64(0),
+    )
+    _, ftb, tx_info = create_foliage(
+        constants,
+        _make_rc_block_unfinished(),
+        gen,
+        None,  # prev_block (genesis)
+        {},  # type: ignore[arg-type]
+        uint128(0),
+        uint64(0),
+        bytes32.zeros,
+        PoolTarget(bytes32.zeros, uint32(0)),
+        _dummy_plot_sig,
+        _dummy_pool_sig,
+        b"seed",
+        _zero_fees,
+    )
+    assert tx_info is not None
+    return tx_info.generator_root
+
+
+@pytest.mark.parametrize(
+    "program_bytes",
+    [
+        b"\x80",  # CLVM nil
+        b"\xff\x01\x80",  # (1)
+    ],
+)
+def test_generator_hash_pre_hf2(program_bytes: bytes) -> None:
+    constants = DEFAULT_CONSTANTS.replace(HARD_FORK2_HEIGHT=uint32(1000))
+    generator_root = _call_create_foliage_genesis(constants, program_bytes)
+
+    from chia_rs import Program
+
+    expected = std_hash(Program.from_bytes(program_bytes))
+    assert generator_root == expected
+
+
+@pytest.mark.parametrize(
+    "program_bytes",
+    [
+        b"\x80",  # CLVM nil
+        b"\xff\x01\x80",  # (1)
+    ],
+)
+def test_generator_hash_post_hf2(program_bytes: bytes) -> None:
+    constants = DEFAULT_CONSTANTS.replace(HARD_FORK2_HEIGHT=uint32(0))
+    generator_root = _call_create_foliage_genesis(constants, program_bytes)
+
+    expected = bytes32(tree_hash(program_bytes))
+    assert generator_root == expected
+
+
+def test_generator_hash_differs_between_forks() -> None:
+    program_bytes = b"\xff\x01\x80"  # (1)
+
+    pre_constants = DEFAULT_CONSTANTS.replace(HARD_FORK2_HEIGHT=uint32(1000))
+    post_constants = DEFAULT_CONSTANTS.replace(HARD_FORK2_HEIGHT=uint32(0))
+
+    pre_root = _call_create_foliage_genesis(pre_constants, program_bytes)
+    post_root = _call_create_foliage_genesis(post_constants, program_bytes)
+
+    assert pre_root != post_root

--- a/chia/_tests/core/consensus/test_block_creation.py
+++ b/chia/_tests/core/consensus/test_block_creation.py
@@ -1,23 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
-
 import pytest
-from chia_rs import (
-    G1Element,
-    G2Element,
-    PoolTarget,
-    ProofOfSpace,
-    RewardChainBlockUnfinished,
-    tree_hash,
-)
+from chia_rs import tree_hash
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
+from chia_rs.sized_ints import uint32, uint64
 
-from chia.consensus.block_creation import compute_block_fee, create_foliage
+from chia.consensus.block_creation import compute_block_fee, generator_root
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.coin import Coin
-from chia.types.generator_types import NewBlockGenerator
 from chia.util.hash import std_hash
 
 
@@ -38,78 +28,6 @@ def test_compute_block_fee(add_amount: list[int], rem_amount: list[int]) -> None
         assert compute_block_fee(additions, removals) == expected
 
 
-def _make_proof_of_space() -> ProofOfSpace:
-    return ProofOfSpace(
-        bytes32.zeros,
-        G1Element(),
-        None,
-        G1Element(),
-        uint8(0),
-        uint16(0),
-        uint8(0),
-        uint8(0),
-        uint8(20),
-        bytes(32 * 5),
-    )
-
-
-def _make_rc_block_unfinished() -> RewardChainBlockUnfinished:
-    return RewardChainBlockUnfinished(
-        uint128(1),
-        uint8(1),
-        bytes32.zeros,
-        _make_proof_of_space(),
-        None,
-        G2Element(),
-        None,
-        G2Element(),
-    )
-
-
-def _dummy_plot_sig(_msg: bytes32, _pk: G1Element) -> G2Element:
-    return G2Element()
-
-
-def _dummy_pool_sig(_target: PoolTarget, _pk: G1Element | None) -> G2Element | None:
-    return G2Element()
-
-
-def _zero_fees(_additions: Sequence[Coin], _removals: Sequence[Coin]) -> uint64:
-    return uint64(0)
-
-
-def _call_create_foliage_genesis(constants, program_bytes: bytes) -> bytes32:
-    """Call create_foliage for a genesis block and return the generator_root."""
-    from chia_rs import Program
-
-    program = Program.from_bytes(program_bytes)
-    gen = NewBlockGenerator(
-        program=program,
-        block_refs=[],
-        signature=G2Element(),
-        additions=[],
-        removals=[],
-        cost=uint64(0),
-    )
-    _, ftb, tx_info = create_foliage(
-        constants,
-        _make_rc_block_unfinished(),
-        gen,
-        None,  # prev_block (genesis)
-        {},  # type: ignore[arg-type]
-        uint128(0),
-        uint64(0),
-        bytes32.zeros,
-        PoolTarget(bytes32.zeros, uint32(0)),
-        _dummy_plot_sig,
-        _dummy_pool_sig,
-        b"seed",
-        _zero_fees,
-    )
-    assert tx_info is not None
-    return tx_info.generator_root
-
-
 @pytest.mark.parametrize(
     "program_bytes",
     [
@@ -117,14 +35,9 @@ def _call_create_foliage_genesis(constants, program_bytes: bytes) -> bytes32:
         b"\xff\x01\x80",  # (1)
     ],
 )
-def test_generator_hash_pre_hf2(program_bytes: bytes) -> None:
+def test_generator_root_pre_hf2(program_bytes: bytes) -> None:
     constants = DEFAULT_CONSTANTS.replace(HARD_FORK2_HEIGHT=uint32(1000))
-    generator_root = _call_create_foliage_genesis(constants, program_bytes)
-
-    from chia_rs import Program
-
-    expected = std_hash(Program.from_bytes(program_bytes))
-    assert generator_root == expected
+    assert generator_root(program_bytes, 0, constants) == std_hash(program_bytes)
 
 
 @pytest.mark.parametrize(
@@ -134,21 +47,6 @@ def test_generator_hash_pre_hf2(program_bytes: bytes) -> None:
         b"\xff\x01\x80",  # (1)
     ],
 )
-def test_generator_hash_post_hf2(program_bytes: bytes) -> None:
+def test_generator_root_post_hf2(program_bytes: bytes) -> None:
     constants = DEFAULT_CONSTANTS.replace(HARD_FORK2_HEIGHT=uint32(0))
-    generator_root = _call_create_foliage_genesis(constants, program_bytes)
-
-    expected = bytes32(tree_hash(program_bytes))
-    assert generator_root == expected
-
-
-def test_generator_hash_differs_between_forks() -> None:
-    program_bytes = b"\xff\x01\x80"  # (1)
-
-    pre_constants = DEFAULT_CONSTANTS.replace(HARD_FORK2_HEIGHT=uint32(1000))
-    post_constants = DEFAULT_CONSTANTS.replace(HARD_FORK2_HEIGHT=uint32(0))
-
-    pre_root = _call_create_foliage_genesis(pre_constants, program_bytes)
-    post_root = _call_create_foliage_genesis(post_constants, program_bytes)
-
-    assert pre_root != post_root
+    assert generator_root(program_bytes, 0, constants) == bytes32(tree_hash(program_bytes))

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -53,6 +53,7 @@ from chia._tests.util.setup_nodes import (
 from chia._tests.util.time_out_assert import time_out_assert, time_out_assert_custom_interval, time_out_messages
 from chia.consensus.augmented_chain import AugmentedBlockchain
 from chia.consensus.block_body_validation import ForkInfo
+from chia.consensus.block_creation import generator_root
 from chia.consensus.blockchain import Blockchain
 from chia.consensus.coin_store_protocol import CoinStoreProtocol
 from chia.consensus.get_block_challenge import get_block_challenge
@@ -1625,7 +1626,7 @@ async def test_unfinished_block_with_replaced_generator(
         tr = block.transactions_info
         assert tr is not None
         transactions_info = TransactionsInfo(
-            std_hash(bytes(replaced_generator)),
+            generator_root(bytes(replaced_generator), block.height, bt.constants),
             tr.generator_refs_root,
             tr.aggregated_signature,
             tr.fees,

--- a/chia/_tests/wallet/wallet_block_tools.py
+++ b/chia/_tests/wallet/wallet_block_tools.py
@@ -25,6 +25,7 @@ from chia_rs.sized_bytes import bytes32, bytes100
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
 from chiabip158 import PyBIP158
 
+from chia.consensus.block_creation import generator_root
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
 from chia.consensus.full_block_to_block_record import block_to_block_record
@@ -278,7 +279,7 @@ def get_full_block_and_block_record(
 
     generator_hash = bytes32.zeros
     if block_generator is not None:
-        generator_hash = std_hash(block_generator.program)
+        generator_hash = generator_root(bytes(block_generator.program), height, constants)
 
     foliage_data = FoliageBlockData(
         bytes32.zeros,

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -332,8 +332,10 @@ async def validate_block_body(
     # 7a. The generator root must be the hash of the serialized bytes of
     #     the generator for this block (or zeroes if no generator)
     if block.transactions_generator is not None:
-        if generator_root(bytes(block.transactions_generator), height, constants) != \
-                block.transactions_info.generator_root:
+        if (
+            generator_root(bytes(block.transactions_generator), height, constants)
+            != block.transactions_info.generator_root
+        ):
             return Err.INVALID_TRANSACTIONS_GENERATOR_HASH
     elif block.transactions_info.generator_root != bytes([0] * 32):
         return Err.INVALID_TRANSACTIONS_GENERATOR_HASH

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -15,12 +15,12 @@ from chia_rs import (
     check_time_locks,
     compute_merkle_set_root,
     is_canonical_serialization,
-    tree_hash,
 )
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 from chiabip158 import PyBIP158
 
+from chia.consensus.block_creation import generator_root
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
@@ -332,11 +332,8 @@ async def validate_block_body(
     # 7a. The generator root must be the hash of the serialized bytes of
     #     the generator for this block (or zeroes if no generator)
     if block.transactions_generator is not None:
-        if height >= constants.HARD_FORK2_HEIGHT:
-            expected_generator_hash = bytes32(tree_hash(bytes(block.transactions_generator)))
-        else:
-            expected_generator_hash = std_hash(bytes(block.transactions_generator))
-        if expected_generator_hash != block.transactions_info.generator_root:
+        if generator_root(bytes(block.transactions_generator), height, constants) != \
+                block.transactions_info.generator_root:
             return Err.INVALID_TRANSACTIONS_GENERATOR_HASH
     elif block.transactions_info.generator_root != bytes([0] * 32):
         return Err.INVALID_TRANSACTIONS_GENERATOR_HASH

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -15,6 +15,7 @@ from chia_rs import (
     check_time_locks,
     compute_merkle_set_root,
     is_canonical_serialization,
+    tree_hash,
 )
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
@@ -331,7 +332,11 @@ async def validate_block_body(
     # 7a. The generator root must be the hash of the serialized bytes of
     #     the generator for this block (or zeroes if no generator)
     if block.transactions_generator is not None:
-        if std_hash(bytes(block.transactions_generator)) != block.transactions_info.generator_root:
+        if height >= constants.HARD_FORK2_HEIGHT:
+            expected_generator_hash = bytes32(tree_hash(bytes(block.transactions_generator)))
+        else:
+            expected_generator_hash = std_hash(bytes(block.transactions_generator))
+        if expected_generator_hash != block.transactions_info.generator_root:
             return Err.INVALID_TRANSACTIONS_GENERATOR_HASH
     elif block.transactions_info.generator_root != bytes([0] * 32):
         return Err.INVALID_TRANSACTIONS_GENERATOR_HASH

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -22,6 +22,7 @@ from chia_rs import (
     TransactionsInfo,
     UnfinishedBlock,
     compute_merkle_set_root,
+    tree_hash,
 )
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64, uint128
@@ -226,7 +227,10 @@ def create_foliage(
 
         generator_hash = bytes32.zeros
         if new_block_gen is not None:
-            generator_hash = std_hash(new_block_gen.program)
+            if height >= constants.HARD_FORK2_HEIGHT:
+                generator_hash = bytes32(tree_hash(bytes(new_block_gen.program)))
+            else:
+                generator_hash = std_hash(new_block_gen.program)
 
         generator_refs_hash = bytes32([1] * 32)
         if generator_block_heights_list not in (None, []):

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -41,6 +41,13 @@ from chia.util.hash import std_hash
 log = logging.getLogger(__name__)
 
 
+def generator_root(program: bytes, height: int, constants: ConsensusConstants) -> bytes32:
+    """Return the generator_root hash for a block at the given height."""
+    if height >= constants.HARD_FORK2_HEIGHT:
+        return bytes32(tree_hash(program))
+    return std_hash(program)
+
+
 def compute_block_fee(additions: Sequence[Coin], removals: Sequence[Coin]) -> uint64:
     removal_amount = 0
     addition_amount = 0
@@ -227,10 +234,7 @@ def create_foliage(
 
         generator_hash = bytes32.zeros
         if new_block_gen is not None:
-            if height >= constants.HARD_FORK2_HEIGHT:
-                generator_hash = bytes32(tree_hash(bytes(new_block_gen.program)))
-            else:
-                generator_hash = std_hash(new_block_gen.program)
+            generator_hash = generator_root(bytes(new_block_gen.program), height, constants)
 
         generator_refs_hash = bytes32([1] * 32)
         if generator_block_heights_list not in (None, []):

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -26,6 +26,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint16, uint32, uint64, uint128
 
 from chia.consensus.block_body_validation import ForkInfo, validate_block_body
+from chia.consensus.block_creation import generator_root
 from chia.consensus.block_header_validation import validate_unfinished_header_block
 from chia.consensus.block_height_map import BlockHeightMap
 from chia.consensus.coin_store_protocol import CoinStoreProtocol
@@ -43,7 +44,6 @@ from chia.types.generator_types import BlockGenerator
 from chia.types.unfinished_header_block import UnfinishedHeaderBlock
 from chia.types.validation_state import ValidationState
 from chia.util.errors import Err
-from chia.util.hash import std_hash
 from chia.util.priority_mutex import PriorityMutex
 from chia.util.priority_thread_pool_executor import Executor
 
@@ -711,9 +711,12 @@ class Blockchain:
         if prev_tx_height >= self.constants.SOFT_FORK9_HEIGHT and block.transactions_generator_ref_list != []:
             return None, Err.TOO_MANY_GENERATOR_REFS
 
+        height = uint32(prev_b.height + 1) if prev_b is not None else uint32(0)
+
         if block.transactions_info is not None:
             if block.transactions_generator is not None:
-                if std_hash(bytes(block.transactions_generator)) != block.transactions_info.generator_root:
+                expected = generator_root(bytes(block.transactions_generator), height, self.constants)
+                if expected != block.transactions_info.generator_root:
                     return None, Err.INVALID_TRANSACTIONS_GENERATOR_HASH
             elif block.transactions_info.generator_root != bytes([0] * 32):
                 return None, Err.INVALID_TRANSACTIONS_GENERATOR_HASH


### PR DESCRIPTION
## Summary

- Switch generator hash computation from `std_hash` (SHA256 of serialized bytes) to `tree_hash` (CLVM tree hash) at `HARD_FORK2_HEIGHT`
- Both block creation (`create_foliage`) and block validation (`validate_block_body`) updated to match
- Without this, farmers would produce blocks with incorrect generator hashes post-fork and validators would reject them

## Changes

- `chia/consensus/block_creation.py`: use `tree_hash()` for generator root when `height >= HARD_FORK2_HEIGHT`
- `chia/consensus/block_body_validation.py`: matching validation-side change
- `chia/_tests/core/consensus/test_block_creation.py`: 5 new tests verifying pre/post fork hash behavior

## Test plan

- [x] Pre-fork: verify `std_hash` is used (parametrized with nil and `(1)`)
- [x] Post-fork: verify `tree_hash` is used (parametrized with nil and `(1)`)
- [x] Verify the two hash methods produce different results
- [ ] Full integration tests via CI

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Consensus-critical change that alters block header/body hashing rules at `HARD_FORK2_HEIGHT`; any mismatch could cause chain splits or rejected blocks around fork heights.
> 
> **Overview**
> Switches transaction block `transactions_info.generator_root` to be computed via `tree_hash` (CLVM tree hash) once `height >= HARD_FORK2_HEIGHT`, centralizing the logic in a new `generator_root()` helper and using it in both block creation and validation paths.
> 
> Updates unfinished-block header validation and test block builders to use the height-aware generator root, and adds/extends tests to ensure **pre-HF2 uses `std_hash`**, **post-HF2 uses `tree_hash`**, and that blocks/unfinished blocks with the old root are rejected post-fork.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f34182ea8fb39664e13d7039960be05ff74d1e01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->