### PR TITLE
CHIA-3948 Improve waiting for the connection to close in WSChiaConnection's _read_one_message

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -694,6 +694,7 @@ class WSChiaConnection:
                 f"{self.peer_info.port}"
             )
             create_referenced_task(self.close(), known_unreferenced=True)
+            # Yield so we let the close task cancel us
             await asyncio.sleep(3)
         elif message.type == WSMsgType.CLOSE:
             self.log.debug(
@@ -702,10 +703,12 @@ class WSChiaConnection:
                 f"{self.peer_info.port}"
             )
             create_referenced_task(self.close(), known_unreferenced=True)
+            # Yield so we let the close task cancel us
             await asyncio.sleep(3)
         elif message.type == WSMsgType.CLOSED:
             if not self.closed:
                 create_referenced_task(self.close(), known_unreferenced=True)
+                # Yield so we let the close task cancel us
                 await asyncio.sleep(3)
                 return None
         elif message.type == WSMsgType.BINARY:
@@ -730,6 +733,7 @@ class WSChiaConnection:
                     self.log.error(f"Peer has been rate limited and will be disconnected: {details}")
                     # Only full node disconnects peers, to prevent abuse and crashing timelords, farmers, etc
                     create_referenced_task(self.close(RATE_LIMITER_BAN_SECONDS), known_unreferenced=True)
+                    # Yield so we let the close task cancel us
                     await asyncio.sleep(3)
                     return None
                 else:
@@ -745,11 +749,13 @@ class WSChiaConnection:
                 create_referenced_task(self.close(RATE_LIMITER_BAN_SECONDS), known_unreferenced=True)
             else:
                 create_referenced_task(self.close(), known_unreferenced=True)
+            # Yield so we let the close task cancel us
             await asyncio.sleep(3)
 
         else:
             self.log.error(f"Unexpected WebSocket message type: {message}")
             create_referenced_task(self.close())
+            # Yield so we let the close task cancel us
             await asyncio.sleep(3)
         return None
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core networking teardown behavior and introduces a fixed delay on close/error paths, which could affect connection shutdown latency and task scheduling under load.
> 
> **Overview**
> Improves WebSocket shutdown handling in `WSChiaConnection._read_one_message` by adding an explicit `await asyncio.sleep(3)` after scheduling `self.close()` for `CLOSING`/`CLOSE`/`CLOSED`, `ERROR`, unexpected message types, and full-node rate-limit disconnects.
> 
> This yields control to let the close task cancel the reader before continuing, reducing the chance the read loop keeps running after initiating connection teardown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d71173d2666cee8a19c0dd8da7e7d517be1b5704. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->