### PR TITLE
mypy: remove exclusion for chia._tests.core.full_node.test_performance

### DIFF
--- a/chia/_tests/core/full_node/test_performance.py
+++ b/chia/_tests/core/full_node/test_performance.py
@@ -14,6 +14,10 @@ from chia._tests.util.misc import BenchmarkRunner
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.pot_iterations import is_overflow_block
 from chia.protocols import full_node_protocol as fnp
+from chia.server.server import ChiaServer
+from chia.simulator.block_tools import BlockTools
+from chia.simulator.full_node_simulator import FullNodeSimulator
+from chia.simulator.wallet_tools import WalletTool
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.util.casts import int_to_bytes
@@ -24,11 +28,14 @@ log = logging.getLogger(__name__)
 class TestPerformance:
     @pytest.mark.anyio
     async def test_full_block_performance(
-        self, request: pytest.FixtureRequest, wallet_nodes_perf, self_hostname, benchmark_runner: BenchmarkRunner
-    ):
+        self,
+        request: pytest.FixtureRequest,
+        wallet_nodes_perf: tuple[FullNodeSimulator, ChiaServer, WalletTool, WalletTool, BlockTools],
+        self_hostname: str,
+        benchmark_runner: BenchmarkRunner,
+    ) -> None:
         full_node_1, server_1, wallet_a, wallet_receiver, bt = wallet_nodes_perf
         blocks = await full_node_1.get_all_full_blocks()
-        full_node_1.full_node.mempool_manager.limit_factor = 1
 
         wallet_ph = wallet_a.get_new_puzzlehash()
         blocks = bt.get_consecutive_blocks(
@@ -40,11 +47,8 @@ class TestPerformance:
         for block in blocks:
             await full_node_1.full_node.add_block(block)
 
-        start_height = (
-            full_node_1.full_node.blockchain.get_peak().height
-            if full_node_1.full_node.blockchain.get_peak() is not None
-            else -1
-        )
+        peak_record = full_node_1.full_node.blockchain.get_peak()
+        start_height = peak_record.height if peak_record is not None else -1
         _incoming_queue, node_id = await add_dummy_connection(server_1, self_hostname, 12312)
         fake_peer = server_1.all_connections[node_id]
         # Mempool has capacity of 100, make 110 unspents that we can use
@@ -52,7 +56,7 @@ class TestPerformance:
 
         # Makes a bunch of coins
         for i in range(20):
-            conditions_dict: dict = {ConditionOpcode.CREATE_COIN: []}
+            conditions_dict: dict[ConditionOpcode, list[ConditionWithArgs]] = {ConditionOpcode.CREATE_COIN: []}
             # This should fit in one transaction
             for _ in range(100):
                 receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
@@ -62,7 +66,7 @@ class TestPerformance:
                 conditions_dict[ConditionOpcode.CREATE_COIN].append(output)
 
             spend_bundle = wallet_a.generate_signed_transaction(
-                100,
+                uint64(100),
                 puzzle_hashes[0],
                 get_future_reward_coins(blocks[1 + i])[0],
                 condition_dic=conditions_dict,
@@ -122,15 +126,12 @@ class TestPerformance:
         while not curr.is_transaction_block:
             curr = full_node_1.full_node.blockchain.block_record(curr.prev_hash)
         mempool_bundle = full_node_1.full_node.mempool_manager.create_bundle_from_mempool(curr.header_hash)
-        if mempool_bundle is None:
-            spend_bundle = None
-        else:
-            spend_bundle = mempool_bundle[0]
+        transaction_data = mempool_bundle[0] if mempool_bundle is not None else None
 
         current_blocks = await full_node_1.get_all_full_blocks()
         blocks = bt.get_consecutive_blocks(
             1,
-            transaction_data=spend_bundle,
+            transaction_data=transaction_data,
             block_list_input=current_blocks,
             guarantee_transaction_block=True,
         )

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -43,7 +43,6 @@ chia._tests.core.consensus.test_pot_iterations
 chia._tests.core.daemon.test_daemon
 chia._tests.core.full_node.test_address_manager
 chia._tests.core.full_node.test_node_load
-chia._tests.core.full_node.test_performance
 chia._tests.core.full_node.test_transactions
 chia._tests.core.ssl.test_ssl
 chia._tests.core.test_crawler_rpc


### PR DESCRIPTION
### Purpose:

Remove `chia._tests.core.full_node.test_performance` from the mypy strict-mode exclusion list by adding concrete type annotations.

### Current Behavior:

`test_performance.py` is excluded from mypy strict checking via `mypy-exclusions.txt`. The test function `test_full_block_performance` lacks return type and parameter type annotations, and uses a bare `dict` without generic type parameters.

### New Behavior:

- Added `-> None` return type and concrete parameter types to `test_full_block_performance`:
  - `wallet_nodes_perf: tuple[FullNodeSimulator, ChiaServer, WalletTool, WalletTool, BlockTools]` (traced from conftest.py fixture)
  - `self_hostname: str`
- Added generic type parameters to `conditions_dict: dict[ConditionOpcode, list[ConditionWithArgs]]`
- Fixed `uint64(100)` argument to `generate_signed_transaction` (was bare `int`, signature expects `uint64`)
- Fixed `union-attr` error on `get_peak()` by using a local variable with a None guard
- Removed dead code: `mempool_manager.limit_factor = 1` (attribute does not exist on `MempoolManager` and is never read anywhere in the codebase)
- Renamed reused `spend_bundle` variable to `transaction_data` to avoid type narrowing conflict (`SpendBundle` vs `SpendBundle | None`)
- Module removed from `mypy-exclusions.txt`

### Testing Notes:

- `mypy --strict` on the target file: zero local errors
- `pre-commit run mypy --all-files`: passed
- `ruff check` and `ruff format --check`: passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only type-annotation and small refactor changes; no production logic or security-sensitive paths are modified.
> 
> **Overview**
> Removes `chia._tests.core.full_node.test_performance` from `mypy-exclusions.txt` by making `test_full_block_performance` mypy-strict compatible.
> 
> The test now has explicit fixture/parameter and return types, uses a properly parameterized `conditions_dict`, passes `uint64` into `generate_signed_transaction`, avoids `Optional` peak access issues, and simplifies mempool bundle handling (including removing a no-op `mempool_manager.limit_factor` assignment).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31b30a17427639b4d483422f5bd00d8d94e0c9bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->