### PR TITLE
[CHIA-3896] 2.6.1 gui patch

### DIFF
--- a/build_scripts/build_linux_deb-1-gui.sh
+++ b/build_scripts/build_linux_deb-1-gui.sh
@@ -19,6 +19,17 @@ if [ "$LAST_EXIT_CODE" -ne 0 ]; then
   exit $LAST_EXIT_CODE
 fi
 
+# Webpack already bundled all JS into build/. Clear production dependencies from
+# package.json so electron-builder v26's node module collector doesn't fail when
+# it can't find workspace packages that are removed below for cache optimization.
+echo "Clearing dependencies from packages/gui/package.json for electron-builder"
+node -e "
+  const fs = require('fs');
+  const p = JSON.parse(fs.readFileSync('./packages/gui/package.json', 'utf8'));
+  p.dependencies = {};
+  fs.writeFileSync('./packages/gui/package.json', JSON.stringify(p, null, 2) + '\n');
+"
+
 # Remove unused packages
 rm -rf node_modules
 
@@ -39,5 +50,5 @@ rm -rf electron/dist # ~186MB
 rm -rf "@mui"        # ~71MB
 rm -rf typescript    # ~63MB
 
-# Remove `packages/gui/node_modules/@chia-network` because it causes an error on later `electron-packager` command
+# Remove `packages/gui/node_modules/@chia-network` to save cache space
 rm -rf "@chia-network"

--- a/build_scripts/build_linux_rpm-1-gui.sh
+++ b/build_scripts/build_linux_rpm-1-gui.sh
@@ -18,6 +18,17 @@ if [ "$LAST_EXIT_CODE" -ne 0 ]; then
   exit $LAST_EXIT_CODE
 fi
 
+# Webpack already bundled all JS into build/. Clear production dependencies from
+# package.json so electron-builder v26's node module collector doesn't fail when
+# it can't find workspace packages that are removed below for cache optimization.
+echo "Clearing dependencies from packages/gui/package.json for electron-builder"
+node -e "
+  const fs = require('fs');
+  const p = JSON.parse(fs.readFileSync('./packages/gui/package.json', 'utf8'));
+  p.dependencies = {};
+  fs.writeFileSync('./packages/gui/package.json', JSON.stringify(p, null, 2) + '\n');
+"
+
 # Remove unused packages
 rm -rf node_modules
 
@@ -38,5 +49,5 @@ rm -rf electron/dist # ~186MB
 rm -rf "@mui"        # ~71MB
 rm -rf typescript    # ~63MB
 
-# Remove `packages/gui/node_modules/@chia-network` because it causes an error on later `electron-packager` command
+# Remove `packages/gui/node_modules/@chia-network` to save cache space
 rm -rf "@chia-network"

--- a/build_scripts/build_macos-1-gui.sh
+++ b/build_scripts/build_macos-1-gui.sh
@@ -20,6 +20,17 @@ if [ "$LAST_EXIT_CODE" -ne 0 ]; then
   exit $LAST_EXIT_CODE
 fi
 
+# Webpack already bundled all JS into build/. Clear production dependencies from
+# package.json so electron-builder v26's node module collector doesn't fail when
+# it can't find workspace packages that are removed below for cache optimization.
+echo "Clearing dependencies from packages/gui/package.json for electron-builder"
+node -e "
+  const fs = require('fs');
+  const p = JSON.parse(fs.readFileSync('./packages/gui/package.json', 'utf8'));
+  p.dependencies = {};
+  fs.writeFileSync('./packages/gui/package.json', JSON.stringify(p, null, 2) + '\n');
+"
+
 # Remove unused packages
 rm -rf node_modules
 
@@ -40,5 +51,5 @@ rm -rf electron/dist # ~186MB
 rm -rf "@mui"        # ~71MB
 rm -rf typescript    # ~63MB
 
-# Remove `packages/gui/node_modules/@chia-network` because it causes an error on later `electron-packager` command
+# Remove `packages/gui/node_modules/@chia-network` to save cache space
 rm -rf "@chia-network"

--- a/build_scripts/build_windows-1-gui.ps1
+++ b/build_scripts/build_windows-1-gui.ps1
@@ -29,6 +29,12 @@ If ($LastExitCode -gt 0){
     Throw "npm run build failed!"
 }
 
+# Webpack already bundled all JS into build/. Clear production dependencies from
+# package.json so electron-builder v26's node module collector doesn't fail when
+# it can't find workspace packages that are removed below for cache optimization.
+Write-Output "Clearing dependencies from packages/gui/package.json for electron-builder"
+node -e "const fs = require('fs'); const p = JSON.parse(fs.readFileSync('./packages/gui/package.json', 'utf8')); p.dependencies = {}; fs.writeFileSync('./packages/gui/package.json', JSON.stringify(p, null, 2) + '\n');"
+
 # Remove unused packages
 Remove-Item node_modules -Recurse -Force
 
@@ -48,5 +54,5 @@ Remove-Item packages\wallets -Recurse -Force
 #Remove-Item "@mui" -Recurse -Force # ~71MB
 #Remove-Item typescript -Recurse -Force # ~63MB
 
-# Remove `packages/gui/node_modules/@chia-network` because it causes an error on later `electron-packager` command
+# Remove `packages/gui/node_modules/@chia-network` to save cache space
 #Remove-Item "@chia-network" -Recurse -Force

--- a/build_scripts/build_windows-1-gui.ps1
+++ b/build_scripts/build_windows-1-gui.ps1
@@ -34,6 +34,9 @@ If ($LastExitCode -gt 0){
 # it can't find workspace packages that are removed below for cache optimization.
 Write-Output "Clearing dependencies from packages/gui/package.json for electron-builder"
 node -e "const fs = require('fs'); const p = JSON.parse(fs.readFileSync('./packages/gui/package.json', 'utf8')); p.dependencies = {}; fs.writeFileSync('./packages/gui/package.json', JSON.stringify(p, null, 2) + '\n');"
+If ($LastExitCode -gt 0){
+    Throw "Failed to clear dependencies from packages/gui/package.json"
+}
 
 # Remove unused packages
 Remove-Item node_modules -Recurse -Force


### PR DESCRIPTION
## Summary

- Fix all 6 installer build failures (macOS DMG, Windows EXE, Linux DEB/RPM) caused by electron-builder v26.7.0's new `TraversalNodeModulesCollector`
- Clear production `dependencies` from `packages/gui/package.json` after the GUI build completes, before the node_modules cleanup runs

## Problem

electron-builder v26.7.0 introduced a `TraversalNodeModulesCollector` that manually walks `node_modules` to resolve the dependency tree. The Phase 1 GUI build scripts aggressively clean up `node_modules` and workspace packages for CI cache optimization:

```
rm -rf node_modules                  # root node_modules removed entirely
rm -rf packages/api packages/api-react packages/core packages/icons packages/wallets
rm -rf "@chia-network"               # from packages/gui/node_modules
rm -rf "@mui"                        # from packages/gui/node_modules
```

When Phase 2 runs electron-builder, the collector reads `packages/gui/package.json`, finds `@chia-network/api` listed in `dependencies`, looks for it in `node_modules`, and fails:

```
⨯ production dependency not found  parent=@chia-network/gui dependency=@chia-network/api version=1.0.0
⨯ Production dependency @chia-network/api not found for package @chia-network/gui
```

## Fix

After `npm run build` completes in each Phase 1 build script, clear the `dependencies` field from `packages/gui/package.json` so the collector finds nothing to resolve:

```js
node -e "
  const fs = require('fs');
  const p = JSON.parse(fs.readFileSync('./packages/gui/package.json', 'utf8'));
  p.dependencies = {};
  fs.writeFileSync('./packages/gui/package.json', JSON.stringify(p, null, 2) + '\n');
"
```

This is safe because:
- Webpack has already bundled all JS into `build/` by this point
- The electron-builder config sets `"npmRebuild": false` and excludes `node_modules` from `files`
- No production `node_modules` are included in the final installer
- `devDependencies` (including the `electron` version) are left untouched

## Files changed

- `build_scripts/build_macos-1-gui.sh`
- `build_scripts/build_linux_deb-1-gui.sh`
- `build_scripts/build_linux_rpm-1-gui.sh`
- `build_scripts/build_windows-1-gui.ps1`

## Testing

CI installer builds on all platforms (macOS intel/m1 DMG, Windows EXE, Linux amd64/arm64 DEB, Linux RPM) should pass without the `Production dependency not found` error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-platform installer build scripts and mutates `packages/gui/package.json` during CI, which could impact packaging if electron-builder assumptions change. Scope is limited to build-time behavior and should not affect runtime app code.
> 
> **Overview**
> Fixes installer build failures introduced by electron-builder v26 by **clearing `dependencies` in `packages/gui/package.json` immediately after `npm run build`** (Linux DEB/RPM, macOS, Windows).
> 
> This ensures electron-builder’s new node_modules traversal doesn’t try to resolve workspace packages that the scripts remove later for cache slimming, and updates comments around the `@chia-network` removal to reflect the new intent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 957ae10398cd74690d477ed5c8dc926ee85ec875. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->