### PR TITLE
mypy: remove exclusion for chia._tests.connection_utils

### DIFF
--- a/chia/_tests/connection_utils.py
+++ b/chia/_tests/connection_utils.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.apis import StubMetadataRegistry
-from chia.protocols.outbound_message import NodeType
+from chia.protocols.outbound_message import Message, NodeType
 from chia.protocols.shared_protocol import Capability, default_capabilities
 from chia.server.server import ChiaServer, ssl_context_for_client
 from chia.server.ssl_context import chia_ssl_ca_paths, private_ssl_ca_paths
@@ -45,7 +45,7 @@ async def add_dummy_connection(
     type: NodeType = NodeType.FULL_NODE,
     *,
     additional_capabilities: list[tuple[uint16, str]] | None = None,
-) -> tuple[asyncio.Queue, bytes32]:
+) -> tuple[asyncio.Queue[Message], bytes32]:
     if additional_capabilities is None:
         additional_capabilities = [(uint16(Capability.HARD_FORK_2.value), "1")]
     wsc, peer_id = await add_dummy_connection_wsc(
@@ -115,7 +115,7 @@ async def connect_and_get_peer(server_1: ChiaServer, server_2: ChiaServer, self_
     """
     await server_2.start_client(PeerInfo(self_hostname, server_1.get_port()))
 
-    async def connected():
+    async def connected() -> bool:
         for node_id_c, _ in server_1.all_connections.items():
             if node_id_c == server_2.node_id:
                 return True

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -42,7 +42,6 @@ chia._tests.clvm.test_puzzles
 chia._tests.clvm.test_singletons
 chia._tests.clvm.test_spend_sim
 chia._tests.conftest
-chia._tests.connection_utils
 chia._tests.core.cmds.test_keys
 chia._tests.core.consensus.test_pot_iterations
 chia._tests.core.daemon.test_daemon


### PR DESCRIPTION
### Purpose:
Remove `chia._tests.connection_utils` from strict-mode mypy exclusions.

### Current Behavior:
`chia._tests.connection_utils` is excluded from strict mypy checks. The module has an unparameterized `asyncio.Queue` return type and a nested async helper without an explicit return type.

### New Behavior:
The module is now strict-mypy compatible by annotating `add_dummy_connection()` as returning `tuple[asyncio.Queue[Message], bytes32]` and adding `-> bool` to the nested `connected()` helper. `chia._tests.connection_utils` is removed from `mypy-exclusions.txt`.

### Testing Notes:
- `source .venv/bin/activate && python3 -m mypy --config-file mypy.ini.template --strict chia/_tests/connection_utils.py`
- `source .venv/bin/activate && python3 manage-mypy.py build-mypy-ini`
- `source .venv/bin/activate && pre-commit run mypy --all-files`
- `source .venv/bin/activate && ruff check chia/_tests/connection_utils.py`
- `source .venv/bin/activate && ruff format --check chia/_tests/connection_utils.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-annotation-only changes in test utilities plus a mypy configuration update; no runtime logic changes expected.
> 
> **Overview**
> Makes `chia._tests.connection_utils` strict-mypy compatible by importing `Message`, parameterizing the `asyncio.Queue` return type in `add_dummy_connection()`, and adding an explicit `-> bool` return annotation to the nested `connected()` helper.
> 
> Removes `chia._tests.connection_utils` from `mypy-exclusions.txt` so it is now checked under strict mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2fc4599337fe2ffe634b8e0b5e3dfc3def5c7d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->