### PR TITLE
CHIA-3895 CHIA-3944 CHIA-3970 Introduce a new window based rate limits capability

### DIFF
--- a/chia/_tests/connection_utils.py
+++ b/chia/_tests/connection_utils.py
@@ -45,11 +45,20 @@ async def add_dummy_connection(
     type: NodeType = NodeType.FULL_NODE,
     *,
     additional_capabilities: list[tuple[uint16, str]] | None = None,
+    wait_for_peer_added: bool = True,
 ) -> tuple[asyncio.Queue[Message], bytes32]:
     if additional_capabilities is None:
-        additional_capabilities = [(uint16(Capability.HARD_FORK_2.value), "1")]
+        additional_capabilities = [
+            (uint16(Capability.HARD_FORK_2.value), "1"),
+            (uint16(Capability.RATE_LIMITS_V3.value), "1"),
+        ]
     wsc, peer_id = await add_dummy_connection_wsc(
-        server, self_hostname, dummy_port, type, additional_capabilities=additional_capabilities
+        server=server,
+        self_hostname=self_hostname,
+        dummy_port=dummy_port,
+        type=type,
+        additional_capabilities=additional_capabilities,
+        wait_for_peer_added=wait_for_peer_added,
     )
 
     return wsc.incoming_queue, peer_id
@@ -61,9 +70,13 @@ async def add_dummy_connection_wsc(
     dummy_port: int,
     type: NodeType = NodeType.FULL_NODE,
     additional_capabilities: list[tuple[uint16, str]] | None = None,
+    wait_for_peer_added: bool = True,
 ) -> tuple[WSChiaConnection, bytes32]:
     if additional_capabilities is None:
-        additional_capabilities = [(uint16(Capability.HARD_FORK_2.value), "1")]
+        additional_capabilities = [
+            (uint16(Capability.HARD_FORK_2.value), "1"),
+            (uint16(Capability.RATE_LIMITS_V3.value), "1"),
+        ]
     timeout = aiohttp.ClientTimeout(total=10)
     session = aiohttp.ClientSession(timeout=timeout)
     config = load_config(server.root_path, "config.yaml")
@@ -104,6 +117,8 @@ async def add_dummy_connection_wsc(
         stub_metadata_for_type=StubMetadataRegistry,
     )
     await wsc.perform_handshake(server._network_id, dummy_port, type)
+    if wait_for_peer_added:
+        await time_out_assert(5, lambda: peer_id in server.all_connections)
     if wsc.incoming_message_task is not None:
         wsc.incoming_message_task.cancel()
     return wsc, peer_id

--- a/chia/_tests/core/farmer/test_farmer_api.py
+++ b/chia/_tests/core/farmer/test_farmer_api.py
@@ -40,7 +40,9 @@ async def test_farmer_ignores_concurrent_duplicate_signage_points(
     _, farmer_service, _ = farmer_one_harvester
     farmer_api: FarmerAPI = farmer_service._api
     farmer_server = farmer_service._server
-    incoming_queue, _peer_id = await add_dummy_connection(farmer_server, self_hostname, 12312, NodeType.HARVESTER)
+    incoming_queue, _ = await add_dummy_connection(
+        farmer_server, self_hostname, 12312, NodeType.HARVESTER, wait_for_peer_added=False
+    )
     # Consume the handshake
     response = (await incoming_queue.get()).type
     assert ProtocolMessageTypes(response).name == "harvester_handshake"
@@ -66,7 +68,9 @@ async def test_farmer_responds_with_signed_values(farmer_one_harvester: FarmerOn
     _, farmer_service, _ = farmer_one_harvester
     farmer_api: FarmerAPI = farmer_service._api
     farmer_server = farmer_service._server
-    dummy_wsc, peer_id = await add_dummy_connection_wsc(farmer_server, self_hostname, 12312, NodeType.HARVESTER)
+    dummy_wsc, peer_id = await add_dummy_connection_wsc(
+        farmer_server, self_hostname, 12312, NodeType.HARVESTER, wait_for_peer_added=False
+    )
     incoming_queue = dummy_wsc.incoming_queue
     # Consume the handshake
     response = (await incoming_queue.get()).type

--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -329,6 +329,7 @@ async def test_sync_bad_peak_while_synced(
     # trigger long sync in full node 2
     peak_block = default_1500_blocks[1050]
     await server_2.start_client(PeerInfo(self_hostname, server_3.get_port()), full_node_2.full_node.on_connect)
+    await time_out_assert(5, lambda: full_node_3.full_node.server.node_id in server_2.all_connections)
     con = server_2.all_connections[full_node_3.full_node.server.node_id]
     peak = full_node_protocol.NewPeak(
         peak_block.header_hash,

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2443,6 +2443,8 @@ async def test_unsolicited_compact_vdf(
     server_1 = full_node_1.full_node.server
     server_2 = full_node_2.full_node.server
     await server_2.start_client(PeerInfo(self_hostname, server_1.get_port()), full_node_2.full_node.on_connect)
+    await time_out_assert(5, lambda: len(server_1.all_connections) == 1)
+    await time_out_assert(5, lambda: len(server_2.all_connections) == 1)
     ws_con_1 = next(iter(server_1.all_connections.values()))
     ws_con_2 = next(iter(server_2.all_connections.values()))
 
@@ -3554,6 +3556,9 @@ async def test_ban_for_mismatched_tx_cost_fee(
     server_3 = full_node_3.full_node.server
     await server_2.start_client(PeerInfo(self_hostname, server_1.get_port()), full_node_2.full_node.on_connect)
     await server_3.start_client(PeerInfo(self_hostname, server_1.get_port()), full_node_3.full_node.on_connect)
+    await time_out_assert(5, lambda: len(server_1.all_connections) == 2)
+    await time_out_assert(5, lambda: len(server_2.all_connections) == 1)
+    await time_out_assert(5, lambda: len(server_3.all_connections) == 1)
     ws_con_1 = next(iter(server_1.all_connections.values()))
     ws_con_2 = next(iter(server_2.all_connections.values()))
     ws_con_3 = next(iter(server_3.all_connections.values()))
@@ -3642,6 +3647,8 @@ async def test_new_tx_zero_cost(
     server_1 = full_node_1.full_node.server
     server_2 = full_node_2.full_node.server
     await server_2.start_client(PeerInfo(self_hostname, server_1.get_port()), full_node_2.full_node.on_connect)
+    await time_out_assert(5, lambda: len(server_1.all_connections) == 1)
+    await time_out_assert(5, lambda: len(server_2.all_connections) == 1)
     ws_con_1 = next(iter(server_1.all_connections.values()))
     ws_con_2 = next(iter(server_2.all_connections.values()))
     await full_node_1.full_node.add_block(bt.get_consecutive_blocks(1)[0])
@@ -3697,7 +3704,9 @@ async def test_send_transaction_peer_tx_queue_full(
     # Set limit to 0 to trigger queue full exception
     full_node_api.full_node.transaction_queue.peer_size_limit = 0
     spend_bundle = SpendBundle([], G2Element())
-    dummy_peer, _ = await add_dummy_connection_wsc(server, self_hostname, 1337, NodeType.WALLET)
+    dummy_peer, _ = await add_dummy_connection_wsc(
+        server, self_hostname, 1337, NodeType.WALLET, wait_for_peer_added=False
+    )
     response_msg = await full_node_api.send_transaction(wallet_protocol.SendTransaction(spend_bundle), dummy_peer)
     assert response_msg is not None
     response = wallet_protocol.TransactionAck.from_bytes(response_msg.data)
@@ -3753,7 +3762,7 @@ async def test_node_type_message_typechecking(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools], self_hostname: str, node_type: NodeType
 ) -> None:
     _, server, _ = one_node_one_block
-    wsc, peer_id = await add_dummy_connection_wsc(server, self_hostname, 1337, node_type)
+    wsc, peer_id = await add_dummy_connection_wsc(server, self_hostname, 1337, node_type, wait_for_peer_added=False)
     await time_out_assert(5, lambda: peer_id in server.all_connections)
     server.all_connections[peer_id].peer_info = PeerInfo("1.3.3.7", 42)
     await wsc._send_message(make_msg(ProtocolMessageTypes.request_peers, b""))
@@ -3789,7 +3798,7 @@ async def test_node_types_inbound_connections_limit(
     assert server.accept_inbound_connections(node_type) is True
     # Set a low limit for this test and reach it with a dummy connection
     server.config[config_key] = 1
-    _, peer_id = await add_dummy_connection(server, self_hostname, 1337, node_type)
+    _, peer_id = await add_dummy_connection(server, self_hostname, 1337, node_type, wait_for_peer_added=False)
     await time_out_assert(5, lambda: peer_id in server.all_connections)
     # New inbound connections should be refused
     assert server.accept_inbound_connections(node_type) is False
@@ -3810,7 +3819,7 @@ async def test_hard_fork_version_enforcement(
     _, server, _ = one_node_one_block
     additional_capabilities = [(uint16(Capability.HARD_FORK_2.value), "1")] if has_hard_fork2_capability else []
     wsc, peer_id = await add_dummy_connection_wsc(
-        server, self_hostname, 42, NodeType.FULL_NODE, additional_capabilities=additional_capabilities
+        server, self_hostname, 42, additional_capabilities=additional_capabilities, wait_for_peer_added=False
     )
     staying_connected = consensus_mode < ConsensusMode.HARD_FORK_3_0 or has_hard_fork2_capability
     if staying_connected:
@@ -3853,7 +3862,9 @@ async def test_register_for_coin_updates(
     remaining_coins = real_coin_ids[1:]
     fake_coin_ids = [bytes32.random() for _ in range(max_subscribe_items)]
     request_ids = first_coin + fake_coin_ids + remaining_coins
-    dummy_peer, _ = await add_dummy_connection_wsc(server, self_hostname, 1337, NodeType.WALLET)
+    dummy_peer, _ = await add_dummy_connection_wsc(
+        server, self_hostname, 1337, NodeType.WALLET, wait_for_peer_added=False
+    )
     msg = wallet_protocol.RegisterForCoinUpdates(request_ids, uint32(0))
     response = await full_node_api.register_for_coin_updates(bytes(msg), dummy_peer)
     assert response is not None
@@ -3879,7 +3890,6 @@ async def test_tx_request_and_timeout_call_api_exception(
     full_node_api, server, _ = one_node_one_block
     full_node = full_node_api.full_node
     _, peer_id = await add_dummy_connection(server, self_hostname, 42)
-    await time_out_assert(5, lambda: peer_id in server.all_connections)
     server_connection = server.all_connections[peer_id]
     transaction_id = bytes32.random()
     full_node.full_node_store.peers_with_tx[transaction_id] = {
@@ -3910,7 +3920,6 @@ async def test_tx_request_and_timeout_queue_full(
     full_node_api, server, _ = one_node_one_block
     full_node = full_node_api.full_node
     _, peer_id = await add_dummy_connection(server, self_hostname, 42)
-    await time_out_assert(5, lambda: peer_id in server.all_connections)
     server_connection = server.all_connections[peer_id]
     sb = SpendBundle([], G2Element())
     transaction_id = sb.name()
@@ -3974,7 +3983,9 @@ async def test_request_puzzle_state_responds_normally(
 
     assert full_node_api.full_node.blockchain.get_peak_height() is not None
 
-    dummy_peer, _ = await add_dummy_connection_wsc(server, self_hostname, 1339, NodeType.WALLET)
+    dummy_peer, _ = await add_dummy_connection_wsc(
+        server, self_hostname, 1339, NodeType.WALLET, wait_for_peer_added=False
+    )
 
     peak_height = full_node_api.full_node.blockchain.get_peak_height()
     assert peak_height is not None

--- a/chia/_tests/core/server/test_dos.py
+++ b/chia/_tests/core/server/test_dos.py
@@ -257,7 +257,7 @@ class TestDos:
 
         await server_2.start_client(PeerInfo(self_hostname, server_1.get_port()), full_node_2.full_node.on_connect)
 
-        assert len(server_1.all_connections) == 1
+        await time_out_assert(5, lambda: len(server_1.all_connections) == 1)
 
         ws_con: WSChiaConnection = next(iter(server_1.all_connections.values()))
         ws_con_2: WSChiaConnection = next(iter(server_2.all_connections.values()))
@@ -316,7 +316,7 @@ class TestDos:
 
         await server_2.start_client(PeerInfo(self_hostname, server_1.get_port()), full_node_2.full_node.on_connect)
 
-        assert len(server_1.all_connections) == 1
+        await time_out_assert(5, lambda: len(server_1.all_connections) == 1)
 
         ws_con: WSChiaConnection = next(iter(server_1.all_connections.values()))
         ws_con_2: WSChiaConnection = next(iter(server_2.all_connections.values()))
@@ -369,7 +369,7 @@ class TestDos:
 
         await server_2.start_client(PeerInfo(self_hostname, server_1.get_port()), full_node_2.full_node.on_connect)
 
-        assert len(server_1.all_connections) == 1
+        await time_out_assert(5, lambda: len(server_1.all_connections) == 1)
 
         ws_con: WSChiaConnection = next(iter(server_1.all_connections.values()))
         ws_con_2: WSChiaConnection = next(iter(server_2.all_connections.values()))
@@ -443,7 +443,7 @@ class TestDos:
                     first = await ws.receive()
                     assert first.type == WSMsgType.BINARY, "Expected handshake response"
 
-                    assert len(server.all_connections) == 1
+                    await time_out_assert(5, lambda: len(server.all_connections) == 1)
                     ws_con = next(iter(server.all_connections.values()))
                     ws_con.peer_info = PeerInfo("1.2.3.4", ws_con.peer_info.port)
 

--- a/chia/_tests/core/server/test_rate_limits.py
+++ b/chia/_tests/core/server/test_rate_limits.py
@@ -399,8 +399,8 @@ async def test_different_versions(
 
     await full_node_server_b.start_client(PeerInfo(self_hostname, full_node_server_a.get_port()), None)
 
-    assert len(full_node_server_b.get_connections()) == 1
-    assert len(full_node_server_a.get_connections()) == 1
+    await time_out_assert(5, lambda: len(full_node_server_b.get_connections()) == 1)
+    await time_out_assert(5, lambda: len(full_node_server_a.get_connections()) == 1)
 
     a_con: WSChiaConnection = full_node_server_a.get_connections()[0]
     b_con: WSChiaConnection = full_node_server_b.get_connections()[0]
@@ -520,8 +520,8 @@ async def test_unsolicited_responses(
 
     await full_node_server_b.start_client(PeerInfo(self_hostname, full_node_server_a.get_port()), None)
 
-    assert len(full_node_server_b.get_connections()) == 1
-    assert len(full_node_server_a.get_connections()) == 1
+    await time_out_assert(5, lambda: len(full_node_server_b.get_connections()) == 1)
+    await time_out_assert(5, lambda: len(full_node_server_a.get_connections()) == 1)
 
     a_con: WSChiaConnection = full_node_server_a.get_connections()[0]
     b_con: WSChiaConnection = full_node_server_b.get_connections()[0]

--- a/chia/_tests/core/server/test_rate_limits_v3.py
+++ b/chia/_tests/core/server/test_rate_limits_v3.py
@@ -1,0 +1,851 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+from chia_rs import RespondToPhUpdates
+from chia_rs.sized_ints import uint8, uint16, uint32
+
+from chia._tests.conftest import ConsensusMode
+from chia._tests.connection_utils import add_dummy_connection_wsc
+from chia._tests.util import network_protocol_data
+from chia._tests.util.time_out_assert import time_out_assert
+from chia.full_node.full_node_api import FullNodeAPI
+from chia.protocols.full_node_protocol import (
+    RejectBlocks,
+    RequestBlocks,
+    RespondBlocks,
+)
+from chia.protocols.outbound_message import Message, NodeType, make_msg
+from chia.protocols.protocol_message_types import ProtocolMessageTypes
+from chia.protocols.shared_protocol import Capability, ConfigureWindowSizes, default_capabilities
+from chia.server.rate_limits_v3 import (
+    MAX_CONFIGURE_RATE_LIMITS_ENTRIES,
+    RLSettingsV3,
+    rate_limits_v3,
+    rl_settings_v3_from_configure_message,
+    rl_v3_to_configure_message,
+)
+from chia.server.server import ChiaServer
+from chia.server.ws_connection import WSChiaConnection
+from chia.simulator.block_tools import BlockTools
+from chia.simulator.full_node_simulator import FullNodeSimulator
+from chia.types.peer_info import PeerInfo
+from chia.util.streamable import Streamable
+from chia.util.task_referencer import create_referenced_task
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        None,
+        {
+            ProtocolMessageTypes.request_blocks: RLSettingsV3(window_size=2),
+            ProtocolMessageTypes.request_block: RLSettingsV3(window_size=1),
+        },
+    ],
+)
+def test_rl_v3_roundtrip(settings: dict[ProtocolMessageTypes, RLSettingsV3] | None) -> None:
+    """
+    Encode a `ConfigureWindowSizes` settings map into a message then parse it
+    back to make sure that works properly.
+    """
+    msg = rl_v3_to_configure_message(settings=settings)
+    parsed = rl_settings_v3_from_configure_message(msg)
+    expected_settings = rate_limits_v3 if settings is None else settings
+    assert parsed == expected_settings
+    actual_map: dict[int, int] = {}
+    for msg_type_val, window_size_val in msg.settings:
+        actual_map[int(msg_type_val)] = int(window_size_val)
+    expected_map = {
+        msg_type.value: 0 if setting.window_size is None else setting.window_size
+        for msg_type, setting in expected_settings.items()
+    }
+    assert actual_map == expected_map
+    for msg_type, setting in expected_settings.items():
+        if setting.window_size is None:
+            assert actual_map[msg_type.value] == 0
+        else:
+            assert actual_map[msg_type.value] == setting.window_size
+
+
+def test_rl_settings_v3_from_configure_message() -> None:
+    """
+    Covers `rl_settings_v3_from_configure_message` to make sure partial
+    overrides, unknown types, and zero (unlimited) values are handled.
+    """
+    test_message_type = ProtocolMessageTypes.request_blocks
+    test_message_type2 = ProtocolMessageTypes.request_block
+    # Partial list: only the explicitly sent type is present
+    msg = ConfigureWindowSizes(settings=[(uint8(test_message_type.value), uint16(5))])
+    parsed = rl_settings_v3_from_configure_message(msg)
+    assert parsed[test_message_type].window_size == 5
+    assert test_message_type2 not in parsed
+    # Multiple entries
+    msg = ConfigureWindowSizes(
+        settings=[(uint8(test_message_type.value), uint16(4)), (uint8(test_message_type2.value), uint16(5))]
+    )
+    parsed = rl_settings_v3_from_configure_message(msg)
+    assert parsed == {test_message_type: RLSettingsV3(window_size=4), test_message_type2: RLSettingsV3(window_size=5)}
+    # Zero value is treated as unlimited
+    msg = ConfigureWindowSizes(settings=[(uint8(test_message_type.value), uint16(0))])
+    parsed = rl_settings_v3_from_configure_message(msg)
+    assert parsed[test_message_type].window_size is None
+    # Message types not in our global defaults should be accepted
+    peer_only_message_type = ProtocolMessageTypes.request_signatures
+    assert peer_only_message_type not in rate_limits_v3
+    msg = ConfigureWindowSizes(
+        settings=[(uint8(peer_only_message_type.value), uint16(5)), (uint8(test_message_type.value), uint16(4))]
+    )
+    parsed = rl_settings_v3_from_configure_message(msg)
+    assert parsed[test_message_type].window_size == 4
+    assert parsed[peer_only_message_type].window_size == 5
+    # Invalid message type (value 2 has no ProtocolMessageTypes member) is skipped
+    msg = ConfigureWindowSizes(settings=[(uint8(2), uint16(5)), (uint8(test_message_type.value), uint16(4))])
+    parsed = rl_settings_v3_from_configure_message(msg)
+    assert parsed[test_message_type].window_size == 4
+    assert len(parsed) == 1
+    # Unlimited value altered
+    unlimited_message_type = next(
+        msg_type for msg_type, setting in rate_limits_v3.items() if setting.window_size is None
+    )
+    msg = ConfigureWindowSizes(settings=[(uint8(unlimited_message_type.value), uint16(42))])
+    with pytest.raises(Exception, match="Error code: INVALID_HANDSHAKE"):
+        rl_settings_v3_from_configure_message(msg)
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+@pytest.mark.parametrize("config_settings_length", [0, MAX_CONFIGURE_RATE_LIMITS_ENTRIES + 1])
+async def test_invalid_config_settings_length(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    config_settings_length: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers the scenario where a peer sends a `ConfigureWindowSizes` message with
+    an invalid number of settings entries.
+    """
+    settings = [(uint8(ProtocolMessageTypes.request_blocks.value), uint16(1))] * config_settings_length
+    monkeypatch.setattr(
+        "chia.server.ws_connection.rl_v3_to_configure_message", lambda: ConfigureWindowSizes(settings=settings)
+    )
+    _, server, _ = one_node_one_block
+    with pytest.raises(Exception, match="INVALID_HANDSHAKE"):
+        await add_dummy_connection_wsc(server, self_hostname, 1337)
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+@pytest.mark.parametrize("receiver_v3_enabled", [False, True])
+@pytest.mark.parametrize("sender_v3_enabled", [False, True])
+async def test_separate_config_msg(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    receiver_v3_enabled: bool,
+    sender_v3_enabled: bool,
+) -> None:
+    """
+    Covers the scenario where we send `configure_window_sizes` message outside
+    the context of a handshake.
+    """
+    _, server, _ = one_node_one_block
+    # Control what the server advertises in its handshake.
+    server_capabilities = list(default_capabilities[NodeType.FULL_NODE])
+    if receiver_v3_enabled:
+        server_capabilities.append((uint16(Capability.RATE_LIMITS_V3.value), "1"))
+    server.set_capabilities(server_capabilities)
+    # Control what the client advertises in its handshake.
+    sender_capabilities: list[tuple[uint16, str]] = [(uint16(Capability.HARD_FORK_2.value), "1")]
+    if sender_v3_enabled:
+        sender_capabilities.append((uint16(Capability.RATE_LIMITS_V3.value), "1"))
+    sender_connection, peer_id = await add_dummy_connection_wsc(
+        server, self_hostname, 42, additional_capabilities=sender_capabilities
+    )
+    server.all_connections[peer_id].peer_info = PeerInfo("1.3.3.7", 42)
+    await sender_connection.send_message(
+        make_msg(
+            ProtocolMessageTypes.configure_window_sizes, ConfigureWindowSizes(settings=[(uint8(42), uint16(1337))])
+        )
+    )
+    await time_out_assert(5, lambda: sender_connection.closed)
+    await time_out_assert(5, lambda: "1.3.3.7" in server.banned_peers)
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_malformed_config_message_bytes(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers the scenario where we send malformed data in the rate limits v3
+    configuration message.
+    """
+    _, server, _ = one_node_one_block
+    malformed_config_msg = make_msg(ProtocolMessageTypes.configure_window_sizes, b"42")
+    original_send_message = WSChiaConnection._send_message
+
+    async def test_send_message(self: WSChiaConnection, message: Message, priority: int = 0) -> None:
+        # Intercept the config message sent by the peer to set malformed data
+        if self.is_outbound and ProtocolMessageTypes(message.type) == ProtocolMessageTypes.configure_window_sizes:
+            message = malformed_config_msg
+        await original_send_message(self, message)
+
+    monkeypatch.setattr(WSChiaConnection, "_send_message", test_send_message)
+    sender_connection, _ = await add_dummy_connection_wsc(server, self_hostname, 1337, wait_for_peer_added=False)
+    await time_out_assert(5, lambda: sender_connection.closed)
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_non_config_msg_during_handshake(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers the scenario where we receive a message other than the expected
+    `configure_window_sizes` message during the handshake.
+    """
+    _, server, _ = one_node_one_block
+    random_non_config_msg = make_msg(ProtocolMessageTypes.request_blocks, b"")
+    original_send_message = WSChiaConnection._send_message
+
+    async def test_send_message(self: WSChiaConnection, message: Message, priority: int = 0) -> None:
+        # Intercept the config message sent by the peer to send an unexpected
+        # message instead.
+        if self.is_outbound and ProtocolMessageTypes(message.type) == ProtocolMessageTypes.configure_window_sizes:
+            message = random_non_config_msg
+        await original_send_message(self, message)
+
+    monkeypatch.setattr(WSChiaConnection, "_send_message", test_send_message)
+    sender_connection, _ = await add_dummy_connection_wsc(server, self_hostname, 1337, wait_for_peer_added=False)
+    await time_out_assert(5, lambda: sender_connection.closed)
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_unsolicited_unlimited_v3_messages(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools], self_hostname: str
+) -> None:
+    """
+    Covers v3 response message types to make sure unsolicited messages of those
+    types get the peers disconnected/banned except `respond_proof_of_weight`.
+    """
+    unsolicited_messages: dict[ProtocolMessageTypes, Streamable | RespondToPhUpdates] = {
+        ProtocolMessageTypes.respond_blocks: network_protocol_data.respond_blocks,
+        ProtocolMessageTypes.reject_blocks: network_protocol_data.reject_blocks,
+        ProtocolMessageTypes.respond_block: network_protocol_data.respond_block,
+        ProtocolMessageTypes.reject_block: network_protocol_data.reject_block,
+        ProtocolMessageTypes.respond_block_header: network_protocol_data.respond_header_block,
+        ProtocolMessageTypes.reject_header_request: network_protocol_data.reject_header_request,
+        ProtocolMessageTypes.respond_block_headers: network_protocol_data.respond_block_headers,
+        ProtocolMessageTypes.reject_block_headers: network_protocol_data.reject_block_headers,
+        ProtocolMessageTypes.respond_header_blocks: network_protocol_data.respond_header_blocks,
+        ProtocolMessageTypes.reject_header_blocks: network_protocol_data.reject_header_blocks,
+        ProtocolMessageTypes.respond_to_ph_updates: network_protocol_data.respond_to_ph_updates,
+        ProtocolMessageTypes.respond_to_coin_updates: network_protocol_data.respond_to_coin_updates,
+        ProtocolMessageTypes.respond_puzzle_state: network_protocol_data.respond_puzzle_state,
+        ProtocolMessageTypes.reject_puzzle_state: network_protocol_data.reject_puzzle_state,
+        ProtocolMessageTypes.respond_coin_state: network_protocol_data.respond_coin_state,
+        ProtocolMessageTypes.reject_coin_state: network_protocol_data.reject_coin_state,
+        ProtocolMessageTypes.respond_additions: network_protocol_data.respond_additions,
+        ProtocolMessageTypes.reject_additions_request: network_protocol_data.reject_additions,
+        ProtocolMessageTypes.respond_removals: network_protocol_data.respond_removals,
+        ProtocolMessageTypes.reject_removals_request: network_protocol_data.reject_removals_request,
+        ProtocolMessageTypes.respond_proof_of_weight: network_protocol_data.respond_proof_of_weight,
+        ProtocolMessageTypes.respond_puzzle_solution: network_protocol_data.respond_puzzle_solution,
+        ProtocolMessageTypes.reject_puzzle_solution: network_protocol_data.reject_puzzle_solution,
+    }
+    expected_unlimited = {msg_type for msg_type, settings in rate_limits_v3.items() if settings.window_size is None}
+    current_unlimited = set(unsolicited_messages)
+    assert current_unlimited == expected_unlimited
+    _, server, _ = one_node_one_block
+    test_host = "1.3.3.7"
+    for msg_type, msg_data in unsolicited_messages.items():
+        if msg_type == ProtocolMessageTypes.respond_proof_of_weight:
+            # This one doesn't disconnect/ban the peer
+            continue
+        sender_connection, peer_id = await add_dummy_connection_wsc(server, self_hostname, dummy_port=msg_type.value)
+        receiver_connection = server.all_connections[peer_id]
+        receiver_connection.peer_info = PeerInfo(test_host, receiver_connection.peer_info.port)
+        server.banned_peers.pop(test_host, None)
+        assert test_host not in server.banned_peers
+        await sender_connection.send_message(make_msg(msg_type, msg_data))
+        await time_out_assert(5, lambda: sender_connection.closed)
+        await time_out_assert(5, lambda: test_host in server.banned_peers)
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+@pytest.mark.parametrize("receiver_v3_enabled", [False, True])
+@pytest.mark.parametrize("sender_v3_enabled", [False, True])
+async def test_v3_init_and_v2_fallback(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    receiver_v3_enabled: bool,
+    sender_v3_enabled: bool,
+) -> None:
+    """
+    Covers the scenario where we connect to a peer using all combinations of v2
+    and v3 capability cases: one side is v3 and the other is v2, both are v2
+    and both are v3.
+    We make sure that each side properly sees the other's v3 capability
+    advertisement and correctly parses the peer's v3 config into
+    `peer_rl_settings_v3`.
+    When the peer doesn't support v3 we make sure to fall back to the v2 rate limiter.
+    We also make sure the v3 windows are initialized for all v3 message types.
+    NOTE: If the sender advertises support for v3, the receiver will advertise
+    support for v3 as well.
+    """
+    _, server, _ = one_node_one_block
+    # Control what the server advertises in its handshake.
+    server_capabilities = list(default_capabilities[NodeType.FULL_NODE])
+    if receiver_v3_enabled:
+        server_capabilities.append((uint16(Capability.RATE_LIMITS_V3.value), "1"))
+    server.set_capabilities(server_capabilities)
+    # Control what the client advertises in its handshake.
+    sender_capabilities: list[tuple[uint16, str]] = [(uint16(Capability.HARD_FORK_2.value), "1")]
+    if sender_v3_enabled:
+        sender_capabilities.append((uint16(Capability.RATE_LIMITS_V3.value), "1"))
+    sender_connection, peer_id = await add_dummy_connection_wsc(
+        server, self_hostname, 1337, additional_capabilities=sender_capabilities
+    )
+    sender_connection.peer_info = PeerInfo("1.3.3.7", sender_connection.peer_info.port)
+    receiver_connection = server.all_connections[peer_id]
+    receiver_connection.peer_info = PeerInfo("1.2.3.4", receiver_connection.peer_info.port)
+    # Make sure the receiver sees exactly what the sender advertised
+    assert (Capability.RATE_LIMITS_V3 in receiver_connection.peer_capabilities) == sender_v3_enabled
+    # Make sure the sender sees what the receiver advertised in reply, it can
+    # end up advertising v3 support either because it's enabled in its setup or
+    # in reaction to the sender advertising support for it (even if it's
+    # disabled in its setup).
+    receiver_advertised_v3 = receiver_v3_enabled or sender_v3_enabled
+    assert (Capability.RATE_LIMITS_V3 in sender_connection.peer_capabilities) == receiver_advertised_v3
+    both_v3 = sender_v3_enabled
+    # Make sure the parsed v3 config matches what the other side advertised
+    assert receiver_connection.peer_rl_settings_v3 == (rate_limits_v3 if both_v3 else {})
+    assert sender_connection.peer_rl_settings_v3 == (rate_limits_v3 if both_v3 else {})
+    # Rate limit windows should always be initialized for all supported v3
+    # message types.
+    for msg_type, settings in rate_limits_v3.items():
+        if settings.window_size is None:
+            continue
+        rl_window = receiver_connection.rate_limit_windows.get(msg_type)
+        assert rl_window is not None
+        assert rl_window.receive_window == 0
+        assert rl_window.in_flight == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+@pytest.mark.parametrize("window_size", [None, 2])
+async def test_receiving_unknown_msg_type_in_config(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    window_size: int | None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Covers the scenario where we receive a `ConfigureWindowSizes` message with a
+    protocol message type that we don't have in our rate limits config, to make
+    sure we parse it and track it properly via the provided window size, and if
+    that's unlimited then we don't rate limit ourselves accordingly.
+    """
+    _, server, _ = one_node_one_block
+    unknown_type_to_us = ProtocolMessageTypes.request_peers
+    assert unknown_type_to_us not in rate_limits_v3
+    config_settings = dict(rate_limits_v3)
+    config_settings[unknown_type_to_us] = RLSettingsV3(window_size=window_size)
+    config_msg_with_unknown_type = make_msg(
+        ProtocolMessageTypes.configure_window_sizes, rl_v3_to_configure_message(settings=config_settings)
+    )
+    original_send_message = WSChiaConnection._send_message
+
+    async def test_send_message(self: WSChiaConnection, message: Message, priority: int = 0) -> None:
+        # Intercept the config message sent by the peer to add to it the
+        # message type that is unknown to us.
+        if self.is_outbound and ProtocolMessageTypes(message.type) == ProtocolMessageTypes.configure_window_sizes:
+            message = config_msg_with_unknown_type
+        await original_send_message(self, message)
+
+    monkeypatch.setattr(WSChiaConnection, "_send_message", test_send_message)
+    sender_connection, peer_id = await add_dummy_connection_wsc(server, self_hostname, 1337)
+    sender_connection.peer_info = PeerInfo("1.3.3.7", sender_connection.peer_info.port)
+    receiver_connection = server.all_connections[peer_id]
+    receiver_connection.peer_info = PeerInfo("1.2.3.4", receiver_connection.peer_info.port)
+    assert receiver_connection.peer_rl_settings_v3[unknown_type_to_us].window_size == window_size
+    if window_size is None:
+        # We don't track unlimited message types, we won't rate limit ourselves
+        assert unknown_type_to_us not in receiver_connection.rate_limit_windows
+    else:
+        assert receiver_connection.rate_limit_windows[unknown_type_to_us].receive_window == 0
+        assert receiver_connection.rate_limit_windows[unknown_type_to_us].in_flight == 0
+
+    async def send_request_task() -> None:
+        await receiver_connection.send_request(make_msg(unknown_type_to_us, b""), timeout=1)
+
+    assert unknown_type_to_us not in sender_connection.rate_limit_windows
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+    # Send more requests than the window size when it's not None to make sure
+    # we rate limit ourselves in that case and we don't when it's None.
+    await asyncio.gather(*(send_request_task() for _ in range(3)))
+    assert (
+        f"Rate limiting ourselves (v3). Dropping and retrying outbound message: {unknown_type_to_us.name}"
+        in caplog.text
+    ) == (window_size is not None)
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_receive_window(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers in-flight receive windows in general and specifically the
+    scenario where we enforce it for multiple peers on multiple protocol
+    message types at the same time.
+    """
+    _, server, _ = one_node_one_block
+    sender_connection1, sender_id = await add_dummy_connection_wsc(server, self_hostname, 1337)
+    receiver_connection1 = server.all_connections[sender_id]
+    receiver_connection1.peer_info = PeerInfo("1.3.3.7", receiver_connection1.peer_info.port)
+    sender_connection2, sender2_id = await add_dummy_connection_wsc(server, self_hostname, 1234)
+    receiver_connection2 = server.all_connections[sender2_id]
+    receiver_connection2.peer_info = PeerInfo("1.2.3.4", receiver_connection2.peer_info.port)
+    localhost_sender, _ = await add_dummy_connection_wsc(server, self_hostname, 5678)
+    msg_type = ProtocolMessageTypes.request_blocks
+    release_handler = asyncio.Event()
+
+    async def slow_handler(api: FullNodeAPI, request_bytes: bytes) -> Message | None:
+        await release_handler.wait()
+        return None
+
+    request_blocks_api = receiver_connection1.api.metadata.message_type_to_request[msg_type]
+    monkeypatch.setattr(request_blocks_api, "method", slow_handler)
+    max_concurrent = rate_limits_v3[msg_type].window_size
+    assert max_concurrent is not None
+
+    async def peer1_task() -> None:
+        # Peer 1 sends more than max_concurrent rapid-fire
+        msg = make_msg(msg_type, RequestBlocks(uint32(0), uint32(0), True))
+        for _ in range(max_concurrent + 1):
+            await sender_connection1.send_message(msg)
+
+    async def peer2_task() -> None:
+        for _ in range(max_concurrent):
+            await sender_connection2.send_message(make_msg(msg_type, RequestBlocks(uint32(0), uint32(0), False)))
+
+    async def localhost_task() -> None:
+        # localhost peer is exempt from rate limits v3
+        for _ in range(max_concurrent + 42):
+            await localhost_sender.send_message(make_msg(msg_type, RequestBlocks(uint32(0), uint32(0), False)))
+
+    await asyncio.gather(peer1_task(), peer2_task(), localhost_task())
+    # Peer1 hits the limit
+    await time_out_assert(5, lambda: sender_connection1.closed)
+    await time_out_assert(5, lambda: "1.3.3.7" in server.banned_peers)
+    # The others are fine
+    assert sender_connection2.closed is False
+    assert localhost_sender.closed is False
+    release_handler.set()
+    await time_out_assert(5, lambda: receiver_connection2.rate_limit_windows[msg_type].receive_window == 0)
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_receive_window_pre_queue_check(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers the scenario where the (unreliable) receive window check in
+    `_read_one_message` kicks in and rejects a message before it gets enqueued
+    for processing. We fill the window by letting handlers start and then
+    before they complete we send one more message and make sure it gets
+    rejected before entering the queue.
+    """
+    _, server, _ = one_node_one_block
+    sender_connection, sender_id = await add_dummy_connection_wsc(server, self_hostname, 1337)
+    receiver_connection = server.all_connections[sender_id]
+    receiver_connection.peer_info = PeerInfo("1.3.3.7", receiver_connection.peer_info.port)
+    msg_type = ProtocolMessageTypes.request_blocks
+    release_handler = asyncio.Event()
+
+    async def slow_handler(api: FullNodeAPI, request_bytes: bytes) -> Message | None:
+        await release_handler.wait()
+        return None  # pragma: no cover
+
+    request_blocks_api = receiver_connection.api.metadata.message_type_to_request[msg_type]
+    monkeypatch.setattr(request_blocks_api, "method", slow_handler)
+    max_concurrent = rate_limits_v3[msg_type].window_size
+    assert max_concurrent is not None
+    rl_window = receiver_connection.rate_limit_windows[msg_type]
+    # Send exactly max_concurrent messages and wait for handlers to start
+    msg = make_msg(msg_type, RequestBlocks(uint32(0), uint32(0), False))
+    for _ in range(max_concurrent):
+        await sender_connection.send_message(msg)
+    await time_out_assert(5, lambda: rl_window.receive_window == max_concurrent)
+    # This message should be rejected in _read_one_message
+    await sender_connection.send_message(msg)
+    await time_out_assert(5, lambda: sender_connection.closed)
+    await time_out_assert(5, lambda: "1.3.3.7" in server.banned_peers)
+    release_handler.set()
+    await time_out_assert(5, lambda: rl_window.receive_window == 0)
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+@pytest.mark.parametrize("server_custom_config", [False, True])
+@pytest.mark.parametrize("bigger_window_size", [False, True])
+async def test_congestion_window(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+    server_custom_config: bool,
+    bigger_window_size: bool,
+) -> None:
+    """
+    Covers the scenario where the peer fills the congestion window for a
+    protocol request type, and further requests of that type get dropped and
+    retried.
+    With `server_custom_config` we control whether we advertise a custom
+    window size via the ConfigureWindowSizes message and make sure the peer
+    honours that value instead of the global default one.
+    With `bigger_window_size` we control whether the custom config advertises
+    a bigger or smaller window size than the default.
+    """
+    _, server, _ = one_node_one_block
+    msg_type = ProtocolMessageTypes.request_blocks
+    test_window_size = rate_limits_v3[msg_type].window_size
+    assert test_window_size is not None
+    if server_custom_config:
+        # Configure a different window size
+        test_window_size += 1 if bigger_window_size else -1
+        # Update the server's global defaults and advertised v3 capability
+        monkeypatch.setitem(rate_limits_v3, msg_type, RLSettingsV3(window_size=test_window_size))
+    sender_connection, sender_id = await add_dummy_connection_wsc(server, self_hostname, 1337)
+    receiver_connection = server.all_connections[sender_id]
+    receiver_connection.peer_info = PeerInfo("1.3.3.7", receiver_connection.peer_info.port)
+    sender_connection.peer_info = PeerInfo("1.2.3.4", sender_connection.peer_info.port)
+    # Make sure the peer's settings are properly set from the capability string
+    assert sender_connection.peer_rl_settings_v3[msg_type].window_size == test_window_size
+    max_concurrent = test_window_size
+    original_method = receiver_connection.api.metadata.message_type_to_request[msg_type].method
+    handler_called_event = asyncio.Event()
+    release_event = asyncio.Event()
+
+    async def slow_handler(api: FullNodeAPI, request_bytes: bytes) -> Message | None:
+        handler_called_event.set()
+        # Wait until get the signal to proceed
+        await release_event.wait()
+        # delegate to the real implementation so that we return a valid response
+        return await original_method(api, request_bytes)
+
+    # Delay the handler's responses so we can fill the slots
+    monkeypatch.setattr(receiver_connection.api.metadata.message_type_to_request[msg_type], "method", slow_handler)
+    # Fill the congestion window
+    for _ in range(max_concurrent):
+        handler_called_event.clear()
+        create_referenced_task(
+            sender_connection.call_api(FullNodeAPI.request_blocks, RequestBlocks(uint32(0), uint32(0), False))
+        )
+        await time_out_assert(5, handler_called_event.is_set)
+
+    rl_window = sender_connection.rate_limit_windows[msg_type]
+    assert rl_window.in_flight == max_concurrent
+    # This extra request should now be dropped and retried
+    request_task = create_referenced_task(
+        sender_connection.call_api(FullNodeAPI.request_blocks, RequestBlocks(uint32(0), uint32(0), False))
+    )
+    # Unblock the original handlers so the congestion window can drain
+    release_event.set()
+    # The retried request should eventually complete with a real response
+    result = await asyncio.wait_for(request_task, timeout=5)
+    assert isinstance(result, RespondBlocks)
+    assert result.start_height == uint32(0)
+    assert result.end_height == uint32(0)
+    assert len(result.blocks) == 1
+    await time_out_assert(5, lambda: rl_window.in_flight == 0)
+    # A fresh request should succeed
+    result = await sender_connection.call_api(FullNodeAPI.request_blocks, RequestBlocks(uint32(0), uint32(0), False))
+    assert isinstance(result, RespondBlocks)
+    assert rl_window.in_flight == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_congestion_window_send_request_timeout(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers the scenario where `send_request` times out waiting for a response
+    to make sure the congestion window is properly updated.
+    """
+    _, server, _ = one_node_one_block
+    sender_connection, sender_id = await add_dummy_connection_wsc(server, self_hostname, 1337)
+    receiver_connection = server.all_connections[sender_id]
+    receiver_connection.peer_info = PeerInfo("1.3.3.7", receiver_connection.peer_info.port)
+    msg_type = ProtocolMessageTypes.request_blocks
+
+    async def hanging_handler(api: FullNodeAPI, request_bytes: bytes) -> None:
+        await asyncio.sleep(42)
+
+    request_meta = receiver_connection.api.metadata.message_type_to_request[msg_type]
+    monkeypatch.setattr(request_meta, "method", hanging_handler)
+    msg = make_msg(msg_type, RequestBlocks(uint32(0), uint32(0), False))
+    result = await sender_connection.send_request(msg, timeout=1)
+    assert result is None
+    # Make sure the congestion window is properly updated
+    assert sender_connection.rate_limit_windows[msg_type].in_flight == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_unlimited_messages_bypass_v2_rl(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers the scenario of v3 supported unlimited messages to make sure they're
+    not subject to the v2 rate limiter.
+    """
+    _, server, _ = one_node_one_block
+    sender_connection, sender_id = await add_dummy_connection_wsc(server, self_hostname, 42)
+    sender_connection.peer_info = PeerInfo("1.3.3.7", sender_connection.peer_info.port)
+    server_connection = server.all_connections[sender_id]
+    server_connection.peer_info = PeerInfo("1.2.3.4", server_connection.peer_info.port)
+    assert Capability.RATE_LIMITS_V3 in server_connection.peer_capabilities
+    assert server_connection.peer_rl_settings_v3[ProtocolMessageTypes.respond_blocks].window_size is None
+
+    def test_process_msg_and_check(
+        message: Message, our_capabilities: list[Capability], peer_capabilities: list[Capability]
+    ) -> str | None:
+        # Make sure the v2 rate limiter didn't process the outbound response type
+        assert False  # pragma: no cover
+
+    monkeypatch.setattr(server_connection.outbound_rate_limiter, "process_msg_and_check", test_process_msg_and_check)
+    result = await sender_connection.call_api(FullNodeAPI.request_blocks, RequestBlocks(uint32(0), uint32(0), False))
+    assert isinstance(result, RespondBlocks)
+    assert result.start_height == uint32(0)
+    assert result.end_height == uint32(0)
+    assert len(result.blocks) == 1
+    assert sender_connection.closed is False
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_close_unblocks_send_request(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers the scenario where we close a connection while `send_request` is
+    blocked to ensure it returns `None` and decrements the congestion window.
+    """
+    _, server, _ = one_node_one_block
+    sender_connection, sender_id = await add_dummy_connection_wsc(server, self_hostname, 1337)
+    receiver_connection = server.all_connections[sender_id]
+    receiver_connection.peer_info = PeerInfo("1.3.3.7", receiver_connection.peer_info.port)
+    sender_connection.peer_info = PeerInfo("1.2.3.4", sender_connection.peer_info.port)
+    msg_type = ProtocolMessageTypes.request_blocks
+    max_concurrent = rate_limits_v3[msg_type].window_size
+    assert max_concurrent is not None
+    # Create a slow handler so that the initial requests fill the window and
+    # one additional request gets stalled in `_send_message` retry logic.
+    handler_called = asyncio.Event()
+    release = asyncio.Event()
+    original_method = receiver_connection.api.metadata.message_type_to_request[msg_type].method
+
+    async def slow_handler(api: FullNodeAPI, request_bytes: bytes) -> Message | None:
+        handler_called.set()
+        await release.wait()
+        return await original_method(api, request_bytes)
+
+    monkeypatch.setattr(receiver_connection.api.metadata.message_type_to_request[msg_type], "method", slow_handler)
+    # Fill the congestion window
+    for _ in range(max_concurrent):
+        handler_called.clear()
+        create_referenced_task(
+            sender_connection.call_api(FullNodeAPI.request_blocks, RequestBlocks(uint32(0), uint32(0), False))
+        )
+        await time_out_assert(5, handler_called.is_set)
+    rl_window = sender_connection.rate_limit_windows[msg_type]
+    assert rl_window.in_flight == max_concurrent
+    # Issue one more request, it will be dropped and retried internally
+    blocked_task = create_referenced_task(
+        sender_connection.call_api(FullNodeAPI.request_blocks, RequestBlocks(uint32(0), uint32(0), False))
+    )
+    await asyncio.sleep(0.1)
+    # Now close the connection and check that `send_request` returns `None`
+    await sender_connection.close()
+    result = await asyncio.wait_for(blocked_task, timeout=5)
+    assert result is None
+    # The congestion window should update properly
+    release.set()
+    await time_out_assert(5, lambda: rl_window.in_flight == 0)
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_api_handler_raises_exception(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers the scenario where an API handler raises an exception, to make sure
+    we decrement the receive window.
+    """
+    _, server, _ = one_node_one_block
+    sender_connection, sender_id = await add_dummy_connection_wsc(server, self_hostname, 1337)
+    receiver_connection = server.all_connections[sender_id]
+    receiver_connection.peer_info = PeerInfo("1.3.3.7", receiver_connection.peer_info.port)
+    msg_type = ProtocolMessageTypes.request_blocks
+    rl_window = receiver_connection.rate_limit_windows[msg_type]
+
+    async def throwing_api_handler(api: FullNodeAPI, request_bytes: bytes) -> None:
+        assert rl_window.receive_window == 1
+        raise Exception
+
+    request_meta = receiver_connection.api.metadata.message_type_to_request[msg_type]
+    monkeypatch.setattr(request_meta, "method", throwing_api_handler)
+    result = await sender_connection.call_api(FullNodeAPI.request_blocks, RequestBlocks(uint32(0), uint32(0), False))
+    assert result is None
+    await time_out_assert(5, lambda: rl_window.receive_window == 0)
+    await time_out_assert(5, lambda: receiver_connection.closed)
+    await time_out_assert(5, lambda: "1.3.3.7" in server.banned_peers)
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+@pytest.mark.parametrize("tracked_request", [False, True])
+async def test_v3_messages_wrt_v2_rate_limiter(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    tracked_request: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers the scenarios where we send a v3 supported protocol message to a
+    peer that advertises RATE_LIMITS_V3, tracked (with nonce) and untracked, to
+    make sure the v2 rate limiter gets properly bypassed/activated.
+    """
+    _, server, _ = one_node_one_block
+    sender_connection, _ = await add_dummy_connection_wsc(server, self_hostname, 42)
+    sender_connection.peer_info = PeerInfo("1.3.3.7", sender_connection.peer_info.port)
+    event = asyncio.Event()
+    processed_msgs: list[ProtocolMessageTypes] = []
+
+    def test_process_msg_and_check(
+        message: Message, our_capabilities: list[Capability], peer_capabilities: list[Capability]
+    ) -> str | None:
+        processed_msgs.append(ProtocolMessageTypes(message.type))
+        event.set()
+        return None
+
+    monkeypatch.setattr(sender_connection.outbound_rate_limiter, "process_msg_and_check", test_process_msg_and_check)
+    msg_type = ProtocolMessageTypes.request_blocks
+    request = RequestBlocks(uint32(0), uint32(0), False)
+    if tracked_request:
+        # V2 rate limiter should not be invoked for v3 tracked messages
+        response = await sender_connection.call_api(FullNodeAPI.request_blocks, request)
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(event.wait(), timeout=1)
+        assert msg_type not in processed_msgs
+        assert isinstance(response, RespondBlocks)
+        assert response.start_height == uint32(0)
+        assert response.end_height == uint32(0)
+        assert len(response.blocks) == 1
+    else:
+        # V2 rate limiter should be invoked for untracked messages
+        await sender_connection.send_message(make_msg(msg_type, request))
+        await asyncio.wait_for(event.wait(), timeout=1)
+        assert msg_type in processed_msgs
+    # Make sure the connection remains open
+    assert sender_connection.closed is False
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_rate_limits_v3_e2e(
+    two_nodes_one_block: tuple[FullNodeSimulator, FullNodeSimulator, ChiaServer, ChiaServer, BlockTools],
+    self_hostname: str,
+) -> None:
+    """
+    Covers rate limits v3 end to end. It verifies RATE_LIMITS_V3 capability
+    as well as the receive and congestion windows.
+    """
+    full_node_api, _, server_1, server_2, _ = two_nodes_one_block
+    await server_2.start_client(PeerInfo(self_hostname, server_1.get_port()))
+    await time_out_assert(5, lambda: len(server_1.all_connections) == 1)
+    await time_out_assert(5, lambda: len(server_2.all_connections) == 1)
+    sender_connection = next(iter(server_2.all_connections.values()))
+    sender_connection.peer_info = PeerInfo("1.3.3.7", server_1.get_port())
+    receiver_connection = next(iter(server_1.all_connections.values()))
+    receiver_connection.peer_info = PeerInfo("1.2.3.4", server_2.get_port())
+    # Capability advertising
+    assert Capability.RATE_LIMITS_V3 in sender_connection.peer_capabilities
+    assert Capability.RATE_LIMITS_V3 in receiver_connection.peer_capabilities
+    # Rate limits v3 windows should have initialized correctly on both sides
+    msg_type = ProtocolMessageTypes.request_blocks
+    sender_rl_window = sender_connection.rate_limit_windows[msg_type]
+    receiver_rl_window = receiver_connection.rate_limit_windows[msg_type]
+    assert sender_rl_window.receive_window == 0
+    assert receiver_rl_window.receive_window == 0
+    # Issue a request to verify the windows state after its completion
+    test_block = (await full_node_api.full_node.block_store.get_full_blocks_at([uint32(0)]))[0]
+    result = await sender_connection.call_api(FullNodeAPI.request_blocks, RequestBlocks(uint32(0), uint32(0), False))
+    assert isinstance(result, RespondBlocks)
+    assert result.start_height == uint32(0)
+    assert result.end_height == uint32(0)
+    assert result.blocks == [test_block]
+    # After completion both sides should have properly updated their
+    # in-flight windows.
+    assert receiver_rl_window.receive_window == 0
+    assert sender_rl_window.in_flight == 0
+    # Fill all slots concurrently
+    max_concurrent = rate_limits_v3[msg_type].window_size
+    assert max_concurrent is not None
+    tasks = [
+        create_referenced_task(
+            sender_connection.call_api(FullNodeAPI.request_blocks, RequestBlocks(uint32(0), uint32(0), False))
+        )
+        for _ in range(max_concurrent)
+    ]
+    results = await asyncio.gather(*tasks)
+    for result in results:
+        assert isinstance(result, RespondBlocks)
+        assert result.start_height == uint32(0)
+        assert result.end_height == uint32(0)
+        assert result.blocks == [test_block]
+    assert receiver_rl_window.receive_window == 0
+    assert sender_rl_window.in_flight == 0
+    # Check that the reject path also frees slots properly
+    result = await sender_connection.call_api(FullNodeAPI.request_blocks, RequestBlocks(uint32(1), uint32(0), False))
+    assert isinstance(result, RejectBlocks)
+    assert result.start_height == uint32(1)
+    assert result.end_height == uint32(0)
+    assert receiver_rl_window.receive_window == 0
+    assert sender_rl_window.in_flight == 0
+    # Issue a request back to the sender from the receiver
+    result = await receiver_connection.call_api(FullNodeAPI.request_blocks, RequestBlocks(uint32(1), uint32(0), False))
+    assert isinstance(result, RejectBlocks)
+    assert result.start_height == uint32(1)
+    assert result.end_height == uint32(0)
+    assert sender_rl_window.receive_window == 0
+    assert not sender_connection.closed
+    assert not receiver_connection.closed

--- a/chia/_tests/core/server/test_server.py
+++ b/chia/_tests/core/server/test_server.py
@@ -31,6 +31,7 @@ from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.types.peer_info import PeerInfo
 from chia.util.errors import ApiError, Err
+from chia.util.task_referencer import create_referenced_task
 from chia.wallet.start_wallet import create_wallet_service
 
 
@@ -116,7 +117,7 @@ async def test_connection_string_conversion(
     # WSChiaConnection(local_type=<NodeType.FULL_NODE: 1>, local_port=50632, local_capabilities=[<Capability.BASE: 1>, <Capability.BLOCK_HEADERS: 2>, <Capability.RATE_LIMITS_V2: 3>, <Capability.MEMPOOL_UPDATES: 5>, <Capability.HARD_FORK_2: 6>], peer_info=PeerInfo(_ip=IPv4Address('127.0.0.1'), _port=50640), peer_node_id=<bytes32: 566a318f0f656125b4fef0e85fbddcf9bc77f8003d35293c392479fc5d067f4d>, outbound_rate_limiter=<chia.server.rate_limits.RateLimiter object at 0x114a13f50>, inbound_rate_limiter=<chia.server.rate_limits.RateLimiter object at 0x114a13e90>, is_outbound=False, creation_time=1675271096.275591, bytes_read=68, bytes_written=162, last_message_time=1675271096.276271, peer_server_port=50636, closed=False, connection_type=<NodeType.FULL_NODE: 1>, request_nonce=32768, peer_capabilities=[<Capability.BASE: 1>, <Capability.BLOCK_HEADERS: 2>, <Capability.RATE_LIMITS_V2: 3>, <Capability.MEMPOOL_UPDATES: 5>, <Capability.HARD_FORK_2: 6>], version='', protocol_version=<Version('0.0.36')>) # noqa
     converted = method(peer)
     print(converted)
-    assert len(converted) < 1100
+    assert len(converted) < 1200
 
 
 @pytest.mark.anyio
@@ -129,7 +130,9 @@ async def test_connection_versions(
     await wallet_node.server.start_client(
         PeerInfo(self_hostname, cast(FullNodeAPI, full_node_service._api).server.get_port()), None
     )
+    await time_out_assert(5, lambda: full_node.server.node_id in wallet_node.server.all_connections)
     outgoing_connection = wallet_node.server.all_connections[full_node.server.node_id]
+    await time_out_assert(5, lambda: wallet_node.server.node_id in full_node.server.all_connections)
     incoming_connection = full_node.server.all_connections[wallet_node.server.node_id]
     for connection in [outgoing_connection, incoming_connection]:
         assert connection.protocol_version == Version(protocol_version[NodeType.WALLET])
@@ -169,6 +172,7 @@ async def test_api_not_ready(
     )
     wallet_node.log_out()
     assert not wallet_service._api.ready()
+    await time_out_assert(5, lambda: wallet_node.server.node_id in full_node.server.all_connections)
     connection = full_node.server.all_connections[wallet_node.server.node_id]
 
     def request_ignored() -> bool:
@@ -201,7 +205,10 @@ async def test_error_response(
     test_version = Version(version)
     request = RequestTransaction(bytes32(32 * b"1"))
     error_message = f"Some error message: {request.transaction_id}"
-    dummy_wsc, dummy_peer_id = await add_dummy_connection_wsc(full_node.server, self_hostname, 1337)
+    dummy_wsc, dummy_peer_id = await add_dummy_connection_wsc(
+        full_node.server, self_hostname, 1337, wait_for_peer_added=False
+    )
+    await time_out_assert(5, lambda: dummy_peer_id in full_node.server.all_connections)
     dummy_full_node_connection = full_node.server.all_connections[dummy_peer_id]
     dummy_full_node_connection.protocol_version = test_version
     with caplog.at_level(logging.DEBUG):
@@ -235,7 +242,9 @@ async def test_error_receive(
     await wallet_node.server.start_client(
         PeerInfo(self_hostname, cast(FullNodeAPI, full_node_service._api).server.get_port()), None
     )
+    await time_out_assert(5, lambda: wallet_node.server.node_id in full_node.server.all_connections)
     wallet_connection = full_node.server.all_connections[wallet_node.server.node_id]
+    await time_out_assert(5, lambda: full_node.server.node_id in wallet_node.server.all_connections)
     full_node_connection = wallet_node.server.all_connections[full_node.server.node_id]
     message = make_msg(ProtocolMessageTypes.error, error)
 
@@ -471,8 +480,7 @@ async def test_inbound_handler_none_msg(
     `_read_one_message`.
     """
     _, server, _ = one_node_one_block
-    wsc, peer_id = await add_dummy_connection_wsc(server, self_hostname, 1337)
-    await time_out_assert(5, lambda: peer_id in server.all_connections)
+    wsc, _ = await add_dummy_connection_wsc(server, self_hostname, 1337)
     read_calls = 0
 
     async def test_read_one_message() -> Message | None:
@@ -482,6 +490,8 @@ async def test_inbound_handler_none_msg(
 
     monkeypatch.setattr(wsc, "_read_one_message", test_read_one_message)
     assert wsc.inbound_task is not None
+    wsc.inbound_task.cancel()
+    wsc.inbound_task = create_referenced_task(wsc.inbound_handler())
     await asyncio.wait_for(wsc.inbound_task, timeout=1)
     assert read_calls == 1
     assert wsc.incoming_queue.qsize() == 0

--- a/chia/_tests/core/test_crawler.py
+++ b/chia/_tests/core/test_crawler.py
@@ -52,6 +52,7 @@ async def test_unknown_messages(
     assert await crawler.server.start_client(
         PeerInfo(self_hostname, cast(FullNodeAPI, full_node_service._api).server.get_port()), None
     )
+    await time_out_assert(5, lambda: crawler.server.node_id in full_node.server.all_connections)
     connection = full_node.server.all_connections[crawler.server.node_id]
 
     def receiving_failed() -> bool:
@@ -76,6 +77,7 @@ async def test_valid_message(
     assert await crawler.server.start_client(
         PeerInfo(self_hostname, cast(FullNodeAPI, full_node_service._api).server.get_port()), None
     )
+    await time_out_assert(5, lambda: crawler.server.node_id in full_node.server.all_connections)
     connection = full_node.server.all_connections[crawler.server.node_id]
 
     def peer_added() -> bool:

--- a/chia/_tests/util/test_network_protocol_test.py
+++ b/chia/_tests/util/test_network_protocol_test.py
@@ -226,7 +226,7 @@ def test_missing_messages() -> None:
 
     solver_msgs = {"SolverInfo", "SolverResponse"}
 
-    shared_msgs = {"Handshake", "Capability", "Error"}
+    shared_msgs = {"Handshake", "ConfigureWindowSizes", "Capability", "Error"}
 
     # if these asserts fail, make sure to add the new network protocol messages
     # to the visitor in build_network_protocol_files.py and rerun it. Then

--- a/chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -661,6 +661,7 @@ async def test_ph_subscribe_limits(simulator_and_wallet: OldSimulatorsAndWallets
     _, server_2 = wallets[0]
     fn_server = full_node_api.full_node.server
     await server_2.start_client(PeerInfo(self_hostname, fn_server.get_port()), None)
+    await time_out_assert(5, lambda: len(fn_server.all_connections) == 1)
     con = next(iter(fn_server.all_connections.values()))
     phs = []
     phs.append(bytes32(32 * b"\0"))
@@ -703,6 +704,7 @@ async def test_coin_subscribe_limits(simulator_and_wallet: OldSimulatorsAndWalle
     _, server_2 = wallets[0]
     fn_server = full_node_api.full_node.server
     await server_2.start_client(PeerInfo(self_hostname, fn_server.get_port()), None)
+    await time_out_assert(5, lambda: len(fn_server.all_connections) == 1)
     con = next(iter(fn_server.all_connections.values()))
     coins = []
     coins.append(bytes32(32 * b"\0"))

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -1849,8 +1849,8 @@ async def test_long_reorg_nodes_and_wallet(
     assert last_blk.weight < last_reorg_blk.weight
 
     await wallet_server.start_client(PeerInfo(self_hostname, full_node_1.server.get_port()), None)
-    assert len(wallet_server.all_connections) == 1
-    assert len(full_node_1.server.all_connections) == 1
+    await time_out_assert(5, lambda: len(wallet_server.all_connections) == 1)
+    await time_out_assert(5, lambda: len(full_node_1.server.all_connections) == 1)
 
     await add_blocks_in_batches(blocks, full_node_1.full_node)
     node_1_peak = full_node_1.full_node.blockchain.get_peak()
@@ -1906,7 +1906,9 @@ async def test_validate_received_state_from_peer_no_additions(
     peer_request_cache.add_to_blocks(new_block_header)
     ph = bytes32.random()
     coin_state = CoinState(Coin(bytes32.random(), ph, uint64(1)), None, created_height)
-    wsc, _ = await add_dummy_connection_wsc(full_node_api.full_node.server, self_hostname, 42, NodeType.WALLET)
+    wsc, _ = await add_dummy_connection_wsc(
+        full_node_api.full_node.server, self_hostname, 42, NodeType.WALLET, wait_for_peer_added=False
+    )
     caplog.clear()
     caplog.set_level(logging.INFO)
     result = await wallet_node.validate_received_state_from_peer(
@@ -1960,7 +1962,7 @@ async def test_validate_received_state_from_peer_no_removals(
             )
         )
         coin_state = CoinState(coin, None, created_height)
-    wsc, _ = await add_dummy_connection_wsc(server, self_hostname, 42, NodeType.WALLET)
+    wsc, _ = await add_dummy_connection_wsc(server, self_hostname, 42, NodeType.WALLET, wait_for_peer_added=False)
     caplog.clear()
     caplog.set_level(logging.INFO)
     request_removals_calls: list[uint32] = []

--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -633,6 +633,7 @@ async def test_transaction_send_cache(self_hostname: str, simulator_and_wallet: 
     [full_node_api], [(wallet_node, wallet_server)], _ = simulator_and_wallet
 
     await wallet_server.start_client(PeerInfo(self_hostname, full_node_api.server.get_port()), None)
+    await time_out_assert(5, lambda: len(full_node_api.full_node.server.get_connections()) == 1)
     wallet = wallet_node.wallet_state_manager.main_wallet
     await full_node_api.farm_rewards_to_wallet(1, wallet)
 
@@ -695,6 +696,7 @@ async def test_transaction_send_cache(self_hostname: str, simulator_and_wallet: 
     # --- Fee-failure retry on new transaction block ---
     # Reconnect and create a second transaction to test fee-failure retry behavior.
     await wallet_server.start_client(PeerInfo(self_hostname, full_node_api.server.get_port()), None)
+    await time_out_assert(5, lambda: len(full_node_api.full_node.server.get_connections()) == 1)
     logged_spends.clear()
 
     assert full_node_api.full_node._server is not None
@@ -766,6 +768,7 @@ async def test_retry_fee_failed_skips_disconnected_and_in_flight(
     [full_node_api], [(wallet_node, wallet_server)], _ = simulator_and_wallet
 
     await wallet_server.start_client(PeerInfo(self_hostname, full_node_api.server.get_port()), None)
+    await time_out_assert(5, lambda: len(full_node_api.full_node.server.get_connections()) == 1)
     wallet = wallet_node.wallet_state_manager.main_wallet
     await full_node_api.farm_rewards_to_wallet(1, wallet)
 
@@ -810,6 +813,7 @@ async def test_retry_fee_failed_skips_disconnected_and_in_flight(
     # Reconnect, re-create the fee-failed state, then manually mark the message as
     # in-flight so _retry_fee_failed_transactions hits the second branch of line 598.
     await wallet_server.start_client(PeerInfo(self_hostname, full_node_api.server.get_port()), None)
+    await time_out_assert(5, lambda: len(full_node_api.full_node.server.get_connections()) == 1)
     logged_spends.clear()
 
     assert full_node_api.full_node._server is not None
@@ -930,6 +934,7 @@ async def test_wallet_node_bad_coin_state_ignore(
     [full_node_api], [(wallet_node, wallet_server)], _ = simulator_and_wallet
 
     await wallet_server.start_client(PeerInfo(self_hostname, full_node_api.server.get_port()), None)
+    await time_out_assert(5, lambda: len(full_node_api.full_node.server.get_connections()) == 1)
 
     async def register_for_coin_updates(
         self: Self, request: wallet_protocol.RegisterForCoinUpdates, *, test: bool = False

--- a/chia/protocols/protocol_message_type_to_node_type.py
+++ b/chia/protocols/protocol_message_type_to_node_type.py
@@ -9,6 +9,7 @@ from chia.protocols.protocol_message_types import ProtocolMessageTypes
 ProtocolMessageTypeToNodeType: dict[ProtocolMessageTypes, set[NodeType]] = {
     # Shared protocol (all services)
     ProtocolMessageTypes.handshake: set(NodeType),
+    ProtocolMessageTypes.configure_window_sizes: set(NodeType),
     # Harvester protocol (harvester <-> farmer)
     ProtocolMessageTypes.harvester_handshake: {NodeType.FARMER},
     ProtocolMessageTypes.new_proof_of_space: {NodeType.HARVESTER},

--- a/chia/protocols/protocol_message_types.py
+++ b/chia/protocols/protocol_message_types.py
@@ -6,6 +6,7 @@ from enum import Enum
 class ProtocolMessageTypes(Enum):
     # Shared protocol (all services)
     handshake = 1
+    configure_window_sizes = 111
 
     # Harvester protocol (harvester <-> farmer)
     harvester_handshake = 3

--- a/chia/protocols/shared_protocol.py
+++ b/chia/protocols/shared_protocol.py
@@ -48,6 +48,14 @@ class Capability(IntEnum):
     # Signals support for Hard Fork 2
     HARD_FORK_2 = 6
 
+    # When both peers advertise this, a ConfigureWindowSizes message is
+    # required immediately following the handshake, and rate limits v3 replace
+    # v2 for supported protocol message types.
+    # Sequence: outbound sends ConfigureWindowSizes then inbound validates and
+    # replies with ConfigureWindowSizes.
+    # Settings must be non empty and window_size == 0 means unlimited.
+    RATE_LIMITS_V3 = 7
+
 
 # These are the default capabilities used in all outgoing handshakes.
 # "1" means the capability is supported and enabled.
@@ -81,6 +89,13 @@ class Handshake(Streamable):
     server_port: uint16
     node_type: uint8
     capabilities: list[tuple[uint16, str]]
+
+
+@streamable
+@dataclass(frozen=True)
+class ConfigureWindowSizes(Streamable):
+    # List of tuples of protocol message type and window size (0 is unlimited)
+    settings: list[tuple[uint8, uint16]]
 
 
 @streamable

--- a/chia/server/rate_limit_numbers.py
+++ b/chia/server/rate_limit_numbers.py
@@ -73,6 +73,7 @@ rate_limits: dict[int, dict[ProtocolMessageTypes, RLSettings | Unlimited]] = {
         ProtocolMessageTypes.transaction_ack: RLSettings(False, 5000, 2048),
         # All non-transaction apis also have an aggregate limit
         ProtocolMessageTypes.handshake: RLSettings(True, 5, 10 * 1024, 5 * 10 * 1024),
+        ProtocolMessageTypes.configure_window_sizes: RLSettings(True, 5, 1024, 1024),
         ProtocolMessageTypes.harvester_handshake: RLSettings(True, 5, 1024 * 1024),
         ProtocolMessageTypes.new_signage_point_harvester: RLSettings(True, 100, 4886),  # Size with 100 pool list
         ProtocolMessageTypes.new_proof_of_space: RLSettings(True, 100, 2048),

--- a/chia/server/rate_limits_v3.py
+++ b/chia/server/rate_limits_v3.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import dataclasses
+
+from chia_rs.sized_ints import uint8, uint16
+
+from chia.protocols.protocol_message_types import ProtocolMessageTypes
+from chia.protocols.shared_protocol import ConfigureWindowSizes
+from chia.util.errors import Err, ProtocolError
+
+
+@dataclasses.dataclass
+class RateLimitsV3:
+    """
+    In-flight window for each peer, for each supported protocol message type
+    """
+
+    # Number of requests currently being processed
+    receive_window: int
+    # Number of in-flight outbound requests
+    in_flight: int
+
+
+@dataclasses.dataclass(frozen=True)
+class RLSettingsV3:
+    # Maximum allowed number of in-flight requests per message type, `None`
+    # means unlimited.
+    window_size: int | None
+
+
+# Message types tracked by v3 in-flight window, where both peers advertise
+# RATE_LIMITS_V3 capability. If a message is in this list, it will not be
+# subject to the time based rate limiter.
+rate_limits_v3: dict[ProtocolMessageTypes, RLSettingsV3] = {
+    ProtocolMessageTypes.request_blocks: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_blocks: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.reject_blocks: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.request_block: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_block: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.reject_block: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.request_block_header: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_block_header: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.reject_header_request: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.request_block_headers: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_block_headers: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.reject_block_headers: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.request_header_blocks: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_header_blocks: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.reject_header_blocks: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.register_for_ph_updates: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_to_ph_updates: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.register_for_coin_updates: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_to_coin_updates: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.request_puzzle_state: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_puzzle_state: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.reject_puzzle_state: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.request_coin_state: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_coin_state: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.reject_coin_state: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.request_additions: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_additions: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.reject_additions_request: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.request_removals: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_removals: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.reject_removals_request: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.request_proof_of_weight: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_proof_of_weight: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.request_puzzle_solution: RLSettingsV3(window_size=2),
+    ProtocolMessageTypes.respond_puzzle_solution: RLSettingsV3(window_size=None),
+    ProtocolMessageTypes.reject_puzzle_solution: RLSettingsV3(window_size=None),
+}
+
+# Maximum number of window sizes we allow to be set by the
+# `ConfigureWindowSizes` message.
+MAX_CONFIGURE_RATE_LIMITS_ENTRIES: int = 256
+
+
+def rl_v3_to_configure_message(
+    settings: dict[ProtocolMessageTypes, RLSettingsV3] | None = None,
+) -> ConfigureWindowSizes:
+    """
+    Encode a set of rate limits into a `ConfigureWindowSizes` message. If
+    `settings` is `None` use the current local defaults in `rate_limits_v3`.
+    """
+    if settings is None:
+        settings = rate_limits_v3
+    assert 0 < len(settings) <= MAX_CONFIGURE_RATE_LIMITS_ENTRIES
+    message_settings: list[tuple[uint8, uint16]] = [
+        (uint8(msg_type.value), uint16(0 if setting.window_size is None else setting.window_size))
+        for msg_type, setting in settings.items()
+    ]
+    return ConfigureWindowSizes(settings=message_settings)
+
+
+def rl_settings_v3_from_configure_message(msg: ConfigureWindowSizes) -> dict[ProtocolMessageTypes, RLSettingsV3]:
+    """
+    Parse a `ConfigureWindowSizes` message rate limit settings. The peer
+    controls what is included so only the entries present in the message are
+    considered. Unknown entries are silently skipped while invalid ones result
+    in a `ProtocolError` exception.
+    """
+    result: dict[ProtocolMessageTypes, RLSettingsV3] = {}
+    for msg_type_val, window_size in msg.settings:
+        try:
+            message_type = ProtocolMessageTypes(msg_type_val)
+        except ValueError:
+            continue
+        # Don't allow peers to alter our unlimited (typically response type)
+        # protocol messages windows.
+        if message_type in rate_limits_v3 and rate_limits_v3[message_type].window_size is None and window_size != 0:
+            raise ProtocolError(Err.INVALID_HANDSHAKE)
+        result[message_type] = RLSettingsV3(window_size=None if window_size == 0 else window_size)
+    return result

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -30,10 +30,18 @@ from chia.protocols.protocol_timing import (
     INTERNAL_PROTOCOL_ERROR_BAN_SECONDS,
     RATE_LIMITER_BAN_SECONDS,
 )
-from chia.protocols.shared_protocol import Capability, Error, Handshake, protocol_version
+from chia.protocols.shared_protocol import Capability, ConfigureWindowSizes, Error, Handshake, protocol_version
 from chia.server.api_protocol import ApiMetadata, ApiProtocol
 from chia.server.capabilities import known_active_capabilities
 from chia.server.rate_limits import RateLimiter
+from chia.server.rate_limits_v3 import (
+    MAX_CONFIGURE_RATE_LIMITS_ENTRIES,
+    RateLimitsV3,
+    RLSettingsV3,
+    rate_limits_v3,
+    rl_settings_v3_from_configure_message,
+    rl_v3_to_configure_message,
+)
 from chia.types.peer_info import PeerInfo
 from chia.util.errors import ApiError, ConsensusError, Err, ProtocolError, TimestampError
 from chia.util.log_exceptions import log_exceptions
@@ -159,6 +167,15 @@ class WSChiaConnection:
         repr=False,
     )
 
+    # Peer's rate limits v3 settings, populated when we perform the handshake
+    # and parse the RATE_LIMITS_V3 capability string.
+    peer_rl_settings_v3: dict[ProtocolMessageTypes, RLSettingsV3] = field(default_factory=dict, repr=False)
+    # Peer's in-flight messages windows for supported protocol message
+    # types when both sides support rate limits v3.
+    rate_limit_windows: dict[ProtocolMessageTypes, RateLimitsV3] = field(default_factory=dict, repr=False)
+    # Tracked v3 request IDs that were sent
+    v3_sent_request_ids: set[uint16] = field(default_factory=set, repr=False)
+
     @classmethod
     def create(
         cls,
@@ -210,6 +227,11 @@ class WSChiaConnection:
             stub_metadata_for_type=stub_metadata_for_type,
             session=session,
             exempt_peer_networks=exempt_peer_networks,
+            rate_limit_windows={
+                msg_type: RateLimitsV3(receive_window=0, in_flight=0)
+                for msg_type, setting in rate_limits_v3.items()
+                if setting.window_size is not None
+            },
         )
 
     def _get_extra_info(self, name: str) -> Any | None:
@@ -285,6 +307,9 @@ class WSChiaConnection:
             self.log.debug("version string too long")
             raise ProtocolError(Err.INVALID_HANDSHAKE)
 
+        # "1" means capability is enabled
+        self.peer_capabilities = known_active_capabilities(inbound_handshake.capabilities)
+        peer_is_v3 = Capability.RATE_LIMITS_V3 in self.peer_capabilities
         if not self.is_outbound:
             if (
                 remote_node_type in {NodeType.FARMER, NodeType.HARVESTER}
@@ -297,6 +322,16 @@ class WSChiaConnection:
                     f"our={protocol_version[remote_node_type]}"
                 )
 
+            # If the peer advertises v3, let's advertise v3 as well
+            reply_capabilities = list(self.local_capabilities_for_handshake)
+            if peer_is_v3 and Capability.RATE_LIMITS_V3 not in self.local_capabilities:
+                self.log.info(
+                    f"Activating rate limits v3 with peer "
+                    f"{self.peer_node_id} / {self.peer_info.host} "
+                    f"version {inbound_handshake.software_version}"
+                )
+                reply_capabilities.append((uint16(Capability.RATE_LIMITS_V3.value), "1"))
+            self.local_capabilities = known_active_capabilities(reply_capabilities)
             outbound_handshake = make_msg(
                 ProtocolMessageTypes.handshake,
                 Handshake(
@@ -305,7 +340,7 @@ class WSChiaConnection:
                     __version__,
                     uint16(server_port),
                     uint8(local_type.value),
-                    self.local_capabilities_for_handshake,
+                    reply_capabilities,
                 ),
             )
             await self._send_message(outbound_handshake)
@@ -314,9 +349,33 @@ class WSChiaConnection:
         self.protocol_version = Version(inbound_handshake.protocol_version)
         self.peer_server_port = inbound_handshake.server_port
         self.connection_type = remote_node_type
-        # "1" means capability is enabled
-        self.peer_capabilities = known_active_capabilities(inbound_handshake.capabilities)
-
+        # Exchange rate limits v3 configuration if both sides support it
+        if peer_is_v3 and Capability.RATE_LIMITS_V3 in self.local_capabilities:
+            rl_config = make_msg(ProtocolMessageTypes.configure_window_sizes, rl_v3_to_configure_message())
+            await self._send_message(rl_config)
+            try:
+                peer_msg = await self._read_one_message()
+                if (
+                    peer_msg is None
+                    or ProtocolMessageTypes(peer_msg.type) != ProtocolMessageTypes.configure_window_sizes
+                ):
+                    raise ProtocolError(Err.INVALID_HANDSHAKE)
+                peer_config = ConfigureWindowSizes.from_bytes(peer_msg.data)
+                if len(peer_config.settings) == 0:
+                    raise ProtocolError(Err.INVALID_HANDSHAKE)
+                if len(peer_config.settings) > MAX_CONFIGURE_RATE_LIMITS_ENTRIES:
+                    raise ProtocolError(Err.INVALID_HANDSHAKE)
+                peer_rl_settings_v3 = rl_settings_v3_from_configure_message(peer_config)
+            except ProtocolError:
+                raise
+            except Exception:
+                raise ProtocolError(Err.INVALID_HANDSHAKE)
+            self.peer_rl_settings_v3 = peer_rl_settings_v3
+            for msg_type, setting in self.peer_rl_settings_v3.items():
+                if setting.window_size is None:
+                    continue
+                if msg_type not in self.rate_limit_windows:
+                    self.rate_limit_windows[msg_type] = RateLimitsV3(receive_window=0, in_flight=0)
         self.outbound_task = create_referenced_task(self.outbound_handler())
         self.inbound_task = create_referenced_task(self.inbound_handler())
         self.incoming_message_task = create_referenced_task(self.incoming_message_handler())
@@ -419,6 +478,8 @@ class WSChiaConnection:
     async def _api_call(self, full_message: Message, task_id: bytes32) -> None:
         start_time = time.time()
         message_type = ""
+        rl_window = None
+        inbound_window_incremented = False
         try:
             if self.received_message_callback is not None:
                 await self.received_message_callback(self)
@@ -457,6 +518,34 @@ class WSChiaConnection:
             if not self.api.ready():
                 self.log.warning(f"API not ready, ignore request: {full_message}")
                 return None
+
+            # Only use rate limits v3 if both peers advertise the capability and
+            # the protocol message type is supported.
+            if (
+                not is_localhost(self.peer_info.host)
+                and not is_in_network(self.peer_info.host, self.exempt_peer_networks)
+                and Capability.RATE_LIMITS_V3 in self.peer_capabilities
+                and Capability.RATE_LIMITS_V3 in self.local_capabilities
+                and bare_message_type in rate_limits_v3
+                and rate_limits_v3[bare_message_type].window_size is not None
+            ):
+                window_size = rate_limits_v3[bare_message_type].window_size
+                assert window_size is not None
+                rl_window = self.rate_limit_windows[bare_message_type]
+                if rl_window.receive_window >= window_size:
+                    details = ", ".join(
+                        [
+                            f"{self.peer_node_id} / {self.peer_info.host} version {self.version}",
+                            f"message: {bare_message_type.name}",
+                            f"receive window: {rl_window.receive_window}",
+                            f"window size: {window_size}",
+                        ]
+                    )
+                    self.log.info(f"Peer has been rate limited (v3) and will be disconnected: {details}")
+                    await self.close(RATE_LIMITER_BAN_SECONDS)
+                    return None
+                rl_window.receive_window += 1
+                inbound_window_incremented = True
 
             timeout: int | None = 600
             if metadata.execute_task:
@@ -525,6 +614,9 @@ class WSChiaConnection:
             # TODO: actually throw one of the errors from errors.py and pass this to close
             await self.close(ban_time, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
         finally:
+            if inbound_window_incremented:
+                assert rl_window is not None
+                rl_window.receive_window -= 1
             if task_id in self.api_tasks:
                 self.api_tasks.pop(task_id)
             if task_id in self.execute_tasks:
@@ -648,41 +740,53 @@ class WSChiaConnection:
         """Sends a message and waits for a response."""
         if self.closed:
             return None
-
-        # We will wait for this event, it will be set either by the response, or the timeout
-        event = asyncio.Event()
-
-        # The request nonce is an integer between 0 and 2**16 - 1, which is used to match requests to responses
-        # If is_outbound, 0 <= nonce < 2^15, else  2^15 <= nonce < 2^16
-        request_id = self._select_request_nonce()
-        if request_id is None:
-            self.log.info(
-                f"Disconnecting peer {self.peer_info.host} version {self.version} for no available request nonces"
-            )
-            await self.close()
-            return None
-
-        message = Message(message_no_id.type, request_id, message_no_id.data)
-        assert message.id is not None
-        self.pending_requests[message.id] = event
-        seq = self._send_seq
-        self._send_seq += 1
-        await self.outgoing_queue.put((priority, seq, message))
-
+        message_id: uint16 | None = None
         try:
-            await asyncio.wait_for(event.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
-            self.log.debug(f"Request timeout: {message}")
+            # We will wait for this event, it will be set either by the response, or the timeout
+            event = asyncio.Event()
 
-        result = self.request_results.pop(message.id, None)
-        if result is None:
-            # This request has timed out
-            self.timed_out_requests.add(message.id)
+            # The request nonce is an integer between 0 and 2**16 - 1, which is used to match requests to responses
+            # If is_outbound, 0 <= nonce < 2^15, else  2^15 <= nonce < 2^16
+            request_id = self._select_request_nonce()
+            if request_id is None:
+                self.log.info(
+                    f"Disconnecting peer {self.peer_info.host} version {self.version} for no available request nonces"
+                )
+                await self.close()
+                return None
+
+            message = Message(message_no_id.type, request_id, message_no_id.data)
+            assert message.id is not None
+            message_id = message.id
+            self.pending_requests[message.id] = event
+            seq = self._send_seq
+            self._send_seq += 1
+            await self.outgoing_queue.put((priority, seq, message))
+
+            try:
+                await asyncio.wait_for(event.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                self.log.debug(f"Request timeout: {message}")
+
+            result = self.request_results.pop(message.id, None)
+            if result is None:
+                # This request has timed out
+                self.timed_out_requests.add(message.id)
+                self.pending_requests.pop(message.id, None)
+                return None
+            self.log.debug(
+                f"<- {ProtocolMessageTypes(result.type).name} from: {self.peer_info.host}:{self.peer_info.port}"
+            )
             self.pending_requests.pop(message.id, None)
-            return None
-        self.log.debug(f"<- {ProtocolMessageTypes(result.type).name} from: {self.peer_info.host}:{self.peer_info.port}")
-        self.pending_requests.pop(message.id, None)
-        return result
+            return result
+        finally:
+            if message_id in self.v3_sent_request_ids:
+                # The request has been processed, decrement congestion window
+                self.v3_sent_request_ids.discard(message_id)
+                message_type = ProtocolMessageTypes(message_no_id.type)
+                rl_window = self.rate_limit_windows[message_type]
+                assert rl_window.in_flight > 0
+                rl_window.in_flight -= 1
 
     async def _wait_and_retry(self, msg: Message, priority: int = 0) -> None:
         try:
@@ -711,38 +815,80 @@ class WSChiaConnection:
             )
             self.timed_out_requests.discard(message.id)
             return None
-        limiter_msg = self.outbound_rate_limiter.process_msg_and_check(
-            message, self.local_capabilities, self.peer_capabilities
+        # Determine whether this message should use the v3 path. This is
+        # independent of whether the peer is subject to rate limits
+        # (localhost/exempt). We still want to bypass the v2 rate limiter
+        # for v3 supported message types.
+        peer_subject_to_rl = not is_localhost(self.peer_info.host) and not is_in_network(
+            self.peer_info.host, self.exempt_peer_networks
         )
-        if limiter_msg is not None:
-            if not is_localhost(self.peer_info.host) and not is_in_network(
-                self.peer_info.host, self.exempt_peer_networks
-            ):
-                last_time = self.log_rate_limit_last_time[message_type]
-                now = time.monotonic()
-                if now - last_time >= 30:
-                    self.log_rate_limit_last_time[message_type] = now
+        both_v3 = (
+            Capability.RATE_LIMITS_V3 in self.peer_capabilities and Capability.RATE_LIMITS_V3 in self.local_capabilities
+        )
+        peer_rl_setting = self.peer_rl_settings_v3.get(message_type)
+        window_size = peer_rl_setting.window_size if peer_rl_setting is not None else None
+        tracked_v3_request = peer_rl_setting is not None and message.id in self.pending_requests
+        # Responses sent from `_api_call` reuse the peer's request nonce so they
+        # have a message ID but it's not in `pending_requests`.
+        v3_response_with_nonce = (
+            peer_rl_setting is not None
+            and window_size is None
+            and message.id is not None
+            and message.id not in self.pending_requests
+        )
+        if both_v3 and (tracked_v3_request or v3_response_with_nonce):
+            if tracked_v3_request and window_size is not None:
+                assert message.id is not None
+                rl_window = self.rate_limit_windows[message_type]
+                # Drop and retry this message if sending it exceeds the window
+                if peer_subject_to_rl and window_size is not None and rl_window.in_flight >= window_size:
+                    create_referenced_task(self._wait_and_retry(message, priority=priority), known_unreferenced=True)
                     details = ", ".join(
                         [
                             f"{message_type.name}",
-                            f"sz: {len(message.data) / 1000:0.2f} kB",
-                            f"peer: {self.peer_info.host}",
-                            f"{limiter_msg}",
+                            f"request ID: {message.id}",
+                            f"peer: {self.peer_node_id} / {self.peer_info.host} version {self.version}",
+                            f"in flight: {rl_window.in_flight}",
+                            f"max concurrent: {window_size}",
                         ]
                     )
-                    self.log.info(f"Rate limiting ourselves. Dropping outbound message: {details}")
+                    self.log.info(f"Rate limiting ourselves (v3). Dropping and retrying outbound message: {details}")
+                    return None
+                rl_window.in_flight += 1
+                self.v3_sent_request_ids.add(message.id)
+        else:
+            limiter_msg = self.outbound_rate_limiter.process_msg_and_check(
+                message, self.local_capabilities, self.peer_capabilities
+            )
+            if limiter_msg is not None:
+                if peer_subject_to_rl:
+                    last_time = self.log_rate_limit_last_time[message_type]
+                    now = time.monotonic()
+                    if now - last_time >= 30:
+                        self.log_rate_limit_last_time[message_type] = now
+                        details = ", ".join(
+                            [
+                                f"{message_type.name}",
+                                f"sz: {len(message.data) / 1000:0.2f} kB",
+                                f"peer: {self.peer_info.host}",
+                                f"{limiter_msg}",
+                            ]
+                        )
+                        self.log.info(f"Rate limiting ourselves. Dropping outbound message: {details}")
 
-                # TODO: fix this special case. This function has rate limits which are too low.
-                if ProtocolMessageTypes(message.type) != ProtocolMessageTypes.respond_peers:
-                    create_referenced_task(self._wait_and_retry(message, priority=priority), known_unreferenced=True)
+                    # TODO: fix this special case. This function has rate limits which are too low.
+                    if ProtocolMessageTypes(message.type) != ProtocolMessageTypes.respond_peers:
+                        create_referenced_task(
+                            self._wait_and_retry(message, priority=priority), known_unreferenced=True
+                        )
 
-                return None
-            else:
-                self.log.debug(
-                    f"Not rate limiting ourselves or exempt peers. "
-                    f"message type: {ProtocolMessageTypes(message.type).name}, "
-                    f"peer: {self.peer_info.host}"
-                )
+                    return None
+                else:
+                    self.log.debug(
+                        f"Not rate limiting ourselves or exempt peers. "
+                        f"message type: {ProtocolMessageTypes(message.type).name}, "
+                        f"peer: {self.peer_info.host}"
+                    )
 
         await self.ws.send_bytes(encoded)
         self.log.debug(
@@ -805,9 +951,51 @@ class WSChiaConnection:
                 # Yield so we let the close task cancel us
                 await asyncio.sleep(3)
                 return None
-            limiter_msg = self.inbound_rate_limiter.process_msg_and_check(
-                full_message_loaded, self.local_capabilities, self.peer_capabilities
+            # Determine whether this message type is supported by v3 rate
+            # limits and the peer advertises the capability. This is
+            # independent of whether the peer is subject to rate limits
+            # (localhost/exempt). We still want to bypass the v2 rate limiter
+            # for v3 supported types.
+            limiter_msg = None
+            peer_subject_to_rl = not is_localhost(self.peer_info.host) and not is_in_network(
+                self.peer_info.host, self.exempt_peer_networks
             )
+            if (
+                Capability.RATE_LIMITS_V3 in self.peer_capabilities
+                and Capability.RATE_LIMITS_V3 in self.local_capabilities
+                and message_type in rate_limits_v3
+            ):
+                if peer_subject_to_rl:
+                    # Skip unlimited v3 message types (responses) and message types
+                    # that are not tracked by v3.
+                    window_size = rate_limits_v3[message_type].window_size
+                    # Checking the receive window at this point is not reliable
+                    # as it only gets incremented/decremented in `_api_call` so
+                    # that's where the reliable check happens (this one here
+                    # can under count). We do it here as well to catch the
+                    # cases where the message will indeed be rate limited.
+                    if (
+                        window_size is not None
+                        and message_type in self.rate_limit_windows
+                        and self.rate_limit_windows[message_type].receive_window >= window_size
+                    ):
+                        details = ", ".join(
+                            [
+                                f"{self.peer_node_id} / {self.peer_info.host} version {self.version}",
+                                f"message: {message_type.name}",
+                                f"receive window: {self.rate_limit_windows[message_type].receive_window}",
+                                f"window size: {window_size}",
+                            ]
+                        )
+                        self.log.info(f"Peer has been rate limited (v3) and will be disconnected: {details}")
+                        create_referenced_task(self.close(RATE_LIMITER_BAN_SECONDS), known_unreferenced=True)
+                        # Yield so we let the close task cancel us
+                        await asyncio.sleep(3)
+                        return None  # pragma: no cover
+            else:
+                limiter_msg = self.inbound_rate_limiter.process_msg_and_check(
+                    full_message_loaded, self.local_capabilities, self.peer_capabilities
+                )
             if limiter_msg is not None:
                 if not is_localhost(self.peer_info.host) and not is_in_network(
                     self.peer_info.host, self.exempt_peer_networks

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -153,7 +153,9 @@ async def setup_full_node(
         if disable_capabilities is not None
         else list(default_capabilities[NodeType.FULL_NODE])
     )
-    override_capabilities.append((uint16(Capability.HARD_FORK_2.value), "1"))
+    override_capabilities.extend(
+        [(uint16(Capability.HARD_FORK_2.value), "1"), (uint16(Capability.RATE_LIMITS_V3.value), "1")]
+    )
     service: FullNodeService | SimulatorFullNodeService
     if simulator:
         service = await create_full_node_simulator_service(
@@ -292,7 +294,9 @@ async def setup_wallet_node(
             service_config.pop("full_node_peers", None)
 
         override_capabilities = list(default_capabilities[NodeType.WALLET])
-        override_capabilities.append((uint16(Capability.HARD_FORK_2.value), "1"))
+        override_capabilities.extend(
+            [(uint16(Capability.HARD_FORK_2.value), "1"), (uint16(Capability.RATE_LIMITS_V3.value), "1")]
+        )
         service = create_wallet_service(
             local_bt.root_path,
             config,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches core P2P handshake and message send/receive paths, adding new disconnect/ban behavior based on in-flight windows; mistakes could cause compatibility issues or unintended peer bans.
> 
> **Overview**
> Adds a new shared-protocol message `ConfigureWindowSizes` and capability `RATE_LIMITS_V3`, plus a new `rate_limits_v3` configuration/codec (`chia/server/rate_limits_v3.py`) to represent per-message in-flight window sizes (including unlimited response types).
> 
> Updates `WSChiaConnection` to negotiate v3 during handshake (including auto-enabling v3 in the reply when the peer advertises it), exchange/validate `ConfigureWindowSizes`, and enforce window-based receive limits and congestion windows while bypassing the existing v2 time-based limiter for v3-supported tracked request/response flows.
> 
> Extensively updates tests to reduce connection-race flakiness (adding `time_out_assert` waits), adjusts test helpers to default-advertise RATE_LIMITS_V3 and optionally skip waiting for server-side connection registration, and adds a comprehensive new `test_rate_limits_v3.py` covering handshake validation, v2 fallback, unsolicited message handling, window enforcement, and window accounting on timeouts/closures/exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fe34f966ad5a5d9133f0bd4ef371e11ea6b69fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->