### PR TITLE
disable consensus mode parametrization on wallet tests, to save time

### DIFF
--- a/chia/_tests/wallet/cat_wallet/test_cat_lifecycle.py
+++ b/chia/_tests/wallet/cat_wallet/test_cat_lifecycle.py
@@ -81,6 +81,7 @@ async def do_spend(
     return cost
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_cat_mod(cost_logger: CostLogger, consensus_mode: ConsensusMode) -> None:
     async with sim_and_client() as (sim, sim_client):
@@ -218,6 +219,7 @@ async def test_cat_mod(cost_logger: CostLogger, consensus_mode: ConsensusMode) -
         )
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_complex_spend(cost_logger: CostLogger, consensus_mode: ConsensusMode) -> None:
     async with sim_and_client() as (sim, sim_client):
@@ -283,6 +285,7 @@ async def test_complex_spend(cost_logger: CostLogger, consensus_mode: ConsensusM
         )
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_genesis_by_id(cost_logger: CostLogger, consensus_mode: ConsensusMode) -> None:
     async with sim_and_client() as (sim, sim_client):
@@ -315,6 +318,7 @@ async def test_genesis_by_id(cost_logger: CostLogger, consensus_mode: ConsensusM
         )
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_genesis_by_puzhash(cost_logger: CostLogger, consensus_mode: ConsensusMode) -> None:
     async with sim_and_client() as (sim, sim_client):
@@ -347,6 +351,7 @@ async def test_genesis_by_puzhash(cost_logger: CostLogger, consensus_mode: Conse
         )
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_everything_with_signature(cost_logger: CostLogger, consensus_mode: ConsensusMode) -> None:
     async with sim_and_client() as (sim, sim_client):
@@ -421,6 +426,7 @@ async def test_everything_with_signature(cost_logger: CostLogger, consensus_mode
         )
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_delegated_tail(cost_logger: CostLogger, consensus_mode: ConsensusMode) -> None:
     async with sim_and_client() as (sim, sim_client):

--- a/chia/_tests/wallet/clawback/test_clawback_decorator.py
+++ b/chia/_tests/wallet/clawback/test_clawback_decorator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from chia._tests.conftest import ConsensusMode
 from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator
@@ -16,6 +17,7 @@ from chia.wallet.wallet_node import WalletNode
     "trusted",
     [True, False],
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_missing_decorator(
     simulator_and_wallet: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
@@ -36,6 +38,7 @@ async def test_missing_decorator(
     "trusted",
     [True, False],
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_unknown_decorator(
     simulator_and_wallet: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
@@ -56,6 +59,7 @@ async def test_unknown_decorator(
     "trusted",
     [True, False],
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_decorator(
     simulator_and_wallet: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],

--- a/chia/_tests/wallet/clawback/test_clawback_metadata.py
+++ b/chia/_tests/wallet/clawback/test_clawback_metadata.py
@@ -6,6 +6,7 @@ import pytest
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint64
 
+from chia._tests.conftest import ConsensusMode
 from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator
@@ -19,6 +20,7 @@ from chia.wallet.wallet_node import WalletNode
     "trusted",
     [True, False],
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_is_recipient(
     simulator_and_wallet: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],

--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -70,6 +70,7 @@ async def make_did_wallet(
 
 #  TODO: See Issue CHIA-1544
 #  This test should be ported to WalletTestFramework once we can replace keys in the wallet node
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.parametrize(
     "trusted",
     [True, False],
@@ -565,6 +566,7 @@ async def test_did_transfer(wallet_environments: WalletTestFramework):
     )
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.parametrize(
     "trusted",
     [True, False],
@@ -1161,6 +1163,7 @@ async def test_did_sign_message(wallet_environments: WalletTestFramework):
 
 #  TODO: See Issue CHIA-1544
 #  This test should be ported to WalletTestFramework once we can replace keys in the wallet node
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.parametrize(
     "trusted",
     [True, False],
@@ -1248,6 +1251,7 @@ async def test_did_resync(
     assert did_info == did_wallet_2.did_info
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.parametrize(
     "wallet_environments",
     [

--- a/chia/_tests/wallet/rpc/test_dl_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_dl_wallet_rpc.py
@@ -8,6 +8,7 @@ import pytest
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
 
+from chia._tests.conftest import ConsensusMode
 from chia._tests.util.rpc import validate_get_routes
 from chia._tests.util.setup_nodes import SimulatorsAndWalletsServices
 from chia._tests.util.time_out_assert import time_out_assert
@@ -43,6 +44,7 @@ log = logging.getLogger(__name__)
 
 
 class TestWalletRpc:
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
     @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.anyio
     async def test_wallet_make_transaction(
@@ -354,6 +356,7 @@ class TestWalletRpc:
                 ]
             )
 
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
     @pytest.mark.parametrize("trusted", [True, False])
     @pytest.mark.anyio
     async def test_wallet_dl_verify_proof(

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -15,6 +15,7 @@ from chia_rs import CoinRecord, CoinSpend, G1Element, G2Element
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint16, uint32, uint64, uint128
 
+from chia._tests.conftest import ConsensusMode
 from chia._tests.environments.wallet import WalletStateTransition, WalletTestFramework
 from chia._tests.util.time_out_assert import time_out_assert
 from chia._tests.wallet.cat_wallet.test_cat_wallet import mint_cat
@@ -4303,6 +4304,7 @@ def test_send_transaction_multi_post_init() -> None:
     [{"num_environments": 1, "blocks_needed": [1], "trusted": True}],
     indirect=True,
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_create_remote_wallet_via_create_new_wallet_is_singleton(
     wallet_environments: WalletTestFramework,
@@ -4334,6 +4336,7 @@ async def test_create_remote_wallet_via_create_new_wallet_is_singleton(
     [{"num_environments": 1, "blocks_needed": [1], "trusted": True}],
     indirect=True,
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_register_remote_coins_validates_wallet_id(wallet_environments: WalletTestFramework) -> None:
     env = wallet_environments.environments[0]

--- a/chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -7,6 +7,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 from colorlog import getLogger
 
+from chia._tests.conftest import ConsensusMode
 from chia._tests.connection_utils import add_dummy_connection
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
 from chia._tests.util.time_out_assert import time_out_assert
@@ -39,6 +40,7 @@ async def get_all_messages_in_queue(queue: asyncio.Queue[Message]) -> list[Messa
     return all_messages
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_subscribe_for_ph(simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str) -> None:
     num_blocks = 4
@@ -215,6 +217,7 @@ async def test_subscribe_for_ph(simulator_and_wallet: OldSimulatorsAndWallets, s
     assert notified_state.spent_height is not None
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_subscribe_for_coin_id(simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str) -> None:
     num_blocks = 4
@@ -316,6 +319,7 @@ async def test_subscribe_for_coin_id(simulator_and_wallet: OldSimulatorsAndWalle
     assert notified_state.spent_height is None
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 @pytest.mark.standard_block_tools
 async def test_subscribe_for_ph_reorg(simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str) -> None:
@@ -393,6 +397,7 @@ async def test_subscribe_for_ph_reorg(simulator_and_wallet: OldSimulatorsAndWall
     assert second_state_coin_2.created_height is None
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_subscribe_for_coin_id_reorg(simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str) -> None:
     num_blocks = 4
@@ -461,6 +466,7 @@ async def test_subscribe_for_coin_id_reorg(simulator_and_wallet: OldSimulatorsAn
     assert second_coin.created_height is None
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_subscribe_for_hint(simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str) -> None:
     num_blocks = 4
@@ -526,6 +532,7 @@ async def test_subscribe_for_hint(simulator_and_wallet: OldSimulatorsAndWallets,
     assert response.coin_states == []
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_subscribe_for_puzzle_hash_coin_hint_duplicates(
     simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str
@@ -561,6 +568,7 @@ async def test_subscribe_for_puzzle_hash_coin_hint_duplicates(
     assert len(set(response.coin_states)) == len(response.coin_states)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 @pytest.mark.standard_block_tools
 async def test_subscribe_for_hint_long_sync(
@@ -642,6 +650,7 @@ async def test_subscribe_for_hint_long_sync(
     check_messages_for_hint(all_messages_1)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_ph_subscribe_limits(simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str) -> None:
     full_nodes, wallets, _ = simulator_and_wallet
@@ -683,6 +692,7 @@ async def test_ph_subscribe_limits(simulator_and_wallet: OldSimulatorsAndWallets
     assert not s.has_puzzle_subscription(phs[5])
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_coin_subscribe_limits(simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str) -> None:
     full_nodes, wallets, _ = simulator_and_wallet

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -213,6 +213,7 @@ async def test_request_block_headers_transactions_filter(
 #     [(80, 99, False, ProtocolMessageTypes.respond_block_headers)],
 #     [(10, 8, False, None)],
 # )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_request_block_headers_rejected(
     simulator_and_wallet: OldSimulatorsAndWallets, default_400_blocks: list[FullBlock]
@@ -357,6 +358,7 @@ async def test_almost_recent(
         await time_out_assert(30, wallet.get_confirmed_balance, 10 * calculate_pool_reward(uint32(1000)))
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_backtrack_sync_wallet(
     two_wallet_nodes: OldSimulatorsAndWallets,
@@ -387,6 +389,7 @@ async def test_backtrack_sync_wallet(
 
 
 # Tests a reorg with the wallet
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_short_batch_sync_wallet(
     two_wallet_nodes: OldSimulatorsAndWallets,
@@ -619,6 +622,7 @@ async def test_wallet_reorg_get_coinbase(
         await time_out_assert(20, wallet.get_confirmed_balance, funds)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_request_additions_errors(simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str) -> None:
     full_nodes, wallets, _ = simulator_and_wallet
@@ -703,6 +707,7 @@ async def test_request_additions_errors(simulator_and_wallet: OldSimulatorsAndWa
     assert response.proofs[0][2] is None
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_request_additions_success(simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str) -> None:
     full_nodes, wallets, _ = simulator_and_wallet
@@ -794,6 +799,7 @@ async def test_request_additions_success(simulator_and_wallet: OldSimulatorsAndW
     assert len(response.coins) == 0
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_request_removals_too_many_coin_names(
     simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str
@@ -823,6 +829,7 @@ async def test_request_removals_too_many_coin_names(
     assert reject.header_hash == last_block.header_hash
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_get_wp_fork_point(
     default_10000_blocks: list[FullBlock], blockchain_constants: ConsensusConstants
@@ -904,6 +911,7 @@ It runs in seven phases:
 """
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 @pytest.mark.parametrize(
     "spam_filter_after_n_txs, xch_spam_amount, dust_value",
@@ -1474,6 +1482,7 @@ async def test_dusted_wallet(
     await time_out_assert(15, get_nft_count, 1, dust_nft_wallet)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_retry_store(
     two_wallet_nodes: OldSimulatorsAndWallets, self_hostname: str, monkeypatch: pytest.MonkeyPatch

--- a/chia/_tests/wallet/test_notifications.py
+++ b/chia/_tests/wallet/test_notifications.py
@@ -9,6 +9,7 @@ import pytest
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
+from chia._tests.conftest import ConsensusMode
 from chia._tests.util.time_out_assert import time_out_assert, time_out_assert_not_none
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.simulator.full_node_simulator import FullNodeSimulator
@@ -51,6 +52,7 @@ async def test_notification_store_backwards_compat() -> None:
     "trusted",
     [True, False],
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_notifications(
     self_hostname: str, two_wallet_nodes: Any, trusted: Any, seeded_random: random.Random

--- a/chia/_tests/wallet/test_signer_protocol.py
+++ b/chia/_tests/wallet/test_signer_protocol.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 
 from chia._tests.cmds.test_cmd_framework import check_click_parsing
 from chia._tests.cmds.wallet.test_consts import STD_TX
+from chia._tests.conftest import ConsensusMode
 from chia._tests.environments.wallet import WalletStateTransition, WalletTestFramework
 from chia.cmds.cmd_classes import chia_command
 from chia.cmds.cmd_helpers import NeedsWalletRPC, TransactionsIn, TransactionsOut, WalletClientInfo
@@ -124,6 +125,7 @@ def test_unsigned_transaction_type() -> None:
     ],
     indirect=True,
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_p2dohp_wallet_signer_protocol(wallet_environments: WalletTestFramework) -> None:
     wallet: Wallet = wallet_environments.environments[0].xch_wallet
@@ -311,6 +313,7 @@ async def test_p2dohp_wallet_signer_protocol(wallet_environments: WalletTestFram
     ],
     indirect=True,
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_p2blsdohp_execute_signing_instructions(wallet_environments: WalletTestFramework) -> None:
     wallet: Wallet = wallet_environments.environments[0].xch_wallet
@@ -602,6 +605,7 @@ def test_blind_signer_translation_layer() -> None:
     ],
     indirect=True,
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_signer_commands(wallet_environments: WalletTestFramework) -> None:
     wallet: Wallet = wallet_environments.environments[0].xch_wallet

--- a/chia/_tests/wallet/test_wallet.py
+++ b/chia/_tests/wallet/test_wallet.py
@@ -9,6 +9,7 @@ from chia_rs import AugSchemeMPL, Coin, CoinSpend, G1Element, G2Element
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64
 
+from chia._tests.conftest import ConsensusMode
 from chia._tests.environments.wallet import WalletStateTransition, WalletTestFramework
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.server.server import ChiaServer
@@ -1432,6 +1433,7 @@ class TestWalletSimulator:
         )
 
     @pytest.mark.parametrize("trusted", [True, False])
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
     @pytest.mark.anyio
     async def test_wallet_send_to_three_peers(
         self,
@@ -2053,6 +2055,7 @@ class TestWalletSimulator:
         ],
         indirect=True,
     )
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
     @pytest.mark.anyio
     async def test_address_sliding_window(self, wallet_environments: WalletTestFramework) -> None:
         full_node_api = wallet_environments.full_node
@@ -2355,6 +2358,7 @@ def test_get_wallet_db_path_testnet() -> None:
     assert wallet_db_path == root_path.joinpath("wallet/db/blockchain_wallet_v2_r1_testnet_1234567890.sqlite")
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_wallet_has_no_server(
     simulator_and_wallet: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],

--- a/chia/_tests/wallet/test_wallet_blockchain.py
+++ b/chia/_tests/wallet/test_wallet_blockchain.py
@@ -4,6 +4,7 @@ import pytest
 from chia_rs import FullBlock, HeaderBlock
 from chia_rs.sized_ints import uint8, uint32
 
+from chia._tests.conftest import ConsensusMode
 from chia._tests.util.db_connection import DBConnection
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
 from chia.consensus.blockchain import AddBlockResult
@@ -15,6 +16,7 @@ from chia.wallet.key_val_store import KeyValStore
 from chia.wallet.wallet_blockchain import WalletBlockchain
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 @pytest.mark.standard_block_tools
 async def test_wallet_blockchain(

--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -491,6 +491,7 @@ async def test_get_timestamp_for_height_from_peer(
     assert f"get_timestamp_for_height_from_peer use cached block for height {1}" in caplog.text
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_unique_puzzle_hash_subscriptions(simulator_and_wallet: OldSimulatorsAndWallets) -> None:
     _, [(node, _)], _ = simulator_and_wallet
@@ -499,6 +500,7 @@ async def test_unique_puzzle_hash_subscriptions(simulator_and_wallet: OldSimulat
     assert len(set(puzzle_hashes)) == len(puzzle_hashes)
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 @pytest.mark.standard_block_tools
 async def test_get_balance(
@@ -578,6 +580,7 @@ async def test_get_balance(
     assert await wallet_node.get_balance(wallet_id) == expected_more_balance
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_add_states_from_peer_reorg_failure(
     simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str, caplog: pytest.LogCaptureFixture
@@ -596,6 +599,7 @@ async def test_add_states_from_peer_reorg_failure(
         assert "Processing reorged states failed" in caplog.text
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_add_states_from_peer_untrusted_shutdown(
     simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str, caplog: pytest.LogCaptureFixture
@@ -726,6 +730,7 @@ async def test_wallet_node_bad_coin_state_ignore(
             await wallet_node.get_coin_state([], wallet_node.get_full_node_peer())
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 @pytest.mark.standard_block_tools
 async def test_start_with_multiple_key_types(
@@ -757,6 +762,7 @@ async def test_start_with_multiple_key_types(
     assert wallet_node.wallet_state_manager.private_key == initial_sk
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 @pytest.mark.standard_block_tools
 async def test_start_with_multiple_keys(

--- a/chia/_tests/wallet/test_wallet_retry.py
+++ b/chia/_tests/wallet/test_wallet_retry.py
@@ -7,6 +7,7 @@ import pytest
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint64
 
+from chia._tests.conftest import ConsensusMode
 from chia._tests.util.time_out_assert import time_out_assert, time_out_assert_custom_interval
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.full_node.mempool import MempoolRemoveReason
@@ -34,6 +35,7 @@ def evict_from_pool(node: FullNodeAPI, sb: WalletSpendBundle) -> None:
     node.full_node.mempool_manager.remove_seen(sb.name())
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_wallet_tx_retry(
     setup_two_nodes_and_wallet_fast_retry: tuple[list[FullNodeSimulator], list[tuple[Any, Any]], BlockTools],

--- a/chia/_tests/wallet/test_wallet_state_manager.py
+++ b/chia/_tests/wallet/test_wallet_state_manager.py
@@ -9,6 +9,7 @@ from chia_rs import CoinState, G2Element
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
+from chia._tests.conftest import ConsensusMode
 from chia._tests.environments.wallet import WalletStateTransition, WalletTestFramework
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
 from chia._tests.util.time_out_assert import time_out_assert
@@ -53,6 +54,7 @@ async def assert_sync_mode(wallet_state_manager: WalletStateManager, target_heig
     assert wallet_state_manager.sync_target is None
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_set_sync_mode(simulator_and_wallet: OldSimulatorsAndWallets) -> None:
     _, [(wallet_node, _)], _ = simulator_and_wallet
@@ -64,6 +66,7 @@ async def test_set_sync_mode(simulator_and_wallet: OldSimulatorsAndWallets) -> N
         pass
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_set_sync_mode_exception(simulator_and_wallet: OldSimulatorsAndWallets) -> None:
     _, [(wallet_node, _)], _ = simulator_and_wallet
@@ -72,6 +75,7 @@ async def test_set_sync_mode_exception(simulator_and_wallet: OldSimulatorsAndWal
 
 
 @pytest.mark.parametrize("hardened", [True, False])
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_get_private_key(simulator_and_wallet: OldSimulatorsAndWallets, hardened: bool) -> None:
     _, [(wallet_node, _)], _ = simulator_and_wallet
@@ -91,6 +95,7 @@ async def test_get_private_key(simulator_and_wallet: OldSimulatorsAndWallets, ha
     assert await wallet_state_manager.get_private_key(record.puzzle_hash) == expected_private_key
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_get_private_key_failure(simulator_and_wallet: OldSimulatorsAndWallets) -> None:
     _, [(wallet_node, _)], _ = simulator_and_wallet
@@ -100,6 +105,7 @@ async def test_get_private_key_failure(simulator_and_wallet: OldSimulatorsAndWal
         await wallet_state_manager.get_private_key(bytes32(b"1" * 32))
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_determine_coin_type(simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str) -> None:
     full_nodes, wallets, _ = simulator_and_wallet

--- a/chia/_tests/wallet/test_wallet_test_framework.py
+++ b/chia/_tests/wallet/test_wallet_test_framework.py
@@ -4,6 +4,7 @@ import pytest
 from chia_rs import BlockRecord
 from chia_rs.sized_bytes import bytes32
 
+from chia._tests.conftest import ConsensusMode
 from chia._tests.environments.wallet import (
     BalanceCheckingError,
     WalletEnvironment,
@@ -27,6 +28,7 @@ from chia.wallet.cat_wallet.cat_wallet import CATWallet
     ],
     indirect=True,
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_basic_functionality(wallet_environments: WalletTestFramework) -> None:
     env_0: WalletEnvironment = wallet_environments.environments[0]
@@ -62,6 +64,7 @@ async def test_basic_functionality(wallet_environments: WalletTestFramework) -> 
     ],
     indirect=True,
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_balance_checking(
     wallet_environments: WalletTestFramework,

--- a/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
@@ -9,6 +9,7 @@ from chia_rs import G2Element
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64
 
+from chia._tests.conftest import ConsensusMode
 from chia._tests.environments.wallet import WalletEnvironment, WalletStateTransition, WalletTestFramework
 from chia._tests.util.time_out_assert import time_out_assert_not_none
 from chia.simulator.full_node_simulator import FullNodeSimulator
@@ -142,6 +143,7 @@ async def mint_cr_cat(
     ],
     indirect=True,
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_vc_lifecycle(wallet_environments: WalletTestFramework) -> None:
     # Setup
@@ -701,6 +703,7 @@ async def test_vc_lifecycle(wallet_environments: WalletTestFramework) -> None:
     ],
     indirect=True,
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_self_revoke(wallet_environments: WalletTestFramework) -> None:
     # Setup
@@ -821,6 +824,7 @@ async def test_self_revoke(wallet_environments: WalletTestFramework) -> None:
     "trusted",
     [True, False],
 )
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
 @pytest.mark.anyio
 async def test_cat_wallet_conversion(
     self_hostname: str,


### PR DESCRIPTION
Save time running wallet tests. The chance of consenus mode affecting these tests is small. Although it did happens when the hard fork was introduced, some aspect of the wallet protocol broke. It would have been caught by these kinds of test

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit dba304f7ea7e0b2402b518635c879a50008ca78e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->