### PR TITLE
mypy: remove exclusion for chia.introducer.introducer_api

### DIFF
--- a/chia/introducer/introducer_api.py
+++ b/chia/introducer/introducer_api.py
@@ -27,7 +27,7 @@ class IntroducerAPI:
     introducer: Introducer
     metadata: ClassVar[ApiMetadata] = ApiMetadata()
 
-    def __init__(self, introducer) -> None:
+    def __init__(self, introducer: Introducer) -> None:
         self.log = logging.getLogger(__name__)
         self.introducer = introducer
 

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -1,7 +1,6 @@
 # File created by: python manage-mypy.py build-exclusions
 chia.daemon.server
 chia.introducer.introducer
-chia.introducer.introducer_api
 chia.plotters.bladebit
 chia.plotters.madmax
 chia.plotters.plotters


### PR DESCRIPTION
### Purpose:

Enable mypy strict-mode checking for `chia.introducer.introducer_api` by adding the missing type annotation and removing the module from the exclusion list.

### Current Behavior:

`chia.introducer.introducer_api` is excluded from mypy strict checking. The `IntroducerAPI.__init__` method has an untyped `introducer` parameter.

### New Behavior:

The module is now covered by strict type checking. `IntroducerAPI.__init__` has an explicit `introducer: Introducer` type annotation.

### Testing Notes:

- `python3 -m mypy --config-file mypy.ini.template --strict chia/introducer/introducer_api.py` — zero local errors
- `pre-commit run mypy --all-files` — passed
- Typing-only change; no runtime behavior is modified