### PR TITLE
Fix flaky VC Wallet test

### DIFF
--- a/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
@@ -721,6 +721,7 @@ async def test_self_revoke(wallet_environments: WalletTestFramework) -> None:
         did_wallet: DIDWallet = await DIDWallet.create_new_did_wallet(
             wallet_node_0.wallet_state_manager, wallet_0, uint64(1), action_scope
         )
+    await wallet_environments.full_node.wait_for_wallet_synced(wallet_node_0)
     did_id: bytes32 = bytes32.from_hexstr(did_wallet.get_my_DID())
 
     async with wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that adds a synchronization wait to reduce flakiness; no production logic is affected.
> 
> **Overview**
> Fixes a race in `test_self_revoke` (`test_vc_wallet.py`) by waiting for `wallet_node_0` to fully sync with the full node immediately after creating the DID, before minting the VC.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 419a6e0d77ed19b2390f5f106532bae8f209467d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->