### PR TITLE
mypy: remove exclusion for chia._tests.util.benchmark_cost

### DIFF
--- a/chia/_tests/util/benchmark_cost.py
+++ b/chia/_tests/util/benchmark_cost.py
@@ -17,7 +17,7 @@ from chia.wallet.derive_keys import master_sk_to_wallet_sk
 from chia.wallet.puzzles.p2_delegated_puzzle import puzzle_for_pk
 
 
-def float_to_str(f):
+def float_to_str(f: float) -> str:
     float_string = repr(f)
     if "e" in float_string:  # detect scientific notation
         digits, exp_str = float_string.split("e")
@@ -32,7 +32,7 @@ def float_to_str(f):
     return float_string
 
 
-def run_and_return_cost_time(chialisp):
+def run_and_return_cost_time(chialisp: str) -> tuple[int, float]:
     start = time.time()
     clvm_loop = "((c (q ((c (f (a)) (c (f (a)) (c (f (r (a))) (c (f (r (r (a))))"
     " (q ()))))))) (c (q ((c (i (f (r (a))) (q (i (q 1) ((c (f (a)) (c (f (a))"
@@ -50,11 +50,11 @@ def run_and_return_cost_time(chialisp):
     return cost, total_time
 
 
-def get_cost_compared_to_addition(addition_cost, addition_time, other_time):
+def get_cost_compared_to_addition(addition_cost: int, addition_time: float, other_time: float) -> float:
     return (addition_cost * other_time) / addition_time
 
 
-def benchmark_all_operators():
+def benchmark_all_operators() -> None:
     addition = "(+ (q 1000000000) (q 1000000000))"
     substraction = "(- (q 1000000000) (q 1000000000))"
     multiply = "(* (q 1000000000) (q 1000000000))"

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -56,6 +56,5 @@ chia._tests.core.util.test_keyring_wrapper
 chia._tests.plotting.test_plot_manager
 chia._tests.pools.test_pool_puzzles_lifecycle
 chia._tests.simulation.test_simulation
-chia._tests.util.benchmark_cost
 chia._tests.util.test_misc
 chia._tests.wallet.did_wallet.test_did


### PR DESCRIPTION
### Purpose:

Remove `chia._tests.util.benchmark_cost` from the mypy strict-mode exclusion list by adding type annotations to the four unannotated functions in the module. This is part of the ongoing effort to achieve full mypy strict coverage across the codebase.

### Current Behavior:

`chia._tests.util.benchmark_cost` is excluded from mypy strict checking in `mypy-exclusions.txt`. The four helper functions (`float_to_str`, `run_and_return_cost_time`, `get_cost_compared_to_addition`, `benchmark_all_operators`) lack type annotations, producing 4 `no-untyped-def` errors and 18 `no-untyped-call` errors under strict mode.

### New Behavior:

All four functions have complete type annotations:
- `float_to_str(f: float) -> str`
- `run_and_return_cost_time(chialisp: str) -> tuple[int, float]`
- `get_cost_compared_to_addition(addition_cost: int, addition_time: float, other_time: float) -> float`
- `benchmark_all_operators() -> None`

The module passes mypy strict checking and is removed from `mypy-exclusions.txt`.

### Testing Notes:

- `pre-commit run mypy --all-files` passes with zero errors
- `ruff check` and `ruff format --check` pass on the changed file
- All changes are self-contained within the module — no external callers are affected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only annotations in a test utility plus a mypy config list update; no runtime logic changes expected.
> 
> **Overview**
> Adds missing type annotations to helper functions in `chia/_tests/util/benchmark_cost.py` so it passes mypy strict checks.
> 
> Removes `chia._tests.util.benchmark_cost` from `mypy-exclusions.txt`, expanding strict-mode coverage to this test utility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d051a86a17d8cca3776a0f4684e18344e63115cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->