### PR TITLE
mypy: remove exclusion for chia.wallet.puzzles.p2_conditions

### DIFF
--- a/chia/_tests/core/mempool/test_singleton_fast_forward.py
+++ b/chia/_tests/core/mempool/test_singleton_fast_forward.py
@@ -273,7 +273,7 @@ async def prepare_singleton_eve(
         Program.to([ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, starting_coin.amount - singleton_amount - 1])
     )
     # Create a solution for standard transaction
-    delegated_puzzle = p2_conditions.puzzle_for_conditions(conditions)
+    delegated_puzzle = p2_conditions.puzzle_for_conditions(Program.to(conditions))
     full_solution = p2_delegated_puzzle_or_hidden_puzzle.solution_for_conditions(conditions)
     starting_coin_spend = make_spend(starting_coin, starting_puzzle, full_solution)
     await make_and_send_spend_bundle(

--- a/chia/_tests/core/mempool/test_singleton_fast_forward.py
+++ b/chia/_tests/core/mempool/test_singleton_fast_forward.py
@@ -273,7 +273,7 @@ async def prepare_singleton_eve(
         Program.to([ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, starting_coin.amount - singleton_amount - 1])
     )
     # Create a solution for standard transaction
-    delegated_puzzle = p2_conditions.puzzle_for_conditions(Program.to(conditions))
+    delegated_puzzle = p2_conditions.puzzle_for_conditions(conditions)
     full_solution = p2_delegated_puzzle_or_hidden_puzzle.solution_for_conditions(conditions)
     starting_coin_spend = make_spend(starting_coin, starting_puzzle, full_solution)
     await make_and_send_spend_bundle(

--- a/chia/wallet/puzzles/p2_conditions.py
+++ b/chia/wallet/puzzles/p2_conditions.py
@@ -13,15 +13,16 @@ the doctor ordered.
 from __future__ import annotations
 
 from chia_puzzles_py.programs import P2_CONDITIONS
+from clvm.SExp import CastableType
 
 from chia.types.blockchain_format.program import Program
 
 MOD = Program.from_bytes(P2_CONDITIONS)
 
 
-def puzzle_for_conditions(conditions: Program) -> Program:
+def puzzle_for_conditions(conditions: CastableType) -> Program:
     return MOD.run([conditions])
 
 
-def solution_for_conditions(conditions: Program) -> Program:
+def solution_for_conditions(conditions: CastableType) -> Program:
     return Program.to([puzzle_for_conditions(conditions), 0])

--- a/chia/wallet/puzzles/p2_conditions.py
+++ b/chia/wallet/puzzles/p2_conditions.py
@@ -19,9 +19,9 @@ from chia.types.blockchain_format.program import Program
 MOD = Program.from_bytes(P2_CONDITIONS)
 
 
-def puzzle_for_conditions(conditions) -> Program:
+def puzzle_for_conditions(conditions: Program) -> Program:
     return MOD.run([conditions])
 
 
-def solution_for_conditions(conditions) -> Program:
+def solution_for_conditions(conditions: Program) -> Program:
     return Program.to([puzzle_for_conditions(conditions), 0])

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -18,7 +18,6 @@ chia.types.blockchain_format.program
 chia.wallet.did_wallet.did_wallet
 chia.wallet.key_val_store
 chia.wallet.puzzles.load_clvm
-chia.wallet.puzzles.p2_conditions
 chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle
 chia.wallet.puzzles.p2_m_of_n_delegate_direct
 chia.wallet.puzzles.tails


### PR DESCRIPTION
### Purpose:

Remove `chia.wallet.puzzles.p2_conditions` from the mypy strict-mode exclusion list by adding concrete type annotations.

### Current Behavior:

The `conditions` parameter in `puzzle_for_conditions` and `solution_for_conditions` is untyped, so the module is excluded from mypy strict checking.

### New Behavior:

Both functions annotate `conditions` as `CastableType` (from `clvm.SExp`), which is the precise type alias for everything `Program.to()` accepts. This matches the actual call patterns seen in tests: callers pass `Program`, `list[Program]`, and raw Python lists. No callers are changed.

### Testing Notes:

- `mypy --strict` on the target file: zero local errors
- `pre-commit run mypy --all-files`: passes
- `ruff check` and `ruff format --check` on changed files: passes
- Verified all test call sites pass types compatible with `CastableType`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only type annotations/imports and mypy configuration are changed, with no runtime logic modifications beyond typing surfaces.
> 
> **Overview**
> Enables mypy strict checking for `chia.wallet.puzzles.p2_conditions` by typing the `conditions` parameter in `puzzle_for_conditions` and `solution_for_conditions` as `CastableType`.
> 
> Removes `chia.wallet.puzzles.p2_conditions` from `mypy-exclusions.txt` now that the module is typed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d75ffba1685fb6ad400e690844a68f33f665b65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->