### PR TITLE
mypy: remove exclusion for chia.wallet.puzzles.p2_delegated_puzzle

### DIFF
--- a/chia/wallet/puzzles/p2_delegated_puzzle.py
+++ b/chia/wallet/puzzles/p2_delegated_puzzle.py
@@ -26,7 +26,7 @@ def puzzle_for_pk(public_key: bytes) -> Program:
     return MOD.curry(public_key)
 
 
-def solution_for_conditions(conditions) -> Program:
+def solution_for_conditions(conditions: Program) -> Program:
     delegated_puzzle = p2_conditions.puzzle_for_conditions(conditions)
     return solution_for_delegated_puzzle(delegated_puzzle, Program.to(0))
 

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -20,7 +20,6 @@ chia.wallet.did_wallet.did_wallet
 chia.wallet.key_val_store
 chia.wallet.puzzles.load_clvm
 chia.wallet.puzzles.p2_conditions
-chia.wallet.puzzles.p2_delegated_puzzle
 chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle
 chia.wallet.puzzles.p2_m_of_n_delegate_direct
 chia.wallet.puzzles.tails


### PR DESCRIPTION
### Purpose:

Remove `chia.wallet.puzzles.p2_delegated_puzzle` from mypy strict-mode exclusions.

### Current Behavior:

`chia.wallet.puzzles.p2_delegated_puzzle` is excluded from mypy strict checking. The `solution_for_conditions` function's `conditions` parameter lacks a type annotation.

### New Behavior:

The module is now covered by strict type checking. The `conditions` parameter is annotated as `Program`, matching the type callers actually pass and consistent with the analogous function in `p2_delegated_conditions`.

### Testing Notes:

- `mypy --strict` on the target file: 0 errors
- `pre-commit run mypy --all-files`: Passed
- `ruff check` and `ruff format --check`: Passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only annotation plus mypy configuration change; no runtime logic changes beyond stricter static checking.
> 
> **Overview**
> Removes `chia.wallet.puzzles.p2_delegated_puzzle` from `mypy-exclusions.txt` so it is checked under mypy strict mode.
> 
> Updates `solution_for_conditions` in `p2_delegated_puzzle.py` to type its `conditions` parameter as `Program`, aligning the function signature with actual call sites and enabling strict type checking for the module.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 031fe5529da2e8c3e5bed12e359329798f41d95a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->