### PR TITLE
fix: correct "committment" and "recieve" typos in wallet conditions and tests

### DIFF
--- a/chia/_tests/clvm/test_message_conditions.py
+++ b/chia/_tests/clvm/test_message_conditions.py
@@ -100,7 +100,7 @@ async def test_basic_message_send_receive(mode: int, cost_logger: CostLogger) ->
 
 
 def test_message_error_conditions() -> None:
-    with pytest.raises(ValueError, match="Must specify at least one committment"):
+    with pytest.raises(ValueError, match="Must specify at least one commitment"):
         MessageParticipant()
 
     test_coin = Coin(bytes32.zeros, bytes32.zeros, uint64(0))
@@ -124,7 +124,7 @@ def test_message_error_conditions() -> None:
                 amount_committed=test_coin.amount if (not mode & 0b001) or (mode == 0b111) else None,
             )
 
-    with pytest.raises(ValueError, match="without committment information"):
+    with pytest.raises(ValueError, match="without commitment information"):
         MessageParticipant(
             mode_integer=uint8(0b111),
         ).necessary_args

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1526,7 +1526,7 @@ async def test_new_unfinished_block2_forward_limit(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "committment,expected",
+    "commitment,expected",
     [
         (0, Err.INVALID_TRANSACTIONS_GENERATOR_HASH),
         (1, Err.INVALID_TRANSACTIONS_INFO_HASH),
@@ -1543,7 +1543,7 @@ async def test_unfinished_block_with_replaced_generator(
         FullNodeSimulator, FullNodeSimulator, ChiaServer, ChiaServer, WalletTool, WalletTool, BlockTools
     ],
     self_hostname: str,
-    committment: int,
+    commitment: int,
     expected: Err,
 ) -> None:
     full_node_1, _full_node_2, server_1, server_2, _wallet_a, _wallet_receiver, bt = wallet_nodes
@@ -1557,7 +1557,7 @@ async def test_unfinished_block_with_replaced_generator(
 
     replaced_generator = SerializedProgram.from_bytes(b"\x80")
 
-    if committment > 0:
+    if commitment > 0:
         tr = block.transactions_info
         assert tr is not None
         transactions_info = TransactionsInfo(
@@ -1572,7 +1572,7 @@ async def test_unfinished_block_with_replaced_generator(
         assert block.transactions_info is not None
         transactions_info = block.transactions_info
 
-    if committment > 1:
+    if commitment > 1:
         tb = block.foliage_transaction_block
         assert tb is not None
         transaction_block = FoliageTransactionBlock(
@@ -1587,7 +1587,7 @@ async def test_unfinished_block_with_replaced_generator(
         assert block.foliage_transaction_block is not None
         transaction_block = block.foliage_transaction_block
 
-    if committment > 2:
+    if commitment > 2:
         fl = block.foliage
         foliage = Foliage(
             fl.prev_block_hash,
@@ -1600,7 +1600,7 @@ async def test_unfinished_block_with_replaced_generator(
     else:
         foliage = block.foliage
 
-    if committment > 3:
+    if commitment > 3:
         fl = block.foliage
 
         secret_key: PrivateKey = AugSchemeMPL.key_gen(bytes([2] * 32))
@@ -1616,10 +1616,10 @@ async def test_unfinished_block_with_replaced_generator(
             signature,
         )
 
-        if committment > 4:
+        if commitment > 4:
             pos = block.reward_chain_block.proof_of_space
 
-            if committment > 5:
+            if commitment > 5:
                 if pos.pool_public_key is None:
                     assert pos.pool_contract_puzzle_hash is not None
                     plot_id = calculate_plot_id_ph(pos.pool_contract_puzzle_hash, public_key)
@@ -1668,7 +1668,7 @@ async def test_unfinished_block_with_replaced_generator(
         reward_chain_block = block.reward_chain_block.get_unfinished()
 
     generator_refs: list[uint32] = []
-    if committment > 6:
+    if commitment > 6:
         generator_refs = [uint32(n) for n in range(600)]
 
     unf = UnfinishedBlock(

--- a/chia/wallet/conditions.py
+++ b/chia/wallet/conditions.py
@@ -427,7 +427,7 @@ class MessageParticipant(Streamable):
             and self.coin_id_committed is None
             and self.mode_integer is None
         ):
-            raise ValueError("Must specify at least one committment. Anyone-can-send/recieve is not allowed.")
+            raise ValueError("Must specify at least one commitment. Anyone-can-send/receive is not allowed.")
         if self.coin_id_committed is not None:
             if self.parent_id_committed is None or self.puzzle_hash_committed is None or self.amount_committed is None:
                 if not (
@@ -450,7 +450,7 @@ class MessageParticipant(Streamable):
                 ), "The value for coin_id_committed must be equal to the implied ID of the other three arguments"
         if self.mode_integer is not None:
             assert self.mode == self.mode_integer, (
-                "If mode_integer is manually specified, you must specify committments that match with the mode"
+                "If mode_integer is manually specified, you must specify commitments that match with the mode"
             )
 
     @property
@@ -482,7 +482,7 @@ class MessageParticipant(Streamable):
     @property
     def necessary_args(self) -> list[Program]:
         if self._nothing_committed:
-            raise ValueError("Cannot generate necessary_args for a participant without committment information")
+            raise ValueError("Cannot generate necessary_args for a participant without commitment information")
 
         if self.coin_id_committed:
             return [Program.to(self.coin_id_committed)]


### PR DESCRIPTION
## Purpose

Fix spelling errors in user-facing error messages and test code. "committment" should be "commitment" and "recieve" should be "receive".

## Current Behavior

Error messages in `MessageParticipant` and variable names in tests use the misspellings "committment" and "recieve".

## New Behavior

All occurrences are corrected to "commitment" and "receive".

## Files Changed

- `chia/wallet/conditions.py`: 3 error message strings fixed
- `chia/_tests/clvm/test_message_conditions.py`: 2 test match strings updated
- `chia/_tests/core/full_node/test_full_node.py`: variable name and parametrize string renamed from `committment` to `commitment`

## Testing Notes

No behavioral changes.