### PR TITLE
Add xz compression for deb package

### DIFF
--- a/build_scripts/electron-builder.json
+++ b/build_scripts/electron-builder.json
@@ -76,6 +76,7 @@
     "icon": "src/assets/img/chia.icns"
   },
   "deb": {
+    "compression": "xz",
     "afterInstall": "../../../build_scripts/assets/deb/postinst.sh",
     "afterRemove": "../../../build_scripts/assets/deb/prerm.sh",
     "depends": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk build-time change that only affects how the Debian package is compressed; main potential impact is installer compatibility/size differences on Linux distributions.
> 
> **Overview**
> Configures Electron Builder to produce Debian (`.deb`) packages using **xz compression** by adding `"compression": "xz"` under the `deb` section in `build_scripts/electron-builder.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53c4aea54353ac7a6f84c1d25239d184096033a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->