### PR TITLE
read_only_augmented_blockchain

### DIFF
--- a/chia/_tests/blockchain/test_augmented_chain.py
+++ b/chia/_tests/blockchain/test_augmented_chain.py
@@ -288,6 +288,45 @@ async def test_augmented_chain_validation_first_block_prev_hash(
 
 @pytest.mark.anyio
 @pytest.mark.limit_consensus_modes(reason="save time")
+async def test_fork_ancestry_populated_on_first_add(default_10000_blocks: list[FullBlock]) -> None:
+    """When the first block added to the augmented chain is on a fork,
+    _populate_fork_ancestry fills _height_to_hash for orphan ancestors
+    so height_to_hash returns fork hashes, not canonical ones."""
+    blocks = default_10000_blocks
+
+    underlying = InMemoryBlockchain()
+    for block in blocks[:5]:
+        underlying.add_block_record(BR(block))
+
+    # Orphan fork blocks at heights 3-4 that branch from canonical height 2.
+    # Added directly to the record cache (not the height map) to simulate orphans.
+    fork_h3 = blocks[10].header_hash
+    fork_h4 = blocks[11].header_hash
+    fork_h5 = blocks[12].header_hash
+    underlying._block_records[fork_h3] = FakeBlockRecord(uint32(3), fork_h3, blocks[2].header_hash)  # type: ignore[assignment]
+    underlying._block_records[fork_h4] = FakeBlockRecord(uint32(4), fork_h4, fork_h3)  # type: ignore[assignment]
+
+    abc = AugmentedBlockchain(underlying)
+    abc.add_extra_block(
+        blocks[12],
+        FakeBlockRecord(uint32(5), fork_h5, fork_h4),  # type: ignore[arg-type]
+    )
+
+    # Orphan heights 3-4 filled into _height_to_hash by _populate_fork_ancestry.
+    assert abc._height_to_hash[uint32(3)] == fork_h3
+    assert abc._height_to_hash[uint32(4)] == fork_h4
+    assert abc._height_to_hash[uint32(5)] == fork_h5
+
+    # height_to_hash returns correct values for all regions.
+    assert abc.height_to_hash(uint32(0)) == blocks[0].header_hash
+    assert abc.height_to_hash(uint32(2)) == blocks[2].header_hash
+    assert abc.height_to_hash(uint32(3)) == fork_h3
+    assert abc.height_to_hash(uint32(4)) == fork_h4
+    assert abc.height_to_hash(uint32(5)) == fork_h5
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(reason="save time")
 async def test_read_only_snapshot_rejects_mutation(default_10000_blocks: list[FullBlock]) -> None:
     blocks = default_10000_blocks
     underlying = InMemoryBlockchain()

--- a/chia/_tests/blockchain/test_augmented_chain.py
+++ b/chia/_tests/blockchain/test_augmented_chain.py
@@ -13,6 +13,7 @@ from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from chia._tests.util.blockchain import create_blockchain
 from chia.consensus.augmented_chain import AugmentedBlockchain, AugmentedBlockchainValidationError
 from chia.simulator.block_tools import BlockTools
+from chia.util.block_cache import BlockCache
 from chia.util.errors import Err
 
 
@@ -57,6 +58,54 @@ class NullBlockchain:
 
     async def prev_block_hash(self, header_hashes: list[bytes32]) -> list[bytes32]:
         raise KeyError("no block records in NullBlockchain")  # pragma: no cover
+
+
+class InMemoryBlockchain:
+    if TYPE_CHECKING:
+        from chia.consensus.blockchain_interface import BlocksProtocol
+
+        _protocol_check: ClassVar[BlocksProtocol] = cast("InMemoryBlockchain", None)
+
+    def __init__(self) -> None:
+        self._cache = BlockCache({})
+        self.added_blocks: set[bytes32] = set()
+
+    @property
+    def heights(self) -> dict[uint32, bytes32]:
+        return self._cache._height_to_hash
+
+    # BlocksProtocol (non-BlockRecordsProtocol methods)
+    async def lookup_block_generators(self, header_hash: bytes32, generator_refs: set[uint32]) -> dict[uint32, bytes]:
+        raise ValueError(Err.GENERATOR_REF_HAS_NO_GENERATOR)  # pragma: no cover
+
+    async def get_block_record_from_db(self, header_hash: bytes32) -> BlockRecord | None:
+        return self._cache.try_block_record(header_hash)
+
+    def add_block_record(self, block_record: BlockRecord) -> None:
+        self.added_blocks.add(block_record.header_hash)
+        self._cache.add_block(block_record)
+
+    # BlockRecordsProtocol — delegate to BlockCache
+    def try_block_record(self, header_hash: bytes32) -> BlockRecord | None:
+        return self._cache.try_block_record(header_hash)
+
+    def block_record(self, header_hash: bytes32) -> BlockRecord:
+        return self._cache.block_record(header_hash)
+
+    def height_to_block_record(self, height: uint32) -> BlockRecord:
+        return self._cache.height_to_block_record(height)
+
+    def height_to_hash(self, height: uint32) -> bytes32 | None:
+        return self._cache.height_to_hash(height)
+
+    def contains_block(self, header_hash: bytes32, height: uint32) -> bool:
+        return self._cache.contains_block(header_hash, height)
+
+    def contains_height(self, height: uint32) -> bool:
+        return self._cache.contains_height(height)
+
+    async def prev_block_hash(self, header_hashes: list[bytes32]) -> list[bytes32]:
+        return await self._cache.prev_block_hash(header_hashes)
 
 
 @dataclass
@@ -262,3 +311,112 @@ async def test_augmented_chain_validation_first_block_prev_hash(
         )
         abc2.add_extra_block(blocks[10], correct_block)  # type: ignore[arg-type]
         assert len(abc2._height_to_hash) == 1
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(reason="save time")
+async def test_remove_promoted_extra_block_cascades(default_10000_blocks: list[FullBlock]) -> None:
+    blocks = default_10000_blocks
+    underlying = InMemoryBlockchain()
+    underlying.add_block_record(BR(blocks[1]))
+    abc = AugmentedBlockchain(underlying)
+
+    abc.add_extra_block(blocks[2], BR(blocks[2]))
+    br5 = FakeBlockRecord(height=uint32(5), header_hash=blocks[5].header_hash, prev_hash=blocks[2].header_hash)
+    abc.add_extra_block(blocks[5], br5)  # type: ignore[arg-type]
+
+    underlying.heights[uint32(2)] = blocks[2].header_hash
+    underlying.heights[uint32(5)] = blocks[5].header_hash
+
+    # block 2 is now in the underlying, so removing it triggers cascade
+    abc.remove_extra_block(blocks[2].header_hash)
+
+    assert uint32(2) not in abc._height_to_hash
+    assert uint32(5) in abc._height_to_hash
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(reason="save time")
+async def test_remove_non_promoted_extra_block(default_10000_blocks: list[FullBlock]) -> None:
+    blocks = default_10000_blocks
+    underlying = InMemoryBlockchain()
+    underlying.add_block_record(BR(blocks[1]))
+    abc = AugmentedBlockchain(underlying)
+
+    abc.add_extra_block(blocks[2], BR(blocks[2]))
+
+    br5 = FakeBlockRecord(height=uint32(5), header_hash=blocks[5].header_hash, prev_hash=blocks[2].header_hash)
+    abc.add_extra_block(blocks[5], br5)  # type: ignore[arg-type]
+
+    br7 = FakeBlockRecord(height=uint32(7), header_hash=blocks[7].header_hash, prev_hash=blocks[5].header_hash)
+    abc.add_extra_block(blocks[7], br7)  # type: ignore[arg-type]
+
+    underlying.heights[uint32(5)] = blocks[5].header_hash
+    underlying.heights[uint32(7)] = blocks[7].header_hash
+
+    # block 5 is in the underlying, so cascade fires downward from height 5
+    # but stops at height 4 (gap in _height_to_hash)
+    abc.remove_extra_block(blocks[5].header_hash)
+
+    assert uint32(5) not in abc._height_to_hash
+    assert uint32(7) in abc._height_to_hash
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(reason="save time")
+async def test_read_only_snapshot_rejects_mutation(default_10000_blocks: list[FullBlock]) -> None:
+    blocks = default_10000_blocks
+    underlying = InMemoryBlockchain()
+    underlying.add_block_record(BR(blocks[1]))
+    abc = AugmentedBlockchain(underlying)
+    abc.add_extra_block(blocks[2], BR(blocks[2]))
+
+    snapshot = abc.read_only_snapshot()
+    expected_error = "Cannot mutate read-only augmented blockchain snapshot"
+
+    with pytest.raises(AugmentedBlockchainValidationError, match=expected_error):
+        snapshot.remove_extra_block(blocks[2].header_hash)
+
+    with pytest.raises(AugmentedBlockchainValidationError, match=expected_error):
+        snapshot.add_block_record(BR(blocks[0]))
+
+    br3 = FakeBlockRecord(height=uint32(3), header_hash=blocks[3].header_hash, prev_hash=blocks[2].header_hash)
+    with pytest.raises(AugmentedBlockchainValidationError, match=expected_error):
+        snapshot.add_extra_block(blocks[3], br3)  # type: ignore[arg-type]
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(reason="save time")
+async def test_read_only_snapshot_preserves_generator_lookup(default_10000_blocks: list[FullBlock]) -> None:
+    blocks = default_10000_blocks
+    underlying = InMemoryBlockchain()
+    underlying.add_block_record(BR(blocks[1]))
+    abc = AugmentedBlockchain(underlying)
+    abc.add_extra_block(blocks[2], BR(blocks[2]))
+
+    generator = blocks[2].transactions_generator
+    assert generator is not None
+    expected = {uint32(2): bytes(generator)}
+
+    snapshot = abc.read_only_snapshot()
+    assert await abc.lookup_block_generators(blocks[2].header_hash, {uint32(2)}) == expected
+    assert await snapshot.lookup_block_generators(blocks[2].header_hash, {uint32(2)}) == expected
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(reason="save time")
+async def test_read_only_snapshot_isolated_from_writer(default_10000_blocks: list[FullBlock]) -> None:
+    blocks = default_10000_blocks
+    underlying = InMemoryBlockchain()
+    underlying.add_block_record(BR(blocks[1]))
+    abc = AugmentedBlockchain(underlying)
+    abc.add_extra_block(blocks[2], BR(blocks[2]))
+
+    snapshot = abc.read_only_snapshot()
+    assert snapshot.block_record(blocks[2].header_hash) == BR(blocks[2])
+
+    br3 = FakeBlockRecord(height=uint32(3), header_hash=blocks[3].header_hash, prev_hash=blocks[2].header_hash)
+    abc.add_extra_block(blocks[3], br3)  # type: ignore[arg-type]
+    assert uint32(3) in abc._height_to_hash
+    assert uint32(3) not in snapshot._height_to_hash
+    assert snapshot.try_block_record(blocks[3].header_hash) is None

--- a/chia/_tests/blockchain/test_augmented_chain.py
+++ b/chia/_tests/blockchain/test_augmented_chain.py
@@ -60,52 +60,25 @@ class NullBlockchain:
         raise KeyError("no block records in NullBlockchain")  # pragma: no cover
 
 
-class InMemoryBlockchain:
+class InMemoryBlockchain(BlockCache):
+    """BlockCache extended with the three BlocksProtocol methods."""
+
     if TYPE_CHECKING:
         from chia.consensus.blockchain_interface import BlocksProtocol
 
         _protocol_check: ClassVar[BlocksProtocol] = cast("InMemoryBlockchain", None)
 
     def __init__(self) -> None:
-        self._cache = BlockCache({})
-        self.added_blocks: set[bytes32] = set()
+        super().__init__({})
 
-    @property
-    def heights(self) -> dict[uint32, bytes32]:
-        return self._cache._height_to_hash
-
-    # BlocksProtocol (non-BlockRecordsProtocol methods)
     async def lookup_block_generators(self, header_hash: bytes32, generator_refs: set[uint32]) -> dict[uint32, bytes]:
         raise ValueError(Err.GENERATOR_REF_HAS_NO_GENERATOR)  # pragma: no cover
 
     async def get_block_record_from_db(self, header_hash: bytes32) -> BlockRecord | None:
-        return self._cache.try_block_record(header_hash)
+        return self.try_block_record(header_hash)
 
     def add_block_record(self, block_record: BlockRecord) -> None:
-        self.added_blocks.add(block_record.header_hash)
-        self._cache.add_block(block_record)
-
-    # BlockRecordsProtocol — delegate to BlockCache
-    def try_block_record(self, header_hash: bytes32) -> BlockRecord | None:
-        return self._cache.try_block_record(header_hash)
-
-    def block_record(self, header_hash: bytes32) -> BlockRecord:
-        return self._cache.block_record(header_hash)
-
-    def height_to_block_record(self, height: uint32) -> BlockRecord:
-        return self._cache.height_to_block_record(height)
-
-    def height_to_hash(self, height: uint32) -> bytes32 | None:
-        return self._cache.height_to_hash(height)
-
-    def contains_block(self, header_hash: bytes32, height: uint32) -> bool:
-        return self._cache.contains_block(header_hash, height)
-
-    def contains_height(self, height: uint32) -> bool:
-        return self._cache.contains_height(height)
-
-    async def prev_block_hash(self, header_hashes: list[bytes32]) -> list[bytes32]:
-        return await self._cache.prev_block_hash(header_hashes)
+        self.add_block(block_record)
 
 
 @dataclass
@@ -311,55 +284,6 @@ async def test_augmented_chain_validation_first_block_prev_hash(
         )
         abc2.add_extra_block(blocks[10], correct_block)  # type: ignore[arg-type]
         assert len(abc2._height_to_hash) == 1
-
-
-@pytest.mark.anyio
-@pytest.mark.limit_consensus_modes(reason="save time")
-async def test_remove_promoted_extra_block_cascades(default_10000_blocks: list[FullBlock]) -> None:
-    blocks = default_10000_blocks
-    underlying = InMemoryBlockchain()
-    underlying.add_block_record(BR(blocks[1]))
-    abc = AugmentedBlockchain(underlying)
-
-    abc.add_extra_block(blocks[2], BR(blocks[2]))
-    br5 = FakeBlockRecord(height=uint32(5), header_hash=blocks[5].header_hash, prev_hash=blocks[2].header_hash)
-    abc.add_extra_block(blocks[5], br5)  # type: ignore[arg-type]
-
-    underlying.heights[uint32(2)] = blocks[2].header_hash
-    underlying.heights[uint32(5)] = blocks[5].header_hash
-
-    # block 2 is now in the underlying, so removing it triggers cascade
-    abc.remove_extra_block(blocks[2].header_hash)
-
-    assert uint32(2) not in abc._height_to_hash
-    assert uint32(5) in abc._height_to_hash
-
-
-@pytest.mark.anyio
-@pytest.mark.limit_consensus_modes(reason="save time")
-async def test_remove_non_promoted_extra_block(default_10000_blocks: list[FullBlock]) -> None:
-    blocks = default_10000_blocks
-    underlying = InMemoryBlockchain()
-    underlying.add_block_record(BR(blocks[1]))
-    abc = AugmentedBlockchain(underlying)
-
-    abc.add_extra_block(blocks[2], BR(blocks[2]))
-
-    br5 = FakeBlockRecord(height=uint32(5), header_hash=blocks[5].header_hash, prev_hash=blocks[2].header_hash)
-    abc.add_extra_block(blocks[5], br5)  # type: ignore[arg-type]
-
-    br7 = FakeBlockRecord(height=uint32(7), header_hash=blocks[7].header_hash, prev_hash=blocks[5].header_hash)
-    abc.add_extra_block(blocks[7], br7)  # type: ignore[arg-type]
-
-    underlying.heights[uint32(5)] = blocks[5].header_hash
-    underlying.heights[uint32(7)] = blocks[7].header_hash
-
-    # block 5 is in the underlying, so cascade fires downward from height 5
-    # but stops at height 4 (gap in _height_to_hash)
-    abc.remove_extra_block(blocks[5].header_hash)
-
-    assert uint32(5) not in abc._height_to_hash
-    assert uint32(7) in abc._height_to_hash
 
 
 @pytest.mark.anyio

--- a/chia/consensus/augmented_chain.py
+++ b/chia/consensus/augmented_chain.py
@@ -45,9 +45,6 @@ class AugmentedBlockchain:
             raise AugmentedBlockchainValidationError("Cannot mutate read-only augmented blockchain snapshot")
 
     def read_only_snapshot(self) -> AugmentedBlockchain:
-        # _underlying is shared by reference; safe because the snapshot is only
-        # used for read-only BlockRecordsProtocol calls in a single executor task
-        # while the asyncio event loop serializes mutations on the writer side.
         snapshot = AugmentedBlockchain.__new__(AugmentedBlockchain)
         snapshot._underlying = self._underlying
         snapshot._extra_blocks = self._extra_blocks.copy()
@@ -60,6 +57,20 @@ class AugmentedBlockchain:
         if eb is None:
             return None
         return eb[1]
+
+    def _populate_fork_ancestry(self, prev_hash: bytes32) -> None:
+        """Walk backward from prev_hash through orphan block records in the
+        underlying chain, filling _height_to_hash until we reach fork point."""
+        curr_hash = prev_hash
+        while True:
+            br = self._underlying.block_record(curr_hash)
+            # if common block, break,
+            if self._underlying.height_to_hash(br.height) == curr_hash:
+                break
+            self._height_to_hash[br.height] = curr_hash
+            if br.height == 0:
+                break
+            curr_hash = br.prev_hash
 
     def add_extra_block(self, block: FullBlock, block_record: BlockRecord) -> None:
         self._ensure_mutable()
@@ -83,6 +94,7 @@ class AugmentedBlockchain:
                     f"First added block's prev_hash must exist in underlying blockchain. "
                     f"Block height {block_record.height}, prev_hash {block_record.prev_hash.hex()[:16]} not found"
                 )
+            self._populate_fork_ancestry(block_record.prev_hash)
 
         self._extra_blocks[block_record.header_hash] = (block, block_record)
         self._height_to_hash[block_record.height] = block_record.header_hash

--- a/chia/consensus/augmented_chain.py
+++ b/chia/consensus/augmented_chain.py
@@ -32,11 +32,28 @@ class AugmentedBlockchain:
     _underlying: BlocksProtocol
     _extra_blocks: dict[bytes32, tuple[FullBlock, BlockRecord]]
     _height_to_hash: dict[uint32, bytes32]
+    _read_only: bool
 
     def __init__(self, underlying: BlocksProtocol) -> None:
         self._underlying = underlying
         self._extra_blocks = {}
         self._height_to_hash = {}
+        self._read_only = False
+
+    def _ensure_mutable(self) -> None:
+        if self._read_only:
+            raise AugmentedBlockchainValidationError("Cannot mutate read-only augmented blockchain snapshot")
+
+    def read_only_snapshot(self) -> AugmentedBlockchain:
+        # _underlying is shared by reference; safe because the snapshot is only
+        # used for read-only BlockRecordsProtocol calls in a single executor task
+        # while the asyncio event loop serializes mutations on the writer side.
+        snapshot = AugmentedBlockchain.__new__(AugmentedBlockchain)
+        snapshot._underlying = self._underlying
+        snapshot._extra_blocks = self._extra_blocks.copy()
+        snapshot._height_to_hash = self._height_to_hash.copy()
+        snapshot._read_only = True
+        return snapshot
 
     def _get_block_record(self, header_hash: bytes32) -> BlockRecord | None:
         eb = self._extra_blocks.get(header_hash)
@@ -45,6 +62,7 @@ class AugmentedBlockchain:
         return eb[1]
 
     def add_extra_block(self, block: FullBlock, block_record: BlockRecord) -> None:
+        self._ensure_mutable()
         if block.header_hash != block_record.header_hash:
             raise AugmentedBlockchainValidationError(
                 f"Block header hash mismatch: block={block.header_hash.hex()[:16]}, "
@@ -70,6 +88,7 @@ class AugmentedBlockchain:
         self._height_to_hash[block_record.height] = block_record.header_hash
 
     def remove_extra_block(self, hh: bytes32) -> None:
+        self._ensure_mutable()
         if hh not in self._extra_blocks:
             return
 
@@ -112,6 +131,7 @@ class AugmentedBlockchain:
         return await self._underlying.get_block_record_from_db(header_hash)
 
     def add_block_record(self, block_record: BlockRecord) -> None:
+        self._ensure_mutable()
         self._underlying.add_block_record(block_record)
         self._height_to_hash[block_record.height] = block_record.header_hash
         # now that we're adding the block to the underlying blockchain, we don't

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -272,7 +272,7 @@ async def pre_validate_block(
         pool,
         _pre_validate_block,
         constants,
-        blockchain,
+        blockchain.read_only_snapshot(),
         block,
         previous_generators,
         conds,


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
The problem without the snapshot: _pre_validate_block runs in a worker thread while the asyncio event loop continues calling pre_validate_block for subsequent blocks, which keeps mutating the augmented chain via
   add_extra_block. The worker thread would be reading from a dict that's being mutated concurrently 

  The snapshot gives each executor task a frozen copy of _extra_blocks and _height_to_hash at the point in time when that block was submitted

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus pre-validation by changing the `BlockRecordsProtocol` view passed into worker threads and by populating fork ancestry on first augment; regressions could affect block validation correctness on forks or under load.
> 
> **Overview**
> Pre-validation workers now receive a **read-only snapshot** of `AugmentedBlockchain` state (`read_only_snapshot()`), avoiding concurrent mutation of `_extra_blocks`/`_height_to_hash` while validation runs in an executor.
> 
> `AugmentedBlockchain` gains snapshot immutability enforcement (mutating methods raise `AugmentedBlockchainValidationError`) and adds `_populate_fork_ancestry()` so the first augmented block on a fork backfills orphan ancestor heights into `_height_to_hash`.
> 
> Tests are expanded to cover fork-ancestry backfill behavior and snapshot semantics (rejects mutation, preserves generator lookup, and remains isolated from subsequent writes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1641c7eae6e03be4c30aeb432f495e0e54a3dcab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->