### PR TITLE
[CHIA-3947] Fix PendingTxCache eviction when encountering empty height buckets

### DIFF
--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -314,6 +314,45 @@ class TestPendingTxCache:
             items[9].spend_bundle_name: items[9],
         }
 
+    def test_eviction_with_empty_height_bucket(self) -> None:
+        # When an empty bucket exists in _by_height, eviction must remove the
+        # bucket rather than attempting to pop from _txs with a height key.
+        c = PendingTxCache(160)
+        item1 = make_item(1, assert_height=uint32(100))
+        item2 = make_item(2, assert_height=uint32(200))
+        c.add(item1)
+        c.add(item2)
+
+        # Inject an empty bucket at the highest height to simulate the edge case.
+        c._by_height[uint32(300)] = {}
+
+        # Adding a third item (total cost 240 > limit 160) forces eviction.
+        # The eviction loop sees the empty bucket at height 300 first.
+        item3 = make_item(3, assert_height=uint32(150))
+        c.add(item3)
+
+        # The empty bucket should be removed, and a real item evicted.
+        # item2 (height 200) is the highest real bucket, so it gets evicted next.
+        assert c.get(item2.name) is None
+        assert c.get(item3.name) is not None
+        assert uint32(300) not in c._by_height
+
+    def test_eviction_removes_highest_height_first(self) -> None:
+        # Verify normal eviction order: highest assert_height evicted first
+        c = PendingTxCache(160)
+        item_low = make_item(1, assert_height=uint32(50))
+        item_mid = make_item(2, assert_height=uint32(100))
+        item_high = make_item(3, assert_height=uint32(200))
+        c.add(item_low)
+        c.add(item_mid)
+        # Adding item_high exceeds cost limit (240 > 160), evicts item_high itself
+        # since it has the highest assert_height
+        c.add(item_high)
+
+        assert c.get(item_low.name) is not None
+        assert c.get(item_mid.name) is not None
+        assert c.get(item_high.name) is None
+
 
 class TestMempool:
     @pytest.mark.anyio

--- a/chia/full_node/pending_tx_cache.py
+++ b/chia/full_node/pending_tx_cache.py
@@ -78,7 +78,7 @@ class PendingTxCache:
             # we start removing items with the highest assert_height first
             to_evict = self._by_height.items()[-1]
             if to_evict[1] == {}:
-                self._txs.pop(to_evict[0])
+                self._by_height.popitem()
                 continue
 
             first_in = next(iter(to_evict[1].keys()))


### PR DESCRIPTION
### Purpose:
Fix incorrect eviction behavior in `PendingTxCache.add()` when the `_by_height` sorted dictionary contains an empty bucket. The eviction loop mistakenly called `self._txs.pop(to_evict[0])` where `to_evict[0]` is a `uint32` height, but `_txs` is keyed by `bytes32` bundle names. This causes a `KeyError` and prevents the cache from correctly managing its size.

### Current Behavior:
When `PendingTxCache` exceeds its cost limit and the highest entry in `_by_height` is an empty dictionary, the eviction loop attempts to remove a key from `_txs` using the height integer. Since `_txs` is keyed by `bytes32` spend bundle names, this raises `KeyError` and the eviction fails.

### New Behavior:
When an empty bucket is found at the top of `_by_height`, it is removed via `self._by_height.popitem()` — consistent with the existing cleanup on line 89 of the same method. The eviction loop then continues to the next highest bucket and correctly evicts real entries.

### Testing Notes:
- Added `test_eviction_with_empty_height_bucket`: injects an empty height bucket and verifies eviction handles it gracefully without raising `KeyError`.
- Added `test_eviction_removes_highest_height_first`: verifies the normal eviction ordering (highest `assert_height` evicted first).
- All existing `PendingTxCache` tests continue to pass.
- ruff lint and format checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to eviction bookkeeping plus regression tests; behavior change is limited to an error path and should reduce runtime `KeyError`s.
> 
> **Overview**
> Fixes a bug in `PendingTxCache.add()` where eviction could crash when the highest `_by_height` entry was an empty bucket; the code now removes the empty bucket via `_by_height.popitem()` and continues evicting real transactions.
> 
> Adds targeted tests in `test_mempool.py` to cover the empty-bucket edge case and to assert the expected eviction order (highest `assert_height` evicted first).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23d4f02f19b7e5946e61b4b2bc2822bf403bd501. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->