### PR TITLE
Update timeout for farm_blocks_to_wallet call

### DIFF
--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -529,7 +529,9 @@ async def test_get_balance(
     # Generate some funds, get the balance and make sure it's as expected
     await wallet_server.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
     await time_out_assert(30, wallet_synced)
-    generated_funds = await full_node_api.farm_blocks_to_wallet(5, wallet_node.wallet_state_manager.main_wallet, timeout=60)
+    generated_funds = await full_node_api.farm_blocks_to_wallet(
+        5, wallet_node.wallet_state_manager.main_wallet, timeout=60
+    )
     expected_generated_balance = Balance(
         confirmed_wallet_balance=uint128(generated_funds),
         unconfirmed_wallet_balance=uint128(generated_funds),

--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -529,7 +529,7 @@ async def test_get_balance(
     # Generate some funds, get the balance and make sure it's as expected
     await wallet_server.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
     await time_out_assert(30, wallet_synced)
-    generated_funds = await full_node_api.farm_blocks_to_wallet(5, wallet_node.wallet_state_manager.main_wallet)
+    generated_funds = await full_node_api.farm_blocks_to_wallet(5, wallet_node.wallet_state_manager.main_wallet, timeout=60)
     expected_generated_balance = Balance(
         confirmed_wallet_balance=uint128(generated_funds),
         unconfirmed_wallet_balance=uint128(generated_funds),


### PR DESCRIPTION
Increased timeout for farming blocks to wallet.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that increases timeout to reduce flaky failures on slower CI environments, with no production code impact.
> 
> **Overview**
> In `test_get_balance` (`chia/_tests/wallet/test_wallet_node.py`), the initial `farm_blocks_to_wallet` call now passes an explicit `timeout=60` to give the simulator more time to farm blocks and have the wallet observe the rewards, reducing test flakiness under slower execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f57fe520bf2cc28c13aba3588d0fcd538e2c90e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->