### PR TITLE
Gap handling on read only

### DIFF
--- a/chia/_tests/blockchain/test_augmented_chain.py
+++ b/chia/_tests/blockchain/test_augmented_chain.py
@@ -288,6 +288,45 @@ async def test_augmented_chain_validation_first_block_prev_hash(
 
 @pytest.mark.anyio
 @pytest.mark.limit_consensus_modes(reason="save time")
+async def test_fork_ancestry_populated_on_first_add(default_10000_blocks: list[FullBlock]) -> None:
+    """When the first block added to the augmented chain is on a fork,
+    _populate_fork_ancestry fills _height_to_hash for orphan ancestors
+    so height_to_hash returns fork hashes, not canonical ones."""
+    blocks = default_10000_blocks
+
+    underlying = InMemoryBlockchain()
+    for block in blocks[:5]:
+        underlying.add_block_record(BR(block))
+
+    # Orphan fork blocks at heights 3-4 that branch from canonical height 2.
+    # Added directly to the record cache (not the height map) to simulate orphans.
+    fork_h3 = blocks[10].header_hash
+    fork_h4 = blocks[11].header_hash
+    fork_h5 = blocks[12].header_hash
+    underlying._block_records[fork_h3] = FakeBlockRecord(uint32(3), fork_h3, blocks[2].header_hash)  # type: ignore[assignment]
+    underlying._block_records[fork_h4] = FakeBlockRecord(uint32(4), fork_h4, fork_h3)  # type: ignore[assignment]
+
+    abc = AugmentedBlockchain(underlying)
+    abc.add_extra_block(
+        blocks[12],
+        FakeBlockRecord(uint32(5), fork_h5, fork_h4),  # type: ignore[arg-type]
+    )
+
+    # Orphan heights 3-4 filled into _height_to_hash by _populate_fork_ancestry.
+    assert abc._height_to_hash[uint32(3)] == fork_h3
+    assert abc._height_to_hash[uint32(4)] == fork_h4
+    assert abc._height_to_hash[uint32(5)] == fork_h5
+
+    # height_to_hash returns correct values for all regions.
+    assert abc.height_to_hash(uint32(0)) == blocks[0].header_hash
+    assert abc.height_to_hash(uint32(2)) == blocks[2].header_hash
+    assert abc.height_to_hash(uint32(3)) == fork_h3
+    assert abc.height_to_hash(uint32(4)) == fork_h4
+    assert abc.height_to_hash(uint32(5)) == fork_h5
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(reason="save time")
 async def test_read_only_snapshot_rejects_mutation(default_10000_blocks: list[FullBlock]) -> None:
     blocks = default_10000_blocks
     underlying = InMemoryBlockchain()

--- a/chia/consensus/augmented_chain.py
+++ b/chia/consensus/augmented_chain.py
@@ -45,9 +45,6 @@ class AugmentedBlockchain:
             raise AugmentedBlockchainValidationError("Cannot mutate read-only augmented blockchain snapshot")
 
     def read_only_snapshot(self) -> AugmentedBlockchain:
-        # _underlying is shared by reference; safe because the snapshot is only
-        # used for read-only BlockRecordsProtocol calls in a single executor task
-        # while the asyncio event loop serializes mutations on the writer side.
         snapshot = AugmentedBlockchain.__new__(AugmentedBlockchain)
         snapshot._underlying = self._underlying
         snapshot._extra_blocks = self._extra_blocks.copy()
@@ -60,6 +57,20 @@ class AugmentedBlockchain:
         if eb is None:
             return None
         return eb[1]
+
+    def _populate_fork_ancestry(self, prev_hash: bytes32) -> None:
+        """Walk backward from prev_hash through orphan block records in the
+        underlying chain, filling _height_to_hash until we reach fork point."""
+        curr_hash = prev_hash
+        while True:
+            br = self._underlying.block_record(curr_hash)
+            # if common block, break,
+            if self._underlying.height_to_hash(br.height) == curr_hash:
+                break
+            self._height_to_hash[br.height] = curr_hash
+            if br.height == 0:
+                break
+            curr_hash = br.prev_hash
 
     def add_extra_block(self, block: FullBlock, block_record: BlockRecord) -> None:
         self._ensure_mutable()
@@ -83,6 +94,7 @@ class AugmentedBlockchain:
                     f"First added block's prev_hash must exist in underlying blockchain. "
                     f"Block height {block_record.height}, prev_hash {block_record.prev_hash.hex()[:16]} not found"
                 )
+            self._populate_fork_ancestry(block_record.prev_hash)
 
         self._extra_blocks[block_record.header_hash] = (block, block_record)
         self._height_to_hash[block_record.height] = block_record.header_hash


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->
when syncing a gap may exist between the fork point of the two chains and the first block tracked by the augmented chain
these blocks exist in the main blockchain as orphans

### Purpose:
add gap handeling to AugmentedBlockchain to get canonical blocks from the gap between the augmented chain and the underlying chain when using height_to_hash
<!-- Does this PR introduce a breaking change? -->

### Current Behavior:
crete an augmented and ignore gap, validation code uses hashes so nothing breaks everything works but height to hash is actually wrong, asking for heights  in the gap will return wrong hash
### New Behavior:
fill the gap on init
<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `AugmentedBlockchain` height-to-hash behavior during fork/gap scenarios; incorrect population could return wrong hashes across a height range, impacting validation and lookups.
> 
> **Overview**
> Fixes a fork/gap case in `AugmentedBlockchain` where `height_to_hash` could incorrectly return canonical hashes for heights between the fork point and the first augmented block.
> 
> When the first `add_extra_block()` is added on a non-canonical fork, the augmented chain now walks backward through underlying orphan `BlockRecord`s and pre-fills `_height_to_hash` for those ancestor heights so subsequent height lookups resolve to the fork hashes. Adds a unit test covering this fork-ancestry population behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c91de47e1b4a7078a24ba790ba4d121afae5bb57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->