### PR TITLE
test fixes

### DIFF
--- a/chia/_tests/blockchain/blockchain_test_utils.py
+++ b/chia/_tests/blockchain/blockchain_test_utils.py
@@ -105,11 +105,21 @@ async def _validate_and_add_block(
     if fork_info is None:
         fork_info = ForkInfo(block.height - 1, block.height - 1, block.prev_header_hash)
 
+    # Match full-node add_prevalidated_blocks() by passing the prevalidated
+    # overlay record into add_block().
+    block_record = aug_blockchain.try_block_record(block.header_hash)
     (
         result,
         err,
         _,
-    ) = await blockchain.add_block(block, results, ssi, fork_info=fork_info)
+    ) = await blockchain.add_block(
+        block,
+        results,
+        ssi,
+        fork_info=fork_info,
+        prev_ses_block=prev_ses_block,
+        block_record=block_record,
+    )
     await check_block_store_invariant(blockchain)
 
     if expected_error is None and expected_result != AddBlockResult.INVALID_BLOCK:

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -3586,6 +3586,8 @@ class TestReorgs:
         fork_block = default_10000_blocks[num_blocks_chain_2_start - 101]
         fork_info = ForkInfo(fork_block.height, fork_block.height, fork_block.header_hash)
         await b.warmup(fork_block.height)
+        # Reuse one augmented overlay to mirror the full-node batch validation path.
+        aug_chain = AugmentedBlockchain(b)
         for block in blocks:
             if (block.height % 128) == 0:
                 peak = b.get_peak()
@@ -3602,7 +3604,13 @@ class TestReorgs:
                     block.weight == peak.weight and block.total_iters < peak.total_iters
                 )
                 expect = AddBlockResult.NEW_PEAK if is_new_peak else AddBlockResult.ADDED_AS_ORPHAN
-            await _validate_and_add_block(b, block, fork_info=fork_info, expected_result=expect)
+            await _validate_and_add_block(
+                b,
+                block,
+                fork_info=fork_info,
+                expected_result=expect,
+                augmented_blockchain=aug_chain,
+            )
 
         # if these asserts fires, there was no reorg back to the original chain
         peak = b.get_peak()

--- a/chia/_tests/blockchain/test_blockchain_transactions.py
+++ b/chia/_tests/blockchain/test_blockchain_transactions.py
@@ -879,14 +879,12 @@ class TestBlockchainTransactions:
 
         # we compare the timestamp against the previous transaction block, so in
         # order to progress the timestamp, we need to farm one more block
-        blocks.extend(
-            bt.get_consecutive_blocks(
-                1,
-                blocks,
-                farmer_reward_puzzle_hash=coinbase_puzzlehash,
-                guarantee_transaction_block=True,
-                time_per_block=301,
-            )
+        blocks = bt.get_consecutive_blocks(
+            1,
+            blocks,
+            farmer_reward_puzzle_hash=coinbase_puzzlehash,
+            guarantee_transaction_block=True,
+            time_per_block=301,
         )
         await _validate_and_add_block(full_node_1.blockchain, blocks[-1])
 
@@ -952,14 +950,12 @@ class TestBlockchainTransactions:
 
         # we compare the timestamp against the previous transaction block, so in
         # order to progress the timestamp, we need to farm one more block
-        blocks.extend(
-            bt.get_consecutive_blocks(
-                1,
-                blocks,
-                farmer_reward_puzzle_hash=coinbase_puzzlehash,
-                guarantee_transaction_block=True,
-                time_per_block=30,
-            )
+        blocks = bt.get_consecutive_blocks(
+            1,
+            blocks,
+            farmer_reward_puzzle_hash=coinbase_puzzlehash,
+            guarantee_transaction_block=True,
+            time_per_block=30,
         )
         await _validate_and_add_block(full_node_1.blockchain, blocks[-1])
 

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3605,7 +3605,7 @@ async def test_corrupt_blockchain(bt: BlockTools, default_400_blocks: list[FullB
     db_path = path_from_root(bt.root_path, db_path_replaced)
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    await make_db(db_path, default_400_blocks)
+    await make_db(db_path, default_400_blocks, bt.constants)
     with contextlib.closing(sqlite3.connect(db_path)) as conn:
         conn.execute("DELETE FROM current_peak;")
         conn.commit()

--- a/chia/_tests/core/test_db_validation.py
+++ b/chia/_tests/core/test_db_validation.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from chia_rs import FullBlock
+from chia_rs import ConsensusConstants, FullBlock
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
@@ -19,7 +19,6 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
-from chia.simulator.block_tools import test_constants
 from chia.util.db_wrapper import DBWrapper2
 
 
@@ -131,7 +130,7 @@ def test_db_validate_in_main_chain(invalid_in_chain: bool, default_config: dict[
             validate_v2(db_file, config=default_config, validate_blocks=False)
 
 
-async def make_db(db_file: Path, blocks: list[FullBlock]) -> None:
+async def make_db(db_file: Path, blocks: list[FullBlock], constants: ConsensusConstants) -> None:
     async with DBWrapper2.managed(database=db_file, reader_count=1, db_version=2) as db_wrapper:
         async with db_wrapper.writer_maybe_transaction() as conn:
             # this is done by chia init normally
@@ -142,8 +141,8 @@ async def make_db(db_file: Path, blocks: list[FullBlock]) -> None:
         coin_store = await CoinStore.create(db_wrapper)
         height_map = await BlockHeightMap.create(Path("."), db_wrapper)
 
-        bc = await Blockchain.create(coin_store, block_store, height_map, test_constants, reserved_cores=0)
-        sub_slot_iters = test_constants.SUB_SLOT_ITERS_STARTING
+        bc = await Blockchain.create(coin_store, block_store, height_map, constants, reserved_cores=0)
+        sub_slot_iters = constants.SUB_SLOT_ITERS_STARTING
         for block in blocks:
             if block.height != 0 and len(block.finished_sub_slots) > 0:
                 if block.finished_sub_slots[0].challenge_chain.new_sub_slot_iters is not None:
@@ -156,10 +155,12 @@ async def make_db(db_file: Path, blocks: list[FullBlock]) -> None:
 
 @pytest.mark.anyio
 async def test_db_validate_default_1000_blocks(
-    default_1000_blocks: list[FullBlock], default_config: dict[str, Any]
+    default_1000_blocks: list[FullBlock],
+    default_config: dict[str, Any],
+    blockchain_constants: ConsensusConstants,
 ) -> None:
     with TempFile() as db_file:
-        await make_db(db_file, default_1000_blocks)
+        await make_db(db_file, default_1000_blocks, blockchain_constants)
 
         # we expect everything to be valid except this is a test chain, so it
         # doesn't have the correct genesis challenge


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
fix minor test issues and inconsistencies with full_node logic
<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test utilities/fixtures and adjust how blocks/DBs are constructed and passed into `add_block`, so product behavior isn’t directly affected. Risk is mainly test brittleness if the new helper signatures or overlay-record assumptions don’t match future full-node behavior.
> 
> **Overview**
> Updates blockchain test helpers to more closely mirror full-node batch validation by reusing a single `AugmentedBlockchain` overlay and passing `prev_ses_block` plus an optional prevalidated `block_record` into `Blockchain.add_block()`.
> 
> Fixes a couple of test inconsistencies: timelock transaction tests now replace the `blocks` list instead of extending it with a nested list, and DB-validation/`test_corrupt_blockchain` setup now passes `ConsensusConstants` through `make_db()` rather than relying on `test_constants`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e7d32a7b99c751d2fefca59d6a07a0a4bc488bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->