### PR TITLE
Close VDF client TCP connections properly

### DIFF
--- a/chia/_tests/timelord/test_timelord.py
+++ b/chia/_tests/timelord/test_timelord.py
@@ -1,80 +1,18 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint64
 
-from chia.timelord import timelord as timelord_module
 from chia.timelord.timelord import Timelord
 from chia.timelord.timelord_service import TimelordService
-from chia.timelord.types import Chain
-from chia.types.blockchain_format.classgroup import ClassgroupElement
 
 
 @pytest.mark.anyio
 async def test_timelord_has_no_server(timelord_service: TimelordService) -> None:
     timelord_server = timelord_service._node.server
     assert timelord_server.webserver is None
-
-
-class _NullTransport(asyncio.Transport):
-    def write(self, data: bytes) -> None:
-        pass
-
-    def is_closing(self) -> bool:
-        return False
-
-
-def _make_null_writer() -> asyncio.StreamWriter:
-    loop = asyncio.get_running_loop()
-    reader = asyncio.StreamReader()
-    protocol = asyncio.StreamReaderProtocol(reader, loop=loop)
-    return asyncio.StreamWriter(_NullTransport(), protocol, reader, loop)
-
-
-@pytest.mark.anyio
-async def test_invalid_vdf_proof_is_ignored_in_process_communication(
-    timelord_service: TimelordService, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    timelord = timelord_service._node
-    chain = Chain.CHALLENGE_CHAIN
-    challenge = bytes32.zeros
-    initial_form = ClassgroupElement.get_default_element()
-    timelord.chain_start_time[chain] = time.time()
-
-    state_changed_calls: list[object] = []
-    monkeypatch.setattr(timelord_module, "validate_vdf", lambda *_args, **_kwargs: False)
-    monkeypatch.setattr(timelord, "state_changed", lambda *args, **kwargs: state_changed_calls.append((args, kwargs)))
-
-    iterations_needed = uint64(10)
-    y_bytes = initial_form.data
-    witness_type = 0
-    proof_bytes = b"\x01\x02"
-    proof_payload = (
-        int(iterations_needed).to_bytes(8, "big", signed=True)
-        + len(y_bytes).to_bytes(8, "big", signed=True)
-        + y_bytes
-        + bytes([witness_type])
-        + proof_bytes
-    )
-    encoded_payload = proof_payload.hex().encode()
-
-    reader = asyncio.StreamReader()
-    reader.feed_data(b"OK")
-    reader.feed_data(len(encoded_payload).to_bytes(4, "big"))
-    reader.feed_data(encoded_payload)
-    reader.feed_data(b"STOP")
-    reader.feed_eof()
-
-    writer = _make_null_writer()
-    await timelord._do_process_communication(chain, challenge, initial_form, "127.0.0.1", reader, writer, proof_label=1)
-
-    assert timelord.proofs_finished == []
-    assert state_changed_calls == []
 
 
 def _make_mock_writer(ip: str = "127.0.0.1") -> MagicMock:

--- a/chia/_tests/timelord/test_timelord.py
+++ b/chia/_tests/timelord/test_timelord.py
@@ -1,11 +1,141 @@
 from __future__ import annotations
 
-import pytest
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint64
+
+from chia.timelord import timelord as timelord_module
+from chia.timelord.timelord import Timelord
 from chia.timelord.timelord_service import TimelordService
+from chia.timelord.types import Chain
+from chia.types.blockchain_format.classgroup import ClassgroupElement
 
 
 @pytest.mark.anyio
 async def test_timelord_has_no_server(timelord_service: TimelordService) -> None:
     timelord_server = timelord_service._node.server
     assert timelord_server.webserver is None
+
+
+class _NullTransport(asyncio.Transport):
+    def write(self, data: bytes) -> None:
+        pass
+
+    def is_closing(self) -> bool:
+        return False
+
+
+def _make_null_writer() -> asyncio.StreamWriter:
+    loop = asyncio.get_running_loop()
+    reader = asyncio.StreamReader()
+    protocol = asyncio.StreamReaderProtocol(reader, loop=loop)
+    return asyncio.StreamWriter(_NullTransport(), protocol, reader, loop)
+
+
+@pytest.mark.anyio
+async def test_invalid_vdf_proof_is_ignored_in_process_communication(
+    timelord_service: TimelordService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    timelord = timelord_service._node
+    chain = Chain.CHALLENGE_CHAIN
+    challenge = bytes32.zeros
+    initial_form = ClassgroupElement.get_default_element()
+    timelord.chain_start_time[chain] = time.time()
+
+    state_changed_calls: list[object] = []
+    monkeypatch.setattr(timelord_module, "validate_vdf", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(timelord, "state_changed", lambda *args, **kwargs: state_changed_calls.append((args, kwargs)))
+
+    iterations_needed = uint64(10)
+    y_bytes = initial_form.data
+    witness_type = 0
+    proof_bytes = b"\x01\x02"
+    proof_payload = (
+        int(iterations_needed).to_bytes(8, "big", signed=True)
+        + len(y_bytes).to_bytes(8, "big", signed=True)
+        + y_bytes
+        + bytes([witness_type])
+        + proof_bytes
+    )
+    encoded_payload = proof_payload.hex().encode()
+
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"OK")
+    reader.feed_data(len(encoded_payload).to_bytes(4, "big"))
+    reader.feed_data(encoded_payload)
+    reader.feed_data(b"STOP")
+    reader.feed_eof()
+
+    writer = _make_null_writer()
+    await timelord._do_process_communication(chain, challenge, initial_form, "127.0.0.1", reader, writer, proof_label=1)
+
+    assert timelord.proofs_finished == []
+    assert state_changed_calls == []
+
+
+def _make_mock_writer(ip: str = "127.0.0.1") -> MagicMock:
+    writer = MagicMock(spec=asyncio.StreamWriter)
+    writer.get_extra_info.return_value = (ip, 12345)
+    writer.close = MagicMock()
+    writer.wait_closed = AsyncMock()
+    return writer
+
+
+def _make_timelord_stub(ip_whitelist: list[str]) -> Timelord:
+    with patch.object(Timelord, "__init__", lambda self, *a, **kw: None):
+        tl = Timelord.__new__(Timelord)
+    tl.free_clients = []
+    tl.max_free_clients = 10
+    tl.ip_whitelist = ip_whitelist
+    tl.lock = asyncio.Lock()
+    return tl
+
+
+class TestHandleClient:
+    @pytest.mark.anyio
+    async def test_non_whitelisted_ip_is_rejected_and_closed(self) -> None:
+        tl = _make_timelord_stub(ip_whitelist=["127.0.0.1"])
+        reader = MagicMock(spec=asyncio.StreamReader)
+        writer = _make_mock_writer(ip="10.0.0.99")
+
+        await tl._handle_client(reader, writer)
+
+        assert len(tl.free_clients) == 0
+        writer.close.assert_called_once()
+        writer.wait_closed.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_whitelisted_ip_is_accepted(self) -> None:
+        tl = _make_timelord_stub(ip_whitelist=["127.0.0.1"])
+        reader = MagicMock(spec=asyncio.StreamReader)
+        writer = _make_mock_writer(ip="127.0.0.1")
+
+        await tl._handle_client(reader, writer)
+
+        assert len(tl.free_clients) == 1
+        assert tl.free_clients[0] == ("127.0.0.1", reader, writer)
+        writer.close.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_excess_clients_beyond_cap_are_rejected(self) -> None:
+        tl = _make_timelord_stub(ip_whitelist=["127.0.0.1"])
+        tl.max_free_clients = 3
+
+        for _ in range(3):
+            reader = MagicMock(spec=asyncio.StreamReader)
+            writer = _make_mock_writer(ip="127.0.0.1")
+            await tl._handle_client(reader, writer)
+
+        assert len(tl.free_clients) == 3
+
+        overflow_reader = MagicMock(spec=asyncio.StreamReader)
+        overflow_writer = _make_mock_writer(ip="127.0.0.1")
+        await tl._handle_client(overflow_reader, overflow_writer)
+
+        assert len(tl.free_clients) == 3
+        overflow_writer.close.assert_called_once()
+        overflow_writer.wait_closed.assert_awaited_once()

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -98,6 +98,7 @@ class Timelord:
         self.constants = constants
         self._shut_down = False
         self.free_clients: list[tuple[str, asyncio.StreamReader, asyncio.StreamWriter]] = []
+        self.max_free_clients: int = 10
         self.ip_whitelist = self.config["vdf_clients"]["ip"]
         self._server: ChiaServer | None = None
         self.chain_type_to_stream: dict[Chain, tuple[str, asyncio.StreamReader, asyncio.StreamWriter]] = {}
@@ -189,6 +190,10 @@ class Timelord:
                 self.main_loop.cancel()
             if self.bluebox_pool is not None:
                 self.bluebox_pool.shutdown()
+            for _, _, writer in self.free_clients:
+                with contextlib.suppress(Exception):
+                    writer.close()
+            self.free_clients.clear()
 
     def get_connections(self, request_node_type: NodeType | None) -> list[dict[str, Any]]:
         return default_get_connections(server=self.server, request_node_type=request_node_type)
@@ -215,9 +220,18 @@ class Timelord:
         async with self.lock:
             client_ip = writer.get_extra_info("peername")[0]
             log.debug(f"New timelord connection from client: {client_ip}.")
-            if client_ip in self.ip_whitelist:
-                self.free_clients.append((client_ip, reader, writer))
-                log.debug(f"Added new VDF client {client_ip}.")
+            if client_ip not in self.ip_whitelist:
+                log.warning(f"Rejected VDF client from non-whitelisted IP: {client_ip}")
+                writer.close()
+                await writer.wait_closed()
+                return
+            if len(self.free_clients) >= self.max_free_clients:
+                log.warning(f"Too many free VDF clients ({len(self.free_clients)}), rejecting {client_ip}")
+                writer.close()
+                await writer.wait_closed()
+                return
+            self.free_clients.append((client_ip, reader, writer))
+            log.debug(f"Added new VDF client {client_ip}.")
 
     async def _stop_chain(self, chain: Chain) -> None:
         try:

--- a/chia/timelord/timelord.py
+++ b/chia/timelord/timelord.py
@@ -217,21 +217,22 @@ class Timelord:
         self._server = server
 
     async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        should_close = False
         async with self.lock:
             client_ip = writer.get_extra_info("peername")[0]
             log.debug(f"New timelord connection from client: {client_ip}.")
             if client_ip not in self.ip_whitelist:
                 log.warning(f"Rejected VDF client from non-whitelisted IP: {client_ip}")
-                writer.close()
-                await writer.wait_closed()
-                return
-            if len(self.free_clients) >= self.max_free_clients:
+                should_close = True
+            elif len(self.free_clients) >= self.max_free_clients:
                 log.warning(f"Too many free VDF clients ({len(self.free_clients)}), rejecting {client_ip}")
-                writer.close()
-                await writer.wait_closed()
-                return
-            self.free_clients.append((client_ip, reader, writer))
-            log.debug(f"Added new VDF client {client_ip}.")
+                should_close = True
+            else:
+                self.free_clients.append((client_ip, reader, writer))
+                log.debug(f"Added new VDF client {client_ip}.")
+        if should_close:
+            writer.close()
+            await writer.wait_closed()
 
     async def _stop_chain(self, chain: Chain) -> None:
         try:


### PR DESCRIPTION
### Purpose:

Close VDF client TCP connections that should not remain open: non-whitelisted clients and overflow clients beyond the free pool cap.

### Current Behavior:

- `_handle_client()` silently drops non-whitelisted TCP connections without closing the `StreamWriter`
- `free_clients` grows without bound once all 3 chains are mapped
- Leftover `free_clients` connections are not closed during timelord shutdown

### New Behavior:

- Non-whitelisted connections are explicitly closed (`writer.close()` + `await writer.wait_closed()`)
- `free_clients` is capped at `max_free_clients` (10); excess connections are closed
- Remaining `free_clients` connections are closed during shutdown

### Testing Notes:

Three new unit tests in `TestHandleClient`:
- `test_non_whitelisted_ip_is_rejected_and_closed` — verifies writer is closed and client is not added to `free_clients`
- `test_whitelisted_ip_is_accepted` — verifies client is added and writer is not closed
- `test_excess_clients_beyond_cap_are_rejected` — verifies overflow connections are closed and `free_clients` stays at cap

All checks pass locally: ruff lint, ruff format, mypy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches timelord networking lifecycle and connection management; incorrect handling could drop legitimate VDF clients or leak sockets under load, but the change is small and covered by targeted unit tests.
> 
> **Overview**
> Timelord now **explicitly closes** VDF client TCP connections that should not be kept: clients from non-whitelisted IPs and clients connecting after the free pool reaches a new `max_free_clients` cap (default `10`).
> 
> Shutdown logic is updated to close any remaining `free_clients` `StreamWriter`s and clear the pool, and new unit tests cover accept/reject behavior and overflow handling in `_handle_client()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 729041dfaa53f1f9abbc06cb027321422768e1fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->