### PR TITLE
CHIA-3952 Improve FullNodeAPI's register_for_coin_updates

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3741,3 +3741,40 @@ def test_hard_fork2_capability_on_release_branch() -> None:
     if branch is not None and branch.startswith("release/3."):
         for capabilities in default_capabilities.values():
             assert (uint16(Capability.HARD_FORK_2.value), "1") in capabilities
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_register_for_coin_updates(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools], self_hostname: str
+) -> None:
+    """
+    Covers the scenario where a peer registers for coin updates to make sure we
+    don't return coin states for coins that are not in the processed list.
+    """
+    full_node_api, server, bt = one_node_one_block
+    blocks = await full_node_api.get_all_full_blocks()
+    blocks = bt.get_consecutive_blocks(2, block_list_input=blocks)
+    for block in blocks:
+        await full_node_api.full_node.add_block(block)
+    real_coin_ids = [c.name() for c in blocks[-1].get_included_reward_coins()]
+    assert len(real_coin_ids) >= 2
+    max_subscribe_items = 42
+    full_node_api.full_node.config["max_subscribe_items"] = max_subscribe_items
+    # Place one coin within the subscription limit and the rest after it so we
+    # can verify the response only includes states for coins that fit.
+    first_coin = real_coin_ids[:1]
+    remaining_coins = real_coin_ids[1:]
+    fake_coin_ids = [bytes32.random() for _ in range(max_subscribe_items)]
+    request_ids = first_coin + fake_coin_ids + remaining_coins
+    dummy_peer, _ = await add_dummy_connection_wsc(server, self_hostname, 1337, NodeType.WALLET)
+    response = await full_node_api.register_for_coin_updates(
+        wallet_protocol.RegisterForCoinUpdates(request_ids, uint32(0)), dummy_peer
+    )
+    assert response is not None
+    assert response.type == ProtocolMessageTypes.respond_to_coin_updates.value
+    response_data = wallet_protocol.RespondToCoinUpdates.from_bytes(response.data)
+    assert len(response_data.coin_ids) == max_subscribe_items
+    assert {cs.coin.name() for cs in response_data.coin_states} == set(first_coin)
+    for coin_id in remaining_coins:
+        assert coin_id not in response_data.coin_ids

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1767,13 +1767,14 @@ class FullNodeAPI:
         # TODO: apparently we have tests that expect to receive a
         # RespondToCoinUpdates even when subscribing to the same coin multiple
         # times, so we can't optimize away such DB lookups (yet)
-        self.full_node.subscriptions.add_coin_subscriptions(peer.peer_node_id, request.coin_ids, max_subscriptions)
+        coin_ids = request.coin_ids[:max_subscriptions]
+        self.full_node.subscriptions.add_coin_subscriptions(peer.peer_node_id, coin_ids, max_subscriptions)
 
         states: list[CoinState] = await self.full_node.coin_store.get_coin_states_by_ids(
-            include_spent_coins=True, coin_ids=set(request.coin_ids), min_height=request.min_height, max_items=max_items
+            include_spent_coins=True, coin_ids=set(coin_ids), min_height=request.min_height, max_items=max_items
         )
 
-        response = wallet_protocol.RespondToCoinUpdates(request.coin_ids, request.min_height, states)
+        response = wallet_protocol.RespondToCoinUpdates(coin_ids, request.min_height, states)
         msg = make_msg(ProtocolMessageTypes.respond_to_coin_updates, response)
         return msg
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes FullNodeAPI wallet protocol behavior by truncating requested coin IDs to `max_subscriptions`, which may affect wallets that relied on receiving responses for over-limit requests. Logic is small but touches subscription and DB query paths used by peers.
> 
> **Overview**
> `register_for_coin_updates` now enforces the peer’s `max_subscriptions` limit by truncating `request.coin_ids` before adding subscriptions, querying coin states, and building `RespondToCoinUpdates`, preventing coin states from being returned for IDs beyond the processed/subscribed set.
> 
> Adds a regression test (`test_register_for_coin_updates`) to ensure the response includes only the limited set of `coin_ids` and only returns `CoinState`s for coins within that limit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 610797b236464f5d81ef3305d4a3c0bd8952c2f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->