### PR TITLE
Switch pytest-xdist to --dist loadscope

### DIFF
--- a/chia/_tests/build-job-matrix.py
+++ b/chia/_tests/build-job-matrix.py
@@ -138,7 +138,7 @@ for path, index in test_paths_with_index:
         "ubuntu": {False: 0, True: 6}.get(conf["parallel"], conf["parallel"]),
         "windows": {False: 0, True: 4}.get(conf["parallel"], conf["parallel"]),
     }
-    pytest_parallel_args = {os: f" -n {count}" for os, count in process_count.items()}
+    pytest_parallel_args = {os: f" -n {count} --dist loadscope" if count else "" for os, count in process_count.items()}
 
     enable_pytest_monitor = conf["check_resource_usage"]
 


### PR DESCRIPTION
## Summary

- Switch `pytest-xdist` distribution mode from default `load` (round-robin) to `loadscope`, which groups tests by module on the same worker
- This lets session/module-scoped fixtures (like `BlockTools` / plot setup) be shared more effectively within a worker and reduces `FileLock` contention on the shared plot directory
- When parallel is disabled (`count=0`), no xdist args are emitted at all

## Test plan

- [ ] Compare CI job wall-clock times against a recent `main` run to check for improvement or regression
- [ ] Verify no test failures introduced by the grouping change


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes test parallelization behavior in CI, which can affect runtime and potentially expose ordering/fixture assumptions or new flakiness, but does not touch production code.
> 
> **Overview**
> Switches the generated pytest xdist arguments in `chia/_tests/build-job-matrix.py` to use `--dist loadscope` so tests from the same module/scope are kept on the same worker.
> 
> Also stops emitting any xdist args when the computed worker count is `0` (i.e., parallelism disabled), avoiding passing `-n 0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a96734042e56d1f7768cc45bb2988e11899a641. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->