### PR TITLE
Optimise pre-commit chialisp_pprint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
     hooks:
       - id: chialispp
         name: Pretty print chialisp files
-        entry: ./activated.py python tools/chialispp.py .
+        entry: ./activated.py python tools/chialispp.py chia
         language: system
         pass_filenames: false
   - repo: local

--- a/tools/chialispp.py
+++ b/tools/chialispp.py
@@ -345,10 +345,10 @@ def main() -> None:
 
             formatter.finish()
 
-            with open(filename, "wb") as f:
-                for i, line in enumerate(formatter.result):
-                    f.write(concat_byte_array(line))
-                    f.write(b"\n")
+            formatted = b"\n".join(concat_byte_array(line) for line in formatter.result) + b"\n"
+            if formatted != filedata:
+                with open(filename, "wb") as f:
+                    f.write(formatted)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

### Purpose:

This changes the pre-commit chialisp pprinter to only crawl the `chia` folder, saving it from looking in the `.venv` and `.git` folders and cutting the time down from 4.42 seconds, to 0.16 seconds.

It also no longer overwrites the files unless there is a change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only pre-commit configuration and formatting tool output behavior; main risk is missing files outside `chia/` that previously got auto-formatted.
> 
> **Overview**
> Speeds up the `chialispp` pre-commit hook by restricting its scan target from the repository root to the `chia` directory.
> 
> Updates `tools/chialispp.py` to *avoid rewriting files when the formatted output is identical*, reducing unnecessary file touches and churn while keeping formatting output the same when changes are needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd4caae546c8f11bc9a7dd39a0b6ca40c32be8b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->