### PR TITLE
mypy: remove exclusion for chia.wallet.transaction_record

### DIFF
--- a/chia/wallet/transaction_record.py
+++ b/chia/wallet/transaction_record.py
@@ -60,14 +60,14 @@ class TransactionRecordOld(Streamable):
     def is_in_mempool(self) -> bool:
         # If one of the nodes we sent it to responded with success or pending, we return True
         for _, mis, _ in self.sent_to:
-            if MempoolInclusionStatus(mis) in {MempoolInclusionStatus.SUCCESS, MempoolInclusionStatus.PENDING}:
+            if mis in {MempoolInclusionStatus.SUCCESS.value, MempoolInclusionStatus.PENDING.value}:
                 return True
         return False
 
     def height_farmed(self, genesis_challenge: bytes32) -> uint32 | None:
         if not self.confirmed:
             return None
-        if TransactionType(self.type) in {TransactionType.FEE_REWARD, TransactionType.COINBASE_REWARD}:
+        if self.type in {TransactionType.FEE_REWARD.value, TransactionType.COINBASE_REWARD.value}:
             for block_index in range(self.confirmed_at_height, self.confirmed_at_height - 100, -1):
                 if block_index < 0:
                     return None
@@ -83,7 +83,7 @@ class TransactionRecordOld(Streamable):
         if len(self.sent_to) < minimum_send_attempts:
             # we haven't tried enough peers yet
             return True
-        if any(MempoolInclusionStatus(x[1]) == MempoolInclusionStatus.SUCCESS for x in self.sent_to):
+        if any(x[1] == MempoolInclusionStatus.SUCCESS.value for x in self.sent_to):
             # we managed to push it to mempool at least once
             return True
         if any(x[2] in {Err.INVALID_FEE_LOW_FEE.name, Err.INVALID_FEE_TOO_CLOSE_TO_ZERO.name} for x in self.sent_to):

--- a/chia/wallet/transaction_record.py
+++ b/chia/wallet/transaction_record.py
@@ -67,7 +67,7 @@ class TransactionRecordOld(Streamable):
     def height_farmed(self, genesis_challenge: bytes32) -> uint32 | None:
         if not self.confirmed:
             return None
-        if self.type in {TransactionType.FEE_REWARD, TransactionType.COINBASE_REWARD}:
+        if TransactionType(self.type) in {TransactionType.FEE_REWARD, TransactionType.COINBASE_REWARD}:
             for block_index in range(self.confirmed_at_height, self.confirmed_at_height - 100, -1):
                 if block_index < 0:
                     return None
@@ -83,7 +83,7 @@ class TransactionRecordOld(Streamable):
         if len(self.sent_to) < minimum_send_attempts:
             # we haven't tried enough peers yet
             return True
-        if any(x[1] == MempoolInclusionStatus.SUCCESS for x in self.sent_to):
+        if any(MempoolInclusionStatus(x[1]) == MempoolInclusionStatus.SUCCESS for x in self.sent_to):
             # we managed to push it to mempool at least once
             return True
         if any(x[2] in {Err.INVALID_FEE_LOW_FEE.name, Err.INVALID_FEE_TOO_CLOSE_TO_ZERO.name} for x in self.sent_to):

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -25,7 +25,6 @@ chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle
 chia.wallet.puzzles.p2_m_of_n_delegate_direct
 chia.wallet.puzzles.tails
 chia.wallet.trading.trade_store
-chia.wallet.transaction_record
 chia.wallet.util.debug_spend_bundle
 chia.wallet.util.new_peak_queue
 chia.wallet.wallet_coin_store


### PR DESCRIPTION
### Purpose:

Remove `chia.wallet.transaction_record` from mypy strict-mode exclusions.

### Current Behavior:

`chia.wallet.transaction_record` is excluded from mypy strict checking. Two `comparison-overlap` errors exist where `uint32`/`uint8` fields are compared directly against `IntEnum` members.

### New Behavior:

The module is now covered by strict type checking. Both comparison-overlap errors are resolved by wrapping the integer fields with their respective `IntEnum` constructors before comparing:

- `chia/wallet/transaction_record.py`
  — Wrapped `self.type` (`uint32`) with `TransactionType()` before comparing against `TransactionType` enum members in `height_farmed()`
  — Wrapped `x[1]` (`uint8`) with `MempoolInclusionStatus()` before comparing against `MempoolInclusionStatus.SUCCESS` in `is_valid()`
- `mypy-exclusions.txt` — removed `chia.wallet.transaction_record`

### Testing Notes:

Low risk — production logic behavior is unchanged. `IntEnum(value) == IntEnum.MEMBER` is equivalent to the previous `uint == IntEnum.MEMBER` at runtime, but now satisfies mypy's strict overlap checks.

Validated locally:
- `pre-commit run mypy --all-files` — passed
- `ruff check` / `ruff format --check` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-safety/mypy-focused change that only alters enum comparison expressions; runtime logic should remain equivalent as long as stored fields continue to hold enum numeric values.
> 
> **Overview**
> Enables mypy strict checking for `chia.wallet.transaction_record` by removing it from `mypy-exclusions.txt`.
> 
> Updates `TransactionRecordOld` comparisons to use underlying `IntEnum.value` constants (e.g., `MempoolInclusionStatus.*.value`, `TransactionType.*.value`) when comparing against stored `uint8`/`uint32` fields, resolving mypy `comparison-overlap` errors while keeping behavior the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1708917923d3ebd1459fe4b73bad1a7f5f29297c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->