### PR TITLE
Fix typos: accidentally (ruff.toml), partial (solver_api.py)

### DIFF
--- a/chia/solver/solver_api.py
+++ b/chia/solver/solver_api.py
@@ -36,7 +36,7 @@ class SolverAPI:
     ) -> Message | None:
         """
         Solve a V2 plot partial proof to get the full proof of space.
-        This is called by the farmer when it receives V2 parital proofs from harvester.
+        This is called by the farmer when it receives V2 partial proofs from harvester.
         """
         if not self.solver.started:
             self.log.error("Solver is not started")
@@ -47,7 +47,7 @@ class SolverAPI:
         try:
             proof = self.solver.solve(request.partial_proof, request.plot_id, request.strength, request.size)
             if proof is None:
-                self.log.warning(f"Solver returned no proof for parital {request.partial_proof.fragments[:5]}")
+                self.log.warning(f"Solver returned no proof for partial {request.partial_proof.fragments[:5]}")
                 return None
 
             self.log.debug(f"Successfully solved partial proof, returning {len(proof)} byte proof")
@@ -57,5 +57,5 @@ class SolverAPI:
             )
 
         except Exception as e:
-            self.log.error(f"Error solving parital {request.partial_proof.fragments[:5]}: {e}")
+            self.log.error(f"Error solving partial {request.partial_proof.fragments[:5]}: {e}")
             return None

--- a/ruff.toml
+++ b/ruff.toml
@@ -46,7 +46,7 @@ ignore = [
     # Ruff Specific
 
     # This code is problematic because using instantiated types as defaults is so common across the codebase.
-    # Its purpose is to prevent accidenatally assigning mutable defaults. However, this is a bit overkill for that.
+    # Its purpose is to prevent accidentally assigning mutable defaults. However, this is a bit overkill for that.
     # That being said, it would be nice to add some way to actually guard against that specific mutable default behavior.
     "RUF009", # function-call-in-dataclass-default-argument
     "RUF056", # falsy-dict-get-fallback


### PR DESCRIPTION
### Purpose:
Fix minor typos in comments and docstrings: "accidenatally" → "accidentally" in `ruff.toml`, and "parital" → "partial" (3 places) in `chia/solver/solver_api.py`. No behavior changes.

### Current Behavior:
- Comment in `ruff.toml` line 49: "accidenatally"
- In `chia/solver/solver_api.py`: "parital" in docstring and in two log messages

### New Behavior:
- Correct spelling: "accidentally" and "partial"

### Testing Notes:
- No code logic changed; comments and docstrings only.
- `ruff format` and `ruff check` unchanged for these files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to spelling corrections in a docstring, log messages, and a `ruff.toml` comment with no functional impact.
> 
> **Overview**
> Fixes minor spelling typos: replaces `parital` with `partial` in `SolverAPI.solve` docstring and log messages, and corrects `accidenatally` to `accidentally` in a `ruff.toml` comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a918c5810c3890cc632b9418f8fe4df16517150. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->