### PR TITLE
CHIA-3951 Improve unknown protocol message type handling in WSChiaConnection's _read_one_message

### DIFF
--- a/chia/_tests/core/server/test_dos.py
+++ b/chia/_tests/core/server/test_dos.py
@@ -174,7 +174,9 @@ class TestDos:
         response = await send_handshake_and_assert_protocol_error(
             server_1, server_2, self_hostname, handshake, message_type=2
         )
-        assert response.extra == str(int(Err.INVALID_HANDSHAKE.value))  # We want INVALID_HANDSHAKE and not UNKNOWN
+        assert response.type == WSMsgType.CLOSE
+        assert response.data == WSCloseCode.PROTOCOL_ERROR
+        assert response.extra == str(int(Err.INVALID_PROTOCOL_MESSAGE.value))
 
     @pytest.mark.anyio
     async def test_handshake_version_too_long_disconnect(

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -714,9 +714,20 @@ class WSChiaConnection:
             self.bytes_read += len(data)
             self.last_message_time = time.time()
             try:
-                message_type = ProtocolMessageTypes(full_message_loaded.type).name
+                message_type = ProtocolMessageTypes(full_message_loaded.type)
             except Exception:
-                message_type = "Unknown"
+                self.log.error(
+                    f"Disconnecting peer for unknown message type {full_message_loaded.type}: {self.peer_info.host}"
+                )
+                create_referenced_task(
+                    self.close(
+                        INTERNAL_PROTOCOL_ERROR_BAN_SECONDS, WSCloseCode.PROTOCOL_ERROR, Err.INVALID_PROTOCOL_MESSAGE
+                    ),
+                    known_unreferenced=True,
+                )
+                # Yield so we let the close task cancel us
+                await asyncio.sleep(3)
+                return None
             limiter_msg = self.inbound_rate_limiter.process_msg_and_check(
                 full_message_loaded, self.local_capabilities, self.peer_capabilities
             )
@@ -726,7 +737,7 @@ class WSChiaConnection:
                     and not is_localhost(self.peer_info.host)
                     and not is_in_network(self.peer_info.host, self.exempt_peer_networks)
                 ):
-                    details = ", ".join([f"{self.peer_info.host}", f"message: {message_type}", limiter_msg])
+                    details = ", ".join([f"{self.peer_info.host}", f"message: {message_type.name}", limiter_msg])
                     self.log.error(f"Peer has been rate limited and will be disconnected: {details}")
                     # Only full node disconnects peers, to prevent abuse and crashing timelords, farmers, etc
                     create_referenced_task(self.close(RATE_LIMITER_BAN_SECONDS), known_unreferenced=True)
@@ -734,7 +745,7 @@ class WSChiaConnection:
                     return None
                 else:
                     self.log.debug(
-                        f"Peer surpassed rate limit {self.peer_info.host}, message: {message_type}, "
+                        f"Peer surpassed rate limit {self.peer_info.host}, message: {message_type.name}, "
                         f"port {self.peer_info.port} but not disconnecting"
                     )
                     return full_message_loaded


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes disconnect/ban behavior for malformed inbound messages; risk is mostly around inadvertently banning peers if message type parsing diverges across versions.
> 
> **Overview**
> `WSChiaConnection._read_one_message` now treats an unknown `ProtocolMessageTypes` value as a **protocol violation**, logging the offending type and peer, closing the websocket with `WSCloseCode.PROTOCOL_ERROR`, and applying `INTERNAL_PROTOCOL_ERROR_BAN_SECONDS` with `Err.INVALID_PROTOCOL_MESSAGE`.
> 
> Tests were updated to assert the new close/error semantics for an invalid-protocol handshake (expecting `Err.INVALID_PROTOCOL_MESSAGE` on a protocol-error close).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2d5ebe522b2a7a72c7c5e63cebe27520357ca0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->