### PR TITLE
mypy: remove exclusion for chia._tests.clvm.test_puzzle_compression

### DIFF
--- a/chia/_tests/clvm/test_puzzle_compression.py
+++ b/chia/_tests/clvm/test_puzzle_compression.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 class CompressionReporter:
     record_property: Callable[[str, object], None]
 
-    def __call__(self, name: str, original: SupportsBytes, compressed: SupportsBytes) -> None:
+    def __call__(self, name: str, original: bytes | SupportsBytes, compressed: bytes | SupportsBytes) -> None:
         ratio = len(bytes(compressed)) / len(bytes(original))
         self.record_property("compression_ratio", ratio)
         log.warning(f"{name} compression ratio: {ratio}")

--- a/chia/_tests/clvm/test_puzzle_compression.py
+++ b/chia/_tests/clvm/test_puzzle_compression.py
@@ -34,20 +34,20 @@ log = logging.getLogger(__name__)
 
 @dataclass
 class CompressionReporter:
-    record_property: Callable
+    record_property: Callable[[str, object], None]
 
-    def __call__(self, name: str, original: SupportsBytes, compressed: SupportsBytes):
+    def __call__(self, name: str, original: SupportsBytes, compressed: SupportsBytes) -> None:
         ratio = len(bytes(compressed)) / len(bytes(original))
-        self.record_property(name="compression_ratio", value=ratio)
+        self.record_property("compression_ratio", ratio)
         log.warning(f"{name} compression ratio: {ratio}")
 
 
 @pytest.fixture(name="report_compression")
-def report_compression_fixture(record_property):
+def report_compression_fixture(record_property: Callable[[str, object], None]) -> CompressionReporter:
     return CompressionReporter(record_property=record_property)
 
 
-def test_standard_puzzle(report_compression):
+def test_standard_puzzle(report_compression: CompressionReporter) -> None:
     coin_spend = make_spend(
         COIN,
         puzzle_for_pk(G1Element()),
@@ -60,16 +60,16 @@ def test_standard_puzzle(report_compression):
     report_compression(name="standard puzzle", original=coin_spend, compressed=compressed)
 
 
-def test_decompress_limit():
+def test_decompress_limit() -> None:
     buffer = bytearray(10 * 1024 * 1024)
-    compressed = compress_object_with_puzzles(buffer, LATEST_VERSION)
+    compressed = compress_object_with_puzzles(bytes(buffer), LATEST_VERSION)
     print(len(compressed))
     decompressed = decompress_object_with_puzzles(compressed)
     print(len(decompressed))
     assert len(decompressed) <= 6 * 1024 * 1024
 
 
-def test_cat_puzzle(report_compression):
+def test_cat_puzzle(report_compression: CompressionReporter) -> None:
     coin_spend = make_spend(
         COIN,
         construct_cat_puzzle(CAT_MOD, Program.to([]).get_tree_hash(), Program.to(1)),
@@ -82,7 +82,7 @@ def test_cat_puzzle(report_compression):
     report_compression(name="CAT puzzle", original=coin_spend, compressed=compressed)
 
 
-def test_offer_puzzle(report_compression):
+def test_offer_puzzle(report_compression: CompressionReporter) -> None:
     coin_spend = make_spend(
         COIN,
         OFFER_MOD,
@@ -95,7 +95,7 @@ def test_offer_puzzle(report_compression):
     report_compression(name="offer puzzle", original=coin_spend, compressed=compressed)
 
 
-def test_nesting_puzzles(report_compression):
+def test_nesting_puzzles(report_compression: CompressionReporter) -> None:
     coin_spend = make_spend(
         COIN,
         construct_cat_puzzle(CAT_MOD, Program.to([]).get_tree_hash(), puzzle_for_pk(G1Element())),
@@ -108,7 +108,7 @@ def test_nesting_puzzles(report_compression):
     report_compression(name="nesting puzzle", original=coin_spend, compressed=compressed)
 
 
-def test_unknown_wrapper(report_compression):
+def test_unknown_wrapper(report_compression: CompressionReporter) -> None:
     unknown = Program.to([2, 2, []])  # (a 2 ())
     coin_spend = make_spend(
         COIN,
@@ -122,13 +122,13 @@ def test_unknown_wrapper(report_compression):
     report_compression(name="unknown wrapper", original=coin_spend, compressed=compressed)
 
 
-def test_lowest_best_version():
+def test_lowest_best_version() -> None:
     assert lowest_best_version([bytes(CAT_MOD)]) == 4
     assert lowest_best_version([bytes(OFFER_MOD_OLD)]) == 2
     assert lowest_best_version([bytes(OFFER_MOD)]) == 5
 
 
-def test_version_override():
+def test_version_override() -> None:
     coin_spend = make_spend(
         COIN,
         OFFER_MOD,

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -35,7 +35,6 @@ chia.wallet.wallet_user_store
 chia._tests.clvm.coin_store
 chia._tests.clvm.test_chialisp_deserialization
 chia._tests.clvm.test_program
-chia._tests.clvm.test_puzzle_compression
 chia._tests.clvm.test_puzzles
 chia._tests.clvm.test_singletons
 chia._tests.clvm.test_spend_sim


### PR DESCRIPTION
### Purpose:

Remove `chia._tests.clvm.test_puzzle_compression` from the mypy strict-mode exclusion list by adding the missing type annotations and fixing a type mismatch.

### Current Behavior:

The module is excluded from mypy strict checking in `mypy-exclusions.txt`. It has 12 strict-mode violations: missing return types on test functions, unparameterized `Callable` generic, missing parameter types on the `report_compression` fixture and test functions that consume it, and a `bytearray` passed where `bytes` is expected.

### New Behavior:

All functions and methods have full type annotations. The `CompressionReporter` dataclass uses `Callable[[str, object], None]` for `record_property` (matching the pytest built-in fixture signature). All test functions receiving the `report_compression` fixture are typed as `CompressionReporter`. The `bytearray` in `test_decompress_limit` is wrapped with `bytes()` to satisfy `compress_object_with_puzzles`. The module is removed from `mypy-exclusions.txt` and now passes mypy strict checking.

### Testing Notes:

- `pre-commit run mypy --all-files` passes with zero errors.
- `ruff check` and `ruff format --check` pass on the changed file.
- No runtime behavior changes: `bytes(bytearray)` produces identical bytes, and positional vs keyword args to `record_property` are semantically equivalent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to add type annotations and a small bytes conversion; no production logic is modified.
> 
> **Overview**
> Makes `chia/_tests/clvm/test_puzzle_compression.py` pass mypy strict by adding full type annotations to the `CompressionReporter` helper, the `report_compression` fixture, and all tests, and by tightening `record_property` to `Callable[[str, object], None]`.
> 
> Fixes a type mismatch in `test_decompress_limit` by converting the `bytearray` buffer to `bytes` before calling `compress_object_with_puzzles`, and removes `chia._tests.clvm.test_puzzle_compression` from `mypy-exclusions.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bf887ff7f777c70dd3892ad900212bd3dc72bd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->