### PR TITLE
Use tmpfs for test temp dirs on Linux CI

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -131,6 +131,7 @@ jobs:
       CHIA_SIMULATOR_ROOT: ${{ github.workspace }}/.chia/simulator
       JOB_FILE_NAME: tests_${{ matrix.os.file_name }}_python-${{ matrix.python.file_name }}_${{ matrix.configuration.module_import_path }}${{ matrix.configuration.file_name_index }}
       BLOCKS_AND_PLOTS_VERSION: 0.45.6
+      TMPDIR: ${{ matrix.os.matrix == 'ubuntu' && '/dev/shm' || '' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- Set `TMPDIR=/dev/shm` for Ubuntu CI runners so that `tempfile`, pytest `tmp_path`, and on-disk SQLite test databases use RAM-backed storage instead of disk I/O
- Only affects Linux runners; macOS and Windows are unchanged
- Block/plot caches under `$GITHUB_WORKSPACE/.chia/` are not affected by `TMPDIR`

## Test plan

- [ ] Compare Ubuntu Intel CI job wall-clock times against baseline (10 recent merged PRs, avg listed below)
- [ ] Verify no test failures from using `/dev/shm`

### Baseline (Ubuntu Intel avg from 10 merged PRs)

- blockchain: 71.2 min
- core.full_node: 67.2 min
- simulation: 41.5 min
- util: 37.9 min
- core.mempool: 37.5 min
- core.data_layer: 23.5 min
- weight_proof: 20.1 min
- wallet: 17.3 min

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that alters where temporary files are created on Ubuntu runners; potential impact is limited to tests that assume disk-backed temp storage or exceed `/dev/shm` limits.
> 
> **Overview**
> Speeds up Linux CI tests by setting `TMPDIR=/dev/shm` for Ubuntu runners in `test-single.yml`, moving temp files (e.g., `tempfile`/pytest temp dirs and transient SQLite DBs) to RAM-backed storage.
> 
> macOS and Windows runners are unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7409d7c046258b83f0d572747cd8515e8973acf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->