### PR TITLE
mypy: remove exclusion for chia._tests.core.test_db_conversion

### DIFF
--- a/chia/_tests/core/test_db_conversion.py
+++ b/chia/_tests/core/test_db_conversion.py
@@ -4,6 +4,7 @@ import random
 from pathlib import Path
 
 import pytest
+from chia_rs import FullBlock
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
@@ -23,7 +24,7 @@ from chia.util.db_wrapper import DBWrapper2
 @pytest.mark.anyio
 @pytest.mark.parametrize("with_hints", [True, False])
 @pytest.mark.skip("we no longer support DB v1")
-async def test_blocks(default_1000_blocks, with_hints: bool):
+async def test_blocks(default_1000_blocks: list[FullBlock], with_hints: bool) -> None:
     blocks = default_1000_blocks
 
     hints: list[tuple[bytes32, bytes]] = []

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -47,7 +47,6 @@ chia._tests.core.full_node.test_performance
 chia._tests.core.full_node.test_transactions
 chia._tests.core.ssl.test_ssl
 chia._tests.core.test_crawler_rpc
-chia._tests.core.test_db_conversion
 chia._tests.core.util.test_config
 chia._tests.core.util.test_file_keyring_synchronization
 chia._tests.core.util.test_files


### PR DESCRIPTION
### Purpose:

Remove `chia._tests.core.test_db_conversion` from the mypy strict-mode exclusion list by adding the missing type annotations.

### Current Behavior:

`chia._tests.core.test_db_conversion` is excluded from mypy strict checking in `mypy-exclusions.txt`. The `test_blocks` function is missing a return type annotation and a type annotation for the `default_1000_blocks` fixture parameter.

### New Behavior:

The module passes mypy strict mode. `test_blocks` now has:
- `default_1000_blocks: list[FullBlock]` — concrete type traced from the fixture definition in `conftest.py` → `persistent_blocks()` return type
- `-> None` return type annotation

### Testing Notes:

- `pre-commit run mypy --all-files` passes
- `ruff check` and `ruff format --check` pass
- The test itself is `@pytest.mark.skip("we no longer support DB v1")` so runtime behavior is unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only changes in a skipped test file plus an exclusion-list update; no runtime behavior changes expected.
> 
> **Overview**
> Removes `chia._tests.core.test_db_conversion` from `mypy-exclusions.txt` so it is checked under mypy strict mode.
> 
> Updates the skipped `test_blocks` test to satisfy mypy by importing `FullBlock` and adding concrete type annotations for `default_1000_blocks` (`list[FullBlock]`) and the `-> None` return type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fd850f0820a1ffef3f4a7c90511d8e27f579b70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->