### PR TITLE
mypy: remove exclusion for chia._tests.clvm.test_chialisp_deserialization

### DIFF
--- a/chia/_tests/clvm/test_chialisp_deserialization.py
+++ b/chia/_tests/clvm/test_chialisp_deserialization.py
@@ -9,7 +9,7 @@ from chia.util.byte_types import hexstr_to_bytes
 DESERIALIZE_MOD = Program.from_bytes(CHIALISP_DESERIALISATION)
 
 
-def serialized_atom_overflow(size):
+def serialized_atom_overflow(size: int) -> str:
     if size == 0:
         size_blob = b"\x80"
     elif size < 0x40:
@@ -52,7 +52,7 @@ def serialized_atom_overflow(size):
     return size_blob.hex() + extra_str
 
 
-def test_deserialization_simple_list():
+def test_deserialization_simple_list() -> None:
     # ("hello" "friend")
     b = hexstr_to_bytes("ff8568656c6c6fff86667269656e6480")
     cost, output = DESERIALIZE_MOD.run_with_cost(INFINITE_COST, [b])
@@ -61,7 +61,7 @@ def test_deserialization_simple_list():
     assert prog == Program.from_bytes(b)
 
 
-def test_deserialization_password_coin():
+def test_deserialization_password_coin() -> None:
     # (i (= (sha256 2) (q 0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824)) (c (q 51) (c 5 (c (q 100) (q ())))) (q "wrong password"))  # noqa
     b = hexstr_to_bytes(
         "ff04ffff0affff0bff0280ffff01ffa02cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b98248080ffff05ffff01ff3380ffff05ff05ffff05ffff01ff6480ffff01ff8080808080ffff01ff8e77726f6e672070617373776f72648080"
@@ -72,7 +72,7 @@ def test_deserialization_password_coin():
     assert prog == Program.from_bytes(b)
 
 
-def test_deserialization_large_numbers():
+def test_deserialization_large_numbers() -> None:
     # '(99999999999999999999999999999999999999999999999999999999999999999 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -99999999999999999999999999999999999999999999999999999999999999999999999999999)'  # noqa
     b = hexstr_to_bytes(
         "ff9c00f316271c7fc3908a8bef464e3945ef7a253609ffffffffffffffffffb00fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa1ff22ea0179500526edb610f148ec0c614155678491902d6000000000000000000180"
@@ -83,7 +83,7 @@ def test_deserialization_large_numbers():
     assert prog == Program.from_bytes(b)
 
 
-def test_overflow_atoms():
+def test_overflow_atoms() -> None:
     b = hexstr_to_bytes(serialized_atom_overflow(0xFFFFFFFF))
     with pytest.raises(Exception):
         _cost, _output = DESERIALIZE_MOD.run_with_cost(INFINITE_COST, [b])

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -32,7 +32,6 @@ chia.wallet.wallet_node_api
 chia.wallet.wallet_puzzle_store
 chia.wallet.wallet_transaction_store
 chia.wallet.wallet_user_store
-chia._tests.clvm.test_chialisp_deserialization
 chia._tests.clvm.test_program
 chia._tests.clvm.test_puzzle_compression
 chia._tests.clvm.test_puzzles


### PR DESCRIPTION
### Purpose:

Remove `chia._tests.clvm.test_chialisp_deserialization` from the mypy strict-mode exclusion list by adding the missing type annotations.

### Current Behavior:

The module is listed in `mypy-exclusions.txt` and skips strict type checking. Five functions lack type annotations:
- `serialized_atom_overflow` has no parameter or return type
- Four test functions are missing `-> None` return types

### New Behavior:

All functions are fully annotated and the module passes `mypy --strict`:
- `serialized_atom_overflow(size: int) -> str`
- All test functions annotated with `-> None`
- Module removed from `mypy-exclusions.txt`

### Testing Notes:

- Ran `mypy --strict` on the target file — zero local errors
- Ran `pre-commit run mypy --all-files` — passed
- Ran `ruff check` and `ruff format --check` — passed
- Self-contained fix: the `no-untyped-call` errors resolved automatically once `serialized_atom_overflow` was annotated; no cross-module dependencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only typing changes plus an exclusion-list update; no runtime logic or production paths are modified.
> 
> **Overview**
> Adds strict mypy-compatible type annotations to `chia/_tests/clvm/test_chialisp_deserialization.py`, including `serialized_atom_overflow(size: int) -> str` and `-> None` return types for the test functions.
> 
> Updates `mypy-exclusions.txt` to stop excluding `chia._tests.clvm.test_chialisp_deserialization` from strict type checking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41e3aaacc3a78aad80728c98b76edbaffd0519c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->