### PR TITLE
CHIA-3957 Improve requesting transactions advertised via NewTransaction

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -9,7 +9,7 @@ import platform
 import random
 import sqlite3
 import time
-from collections.abc import Awaitable, Coroutine
+from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any
 
 import pytest
@@ -60,8 +60,9 @@ from chia.consensus.multiprocess_validation import PreValidationResult, pre_vali
 from chia.consensus.pot_iterations import is_overflow_block
 from chia.consensus.signage_point import SignagePoint
 from chia.full_node.full_node import FullNode, WalletUpdate
-from chia.full_node.full_node_api import FullNodeAPI
+from chia.full_node.full_node_api import FullNodeAPI, tx_request_and_timeout
 from chia.full_node.sync_store import Peak
+from chia.full_node.tx_processing_queue import PeerWithTx
 from chia.protocols import full_node_protocol, timelord_protocol, wallet_protocol
 from chia.protocols import full_node_protocol as fnp
 from chia.protocols.farmer_protocol import DeclareProofOfSpace
@@ -111,6 +112,7 @@ from chia.util.hash import std_hash
 from chia.util.limited_semaphore import LimitedSemaphore
 from chia.util.path import path_from_root
 from chia.util.recursive_replace import recursive_replace
+from chia.util.streamable import Streamable
 from chia.util.task_referencer import create_referenced_task
 from chia.wallet.estimate_fees import estimate_fees
 from chia.wallet.transaction_record import TransactionRecord
@@ -1169,7 +1171,7 @@ async def test_request_respond_transaction(
     spend_bundle = wallet_a.generate_signed_transaction(uint64(100), receiver_puzzlehash, coin)
     assert spend_bundle is not None
     respond_transaction = fnp.RespondTransaction(spend_bundle)
-    peer.expected_mempool_responses += 1
+    peer.expected_mempool_responses = 1
     res = await full_node_1.respond_transaction(respond_transaction, peer)
     assert res is None
 
@@ -1225,7 +1227,7 @@ async def test_respond_transaction_fail(
 
     assert spend_bundle is not None
     respond_transaction = fnp.RespondTransaction(spend_bundle)
-    peer.expected_mempool_responses += 1
+    peer.expected_mempool_responses = 1
     msg = await full_node_1.respond_transaction(respond_transaction, peer)
     assert msg is None
 
@@ -3821,3 +3823,67 @@ async def test_register_for_coin_updates(
     assert {cs.coin.name() for cs in response_data.coin_states} == set(first_coin)
     for coin_id in remaining_coins:
         assert coin_id not in response_data.coin_ids
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_tx_request_and_timeout_call_api_exception(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers the case where `call_api` raises an exception in
+    `tx_request_and_timeout` to make sure that's handled properly.
+    """
+    full_node_api, server, _ = one_node_one_block
+    full_node = full_node_api.full_node
+    _, peer_id = await add_dummy_connection(server, self_hostname, 42)
+    await time_out_assert(5, lambda: peer_id in server.all_connections)
+    server_connection = server.all_connections[peer_id]
+    transaction_id = bytes32.random()
+    full_node.full_node_store.peers_with_tx[transaction_id] = {
+        peer_id: PeerWithTx(peer_host=self_hostname, advertised_fee=uint64(0), advertised_cost=uint64(1))
+    }
+
+    async def test_call_api(
+        request_method: Callable[..., Awaitable[Message | None]], message: Streamable, timeout: int = 60
+    ) -> Any:
+        raise ValueError
+
+    monkeypatch.setattr(server_connection, "call_api", test_call_api)
+    await tx_request_and_timeout(full_node=full_node, transaction_id=transaction_id, task_id=bytes32.random())
+    assert transaction_id not in full_node.full_node_store.peers_with_tx
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_tx_request_and_timeout_queue_full(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers the case where a peer's transaction queue is full when attempting to
+    put a transaction into it via `tx_request_and_timeout`.
+    """
+    full_node_api, server, _ = one_node_one_block
+    full_node = full_node_api.full_node
+    _, peer_id = await add_dummy_connection(server, self_hostname, 42)
+    await time_out_assert(5, lambda: peer_id in server.all_connections)
+    server_connection = server.all_connections[peer_id]
+    sb = SpendBundle([], G2Element())
+    transaction_id = sb.name()
+    full_node.full_node_store.peers_with_tx[transaction_id] = {
+        peer_id: PeerWithTx(peer_host=self_hostname, advertised_fee=uint64(0), advertised_cost=uint64(1))
+    }
+    full_node.transaction_queue.peer_size_limit = 0
+
+    async def test_call_api(
+        request_method: Callable[..., Awaitable[Message | None]], message: Streamable, timeout: int = 60
+    ) -> Any:
+        return full_node_protocol.RespondTransaction(sb)
+
+    monkeypatch.setattr(server_connection, "call_api", test_call_api)
+    await tx_request_and_timeout(full_node=full_node, transaction_id=transaction_id, task_id=bytes32.random())
+    assert transaction_id not in full_node.full_node_store.peers_with_tx

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -465,7 +465,7 @@ class TestMempoolManager:
         spend_bundle = generate_test_spend_bundle(wallet_a, coin)
         assert spend_bundle is not None
         tx: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle)
-        peer.expected_mempool_responses += 1
+        peer.expected_mempool_responses = 1
         await full_node_1.respond_transaction(tx, peer, test=True)
 
         await time_out_assert(

--- a/chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -506,7 +506,7 @@ async def test_subscribe_for_hint(simulator_and_wallet: OldSimulatorsAndWallets,
     await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
     tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin_spent, condition_dic=condition_dict)
-    fake_wallet_peer.expected_mempool_responses += 1
+    fake_wallet_peer.expected_mempool_responses = 1
     await full_node_api.respond_transaction(RespondTransaction(tx), fake_wallet_peer)
 
     await full_node_api.process_spend_bundles(bundles=[tx])
@@ -558,7 +558,7 @@ async def test_subscribe_for_puzzle_hash_coin_hint_duplicates(
             ConditionOpcode.CREATE_COIN: [ConditionWithArgs(ConditionOpcode.CREATE_COIN, [ph, int_to_bytes(1), ph])]
         },
     )
-    wallet_connection.expected_mempool_responses += 1
+    wallet_connection.expected_mempool_responses = 1
     await full_node_api.respond_transaction(RespondTransaction(tx), wallet_connection)
     await full_node_api.process_spend_bundles(bundles=[tx])
     # Query the coin states and make sure it doesn't contain duplicated entries
@@ -617,7 +617,7 @@ async def test_subscribe_for_hint_long_sync(
     await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
     tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin_spent, condition_dic=condition_dict)
-    fake_wallet_peer.expected_mempool_responses += 1
+    fake_wallet_peer.expected_mempool_responses = 1
     await full_node_api.respond_transaction(RespondTransaction(tx), fake_wallet_peer)
 
     await full_node_api.process_spend_bundles(bundles=[tx])

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -949,7 +949,7 @@ class FullNode:
                 except Exception:
                     old_peer = True
                 if old_peer:
-                    connection.expected_mempool_responses += 100
+                    connection.expected_mempool_responses = 100
 
         peak_full: FullBlock | None = await self.blockchain.get_full_peak()
 

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -110,12 +110,32 @@ async def tx_request_and_timeout(full_node: FullNode, transaction_id: bytes32, t
             if peer_id not in full_node.server.all_connections:
                 continue
             random_peer = full_node.server.all_connections[peer_id]
-            request_tx = full_node_protocol.RequestTransaction(transaction_id)
-            msg = make_msg(ProtocolMessageTypes.request_transaction, request_tx)
-            await random_peer.send_message(msg)
-            await asyncio.sleep(5)
-            if full_node.mempool_manager.seen(transaction_id):
-                break
+            try:
+                response = await random_peer.call_api(
+                    FullNodeAPI.request_transaction, full_node_protocol.RequestTransaction(transaction_id), timeout=5
+                )
+            except Exception:
+                continue
+            if not isinstance(response, full_node_protocol.RespondTransaction):
+                continue
+            entry = TransactionQueueEntry(
+                transaction=response.transaction,
+                transaction_bytes=bytes(response.transaction),
+                spend_name=response.transaction.name(),
+                peer=random_peer,
+                test=False,
+                peers_with_tx=peers_with_tx,
+            )
+            # Try to put the transaction in this peer's queue, but if it's full
+            # then try another peer's queue. `TransactionQueue` has an internal
+            # queue for each peer.
+            for pid in [random_peer.peer_node_id, *peers_with_tx]:
+                try:
+                    full_node.transaction_queue.put(entry, pid)
+                    break
+                except TransactionQueueFull:
+                    continue
+            break
     except asyncio.CancelledError:
         pass
     finally:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the transaction fetch path for `NewTransaction`-advertised spends, including new queueing behavior and broader exception handling; this can affect propagation and mempool ingest under load.
> 
> **Overview**
> Improves how a full node fetches transactions advertised via `NewTransaction` by switching `tx_request_and_timeout` from fire-and-sleep messaging to a `call_api` request/response flow, then enqueuing the received spend into `TransactionQueue` (with fallback when a peer’s per-peer queue is full).
> 
> Updates tests and connect-time mempool expectations to set `expected_mempool_responses` deterministically (instead of incrementing), and adds new tests covering `tx_request_and_timeout` cleanup when `call_api` raises and when the transaction queue is full.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e122293d1dbd7c325fedf28d481c8839daf6ccb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->