### PR TITLE
mypy: remove exclusion for chia._tests.core.util.test_file_keyring_synchronization

### DIFF
--- a/chia/_tests/core/util/test_file_keyring_synchronization.py
+++ b/chia/_tests/core/util/test_file_keyring_synchronization.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 DUMMY_SLEEP_VALUE = 2
 
 
-def dummy_set_passphrase(service, user, passphrase, keyring_path, index):
+def dummy_set_passphrase(service: str, user: str, passphrase: Key, keyring_path: str, index: int) -> None:
     with TempKeyring(existing_keyring_path=keyring_path, delete_on_cleanup=False):
         if platform == "linux" or platform == "win32" or platform == "cygwin":
             # FileKeyring's setup_keyring_file_watcher needs to be called explicitly here,
@@ -61,7 +61,7 @@ def dummy_set_passphrase(service, user, passphrase, keyring_path, index):
 
 class TestFileKeyringSynchronization:
     # When: using a new empty keyring
-    def test_multiple_writers(self, empty_temp_file_keyring: TempKeyring):
+    def test_multiple_writers(self, empty_temp_file_keyring: TempKeyring) -> None:
         num_workers = 10
         keyring_path = str(KeyringWrapper.get_shared_instance().keyring.keyring_path)
         passphrase_list = [

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -49,7 +49,6 @@ chia._tests.core.ssl.test_ssl
 chia._tests.core.test_crawler_rpc
 chia._tests.core.test_db_conversion
 chia._tests.core.util.test_config
-chia._tests.core.util.test_file_keyring_synchronization
 chia._tests.core.util.test_files
 chia._tests.core.util.test_keychain
 chia._tests.core.util.test_keyring_wrapper


### PR DESCRIPTION
### Purpose:

Remove `chia._tests.core.util.test_file_keyring_synchronization` from the mypy strict-mode exclusion list by adding missing type annotations.

### Current Behavior:

The module is excluded from mypy strict checking in `mypy-exclusions.txt`. Two functions lack type annotations:
- `dummy_set_passphrase` (line 23) — missing all parameter and return type annotations
- `test_multiple_writers` (line 64) — missing return type annotation

### New Behavior:

Both functions are fully annotated:
- `dummy_set_passphrase(service: str, user: str, passphrase: Key, keyring_path: str, index: int) -> None`
- `test_multiple_writers(self, empty_temp_file_keyring: TempKeyring) -> None`

The module passes mypy strict mode and is removed from `mypy-exclusions.txt`.

### Testing Notes:

- Ran `mypy --strict` on the target file — zero local errors
- Ran `pre-commit run mypy --all-files` — passed
- Ran `ruff check` and `ruff format --check` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only changes in a test file plus a mypy configuration update; no runtime behavior or production code paths are affected.
> 
> **Overview**
> Enables mypy strict checking for `chia/_tests/core/util/test_file_keyring_synchronization.py` by adding explicit type annotations to `dummy_set_passphrase(...) -> None` and `TestFileKeyringSynchronization.test_multiple_writers(...) -> None`.
> 
> Removes `chia._tests.core.util.test_file_keyring_synchronization` from `mypy-exclusions.txt` so the test module is now type-checked instead of being skipped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d60634dfcbfb9fac96e8e361b115a8451b62234. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->