### PR TITLE
Restrict Coveralls action to public repositories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -305,6 +305,8 @@ jobs:
         if: always() && steps.alls-green.outputs.success == 'true' && github.event.repository.visibility == 'public'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        with:
+          fail-on-error: false
 
       - name: Coverage report (chia/)
         if: always() && steps.alls-green.outputs.success == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -302,7 +302,7 @@ jobs:
           coverage html --rcfile=.coveragerc --data-file=coverage-reports/.coverage --directory coverage-reports/html/
 
       - uses: coverallsapp/github-action@v2
-        if: always() && steps.alls-green.outputs.success == 'true'
+        if: always() && steps.alls-green.outputs.success == 'true' && github.event.repository.visibility == 'public'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 


### PR DESCRIPTION
Only do the coveralls action for public repos and also set `fail-on-error` to false 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only change that just gates the Coveralls upload step based on repo visibility, with no impact on build/test execution or production code.
> 
> **Overview**
> Restricts coverage reporting to Coveralls by adding a repository visibility check.
> 
> In `.github/workflows/test.yml`, the `coverallsapp/github-action@v2` step now runs only when the workflow is green *and* `github.event.repository.visibility == 'public'`, preventing Coveralls execution on private repos.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b04c38dfb60f79a9b14328e0f7607112560a1a7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->