### PR TITLE
mypy: remove exclusion for chia._tests.clvm.coin_store

### DIFF
--- a/chia/_tests/clvm/coin_store.py
+++ b/chia/_tests/clvm/coin_store.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from collections.abc import Iterator
 from dataclasses import dataclass
 
-from chia_rs import CoinRecord, ConsensusConstants, SpendBundle, check_time_locks
+from chia_rs import CoinRecord, CoinSpend, ConsensusConstants, SpendBundle, check_time_locks
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
@@ -30,7 +30,7 @@ class CoinTimestamp:
 class CoinStore:
     def __init__(self, constants: ConsensusConstants, reward_mask: int = 0):
         self._db: dict[bytes32, CoinRecord] = dict()
-        self._ph_index: dict = defaultdict(list)
+        self._ph_index: dict[bytes32, list[bytes32]] = defaultdict(list)
         self._reward_mask = reward_mask
         self._constants = constants
 
@@ -39,7 +39,7 @@ class CoinStore:
         puzzle_hash: bytes32,
         birthday: CoinTimestamp,
         amount: int = 1024,
-        prefix=bytes32.fromhex("ccd5bb71183532bff220ba46c268991a00000000000000000000000000000000"),
+        prefix: bytes32 = bytes32.fromhex("ccd5bb71183532bff220ba46c268991a00000000000000000000000000000000"),
     ) -> Coin:
         parent = bytes32(
             [
@@ -101,7 +101,7 @@ class CoinStore:
         spend_bundle: SpendBundle,
         now: CoinTimestamp,
         max_cost: int,
-    ):
+    ) -> tuple[list[Coin], list[CoinSpend]]:
         err = self.validate_spend_bundle(spend_bundle, now, max_cost)
         if err != 0:
             raise BadSpendBundleError(f"validation failure {err}")

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -34,7 +34,6 @@ chia.wallet.wallet_node_api
 chia.wallet.wallet_puzzle_store
 chia.wallet.wallet_transaction_store
 chia.wallet.wallet_user_store
-chia._tests.clvm.coin_store
 chia._tests.clvm.test_chialisp_deserialization
 chia._tests.clvm.test_program
 chia._tests.clvm.test_puzzle_compression


### PR DESCRIPTION
## Purpose

Remove `chia._tests.clvm.coin_store` from mypy strict-mode exclusions.

## Current Behavior

`chia._tests.clvm.coin_store` is excluded from mypy strict checking. The `CoinStore` class has three strict-mode violations: a bare `dict` without type parameters, a missing parameter annotation, and a missing return type.

## New Behavior

The module is now covered by strict type checking with all concrete types — no `Any` or `# type: ignore` needed.

## Changes

* `chia/_tests/clvm/coin_store.py`
  — Added generic type parameters to `_ph_index`: `dict[bytes32, list[bytes32]]`
  — Added `bytes32` type annotation to `farm_coin`'s `prefix` parameter
  — Added return type `tuple[list[Coin], list[CoinSpend]]` to `update_coin_store_for_spend_bundle`
  — Added `CoinSpend` import from `chia_rs`
* `mypy-exclusions.txt` — removed `chia._tests.clvm.coin_store`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only changes in test utilities plus a mypy config tweak; runtime behavior should be unchanged aside from exposing potential type errors during CI.
> 
> **Overview**
> Makes `chia._tests.clvm.coin_store` pass mypy strict-mode by tightening type annotations: `_ph_index` is now a `dict[bytes32, list[bytes32]]`, `farm_coin`’s `prefix` is explicitly a `bytes32`, and `update_coin_store_for_spend_bundle` now declares a return type of `tuple[list[Coin], list[CoinSpend]]` (including importing `CoinSpend`).
> 
> Updates `mypy-exclusions.txt` to stop excluding this module from strict checking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cd02a4a32e63b7cf9ed9c68fb7648f090c5a876. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->