### PR TITLE
Use blacksmith runners in certain cases for CI tests

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -144,6 +144,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python environment
+        if: ${{ !contains(inputs.runs-on, 'blacksmith-4vcpu-windows') }}
         uses: Chia-Network/actions/setup-python@main
         with:
           python-version: ${{ matrix.python.action }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,7 +157,7 @@ jobs:
       concurrency-name: ubuntu-intel
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
-      runs-on: ${{ github.event.repository.visibility == 'private' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest' }}
+      runs-on: ${{ github.repository_owner == 'Chia-Network' && github.event.repository.visibility == 'private' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest' }}
       arch: intel
       arch-emoji: 🌀
       collect-junit: false
@@ -173,7 +173,7 @@ jobs:
       concurrency-name: ubuntu-arm
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
-      runs-on: ${{ github.event.repository.visibility == 'private' && 'blacksmith-4vcpu-ubuntu-2404-arm' || 'ubuntu-24.04-arm' }}
+      runs-on: ${{ github.repository_owner == 'Chia-Network' && github.event.repository.visibility == 'private' && 'blacksmith-4vcpu-ubuntu-2404-arm' || 'ubuntu-24.04-arm' }}
       arch: arm
       arch-emoji: 💪
       collect-junit: false
@@ -189,7 +189,7 @@ jobs:
       concurrency-name: windows
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
-      runs-on: ${{ github.event.repository.visibility == 'private' && 'blacksmith-4vcpu-windows-2025' || 'windows-latest' }}
+      runs-on: ${{ github.repository_owner == 'Chia-Network' && github.event.repository.visibility == 'private' && 'blacksmith-4vcpu-windows-2025' || 'windows-latest' }}
       arch: intel
       arch-emoji: 🌀
       collect-junit: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,7 +157,7 @@ jobs:
       concurrency-name: ubuntu-intel
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
-      runs-on: ubuntu-latest
+      runs-on: ${{ github.event.repository.visibility == 'private' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-latest' }}
       arch: intel
       arch-emoji: 🌀
       collect-junit: false
@@ -173,7 +173,7 @@ jobs:
       concurrency-name: ubuntu-arm
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
-      runs-on: ubuntu-24.04-arm
+      runs-on: ${{ github.event.repository.visibility == 'private' && 'blacksmith-4vcpu-ubuntu-2404-arm' || 'ubuntu-24.04-arm' }}
       arch: arm
       arch-emoji: 💪
       collect-junit: false
@@ -189,7 +189,7 @@ jobs:
       concurrency-name: windows
       configuration: ${{ needs.configure.outputs.configuration }}
       matrix_mode: ${{ needs.configure.outputs.matrix_mode }}
-      runs-on: windows-latest
+      runs-on: ${{ github.event.repository.visibility == 'private' && 'blacksmith-4vcpu-windows-2025' || 'windows-latest' }}
       arch: intel
       arch-emoji: 🌀
       collect-junit: false


### PR DESCRIPTION
Allows use of blacksmith.sh runners in certain cases


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI runner selection and Python setup behavior, which can cause workflow failures if the Blacksmith images or conditions don’t match expectations (especially on Windows).
> 
> **Overview**
> Updates CI to **conditionally run Linux and Windows test jobs on Blacksmith runners** when the repo is owned by `Chia-Network` *and* the repository is private, otherwise falling back to GitHub-hosted runners.
> 
> In the reusable `test-single.yml` workflow, skips the `setup-python` step when running on the Blacksmith Windows runner (`blacksmith-4vcpu-windows-*`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d7d41ede1e5edfbca3dc477d32991d89ce3a75e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->