### PR TITLE
mypy: remove exclusion for chia._tests.core.full_node.stores.test_sync_store

### DIFF
--- a/chia/_tests/core/full_node/stores/test_sync_store.py
+++ b/chia/_tests/core/full_node/stores/test_sync_store.py
@@ -4,13 +4,14 @@ import random
 
 import pytest
 from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint32, uint128
 
 from chia.full_node.sync_store import SyncStore
 from chia.util.hash import std_hash
 
 
 @pytest.mark.anyio
-async def test_basic_store():
+async def test_basic_store() -> None:
     store = SyncStore()
 
     # Save/get sync
@@ -25,18 +26,20 @@ async def test_basic_store():
 
     assert store.get_heaviest_peak() is None
     assert len(store.get_peak_of_each_peer()) == 0
-    store.peer_has_block(std_hash(b"block10"), peer_ids[0], 500, 10, True)
-    store.peer_has_block(std_hash(b"block1"), peer_ids[0], 300, 1, False)
-    store.peer_has_block(std_hash(b"block1"), peer_ids[1], 300, 1, True)
-    store.peer_has_block(std_hash(b"block10"), peer_ids[2], 500, 10, False)
-    store.peer_has_block(std_hash(b"block1"), peer_ids[2], 300, 1, False)
+    store.peer_has_block(std_hash(b"block10"), peer_ids[0], uint128(500), uint32(10), True)
+    store.peer_has_block(std_hash(b"block1"), peer_ids[0], uint128(300), uint32(1), False)
+    store.peer_has_block(std_hash(b"block1"), peer_ids[1], uint128(300), uint32(1), True)
+    store.peer_has_block(std_hash(b"block10"), peer_ids[2], uint128(500), uint32(10), False)
+    store.peer_has_block(std_hash(b"block1"), peer_ids[2], uint128(300), uint32(1), False)
 
-    assert store.get_heaviest_peak().header_hash == std_hash(b"block10")
-    assert store.get_heaviest_peak().height == 10
-    assert store.get_heaviest_peak().weight == 500
+    peak = store.get_heaviest_peak()
+    assert peak is not None
+    assert peak.header_hash == std_hash(b"block10")
+    assert peak.height == 10
+    assert peak.weight == 500
 
     assert len(store.get_peak_of_each_peer()) == 2
-    store.peer_has_block(std_hash(b"block1"), peer_ids[2], 500, 1, True)
+    store.peer_has_block(std_hash(b"block1"), peer_ids[2], uint128(500), uint32(1), True)
     assert len(store.get_peak_of_each_peer()) == 3
     assert store.get_peak_of_each_peer()[peer_ids[0]].weight == 500
     assert store.get_peak_of_each_peer()[peer_ids[1]].weight == 300
@@ -46,14 +49,20 @@ async def test_basic_store():
     assert store.get_peers_that_have_peak([std_hash(b"block10")]) == {peer_ids[0], peer_ids[2]}
 
     store.peer_disconnected(peer_ids[0])
-    assert store.get_heaviest_peak().weight == 500
+    peak = store.get_heaviest_peak()
+    assert peak is not None
+    assert peak.weight == 500
     assert len(store.get_peak_of_each_peer()) == 2
     assert store.get_peers_that_have_peak([std_hash(b"block10")]) == {peer_ids[2]}
     store.peer_disconnected(peer_ids[2])
-    assert store.get_heaviest_peak().weight == 300
-    store.peer_has_block(std_hash(b"block30"), peer_ids[0], 700, 30, True)
+    peak = store.get_heaviest_peak()
+    assert peak is not None
+    assert peak.weight == 300
+    store.peer_has_block(std_hash(b"block30"), peer_ids[0], uint128(700), uint32(30), True)
     assert store.get_peak_of_each_peer()[peer_ids[0]].weight == 700
-    assert store.get_heaviest_peak().weight == 700
+    peak = store.get_heaviest_peak()
+    assert peak is not None
+    assert peak.weight == 700
 
 
 @pytest.mark.anyio

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -46,7 +46,6 @@ chia._tests.connection_utils
 chia._tests.core.cmds.test_keys
 chia._tests.core.consensus.test_pot_iterations
 chia._tests.core.daemon.test_daemon
-chia._tests.core.full_node.stores.test_sync_store
 chia._tests.core.full_node.test_address_manager
 chia._tests.core.full_node.test_node_load
 chia._tests.core.full_node.test_performance


### PR DESCRIPTION
### Purpose:
Remove `chia._tests.core.full_node.stores.test_sync_store` from mypy strict-mode exclusions.

### Current Behavior:
`chia._tests.core.full_node.stores.test_sync_store` is excluded from mypy strict checking. The file currently has a missing return annotation, integer literal argument-type mismatches for `peer_has_block()`, and Optional peak attribute access without None guards under strict mode.

### New Behavior:
The test file is strict-mypy clean by adding `-> None`, using `uint128`/`uint32` for `peer_has_block()` arguments, and guarding `get_heaviest_peak()` before attribute access. The module is removed from `mypy-exclusions.txt`.

### Testing Notes:
- `python3 -m mypy --config-file mypy.ini.template --strict chia/_tests/core/full_node/stores/test_sync_store.py`
- `pre-commit run mypy --all-files`
- `ruff check chia/_tests/core/full_node/stores/test_sync_store.py`
- `ruff format --check chia/_tests/core/full_node/stores/test_sync_store.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only typing changes plus an update to mypy configuration; no runtime or consensus logic is modified.
> 
> **Overview**
> Updates `chia._tests.core.full_node.stores.test_sync_store` to satisfy mypy strict mode by adding an explicit `-> None` return type, using `uint128`/`uint32` for `SyncStore.peer_has_block()` arguments, and guarding `get_heaviest_peak()` results before dereferencing.
> 
> Removes `chia._tests.core.full_node.stores.test_sync_store` from `mypy-exclusions.txt` so it is now type-checked under strict mypy runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 689f734da96d78bb2e4e9b1ee4255aa6ad93fd96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->