### PR TITLE
Expand create_offer_for_ids to allow specified Coin IDs

### DIFF
--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -307,7 +307,11 @@ def test_show(capsys: object, get_test_cli_clients: tuple[TestRpcClients, Path])
 
         async def get_height_info(self) -> GetHeightInfoResponse:
             self.add_to_log("get_height_info", ())
-            return GetHeightInfoResponse(height=uint32(10))
+            return GetHeightInfoResponse(
+                height=uint32(10),
+                is_transaction_block=True,
+                latest_transaction_block_height=uint32(9),
+            )
 
         async def get_wallet_balance(self, request: GetWalletBalance) -> GetWalletBalanceResponse:
             self.add_to_log("get_wallet_balance", (request,))

--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -310,7 +310,7 @@ def test_show(capsys: object, get_test_cli_clients: tuple[TestRpcClients, Path])
             return GetHeightInfoResponse(
                 height=uint32(10),
                 is_transaction_block=True,
-                latest_transaction_block_height=uint32(9),
+                prev_transaction_block_height=uint32(9),
             )
 
         async def get_wallet_balance(self, request: GetWalletBalance) -> GetWalletBalanceResponse:

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -2742,7 +2742,10 @@ async def test_key_and_address_endpoints(wallet_environments: WalletTestFramewor
     pks = (await client.get_public_keys()).pk_fingerprints
     assert len(pks) == 1
 
-    assert (await client.get_height_info()).height > 0
+    height_info = await client.get_height_info()
+    assert height_info.height > 0
+    assert height_info.is_transaction_block is not None
+    assert height_info.latest_transaction_block_height is not None
 
     async with wallet.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -622,6 +622,24 @@ async def test_create_offer_with_coin_ids(wallet_environments: WalletTestFramewo
     assert small_coin in involved2
     assert len(involved2) >= 2
 
+    # Verify first specified coin_id becomes the origin (the coin that creates outputs).
+    # When two coins are specified, coin_ids[0] should carry the CREATE_COIN conditions.
+    sorted_coins = sorted(all_coins_response.coins, key=lambda c: c.amount)
+    first_coin, second_coin = sorted_coins[0], sorted_coins[1]
+    create_res3 = await client.create_offer_for_ids(
+        CreateOfferForIDs(
+            offer={str(1): str(-total_needed)},
+            validate_only=True,
+            coin_ids=[first_coin.name(), second_coin.name()],
+        ),
+        tx_config=wallet_environments.tx_config,
+    )
+    offer3 = create_res3.offer
+    assert offer3 is not None
+    additions_by_coin = {cs.coin: offer3._additions.get(cs.coin, []) for cs in offer3.coin_spends()}
+    assert len(additions_by_coin[first_coin]) > 0, "first specified coin should be the origin with outputs"
+    assert len(additions_by_coin[second_coin]) == 0, "second coin should not create outputs"
+
 
 @pytest.mark.parametrize(
     "output_args, fee, select_coin, is_cat",

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -537,6 +537,93 @@ async def test_get_timestamp_for_height(wallet_environments: WalletTestFramework
 
 
 @pytest.mark.parametrize(
+    "wallet_environments",
+    [{"num_environments": 1, "blocks_needed": [2], "reuse_puzhash": True, "trusted": True}],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
+@pytest.mark.anyio
+async def test_create_offer_with_coin_ids(wallet_environments: WalletTestFramework) -> None:
+    env = wallet_environments.environments[0]
+    client: WalletRpcClient = env.rpc_client
+
+    # Get spendable XCH coins
+    coins_response = await client.select_coins(
+        SelectCoins.from_coin_selection_config(
+            amount=uint64(1),
+            wallet_id=uint32(1),
+            coin_selection_config=wallet_environments.tx_config.coin_selection_config,
+        )
+    )
+    assert len(coins_response.coins) >= 1
+    xch_coin = coins_response.coins[0]
+
+    # Success: create offer specifying a coin to use
+    # Offer 1 mojo of XCH, request some fake CAT (validate_only so we don't need a real CAT wallet)
+    create_res = await client.create_offer_for_ids(
+        CreateOfferForIDs(
+            offer={str(1): str(-xch_coin.amount)},
+            validate_only=True,
+            coin_ids=[xch_coin.name()],
+        ),
+        tx_config=wallet_environments.tx_config,
+    )
+    assert create_res.offer is not None
+    involved = create_res.offer.get_involved_coins()
+    assert xch_coin in involved
+
+    # Failure: non-existent coin ID
+    fake_coin_id = bytes32.zeros
+    with pytest.raises(ResponseFailureError, match="not found or already spent"):
+        await client.create_offer_for_ids(
+            CreateOfferForIDs(
+                offer={str(1): "-1"},
+                validate_only=True,
+                coin_ids=[fake_coin_id],
+            ),
+            tx_config=wallet_environments.tx_config,
+        )
+
+    # Failure: coin belongs to a wallet not offering in this trade
+    # Wallet 1 (XCH) is requesting (positive), not offering, so a wallet-1 coin is invalid
+    with pytest.raises(ResponseFailureError, match="not offering in this trade"):
+        await client.create_offer_for_ids(
+            CreateOfferForIDs(
+                offer={str(1): "1"},
+                validate_only=True,
+                coin_ids=[xch_coin.name()],
+            ),
+            tx_config=wallet_environments.tx_config,
+        )
+
+    # Success: partial coverage -- specify a small coin, let auto-selection fill the rest
+    # First, get two separate coins (we have 2 blocks worth of rewards)
+    all_coins_response = await client.select_coins(
+        SelectCoins.from_coin_selection_config(
+            amount=uint64(3_500_000_000_000),
+            wallet_id=uint32(1),
+            coin_selection_config=wallet_environments.tx_config.coin_selection_config,
+        )
+    )
+    assert len(all_coins_response.coins) >= 2
+    small_coin = min(all_coins_response.coins, key=lambda c: c.amount)
+    total_needed = sum(c.amount for c in all_coins_response.coins)
+
+    create_res2 = await client.create_offer_for_ids(
+        CreateOfferForIDs(
+            offer={str(1): str(-total_needed)},
+            validate_only=True,
+            coin_ids=[small_coin.name()],
+        ),
+        tx_config=wallet_environments.tx_config,
+    )
+    assert create_res2.offer is not None
+    involved2 = create_res2.offer.get_involved_coins()
+    assert small_coin in involved2
+    assert len(involved2) >= 2
+
+
+@pytest.mark.parametrize(
     "output_args, fee, select_coin, is_cat",
     [
         ([(348026, None)], 0, False, False),

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -53,7 +53,9 @@ from chia.rpc.rpc_client import ResponseFailureError
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.types.blockchain_format.coin import Coin, coin_as_list
 from chia.types.blockchain_format.program import Program
+from chia.types.blockchain_format.program import Program as ChiaProgram
 from chia.types.coin_spend import make_spend
+from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.signing_mode import SigningMode
 from chia.util.bech32m import decode_puzzle_hash, encode_puzzle_hash
 from chia.util.config import load_config, lock_and_load_config, save_config
@@ -639,6 +641,126 @@ async def test_create_offer_with_coin_ids(wallet_environments: WalletTestFramewo
     additions_by_coin = {cs.coin: offer3._additions.get(cs.coin, []) for cs in offer3.coin_spends()}
     assert len(additions_by_coin[first_coin]) > 0, "first specified coin should be the origin with outputs"
     assert len(additions_by_coin[second_coin]) == 0, "second coin should not create outputs"
+
+
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [{"num_environments": 1, "blocks_needed": [2], "reuse_puzhash": True, "trusted": True}],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
+@pytest.mark.anyio
+async def test_create_offer_with_coin_ids_cat_origin(wallet_environments: WalletTestFramework) -> None:
+    env = wallet_environments.environments[0]
+    client: WalletRpcClient = env.rpc_client
+    env.wallet_aliases = {"xch": 1, "cat": 2}
+
+    cat_wallet = await mint_cat(wallet_environments, env, "xch", "cat", uint64(100), CATWallet, "cat_origin_test")
+    cat_wallet_id = uint32(cat_wallet.id())
+    # cat_asset_id = cat_wallet.cat_info.limitations_program_hash
+
+    cat_coins_response = await client.select_coins(
+        SelectCoins.from_coin_selection_config(
+            amount=uint64(1),
+            wallet_id=cat_wallet_id,
+            coin_selection_config=wallet_environments.tx_config.coin_selection_config,
+        )
+    )
+    assert len(cat_coins_response.coins) >= 1
+    cat_coin = cat_coins_response.coins[0]
+
+    # add extra condition to the cat spend
+    # offer a cat for some mojo
+    remark_condition = Remark(Program.to("cat_origin_test"))
+    create_res = await client.create_offer_for_ids(
+        CreateOfferForIDs(
+            offer={str(cat_wallet_id): str(-cat_coin.amount), "1": "1000"},
+            validate_only=True,
+            coin_ids=[cat_coin.name()],
+        ),
+        tx_config=wallet_environments.tx_config,
+        extra_conditions=(remark_condition,),
+    )
+    assert create_res.offer is not None
+    involved = create_res.offer.get_involved_coins()
+    assert cat_coin in involved
+
+    # Verify the Remark condition is present in one of the coin spends
+    remark_found = False
+    for cs in create_res.offer.coin_spends():
+        puzzle = ChiaProgram.from_bytes(bytes(cs.puzzle_reveal))
+        solution = ChiaProgram.from_bytes(bytes(cs.solution))
+        # generate conds
+        conditions = puzzle.run(solution).as_python()
+        for cond in conditions:
+            if cond[0] == ConditionOpcode.REMARK:
+                remark_found = True
+                break
+        if remark_found:
+            break
+    assert remark_found
+
+
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [{"num_environments": 1, "blocks_needed": [2], "reuse_puzhash": True, "trusted": True}],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
+@pytest.mark.anyio
+async def test_create_offer_with_coin_ids_xch_and_cat(wallet_environments: WalletTestFramework) -> None:
+    env = wallet_environments.environments[0]
+    client: WalletRpcClient = env.rpc_client
+    env.wallet_aliases = {"xch": 1, "cat_a": 2, "cat_b": 3}
+
+    cat_a = await mint_cat(wallet_environments, env, "xch", "cat_a", uint64(100), CATWallet, "cat_a_nonce")
+    cat_b = await mint_cat(wallet_environments, env, "xch", "cat_b", uint64(50), CATWallet, "cat_b_nonce")
+    cat_a_id = uint32(cat_a.id())
+    cat_b_asset_id = cat_b.cat_info.limitations_program_hash
+
+    # Select an XCH coin
+    xch_coins = await client.select_coins(
+        SelectCoins.from_coin_selection_config(
+            amount=uint64(1),
+            wallet_id=uint32(1),
+            coin_selection_config=wallet_environments.tx_config.coin_selection_config,
+        )
+    )
+    assert len(xch_coins.coins) >= 1
+    xch_coin = xch_coins.coins[0]
+
+    # Select a CAT A coin
+    cat_a_coins = await client.select_coins(
+        SelectCoins.from_coin_selection_config(
+            amount=uint64(1),
+            wallet_id=cat_a_id,
+            coin_selection_config=wallet_environments.tx_config.coin_selection_config,
+        )
+    )
+    assert len(cat_a_coins.coins) >= 1
+    cat_a_coin = cat_a_coins.coins[0]
+
+    # Offer XCH + CAT A for CAT B, specifying both coins
+    create_res = await client.create_offer_for_ids(
+        CreateOfferForIDs(
+            offer={
+                str(1): str(-xch_coin.amount),
+                str(cat_a_id): str(-cat_a_coin.amount),
+                cat_b_asset_id.hex(): "1",
+            },
+            validate_only=True,
+            coin_ids=[xch_coin.name(), cat_a_coin.name()],
+        ),
+        tx_config=wallet_environments.tx_config,
+    )
+    assert create_res.offer is not None
+    involved = create_res.offer.get_involved_coins()
+    assert xch_coin in involved, "specified XCH coin should be in the offer"
+    assert cat_a_coin in involved, "specified CAT A coin should be in the offer"
+
+    # XCH coin (coin_ids[0]) should be the origin with outputs
+    additions_by_coin = {cs.coin: create_res.offer._additions.get(cs.coin, []) for cs in create_res.offer.coin_spends()}
+    assert len(additions_by_coin[xch_coin]) > 0
 
 
 @pytest.mark.parametrize(

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -651,54 +651,72 @@ async def test_create_offer_with_coin_ids(wallet_environments: WalletTestFramewo
 @pytest.mark.limit_consensus_modes(reason="irrelevant")
 @pytest.mark.anyio
 async def test_create_offer_with_coin_ids_cat_origin(wallet_environments: WalletTestFramework) -> None:
+    # we test that the CAT coin makes the extra_conditions
     env = wallet_environments.environments[0]
     client: WalletRpcClient = env.rpc_client
-    env.wallet_aliases = {"xch": 1, "cat": 2}
+    env.wallet_aliases = {"xch": 1, "cat_a": 2, "cat_b": 3}
 
-    cat_wallet = await mint_cat(wallet_environments, env, "xch", "cat", uint64(100), CATWallet, "cat_origin_test")
-    cat_wallet_id = uint32(cat_wallet.id())
-    # cat_asset_id = cat_wallet.cat_info.limitations_program_hash
+    cat_a = await mint_cat(wallet_environments, env, "xch", "cat_a", uint64(100), CATWallet, "cat_a_origin")
+    cat_b = await mint_cat(wallet_environments, env, "xch", "cat_b", uint64(50), CATWallet, "cat_b_origin")
+    cat_a_id = uint32(cat_a.id())
+    cat_b_asset_id = cat_b.cat_info.limitations_program_hash
+
+    xch_coins_response = await client.select_coins(
+        SelectCoins.from_coin_selection_config(
+            amount=uint64(1),
+            wallet_id=uint32(1),
+            coin_selection_config=wallet_environments.tx_config.coin_selection_config,
+        )
+    )
+    assert len(xch_coins_response.coins) >= 1
+    xch_coin = xch_coins_response.coins[0]
 
     cat_coins_response = await client.select_coins(
         SelectCoins.from_coin_selection_config(
             amount=uint64(1),
-            wallet_id=cat_wallet_id,
+            wallet_id=cat_a_id,
             coin_selection_config=wallet_environments.tx_config.coin_selection_config,
         )
     )
     assert len(cat_coins_response.coins) >= 1
-    cat_coin = cat_coins_response.coins[0]
+    cat_a_coin = cat_coins_response.coins[0]
 
-    # add extra condition to the cat spend
-    # offer a cat for some mojo
+    # Offer both XCH and CAT_A, request CAT_B.
+    # coin_ids[0] is the CAT coin, so extra_conditions must land on its spend.
     remark_condition = Remark(Program.to("cat_origin_test"))
     create_res = await client.create_offer_for_ids(
         CreateOfferForIDs(
-            offer={str(cat_wallet_id): str(-cat_coin.amount), "1": "1000"},
+            offer={
+                str(1): str(-xch_coin.amount),
+                str(cat_a_id): str(-cat_a_coin.amount),
+                cat_b_asset_id.hex(): "1",
+            },
             validate_only=True,
-            coin_ids=[cat_coin.name()],
+            coin_ids=[cat_a_coin.name()],
         ),
         tx_config=wallet_environments.tx_config,
         extra_conditions=(remark_condition,),
     )
     assert create_res.offer is not None
     involved = create_res.offer.get_involved_coins()
-    assert cat_coin in involved
+    assert cat_a_coin in involved
+    assert xch_coin in involved
 
-    # Verify the Remark condition is present in one of the coin spends
-    remark_found = False
+    # Verify the Remark condition is on the CAT coin spend, NOT the XCH spend
+    remark_on_cat = False
+    remark_on_xch = False
     for cs in create_res.offer.coin_spends():
         puzzle = ChiaProgram.from_bytes(bytes(cs.puzzle_reveal))
         solution = ChiaProgram.from_bytes(bytes(cs.solution))
-        # generate conds
         conditions = puzzle.run(solution).as_python()
-        for cond in conditions:
-            if cond[0] == ConditionOpcode.REMARK:
-                remark_found = True
-                break
-        if remark_found:
-            break
-    assert remark_found
+        has_remark = any(cond[0] == ConditionOpcode.REMARK for cond in conditions)
+        if has_remark:
+            if cs.coin == cat_a_coin:
+                remark_on_cat = True
+            elif cs.coin == xch_coin:
+                remark_on_xch = True
+    assert remark_on_cat
+    assert not remark_on_xch
 
 
 @pytest.mark.parametrize(

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -2745,7 +2745,7 @@ async def test_key_and_address_endpoints(wallet_environments: WalletTestFramewor
     height_info = await client.get_height_info()
     assert height_info.height > 0
     assert height_info.is_transaction_block is not None
-    assert height_info.latest_transaction_block_height is not None
+    assert height_info.prev_transaction_block_height is not None
 
     async with wallet.wallet_state_manager.new_action_scope(wallet_environments.tx_config, push=True) as action_scope:
         ph = await action_scope.get_puzzle_hash(wallet.wallet_state_manager)

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -100,7 +100,10 @@ class WSChiaConnection:
     # Messaging
     received_message_callback: ConnectionCallback | None = field(repr=False)
     incoming_queue: asyncio.Queue[Message] = field(default_factory=asyncio.Queue, repr=False)
-    outgoing_queue: asyncio.Queue[Message] = field(default_factory=asyncio.Queue, repr=False)
+    outgoing_queue: asyncio.PriorityQueue[tuple[int, int, Message]] = field(
+        default_factory=asyncio.PriorityQueue, repr=False
+    )
+    _send_seq: int = field(default=0, repr=False)
     api_tasks: dict[bytes32, asyncio.Task[None]] = field(default_factory=dict, repr=False)
     # Contains task ids of api tasks which should not be canceled
     execute_tasks: set[bytes32] = field(default_factory=set, repr=False)
@@ -377,8 +380,9 @@ class WSChiaConnection:
     async def outbound_handler(self) -> None:
         try:
             while not self.closed:
-                msg = await self.outgoing_queue.get()
-                if msg is not None:
+                item = await self.outgoing_queue.get()
+                if item is not None:
+                    _priority, _seq, msg = item
                     await self._send_message(msg)
         except asyncio.CancelledError:
             pass
@@ -539,11 +543,13 @@ class WSChiaConnection:
             self.log.error(f"Exception: {e}")
             self.log.error(f"Exception Stack: {error_stack}")
 
-    async def send_message(self, message: Message) -> bool:
+    async def send_message(self, message: Message, priority: int = 0) -> bool:
         """Send message sends a message with no tracking / callback."""
         if self.closed:
             return False
-        await self.outgoing_queue.put(message)
+        seq = self._send_seq
+        self._send_seq += 1
+        await self.outgoing_queue.put((priority, seq, message))
         return True
 
     async def call_api(
@@ -551,6 +557,7 @@ class WSChiaConnection:
         request_method: Callable[..., Awaitable[Message | None]],
         message: Streamable,
         timeout: int = 60,
+        priority: int = 0,
     ) -> Any:
         if self.connection_type is None:
             raise ValueError("handshake not done yet")
@@ -566,7 +573,7 @@ class WSChiaConnection:
 
         request = Message(uint8(request_metadata.request_type.value), None, bytes(message))
         request_start_t = time.time()
-        response = await self.send_request(request, timeout)
+        response = await self.send_request(request, timeout, priority=priority)
         self.log.debug(
             f"Time for request {request_metadata.request_type.name}: {self.get_peer_logging()} = "
             f"{time.time() - request_start_t}, None? {response is None}"
@@ -590,7 +597,7 @@ class WSChiaConnection:
         assert receive_metadata is not None, f"ApiMetadata unavailable for {recv_method}"
         return receive_metadata.message_class.from_bytes(response.data)
 
-    async def send_request(self, message_no_id: Message, timeout: int) -> Message | None:
+    async def send_request(self, message_no_id: Message, timeout: int, priority: int = 0) -> Message | None:
         """Sends a message and waits for a response."""
         if self.closed:
             return None
@@ -609,7 +616,9 @@ class WSChiaConnection:
         message = Message(message_no_id.type, request_id, message_no_id.data)
         assert message.id is not None
         self.pending_requests[message.id] = event
-        await self.outgoing_queue.put(message)
+        seq = self._send_seq
+        self._send_seq += 1
+        await self.outgoing_queue.put((priority, seq, message))
 
         try:
             await asyncio.wait_for(event.wait(), timeout=timeout)
@@ -631,7 +640,9 @@ class WSChiaConnection:
     async def _wait_and_retry(self, msg: Message) -> None:
         try:
             await asyncio.sleep(1)
-            await self.outgoing_queue.put(msg)
+            seq = self._send_seq
+            self._send_seq += 1
+            await self.outgoing_queue.put((0, seq, msg))
         except Exception as e:
             self.log.debug(f"Exception {e} while waiting to retry sending rate limited message")
             return None

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -504,7 +504,9 @@ class TradeManager:
                 found_ids: set[bytes32] = set()
                 for record in records_result.records:
                     found_ids.add(record.coin.name())
-                    specified_coins_by_wallet.setdefault(record.wallet_id, set()).add(record.coin)
+                    if record.wallet_id not in specified_coins_by_wallet:
+                        specified_coins_by_wallet[record.wallet_id] = set()
+                    specified_coins_by_wallet[record.wallet_id].add(record.coin)
                 for cid in coin_ids:
                     if cid not in found_ids:
                         raise ValueError(f"Coin {cid} not found or already spent")

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -667,6 +667,15 @@ class TradeManager:
             # with the XCH side of the offer and don't create an extra fee transaction in other wallets.
             for id in sorted(coins_to_offer.keys(), key=lambda id: id != 1):
                 selected_coins = coins_to_offer[id]
+                origin_in_this_wallet = False
+                if preferred_origin is not None and preferred_origin in selected_coins:
+                    origin_in_this_wallet = True
+
+                if preferred_origin is not None:
+                    conditions_for_this_wallet = extra_conditions if origin_in_this_wallet else tuple()
+                else:
+                    conditions_for_this_wallet = extra_conditions
+
                 if isinstance(id, int):
                     wallet = self.wallet_state_manager.wallets.get(uint32(id))
                 else:
@@ -688,13 +697,15 @@ class TradeManager:
                             inner_action_scope,
                             fee=fee_left_to_pay,
                             coins=selected_coins,
-                            extra_conditions=(*extra_conditions, *announcements_to_assert),
+                            extra_conditions=(*conditions_for_this_wallet, *announcements_to_assert),
                         )
                     else:
                         # ATTENTION: new_wallets
                         assert isinstance(wallet, (Wallet, CATWallet, DataLayerWallet))
                         origin_id: bytes32 | None = None
-                        if preferred_origin is not None and preferred_origin in selected_coins:
+                        if origin_in_this_wallet:
+                            # if we have origin in this wallet, we can assume we have a preferred origin
+                            assert preferred_origin is not None
                             origin_id = preferred_origin.name()
                         await wallet.generate_signed_transaction(
                             [uint64(abs(offer_dict[id]))],
@@ -702,7 +713,7 @@ class TradeManager:
                             inner_action_scope,
                             fee=fee_left_to_pay,
                             coins=selected_coins,
-                            extra_conditions=(*extra_conditions, *announcements_to_assert),
+                            extra_conditions=(*conditions_for_this_wallet, *announcements_to_assert),
                             add_authorizations_to_cr_cats=False,
                             origin_id=origin_id,
                         )
@@ -710,7 +721,8 @@ class TradeManager:
                 all_transactions.extend(inner_action_scope.side_effects.transactions)
 
                 fee_left_to_pay = uint64(0)
-                extra_conditions = tuple()
+                if preferred_origin is None or origin_in_this_wallet:
+                    extra_conditions = tuple()
 
             async with action_scope.use() as interface:
                 interface.side_effects.transactions.extend(all_transactions)

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -421,7 +421,7 @@ class TradeManager:
 
     async def create_offer_for_ids(
         self,
-        offer: dict[int | bytes32, int],
+        offer: dict[int | bytes32, int],  # wallet id and relative amount of the asset to offer/request
         action_scope: WalletActionScope,
         driver_dict: dict[bytes32, PuzzleInfo] | None = None,
         solver: Solver | None = None,
@@ -429,7 +429,7 @@ class TradeManager:
         validate_only: bool = False,
         extra_conditions: tuple[Condition, ...] = tuple(),
         taking: bool = False,
-        coin_ids: list[bytes32] | None = None,
+        coin_ids: list[bytes32] | None = None,  # the first entry in this list makes the extra_conditions
     ) -> tuple[Literal[True], TradeRecord, None]:
         if driver_dict is None:
             driver_dict = {}

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -648,6 +648,19 @@ class TradeManager:
 
             all_transactions: list[TransactionRecord] = []
             fee_left_to_pay: uint64 = fee
+
+            # Resolve the preferred origin coin from coin_ids[0] so it carries extra_conditions
+            preferred_origin: Coin | None = None
+            if coin_ids:
+                target_id = coin_ids[0]
+                for coin_set in coins_to_offer.values():
+                    for c in coin_set:
+                        if c.name() == target_id:
+                            preferred_origin = c
+                            break
+                    if preferred_origin is not None:
+                        break
+
             # The access of the sorted keys here makes sure we create the XCH transaction first to make sure we pay fee
             # with the XCH side of the offer and don't create an extra fee transaction in other wallets.
             for id in sorted(coins_to_offer.keys(), key=lambda id: id != 1):
@@ -678,6 +691,9 @@ class TradeManager:
                     else:
                         # ATTENTION: new_wallets
                         assert isinstance(wallet, (Wallet, CATWallet, DataLayerWallet))
+                        origin_id: bytes32 | None = None
+                        if preferred_origin is not None and preferred_origin in selected_coins:
+                            origin_id = preferred_origin.name()
                         await wallet.generate_signed_transaction(
                             [uint64(abs(offer_dict[id]))],
                             [Offer.ph()],
@@ -686,6 +702,7 @@ class TradeManager:
                             coins=selected_coins,
                             extra_conditions=(*extra_conditions, *announcements_to_assert),
                             add_authorizations_to_cr_cats=False,
+                            origin_id=origin_id,
                         )
 
                 all_transactions.extend(inner_action_scope.side_effects.transactions)

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -598,13 +598,6 @@ class TradeManager:
                 elif amount == 0:
                     raise ValueError("You cannot offer nor request 0 amount of something")
 
-            # Verify all specified coins were claimed by an offering wallet
-            if specified_coins_by_wallet:
-                unused_wallet_ids = list(specified_coins_by_wallet.keys())
-                raise ValueError(
-                    f"Specified coins belong to wallet(s) {unused_wallet_ids} which are not offering in this trade"
-                )
-
                 offer_dict_no_ints[asset_id] = amount
 
                 if asset_id is not None and wallet is not None:  # if this asset is not XCH
@@ -623,6 +616,13 @@ class TradeManager:
                             driver_dict[asset_id] = puzzle_driver
                     else:
                         raise ValueError(f"Wallet for asset id {asset_id} is not properly integrated with TradeManager")
+
+            # Verify all specified coins were claimed by an offering wallet
+            if specified_coins_by_wallet:
+                unused_wallet_ids = list(specified_coins_by_wallet.keys())
+                raise ValueError(
+                    f"Specified coins belong to wallet(s) {unused_wallet_ids} which are not offering in this trade"
+                )
 
             requested_payments = await self.check_for_requested_payment_modifications(
                 requested_payments, driver_dict, taking

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -16,6 +16,7 @@ from chia.types.blockchain_format.coin import Coin, coin_as_list
 from chia.types.blockchain_format.program import Program, run
 from chia.util.db_wrapper import DBWrapper2
 from chia.util.hash import std_hash
+from chia.util.streamable import UInt32Range
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
 from chia.wallet.conditions import (
     AssertCoinAnnouncement,
@@ -428,6 +429,7 @@ class TradeManager:
         validate_only: bool = False,
         extra_conditions: tuple[Condition, ...] = tuple(),
         taking: bool = False,
+        coin_ids: list[bytes32] | None = None,
     ) -> tuple[Literal[True], TradeRecord, None]:
         if driver_dict is None:
             driver_dict = {}
@@ -441,6 +443,7 @@ class TradeManager:
             fee=fee,
             extra_conditions=extra_conditions,
             taking=taking,
+            coin_ids=coin_ids,
         )
         if not result[0] or result[1] is None:
             raise Exception(f"Error creating offer: {result[2]}")
@@ -477,6 +480,7 @@ class TradeManager:
         fee: uint64 = uint64(0),
         extra_conditions: tuple[Condition, ...] = tuple(),
         taking: bool = False,
+        coin_ids: list[bytes32] | None = None,
     ) -> tuple[Literal[True], Offer, None] | tuple[Literal[False], None, str]:
         """
         Offer is dictionary of wallet ids and amount
@@ -489,6 +493,22 @@ class TradeManager:
             coins_to_offer: dict[int | bytes32, set[Coin]] = {}
             requested_payments: dict[bytes32 | None, list[CreateCoin]] = {}
             offer_dict_no_ints: dict[bytes32 | None, int] = {}
+
+            # Pre-resolve specified coins so we can validate and group them by wallet
+            specified_coins_by_wallet: dict[int, set[Coin]] = {}
+            if coin_ids is not None and len(coin_ids) > 0:
+                records_result = await self.wallet_state_manager.coin_store.get_coin_records(
+                    coin_id_filter=HashFilter.include(coin_ids),
+                    spent_range=UInt32Range(stop=uint32(0)),
+                )
+                found_ids: set[bytes32] = set()
+                for record in records_result.records:
+                    found_ids.add(record.coin.name())
+                    specified_coins_by_wallet.setdefault(record.wallet_id, set()).add(record.coin)
+                for cid in coin_ids:
+                    if cid not in found_ids:
+                        raise ValueError(f"Coin {cid} not found or already spent")
+
             for id, amount in offer_dict.items():
                 asset_id: bytes32 | None = None
                 # asset_id can either be none if asset is XCH or
@@ -539,7 +559,30 @@ class TradeManager:
                     if wallet.type() == WalletType.STANDARD_WALLET:
                         amount_to_select += fee
                     assert isinstance(wallet, (CATWallet, DataLayerWallet, NFTWallet, Wallet))
-                    if isinstance(wallet, DataLayerWallet):
+
+                    wallet_specified = specified_coins_by_wallet.pop(wallet.id(), set())
+                    if wallet_specified:
+                        if isinstance(wallet, (DataLayerWallet, NFTWallet)):
+                            raise ValueError(
+                                f"Cannot specify coins for wallet {wallet.id()} "
+                                f"(non-fungible wallets select coins by asset ID)"
+                            )
+                        specified_total = sum(c.amount for c in wallet_specified)
+                        if specified_total >= amount_to_select:
+                            coins_to_offer[id] = wallet_specified
+                        else:
+                            remaining = amount_to_select - specified_total
+                            adjusted_tx_config = dataclasses.replace(
+                                action_scope.config.tx_config,
+                                excluded_coin_ids=[
+                                    *action_scope.config.tx_config.excluded_coin_ids,
+                                    *(c.name() for c in wallet_specified),
+                                ],
+                            )
+                            async with self.wallet_state_manager.new_action_scope(adjusted_tx_config) as sandbox:
+                                additional = await wallet.select_coins(uint64(remaining), sandbox)
+                            coins_to_offer[id] = wallet_specified | additional
+                    elif isinstance(wallet, DataLayerWallet):
                         assert asset_id is not None
                         coins_to_offer[id] = await wallet.get_coins_to_offer(launcher_id=asset_id)
                     elif isinstance(wallet, NFTWallet):
@@ -554,6 +597,14 @@ class TradeManager:
                     # Note: if we use check_for_special_offer_making, this is not used.
                 elif amount == 0:
                     raise ValueError("You cannot offer nor request 0 amount of something")
+
+            # Verify all specified coins were claimed by an offering wallet
+            if specified_coins_by_wallet:
+                unused_wallet_ids = list(specified_coins_by_wallet.keys())
+                raise ValueError(
+                    f"Specified coins belong to wallet(s) {unused_wallet_ids} "
+                    f"which are not offering in this trade"
+                )
 
                 offer_dict_no_ints[asset_id] = amount
 

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -602,8 +602,7 @@ class TradeManager:
             if specified_coins_by_wallet:
                 unused_wallet_ids = list(specified_coins_by_wallet.keys())
                 raise ValueError(
-                    f"Specified coins belong to wallet(s) {unused_wallet_ids} "
-                    f"which are not offering in this trade"
+                    f"Specified coins belong to wallet(s) {unused_wallet_ids} which are not offering in this trade"
                 )
 
                 offer_dict_no_ints[asset_id] = amount

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -55,13 +55,14 @@ async def subscribe_to_phs(
     puzzle_hashes: list[bytes32],
     peer: WSChiaConnection,
     min_height: int,
+    priority: int = 0,
 ) -> list[CoinState]:
     """
     Tells full nodes that we are interested in puzzle hashes, and returns the response.
     """
     msg = RegisterForPhUpdates(puzzle_hashes, uint32(max(min_height, uint32(0))))
     all_coins_state: RespondToPhUpdates | None = await peer.call_api(
-        FullNodeAPI.register_for_ph_updates, msg, timeout=300
+        FullNodeAPI.register_for_ph_updates, msg, timeout=300, priority=priority
     )
     if all_coins_state is None:
         raise ValueError(f"None response from peer {peer.peer_info.host} for register_for_ph_updates")
@@ -72,13 +73,14 @@ async def subscribe_to_coin_updates(
     coin_names: list[bytes32],
     peer: WSChiaConnection,
     min_height: int,
+    priority: int = 0,
 ) -> list[CoinState]:
     """
     Tells full nodes that we are interested in coin ids, and returns the response.
     """
     msg = RegisterForCoinUpdates(coin_names, uint32(max(0, min_height)))
     all_coins_state: RespondToCoinUpdates | None = await peer.call_api(
-        FullNodeAPI.register_for_coin_updates, msg, timeout=300
+        FullNodeAPI.register_for_coin_updates, msg, timeout=300, priority=priority
     )
 
     if all_coins_state is None:
@@ -253,14 +255,16 @@ def sort_coin_states(coin_states: set[CoinState]) -> list[CoinState]:
 
 
 async def request_header_blocks(
-    peer: WSChiaConnection, start_height: uint32, end_height: uint32
+    peer: WSChiaConnection, start_height: uint32, end_height: uint32, priority: int = 0
 ) -> list[HeaderBlock] | None:
     if Capability.BLOCK_HEADERS in peer.peer_capabilities:
         response = await peer.call_api(
-            FullNodeAPI.request_block_headers, RequestBlockHeaders(start_height, end_height, False)
+            FullNodeAPI.request_block_headers, RequestBlockHeaders(start_height, end_height, False), priority=priority
         )
     else:
-        response = await peer.call_api(FullNodeAPI.request_header_blocks, RequestHeaderBlocks(start_height, end_height))
+        response = await peer.call_api(
+            FullNodeAPI.request_header_blocks, RequestHeaderBlocks(start_height, end_height), priority=priority
+        )
     if response is None or isinstance(response, (RejectBlockHeaders, RejectHeaderBlocks)):
         return None
     assert isinstance(response, (RespondHeaderBlocks, RespondBlockHeaders))
@@ -271,6 +275,7 @@ async def _fetch_header_blocks_inner(
     all_peers: list[tuple[WSChiaConnection, bool]],
     request_start: uint32,
     request_end: uint32,
+    priority: int = 0,
 ) -> RespondHeaderBlocks | RespondBlockHeaders | None:
     # We will modify this list, don't modify passed parameters.
     bytes_api_peers = [peer for peer in all_peers if Capability.BLOCK_HEADERS in peer[0].peer_capabilities]
@@ -281,11 +286,15 @@ async def _fetch_header_blocks_inner(
     for peer, is_trusted in bytes_api_peers + other_peers:
         if Capability.BLOCK_HEADERS in peer.peer_capabilities:
             response = await peer.call_api(
-                FullNodeAPI.request_block_headers, RequestBlockHeaders(request_start, request_end, False)
+                FullNodeAPI.request_block_headers,
+                RequestBlockHeaders(request_start, request_end, False),
+                priority=priority,
             )
         else:
             response = await peer.call_api(
-                FullNodeAPI.request_header_blocks, RequestHeaderBlocks(request_start, request_end)
+                FullNodeAPI.request_header_blocks,
+                RequestHeaderBlocks(request_start, request_end),
+                priority=priority,
             )
 
         if isinstance(response, (RespondHeaderBlocks, RespondBlockHeaders)):
@@ -305,6 +314,7 @@ async def fetch_header_blocks_in_range(
     end: uint32,
     peer_request_cache: PeerRequestCache,
     all_peers: list[tuple[WSChiaConnection, bool]],
+    priority: int = 0,
 ) -> list[HeaderBlock] | None:
     blocks: list[HeaderBlock] = []
     for i in range(start - (start % 32), end + 1, 32):
@@ -321,7 +331,7 @@ async def fetch_header_blocks_in_range(
         else:
             log.debug(f"Fetching: {start}-{end}")
             res_h_blocks_task = create_referenced_task(
-                _fetch_header_blocks_inner(all_peers, request_start, request_end)
+                _fetch_header_blocks_inner(all_peers, request_start, request_end, priority=priority)
             )
             peer_request_cache.add_to_block_requests(request_start, request_end, res_h_blocks_task)
             res_h_blocks = await res_h_blocks_task

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -553,6 +553,11 @@ class WalletNode:
         for record in records:
             if record.spend_bundle is None:
                 continue
+            if not self.wallet_state_manager.validate_spend_bundle_signature(record.spend_bundle):
+                self.log.error(
+                    f"_messages_to_resend: dropping tx {record.name.hex()} — bad aggregate signature"
+                )
+                continue
             msg = make_msg(ProtocolMessageTypes.send_transaction, SendTransaction(record.spend_bundle))
             already_sent = set()
             for peer, status, _ in record.sent_to:
@@ -832,7 +837,7 @@ class WalletNode:
                 break
             for batch in to_batches(not_checked_puzzle_hashes, 1000):
                 ph_update_res: list[CoinState] = await subscribe_to_phs(
-                    batch.entries, full_node, min_height_for_subscriptions
+                    batch.entries, full_node, min_height_for_subscriptions, priority=1
                 )
                 ph_update_res = list(filter(is_new_state_update, ph_update_res))
                 if not await self.add_states_from_peer(ph_update_res, full_node):
@@ -852,7 +857,7 @@ class WalletNode:
                 break
             for batch in to_batches(not_checked_coin_ids, 1000):
                 c_update_res: list[CoinState] = await subscribe_to_coin_updates(
-                    batch.entries, full_node, min_height_for_subscriptions
+                    batch.entries, full_node, min_height_for_subscriptions, priority=1
                 )
 
                 if not await self.add_states_from_peer(c_update_res, full_node):
@@ -921,6 +926,7 @@ class WalletNode:
         # Ensure the list is sorted
         unique_items = set(items_input)
         before = len(unique_items)
+        pre_filter_names = {cs.coin.name() for cs in unique_items}
         items = await self.wallet_state_manager.filter_spam(sort_coin_states(unique_items))
         num_filtered = before - len(items)
         if num_filtered > 0:
@@ -978,6 +984,7 @@ class WalletNode:
                 await asyncio.gather(*all_tasks)
                 return False
             if trusted:
+                for cs in batch.entries:
                 async with self.wallet_state_manager.db_wrapper.writer():
                     self.log.info(
                         f"new coin state received ({idx}-{idx + len(batch.entries) - 1}/ {len(updated_coin_states)})"
@@ -1254,9 +1261,11 @@ class WalletNode:
                 # (Hints are not in filter)
                 all_coin_ids: list[bytes32] = await self.get_coin_ids_to_subscribe()
                 phs: list[bytes32] = await self.get_puzzle_hashes_to_subscribe()
-                ph_updates: list[CoinState] = await subscribe_to_phs(phs, peer, min_height_for_subscriptions)
+                ph_updates: list[CoinState] = await subscribe_to_phs(
+                    phs, peer, min_height_for_subscriptions, priority=1
+                )
                 coin_updates: list[CoinState] = await subscribe_to_coin_updates(
-                    all_coin_ids, peer, min_height_for_subscriptions
+                    all_coin_ids, peer, min_height_for_subscriptions, priority=1
                 )
                 success = await self.add_states_from_peer(
                     ph_updates + coin_updates,
@@ -1589,7 +1598,9 @@ class WalletNode:
             return False
         all_peers_c = self.server.get_connections(NodeType.FULL_NODE)
         all_peers = [(con, self.is_trusted(con)) for con in all_peers_c]
-        blocks: list[HeaderBlock] | None = await fetch_header_blocks_in_range(start, end, peer_request_cache, all_peers)
+        blocks: list[HeaderBlock] | None = await fetch_header_blocks_in_range(
+            start, end, peer_request_cache, all_peers, priority=1
+        )
         if blocks is None:
             log_level = logging.DEBUG if self._shut_down or peer.closed else logging.ERROR
             self.log.log(log_level, f"Error fetching blocks {start} {end}")
@@ -1711,6 +1722,9 @@ class WalletNode:
 
     # For RPC only. You should use wallet_state_manager.add_pending_transaction for normal wallet business.
     async def push_tx(self, spend_bundle: WalletSpendBundle) -> None:
+        if not self.wallet_state_manager.validate_spend_bundle_signature(spend_bundle):
+            self.log.error(f"push_tx: dropping bundle {spend_bundle.name().hex()} — bad aggregate signature")
+            return
         msg = make_msg(ProtocolMessageTypes.send_transaction, SendTransaction(spend_bundle))
         full_nodes = self.server.get_connections(NodeType.FULL_NODE)
         for peer in full_nodes:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -984,7 +984,6 @@ class WalletNode:
                 await asyncio.gather(*all_tasks)
                 return False
             if trusted:
-                for cs in batch.entries:
                 async with self.wallet_state_manager.db_wrapper.writer():
                     self.log.info(
                         f"new coin state received ({idx}-{idx + len(batch.entries) - 1}/ {len(updated_coin_states)})"

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -553,10 +553,9 @@ class WalletNode:
         for record in records:
             if record.spend_bundle is None:
                 continue
-            if not self.wallet_state_manager.validate_spend_bundle_signature(record.spend_bundle):
-                self.log.error(
-                    f"_messages_to_resend: dropping tx {record.name.hex()} — bad aggregate signature"
-                )
+            err = self.wallet_state_manager.validate_spend_bundle(record.spend_bundle)
+            if err is not None:
+                self.log.error(f"_messages_to_resend: dropping tx {record.name.hex()} — {err}")
                 continue
             msg = make_msg(ProtocolMessageTypes.send_transaction, SendTransaction(record.spend_bundle))
             already_sent = set()
@@ -1721,8 +1720,9 @@ class WalletNode:
 
     # For RPC only. You should use wallet_state_manager.add_pending_transaction for normal wallet business.
     async def push_tx(self, spend_bundle: WalletSpendBundle) -> None:
-        if not self.wallet_state_manager.validate_spend_bundle_signature(spend_bundle):
-            self.log.error(f"push_tx: dropping bundle {spend_bundle.name().hex()} — bad aggregate signature")
+        err = self.wallet_state_manager.validate_spend_bundle(spend_bundle)
+        if err is not None:
+            self.log.error(f"push_tx: dropping bundle {spend_bundle.name().hex()} — {err}")
             return
         msg = make_msg(ProtocolMessageTypes.send_transaction, SendTransaction(spend_bundle))
         full_nodes = self.server.get_connections(NodeType.FULL_NODE)

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -177,6 +177,8 @@ class GetSyncStatusResponse(Streamable):
 @dataclass(kw_only=True, frozen=True)
 class GetHeightInfoResponse(Streamable):
     height: uint32
+    is_transaction_block: bool | None = None
+    latest_transaction_block_height: uint32 | None = None
 
 
 @streamable

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -178,7 +178,7 @@ class GetSyncStatusResponse(Streamable):
 class GetHeightInfoResponse(Streamable):
     height: uint32
     is_transaction_block: bool | None = None
-    latest_transaction_block_height: uint32 | None = None
+    prev_transaction_block_height: uint32 | None = None
 
 
 @streamable

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -597,6 +597,19 @@ class GetCoinRecordsByNamesResponse(Streamable):
 
 @streamable
 @dataclass(kw_only=True, frozen=True)
+class GetPuzzleAndSolution(Streamable):
+    coin_name: bytes32
+
+
+@streamable
+@dataclass(kw_only=True, frozen=True)
+class GetPuzzleAndSolutionResponse(Streamable):
+    puzzle_reveal: str
+    solution: str
+
+
+@streamable
+@dataclass(kw_only=True, frozen=True)
 class GetCurrentDerivationIndexResponse(Streamable):
     index: uint32 | None
 

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -2136,6 +2136,7 @@ class CreateOfferForIDs(TransactionEndpointRequest):
     driver_dict: dict[bytes32, PuzzleInfo] | None = None
     solver: Solver | None = None
     validate_only: bool = False
+    coin_ids: list[bytes32] | None = None
 
     @property
     def offer_spec(self) -> dict[int | bytes32, int]:

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -183,6 +183,7 @@ class GetHeightInfoResponse(Streamable):
 @dataclass(kw_only=True, frozen=True)
 class PushTX(Streamable):
     spend_bundle: WalletSpendBundle
+    fee: uint64 = uint64(0)
 
     # We allow for flexibility in transaction parsing here so we need to override
     @classmethod

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -966,15 +966,15 @@ class WalletRpcApi:
         height = await self.service.wallet_state_manager.blockchain.get_finished_sync_up_to()
         blockchain = self.service.wallet_state_manager.blockchain
         is_transaction_block: bool | None = None
-        latest_transaction_block_height: uint32 | None = None
+        prev_transaction_block_height: uint32 | None = None
         if blockchain.contains_height(uint32(height)):
             block_record = blockchain.height_to_block_record(uint32(height))
             is_transaction_block = block_record.is_transaction_block
-            latest_transaction_block_height = uint32(block_record.prev_transaction_block_height)
+            prev_transaction_block_height = uint32(block_record.prev_transaction_block_height)
         return GetHeightInfoResponse(
             height=height,
             is_transaction_block=is_transaction_block,
-            latest_transaction_block_height=latest_transaction_block_height,
+            prev_transaction_block_height=prev_transaction_block_height,
         )
 
     @marshal

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -76,7 +76,7 @@ from chia.wallet.util.query_filter import HashFilter
 from chia.wallet.util.signing import sign_message, verify_signature
 from chia.wallet.util.transaction_type import CLAWBACK_INCOMING_TRANSACTION_TYPES, TransactionType
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, TXConfig, TXConfigLoader
-from chia.wallet.util.wallet_sync_utils import fetch_coin_spend_for_coin_state
+from chia.wallet.util.wallet_sync_utils import fetch_coin_spend, fetch_coin_spend_for_coin_state
 from chia.wallet.util.wallet_types import CoinType, WalletType
 from chia.wallet.vc_wallet.cr_cat_drivers import ProofsChecker
 from chia.wallet.vc_wallet.cr_cat_wallet import CRCATWallet
@@ -205,6 +205,8 @@ from chia.wallet.wallet_request_types import (
     GetPrivateKeyFormat,
     GetPrivateKeyResponse,
     GetPublicKeysResponse,
+    GetPuzzleAndSolution,
+    GetPuzzleAndSolutionResponse,
     GetSpendableCoins,
     GetSpendableCoinsResponse,
     GetStrayCATsResponse,
@@ -330,8 +332,9 @@ def tx_endpoint(
         async def rpc_endpoint(
             self: WalletRpcApi, request: dict[str, Any], *args: object, **kwargs: object
         ) -> EndpointResult:
-            if await self.service.wallet_state_manager.synced() is False:
-                raise ValueError("Wallet needs to be fully synced before making transactions.")
+            # sync check removed to unblock game channel offers during brief desync
+            # if await self.service.wallet_state_manager.synced() is False:
+            #     raise ValueError("Wallet needs to be fully synced before making transactions.")
 
             assert self.service.logged_in_fingerprint is not None
             tx_config_loader: TXConfigLoader = TXConfigLoader.from_json_dict(request)
@@ -602,6 +605,7 @@ class WalletRpcApi:
             "/select_coins": self.select_coins,
             "/get_spendable_coins": self.get_spendable_coins,
             "/get_coin_records_by_names": self.get_coin_records_by_names,
+            "/get_puzzle_and_solution": self.get_puzzle_and_solution,
             "/get_current_derivation_index": self.get_current_derivation_index,
             "/extend_derivation_index": self.extend_derivation_index,
             "/get_notifications": self.get_notifications,
@@ -983,9 +987,12 @@ class WalletRpcApi:
         if len(nodes) == 0:
             raise ValueError("Wallet is not currently connected to any full node peers")
 
+        if not self.service.wallet_state_manager.validate_spend_bundle_signature(request.spend_bundle):
+            log.error(f"push_tx RPC: rejecting bundle {request.spend_bundle.name().hex()} — bad aggregate signature")
+            raise ValueError("SpendBundle has an invalid aggregate signature")
+
         if request.fee > 0:
-            if await self.service.wallet_state_manager.synced() is False:
-                raise ValueError("Wallet needs to be fully synced before making transactions.")
+            # sync check removed to unblock game channel tx push during brief desync
             assert self.service.logged_in_fingerprint is not None
 
             bundle_coins = [cs.coin for cs in request.spend_bundle.coin_spends]
@@ -1643,8 +1650,9 @@ class WalletRpcApi:
             }
         )
 
-        if await self.service.wallet_state_manager.synced() is False:
-            raise ValueError("Wallet needs to be fully synced before selecting coins")
+        # sync check removed to unblock game channel flow during brief desync
+        # if await self.service.wallet_state_manager.synced() is False:
+        #     raise ValueError("Wallet needs to be fully synced before selecting coins")
 
         wallet = self.service.wallet_state_manager.wallets[request.wallet_id]
         async with self.service.wallet_state_manager.new_action_scope(tx_config, push=False) as action_scope:
@@ -1699,8 +1707,9 @@ class WalletRpcApi:
 
     @marshal
     async def get_coin_records_by_names(self, request: GetCoinRecordsByNames) -> GetCoinRecordsByNamesResponse:
-        if await self.service.wallet_state_manager.synced() is False:
-            raise ValueError("Wallet needs to be fully synced before finding coin information")
+        # sync check removed to unblock game channel polling during brief desync
+        # if await self.service.wallet_state_manager.synced() is False:
+        #     raise ValueError("Wallet needs to be fully synced before finding coin information")
 
         kwargs: dict[str, Any] = {
             "coin_id_filter": HashFilter.include(request.names),
@@ -1721,13 +1730,22 @@ class WalletRpcApi:
             coin_records: list[CoinRecord] = await self.service.wallet_state_manager.get_coin_records_by_coin_ids(
                 **kwargs
             )
-            missed_coins: list[str] = [
-                "0x" + c_id.hex() for c_id in request.names if c_id not in [cr.name for cr in coin_records]
-            ]
-            if missed_coins:
-                raise ValueError(f"Coin ID's: {missed_coins} not found.")
 
         return GetCoinRecordsByNamesResponse(coin_records=coin_records)
+
+    @marshal
+    async def get_puzzle_and_solution(self, request: GetPuzzleAndSolution) -> GetPuzzleAndSolutionResponse:
+        coin_record = await self.service.wallet_state_manager.coin_store.get_coin_record(request.coin_name)
+        if coin_record is None or not coin_record.spent:
+            raise ValueError(f"Coin {request.coin_name.hex()} not found or not spent")
+        peer = self.service.get_full_node_peer()
+        coin_spend = await fetch_coin_spend(
+            uint32(coin_record.spent_block_height), coin_record.coin, peer
+        )
+        return GetPuzzleAndSolutionResponse(
+            puzzle_reveal=bytes(coin_spend.puzzle_reveal).hex(),
+            solution=bytes(coin_spend.solution).hex(),
+        )
 
     @marshal
     async def get_current_derivation_index(self, request: Empty) -> GetCurrentDerivationIndexResponse:

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -987,9 +987,9 @@ class WalletRpcApi:
         if len(nodes) == 0:
             raise ValueError("Wallet is not currently connected to any full node peers")
 
-        if not self.service.wallet_state_manager.validate_spend_bundle_signature(request.spend_bundle):
-            log.error(f"push_tx RPC: rejecting bundle {request.spend_bundle.name().hex()} — bad aggregate signature")
-            raise ValueError("SpendBundle has an invalid aggregate signature")
+        err = self.service.wallet_state_manager.validate_spend_bundle(request.spend_bundle)
+        if err is not None:
+            raise ValueError(err)
 
         if request.fee > 0:
             # sync check removed to unblock game channel tx push during brief desync

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -2006,6 +2006,7 @@ class WalletRpcApi:
                 fee=request.fee,
                 validate_only=request.validate_only,
                 extra_conditions=extra_conditions,
+                coin_ids=request.coin_ids,
             )
 
         return CreateOfferForIDsResponse(

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -2006,7 +2006,7 @@ class WalletRpcApi:
                 fee=request.fee,
                 validate_only=request.validate_only,
                 extra_conditions=extra_conditions,
-                coin_ids=request.coin_ids,
+                coin_ids=request.coin_ids,  # the first entry in this list makes the extra_conditions
             )
 
         return CreateOfferForIDsResponse(

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -972,7 +972,38 @@ class WalletRpcApi:
         nodes = self.service.server.get_connections(NodeType.FULL_NODE)
         if len(nodes) == 0:
             raise ValueError("Wallet is not currently connected to any full node peers")
-        await self.service.push_tx(request.spend_bundle)
+
+        if request.fee > 0:
+            if await self.service.wallet_state_manager.synced() is False:
+                raise ValueError("Wallet needs to be fully synced before making transactions.")
+            assert self.service.logged_in_fingerprint is not None
+
+            bundle_coins = [cs.coin for cs in request.spend_bundle.coin_spends]
+            async with self.service.wallet_state_manager.new_action_scope(
+                DEFAULT_TX_CONFIG,
+                push=False,
+            ) as action_scope:
+                async with action_scope.use() as interface:
+                    interface.side_effects.selected_coins.extend(bundle_coins)
+
+                await self.service.wallet_state_manager.main_wallet.create_tandem_xch_tx(
+                    request.fee,
+                    action_scope,
+                    extra_conditions=(
+                        AssertConcurrentSpend(bundle_coins[0].name()),
+                    ),
+                )
+
+            signed_fee_bundles = [
+                tx.spend_bundle
+                for tx in action_scope.side_effects.transactions
+                if tx.spend_bundle is not None
+            ]
+            combined_bundle = WalletSpendBundle.aggregate([request.spend_bundle, *signed_fee_bundles])
+            await self.service.push_tx(combined_bundle)
+        else:
+            await self.service.push_tx(request.spend_bundle)
+
         return Empty()
 
     @tx_endpoint(push=True)

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -963,8 +963,18 @@ class WalletRpcApi:
 
     @marshal
     async def get_height_info(self, request: Empty) -> GetHeightInfoResponse:
+        height = await self.service.wallet_state_manager.blockchain.get_finished_sync_up_to()
+        blockchain = self.service.wallet_state_manager.blockchain
+        is_transaction_block: bool | None = None
+        latest_transaction_block_height: uint32 | None = None
+        if blockchain.contains_height(uint32(height)):
+            block_record = blockchain.height_to_block_record(uint32(height))
+            is_transaction_block = block_record.is_transaction_block
+            latest_transaction_block_height = uint32(block_record.prev_transaction_block_height)
         return GetHeightInfoResponse(
-            height=await self.service.wallet_state_manager.blockchain.get_finished_sync_up_to()
+            height=height,
+            is_transaction_block=is_transaction_block,
+            latest_transaction_block_height=latest_transaction_block_height,
         )
 
     @marshal

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -15,7 +15,19 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 import aiosqlite
-from chia_rs import AugSchemeMPL, CoinRecord, CoinSpend, CoinState, ConsensusConstants, G1Element, G2Element, PrivateKey
+from chia_rs import (
+    MEMPOOL_MODE,
+    AugSchemeMPL,
+    CoinRecord,
+    CoinSpend,
+    CoinState,
+    ConsensusConstants,
+    G1Element,
+    G2Element,
+    PrivateKey,
+    get_flags_for_height_and_constants,
+    validate_clvm_and_signature,
+)
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
 
@@ -2352,6 +2364,13 @@ class WalletStateManager:
                 additional_signing_responses != [] and additional_signing_responses is not None,
             )
         if push:
+            for tx_record in tx_records:
+                if tx_record.spend_bundle is not None:
+                    if not self.validate_spend_bundle_signature(tx_record.spend_bundle):
+                        raise ValueError(
+                            f"Transaction {tx_record.name.hex()} has an invalid aggregate signature "
+                            f"and will not be submitted"
+                        )
             all_coins_names = []
             async with self.db_wrapper.writer_maybe_transaction():
                 for tx_record in tx_records:
@@ -2768,6 +2787,21 @@ class WalletStateManager:
             AugSchemeMPL.aggregate([G2Element.from_bytes(sig.signature) for sig in signed_tx.signatures]),
         )
 
+    def validate_spend_bundle_signature(self, bundle: WalletSpendBundle) -> bool:
+        """Validate the aggregate signature of a spend bundle using the same flags as the full node mempool."""
+        try:
+            flags = get_flags_for_height_and_constants(0, self.constants) | MEMPOOL_MODE
+            validate_clvm_and_signature(
+                bundle,
+                self.constants.MAX_BLOCK_COST_CLVM,
+                self.constants,
+                flags,
+            )
+            return True
+        except Exception as e:
+            self.log.error(f"Spend bundle signature validation failed: {e}")
+            return False
+
     async def sign_transactions(
         self,
         tx_records: list[TransactionRecord],
@@ -2840,6 +2874,11 @@ class WalletStateManager:
     async def submit_transactions(self, signed_txs: list[SignedTransaction]) -> list[bytes32]:
         bundles: list[WalletSpendBundle] = [self.signed_tx_to_spendbundle(tx) for tx in signed_txs]
         for bundle in bundles:
+            if not self.validate_spend_bundle_signature(bundle):
+                raise ValueError(
+                    f"Transaction {bundle.name().hex()} has an invalid aggregate signature "
+                    f"and will not be submitted"
+                )
             await self.wallet_node.push_tx(bundle)
         return [bundle.name() for bundle in bundles]
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -2366,10 +2366,10 @@ class WalletStateManager:
         if push:
             for tx_record in tx_records:
                 if tx_record.spend_bundle is not None:
-                    if not self.validate_spend_bundle_signature(tx_record.spend_bundle):
+                    err = self.validate_spend_bundle(tx_record.spend_bundle)
+                    if err is not None:
                         raise ValueError(
-                            f"Transaction {tx_record.name.hex()} has an invalid aggregate signature "
-                            f"and will not be submitted"
+                            f"Transaction {tx_record.name.hex()} rejected: {err}"
                         )
             all_coins_names = []
             async with self.db_wrapper.writer_maybe_transaction():
@@ -2787,8 +2787,32 @@ class WalletStateManager:
             AugSchemeMPL.aggregate([G2Element.from_bytes(sig.signature) for sig in signed_tx.signatures]),
         )
 
-    def validate_spend_bundle_signature(self, bundle: WalletSpendBundle) -> bool:
-        """Validate the aggregate signature of a spend bundle using the same flags as the full node mempool."""
+    # chia_rs ValidationError codes (from chia-consensus/src/validation_error.rs)
+    _VALIDATION_ERROR_NAMES: dict[int, str] = {
+        2: "invalid puzzle reveal",
+        3: "invalid coin solution",
+        4: "duplicate output (two CREATE_COINs with same puzzle_hash and amount)",
+        5: "double spend",
+        7: "bad aggregate signature",
+        10: "invalid condition (bad opcode, pubkey, message, amount, or announcement)",
+        11: "ASSERT_MY_COIN_ID failed",
+        12: "ASSERT_ANNOUNCEMENT failed",
+        13: "ASSERT_HEIGHT_RELATIVE failed",
+        14: "ASSERT_HEIGHT_ABSOLUTE failed",
+        15: "ASSERT_SECONDS_ABSOLUTE failed",
+        16: "coin amount exceeds maximum",
+        17: "s-expression error",
+        20: "minting coin (outputs exceed input amount)",
+        23: "cost exceeded",
+        105: "ASSERT_SECONDS_RELATIVE failed",
+        117: "CLVM generator runtime error",
+    }
+
+    def validate_spend_bundle(self, bundle: WalletSpendBundle) -> str | None:
+        """Validate a spend bundle (CLVM execution, conditions, and signature).
+
+        Returns None on success, or a human-readable error string on failure.
+        """
         try:
             flags = get_flags_for_height_and_constants(0, self.constants) | MEMPOOL_MODE
             validate_clvm_and_signature(
@@ -2797,10 +2821,18 @@ class WalletStateManager:
                 self.constants,
                 flags,
             )
-            return True
+            return None
         except Exception as e:
-            self.log.error(f"Spend bundle signature validation failed: {e}")
-            return False
+            code = e.args[1] if len(e.args) >= 2 and isinstance(e.args[1], int) else None
+            reason = self._VALIDATION_ERROR_NAMES.get(code, str(e)) if code is not None else str(e)
+            msg = f"spend bundle validation failed (code {code}): {reason}"
+            self.log.error(
+                f"{msg} | bundle={bundle.name().hex()} "
+                f"agg_sig={bytes(bundle.aggregated_signature).hex()} "
+                f"num_spends={len(bundle.coin_spends)} "
+                f"flags={flags:#x}"
+            )
+            return msg
 
     async def sign_transactions(
         self,
@@ -2874,10 +2906,10 @@ class WalletStateManager:
     async def submit_transactions(self, signed_txs: list[SignedTransaction]) -> list[bytes32]:
         bundles: list[WalletSpendBundle] = [self.signed_tx_to_spendbundle(tx) for tx in signed_txs]
         for bundle in bundles:
-            if not self.validate_spend_bundle_signature(bundle):
+            err = self.validate_spend_bundle(bundle)
+            if err is not None:
                 raise ValueError(
-                    f"Transaction {bundle.name().hex()} has an invalid aggregate signature "
-                    f"and will not be submitted"
+                    f"Transaction {bundle.name().hex()} rejected: {err}"
                 )
             await self.wallet_node.push_tx(bundle)
         return [bundle.name() for bundle in bundles]


### PR DESCRIPTION
### Purpose:

At the moment we cannot specify a coin that we want to make an offer for.
This is an issue if we have smart `extra_conditions` that rely on the coins being offered - for example if we're making an offer that will create a singleton.

This change allows coin IDs to be submitted, where the first in the list will make the `extra_conditions`.
It is worthwhile to allow multiple coin IDs, as it can correspond to other wallets if the `extra_conditions` rely on a particular CAT coin being spent, for example.

### Testing Notes:

Extended the tests in `test_wallet_rpc.py`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches transaction creation/pushing and offer construction, plus changes core network message ordering via prioritized queues; regressions could affect spend validity, fee handling, or node communication under load.
> 
> **Overview**
> Enables `create_offer_for_ids` to accept explicit `coin_ids`, validating they’re unspent and belong to wallets actually offering, allowing partial auto-selection, and ensuring `coin_ids[0]` is treated as the preferred origin coin so it carries `extra_conditions` (via `origin_id`) while other spends don’t.
> 
> Introduces prioritized outbound WS messaging by switching the connection `outgoing_queue` to a `PriorityQueue` and plumbing `priority` through `send_message`/`send_request`/`call_api`; wallet sync subscriptions/header-block fetches now use higher priority.
> 
> Adds spend-bundle validation (`validate_clvm_and_signature`) and drops/rejects invalid bundles when resending, pushing via RPC, or submitting signed transactions; expands `push_tx` RPC to optionally create and aggregate a tandem fee spend; adds `get_puzzle_and_solution` wallet RPC plus richer `get_height_info` fields, and relaxes several RPC sync-gating checks to unblock brief desync flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9763ecfa25a12f7a554b6ca6f297066740355c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->