### PR TITLE
mypy: remove exclusion for chia.wallet.key_val_store

### DIFF
--- a/chia/_tests/wallet/test_wallet_blockchain.py
+++ b/chia/_tests/wallet/test_wallet_blockchain.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pytest
-from chia_rs import FullBlock, HeaderBlock
-from chia_rs.sized_ints import uint8, uint32
+from chia_rs import ConsensusConstants, FullBlock, HeaderBlock
+from chia_rs.sized_ints import uint8, uint32, uint64
 
 from chia._tests.util.db_connection import DBConnection
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
@@ -108,3 +108,29 @@ async def test_wallet_blockchain(
         peak_block = await chain.get_peak_block()
         assert peak_block is not None
         assert peak_block.height == 999
+
+
+@pytest.mark.anyio
+async def test_wallet_blockchain_create_uses_persisted_values(blockchain_constants: ConsensusConstants) -> None:
+    async with DBConnection(1) as db_wrapper:
+        store = await KeyValStore.create(db_wrapper)
+        sub_slot_iters = uint64(42)
+        difficulty = uint64(1337)
+        await store.set_object("SUB_SLOT_ITERS", sub_slot_iters)
+        await store.set_object("DIFFICULTY", difficulty)
+
+        chain = await WalletBlockchain.create(store, blockchain_constants)
+        assert chain._sub_slot_iters == sub_slot_iters
+        assert chain._difficulty == difficulty
+
+
+@pytest.mark.anyio
+async def test_wallet_blockchain_create_defaults_without_persisted_values(
+    blockchain_constants: ConsensusConstants,
+) -> None:
+    async with DBConnection(1) as db_wrapper:
+        store = await KeyValStore.create(db_wrapper)
+        chain = await WalletBlockchain.create(store, blockchain_constants)
+
+        assert chain._sub_slot_iters == blockchain_constants.SUB_SLOT_ITERS_STARTING
+        assert chain._difficulty == blockchain_constants.DIFFICULTY_STARTING

--- a/chia/wallet/key_val_store.py
+++ b/chia/wallet/key_val_store.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Protocol, TypeVar
+
+from typing_extensions import Self
 
 from chia.util.db_wrapper import DBWrapper2
+
+
+class _Serializable(Protocol):
+    @classmethod
+    def from_bytes(cls, blob: bytes) -> Self: ...
+    def stream_to_bytes(self) -> bytes: ...
+
+
+_T = TypeVar("_T", bound=_Serializable)
 
 
 class KeyValStore:
@@ -13,7 +24,7 @@ class KeyValStore:
     db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper2):
+    async def create(cls, db_wrapper: DBWrapper2) -> Self:
         self = cls()
         self.db_wrapper = db_wrapper
         async with self.db_wrapper.writer_maybe_transaction() as conn:
@@ -23,7 +34,7 @@ class KeyValStore:
             await conn.execute("DROP INDEX IF EXISTS key_val_name")
         return self
 
-    async def get_object(self, key: str, object_type: Any) -> Any:
+    async def get_object(self, key: str, object_type: type[_T]) -> _T | None:
         """
         Return bytes representation of stored object
         """
@@ -38,9 +49,9 @@ class KeyValStore:
 
         return object_type.from_bytes(row[0])
 
-    async def set_object(self, key: str, obj: Any):
+    async def set_object(self, key: str, obj: _Serializable) -> None:
         """
-        Adds object to key val store. Obj MUST support __bytes__ and bytes() methods.
+        Adds object to key val store. Obj MUST support stream_to_bytes() method.
         """
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             cursor = await conn.execute(
@@ -49,7 +60,7 @@ class KeyValStore:
             )
             await cursor.close()
 
-    async def remove_object(self, key: str):
+    async def remove_object(self, key: str) -> None:
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             cursor = await conn.execute("DELETE FROM key_val_store where key=?", (key,))
             await cursor.close()

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -54,11 +54,12 @@ class WalletBlockchain:
         self.constants = constants
         self.CACHE_SIZE = constants.SUB_EPOCH_BLOCKS * 3
         self.synced_weight_proof = await self._basic_store.get_object("SYNCED_WEIGHT_PROOF", WeightProof)
-        self._sub_slot_iters = await self._basic_store.get_object("SUB_SLOT_ITERS", uint64)
-        self._difficulty = await self._basic_store.get_object("DIFFICULTY", uint64)
-        self._finished_sync_up_to = await self._basic_store.get_object("FINISHED_SYNC_UP_TO", uint32)
-        if self._finished_sync_up_to is None:
-            self._finished_sync_up_to = uint32(0)
+        sub_slot_iters = await self._basic_store.get_object("SUB_SLOT_ITERS", uint64)
+        self._sub_slot_iters = sub_slot_iters if sub_slot_iters is not None else constants.SUB_SLOT_ITERS_STARTING
+        difficulty = await self._basic_store.get_object("DIFFICULTY", uint64)
+        self._difficulty = difficulty if difficulty is not None else constants.DIFFICULTY_STARTING
+        finished_sync_up_to = await self._basic_store.get_object("FINISHED_SYNC_UP_TO", uint32)
+        self._finished_sync_up_to = finished_sync_up_to if finished_sync_up_to is not None else uint32(0)
         self._peak = None
         self._peak = await self.get_peak_block()
         self._latest_timestamp = uint64(0)

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -65,8 +65,6 @@ class WalletBlockchain:
         self._latest_timestamp = uint64(0)
         self._height_to_hash = {}
         self._block_records = {}
-        self._sub_slot_iters = constants.SUB_SLOT_ITERS_STARTING
-        self._difficulty = constants.DIFFICULTY_STARTING
 
         return self
 

--- a/chia/wallet/wallet_blockchain.py
+++ b/chia/wallet/wallet_blockchain.py
@@ -55,9 +55,15 @@ class WalletBlockchain:
         self.CACHE_SIZE = constants.SUB_EPOCH_BLOCKS * 3
         self.synced_weight_proof = await self._basic_store.get_object("SYNCED_WEIGHT_PROOF", WeightProof)
         sub_slot_iters = await self._basic_store.get_object("SUB_SLOT_ITERS", uint64)
-        self._sub_slot_iters = sub_slot_iters if sub_slot_iters is not None else constants.SUB_SLOT_ITERS_STARTING
         difficulty = await self._basic_store.get_object("DIFFICULTY", uint64)
-        self._difficulty = difficulty if difficulty is not None else constants.DIFFICULTY_STARTING
+        if sub_slot_iters is not None:
+            assert difficulty is not None
+            self._sub_slot_iters = sub_slot_iters
+            self._difficulty = difficulty
+        else:
+            assert difficulty is None
+            self._sub_slot_iters = constants.SUB_SLOT_ITERS_STARTING
+            self._difficulty = constants.DIFFICULTY_STARTING
         finished_sync_up_to = await self._basic_store.get_object("FINISHED_SYNC_UP_TO", uint32)
         self._finished_sync_up_to = finished_sync_up_to if finished_sync_up_to is not None else uint32(0)
         self._peak = None

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -16,7 +16,6 @@ chia.timelord.timelord_api
 chia.timelord.timelord_launcher
 chia.types.blockchain_format.program
 chia.wallet.did_wallet.did_wallet
-chia.wallet.key_val_store
 chia.wallet.puzzles.load_clvm
 chia.wallet.puzzles.p2_conditions
 chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle


### PR DESCRIPTION
### Purpose:

Remove `chia.wallet.key_val_store` from the mypy strict-mode exclusion list by adding full type annotations. Also fixes a pre-existing bug in `WalletBlockchain.create()` where DB-persisted `SUB_SLOT_ITERS` and `DIFFICULTY` values were silently discarded. This does not introduce a breaking change.

### Current Behavior:

- `chia.wallet.key_val_store` is excluded from mypy strict checking. The `KeyValStore` methods use `Any` for `object_type` and `obj` parameters, and `create`, `set_object`, and `remove_object` lack return type annotations.
- `WalletBlockchain.create()` loads `SUB_SLOT_ITERS` and `DIFFICULTY` from the key-value store, but unconditionally overwrites them with `constants.SUB_SLOT_ITERS_STARTING` and `constants.DIFFICULTY_STARTING` a few lines later, making the DB reads dead stores.

### New Behavior:

- Define a `_Serializable` Protocol capturing the `from_bytes`/`stream_to_bytes` interface used by all stored types (`Streamable` subclasses, `uint32`, `uint64`, etc.).
- `get_object` is now generic: `(key: str, object_type: type[_T]) -> _T | None` where `_T` is bound to `_Serializable`.
- `set_object` annotates `obj` as `_Serializable` instead of `Any`, with `-> None`.
- `create` returns `Self`; `remove_object` returns `None`.
- Fix downstream `assignment` errors in `wallet_blockchain.py` where `get_object` now correctly returns `T | None` — uses temporary variables with `None` defaults.
- Remove the unconditional overwrites of `_sub_slot_iters` and `_difficulty` in `WalletBlockchain.create()`, so DB-persisted values are preserved when available, falling back to starting constants only when the store returns `None`.
- Remove `chia.wallet.key_val_store` from `mypy-exclusions.txt`.

### Testing Notes:

- `pre-commit run mypy --all-files` passes (936 source files checked, zero errors).
- `ruff check` and `ruff format --check` pass on all changed files.
- `test_wallet_key_val_store` passes locally (all 5 consensus mode variants).
- mypy verified on all caller files (`wallet_state_manager.py`, `wallet_blockchain.py`, both test files) — zero `arg-type`/`call-arg`/`assignment` errors.
- The `WalletBlockchain.create()` change is an intentional bug fix (confirmed by reviewer): previously-persisted `SUB_SLOT_ITERS` and `DIFFICULTY` values are now used on wallet restart instead of being silently reset to genesis constants.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet chain initialization to use persisted consensus parameters, which can affect sync/validation behavior on restart if the stored values are wrong or inconsistent. Type-only updates to `KeyValStore` are low risk but may surface stricter mypy expectations for callers.
> 
> **Overview**
> Fixes `WalletBlockchain.create()` so persisted `SUB_SLOT_ITERS`/`DIFFICULTY` from `KeyValStore` are actually used when present, falling back to starting constants only when nothing is stored.
> 
> Adds full mypy-friendly typing to `KeyValStore` via a `_Serializable` protocol and a generic `get_object`, and removes `chia.wallet.key_val_store` from `mypy-exclusions.txt`.
> 
> Extends wallet blockchain tests to cover both the persisted-values and default-values initialization paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a2ae91824a53c7e91142ae611b997cb13d0a933. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->