### PR TITLE
mypy: remove exclusion for chia.wallet.puzzles.tails

### DIFF
--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from chia.wallet.cat_wallet.cat_wallet import CATWallet
 
 from chia_puzzles_py.programs import (
     DELEGATED_TAIL,
@@ -48,12 +51,17 @@ class LimitationsProgram:
         raise NotImplementedError("Need to implement 'construct' on limitations programs")
 
     @staticmethod
-    def solve(args: list[Program], solution_dict: dict) -> Program:
+    def solve(args: list[Program], solution_dict: dict[str, Any]) -> Program:
         raise NotImplementedError("Need to implement 'solve' on limitations programs")
 
     @classmethod
     async def generate_issuance_bundle(
-        cls, wallet, cat_tail_info: dict, amount: uint64, action_scope: WalletActionScope
+        cls,
+        wallet: CATWallet,
+        cat_tail_info: dict[str, Any],
+        amount: uint64,
+        action_scope: WalletActionScope,
+        fee: uint64 = uint64(0),
     ) -> WalletSpendBundle:
         raise NotImplementedError("Need to implement 'generate_issuance_bundle' on limitations programs")
 
@@ -77,19 +85,19 @@ class GenesisById(LimitationsProgram):
         return GENESIS_BY_ID_MOD.curry(args[0])
 
     @staticmethod
-    def solve(args: list[Program], solution_dict: dict) -> Program:
+    def solve(args: list[Program], solution_dict: dict[str, Any]) -> Program:
         return Program.to([])
 
     @classmethod
     async def generate_issuance_bundle(
         cls,
-        wallet,
-        _: dict,
+        wallet: CATWallet,
+        _: dict[str, Any],
         amount: uint64,
         action_scope: WalletActionScope,
         fee: uint64 = uint64(0),
     ) -> WalletSpendBundle:
-        coins = await wallet.standard_wallet.select_coins(amount + fee, action_scope)
+        coins = await wallet.standard_wallet.select_coins(uint64(amount + fee), action_scope)
 
         origin = coins.copy().pop()
         origin_id = origin.name()
@@ -162,7 +170,7 @@ class GenesisByPuzhash(LimitationsProgram):
         return GENESIS_BY_PUZHASH_MOD.curry(args[0])
 
     @staticmethod
-    def solve(args: list[Program], solution_dict: dict) -> Program:
+    def solve(args: list[Program], solution_dict: dict[str, Any]) -> Program:
         pid = hexstr_to_bytes(solution_dict["parent_coin_info"])
         return Program.to([pid, solution_dict["amount"]])
 
@@ -185,7 +193,7 @@ class EverythingWithSig(LimitationsProgram):
         return EVERYTHING_WITH_SIG_MOD.curry(args[0])
 
     @staticmethod
-    def solve(args: list[Program], solution_dict: dict) -> Program:
+    def solve(args: list[Program], solution_dict: dict[str, Any]) -> Program:
         return Program.to([])
 
 
@@ -207,7 +215,7 @@ class DelegatedLimitations(LimitationsProgram):
         return DELEGATED_LIMITATIONS_MOD.curry(args[0])
 
     @staticmethod
-    def solve(args: list[Program], solution_dict: dict) -> Program:
+    def solve(args: list[Program], solution_dict: dict[str, Any]) -> Program:
         signed_program = ALL_LIMITATIONS_PROGRAMS[solution_dict["signed_program"]["identifier"]]
         inner_program_args = [Program.fromhex(item) for item in solution_dict["signed_program"]["args"]]
         inner_solution_dict = solution_dict["program_arguments"]
@@ -221,7 +229,7 @@ class DelegatedLimitations(LimitationsProgram):
 
 # This should probably be much more elegant than just a dictionary with strings as identifiers
 # Right now this is small and experimental so it can stay like this
-ALL_LIMITATIONS_PROGRAMS: dict[str, Any] = {
+ALL_LIMITATIONS_PROGRAMS: dict[str, type[LimitationsProgram]] = {
     "genesis_by_id": GenesisById,
     "genesis_by_puzhash": GenesisByPuzhash,
     "everything_with_signature": EverythingWithSig,
@@ -229,7 +237,7 @@ ALL_LIMITATIONS_PROGRAMS: dict[str, Any] = {
 }
 
 
-def match_limitations_program(limitations_program: Program) -> tuple[LimitationsProgram | None, list[Program]]:
+def match_limitations_program(limitations_program: Program) -> tuple[type[LimitationsProgram] | None, list[Program]]:
     uncurried_mod, curried_args = limitations_program.uncurry()
     for key, lp in ALL_LIMITATIONS_PROGRAMS.items():
         matched, args = lp.match(uncurried_mod, curried_args)

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -21,7 +21,6 @@ chia.wallet.puzzles.load_clvm
 chia.wallet.puzzles.p2_conditions
 chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle
 chia.wallet.puzzles.p2_m_of_n_delegate_direct
-chia.wallet.puzzles.tails
 chia.wallet.trading.trade_store
 chia.wallet.transaction_record
 chia.wallet.util.debug_spend_bundle


### PR DESCRIPTION
### Purpose:

Enable mypy strict mode for `chia.wallet.puzzles.tails` by adding missing type annotations and removing it from the exclusion list. This improves type safety across the CAT TAIL limitations program infrastructure.

### Current Behavior:

`chia.wallet.puzzles.tails` is excluded from mypy strict checking. Several methods use bare `dict` without generic parameters, the `wallet` parameter in `generate_issuance_bundle` methods is untyped, and `ALL_LIMITATIONS_PROGRAMS` is typed as `dict[str, Any]` instead of the precise class type.

### New Behavior:

- All `solution_dict` and `cat_tail_info` parameters are typed as `dict[str, Any]` (heterogeneous solution dicts with mixed value types).
- The `wallet` parameter in `generate_issuance_bundle` methods is typed as `CATWallet` (imported under `TYPE_CHECKING` to avoid circular imports).
- The base class `LimitationsProgram.generate_issuance_bundle` signature now includes the `fee` parameter with a default, matching the subclass and caller signatures.
- `ALL_LIMITATIONS_PROGRAMS` is typed as `dict[str, type[LimitationsProgram]]` — the values are subclasses, not instances.
- `match_limitations_program` return type updated to `type[LimitationsProgram] | None` to match the actual returned values.
- `amount + fee` wrapped in `uint64()` to satisfy the `select_coins` parameter type.
- Module removed from `mypy-exclusions.txt`.

### Testing Notes:

- `pre-commit run mypy --all-files` passes (936 source files checked, 0 errors).
- `ruff check` and `ruff format --check` pass on the changed file.
- No runtime behavior changes — all fixes are annotation-only except the `uint64()` wrap which preserves the same numeric value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily type-annotation tightening to satisfy mypy strict mode, with only a small numeric cast (`uint64(amount + fee)`) that should preserve runtime behavior.
> 
> **Overview**
> Enables mypy strict checking for `chia.wallet.puzzles.tails` by adding/adjusting type annotations across the CAT TAIL limitations-program interface.
> 
> This types `wallet` as `CATWallet` (via `TYPE_CHECKING` import), makes `solution_dict`/`cat_tail_info` explicitly `dict[str, Any]`, refines `ALL_LIMITATIONS_PROGRAMS` and `match_limitations_program` to return limitation-program *classes* (`type[LimitationsProgram]`), and aligns the base `generate_issuance_bundle` signature to include `fee`. The module is removed from `mypy-exclusions.txt`, and `select_coins` is called with an explicit `uint64(amount + fee)` cast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13d7215acaf8ddf0ee5647f0879ec4089c6ffd15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->