### PR TITLE
[ASB-201] [CHIA-4003] Make sure to close connections on bad data

### DIFF
--- a/chia/_tests/core/server/test_dos.py
+++ b/chia/_tests/core/server/test_dos.py
@@ -17,14 +17,17 @@ from chia.protocols.outbound_message import Message, NodeType, make_msg
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.shared_protocol import Capability, Handshake, default_capabilities, protocol_version
 from chia.server.rate_limits import RateLimiter
-from chia.server.server import ChiaServer
+from chia.server.server import ChiaServer, ssl_context_for_client
+from chia.server.ssl_context import chia_ssl_ca_paths
 from chia.server.ws_connection import (
     MAX_VERSION_STRING_BYTES,
     WSChiaConnection,
 )
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator
+from chia.ssl.create_ssl import generate_ca_signed_cert
 from chia.types.peer_info import PeerInfo
+from chia.util.config import load_config
 from chia.util.errors import Err
 from chia.util.timing import adjusted_timeout
 from chia.wallet.wallet_node import WalletNode
@@ -163,7 +166,6 @@ class TestDos:
         await ws.close()
 
     @pytest.mark.anyio
-    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
     async def test_invalid_protocol_handshake(
         self,
         setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
@@ -178,7 +180,7 @@ class TestDos:
         )
         assert response.type == WSMsgType.CLOSE
         assert response.data == WSCloseCode.PROTOCOL_ERROR
-        assert response.extra == str(int(Err.INVALID_HANDSHAKE.value))
+        assert response.extra == str(int(Err.INVALID_PROTOCOL_MESSAGE.value))
 
     @pytest.mark.anyio
     async def test_handshake_version_too_long_disconnect(
@@ -403,20 +405,13 @@ class TestDos:
     @pytest.mark.anyio
     @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
     async def test_invalid_message_format_disconnect(
-        self,
-        setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
-        self_hostname: str,
+        self, one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools], self_hostname: str
     ) -> None:
         """Invalid binary after handshake disconnects with PROTOCOL_ERROR and peer is banned."""
-        nodes, _, _ = setup_two_nodes_fixture
-        server_1 = nodes[0].full_node.server
-        server_2 = nodes[1].full_node.server
-
-        capabilities = default_capabilities[NodeType.FULL_NODE] + [
-            (uint16(Capability.HARD_FORK_2.value), "1"),
-        ]
+        _, server, _ = one_node_one_block
+        capabilities = default_capabilities[NodeType.FULL_NODE] + [(uint16(Capability.HARD_FORK_2.value), "1")]
         handshake = Handshake(
-            server_1._network_id,
+            server._network_id,
             protocol_version[NodeType.FULL_NODE],
             "test",
             uint16(0),
@@ -433,24 +428,23 @@ class TestDos:
             b"\xff\xff\xff",  # type=255, optional prefix 0xff invalid
         ]
         timeout = ClientTimeout(total=10)
-        url = f"wss://{self_hostname}:{server_1._port}/ws"
+        url = f"wss://{self_hostname}:{server._port}/ws"
+        ca_crt_path, ca_key_path = chia_ssl_ca_paths(server.root_path, load_config(server.root_path, "config.yaml"))
+        dummy_crt_path = server.root_path / "dummy.crt"
+        dummy_key_path = server.root_path / "dummy.key"
+        generate_ca_signed_cert(ca_crt_path.read_bytes(), ca_key_path.read_bytes(), dummy_crt_path, dummy_key_path)
+        ssl_context = ssl_context_for_client(ca_crt_path, ca_key_path, dummy_crt_path, dummy_key_path)
         async with ClientSession(timeout=timeout) as session:
             for invalid_payload in invalid_payloads:
-                async with session.ws_connect(
-                    url,
-                    autoclose=True,
-                    autoping=True,
-                    ssl=server_2.ssl_client_context,
-                    max_msg_size=50 * 1024 * 1024,
-                ) as ws:
+                async with session.ws_connect(url, ssl=ssl_context) as ws:
                     await ws.send_bytes(
                         bytes(Message(uint8(ProtocolMessageTypes.handshake.value), None, bytes(handshake)))
                     )
                     first = await ws.receive()
                     assert first.type == WSMsgType.BINARY, "Expected handshake response"
 
-                    assert len(server_1.all_connections) == 1
-                    ws_con = next(iter(server_1.all_connections.values()))
+                    assert len(server.all_connections) == 1
+                    ws_con = next(iter(server.all_connections.values()))
                     ws_con.peer_info = PeerInfo("1.2.3.4", ws_con.peer_info.port)
 
                     await ws.send_bytes(invalid_payload)
@@ -461,10 +455,7 @@ class TestDos:
                     assert response.type == WSMsgType.CLOSE
                     assert response.data == WSCloseCode.PROTOCOL_ERROR
 
-                def is_banned() -> bool:
-                    return "1.2.3.4" in server_1.banned_peers
-
-                await time_out_assert(10, is_banned)
+                await time_out_assert(5, lambda: "1.2.3.4" in server.banned_peers)
 
         # Final check that peer remained banned after all iterations
-        assert "1.2.3.4" in server_1.banned_peers
+        assert "1.2.3.4" in server.banned_peers

--- a/chia/_tests/core/server/test_dos.py
+++ b/chia/_tests/core/server/test_dos.py
@@ -163,6 +163,7 @@ class TestDos:
         await ws.close()
 
     @pytest.mark.anyio
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
     async def test_invalid_protocol_handshake(
         self,
         setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
@@ -177,7 +178,7 @@ class TestDos:
         )
         assert response.type == WSMsgType.CLOSE
         assert response.data == WSCloseCode.PROTOCOL_ERROR
-        assert response.extra == str(int(Err.INVALID_PROTOCOL_MESSAGE.value))
+        assert response.extra == str(int(Err.INVALID_HANDSHAKE.value))
 
     @pytest.mark.anyio
     async def test_handshake_version_too_long_disconnect(

--- a/chia/_tests/core/server/test_dos.py
+++ b/chia/_tests/core/server/test_dos.py
@@ -10,11 +10,12 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint64
 
 import chia.server.server
+from chia._tests.conftest import ConsensusMode
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.protocols import full_node_protocol
 from chia.protocols.outbound_message import Message, NodeType, make_msg
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
-from chia.protocols.shared_protocol import Capability, Handshake, protocol_version
+from chia.protocols.shared_protocol import Capability, Handshake, default_capabilities, protocol_version
 from chia.server.rate_limits import RateLimiter
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import (
@@ -397,3 +398,72 @@ class TestDos:
             return "1.2.3.4" in server_2.banned_peers
 
         await time_out_assert(15, is_banned)
+
+    @pytest.mark.anyio
+    @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
+    async def test_invalid_message_format_disconnect(
+        self,
+        setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+        self_hostname: str,
+    ) -> None:
+        """Invalid binary after handshake disconnects with PROTOCOL_ERROR and peer is banned."""
+        nodes, _, _ = setup_two_nodes_fixture
+        server_1 = nodes[0].full_node.server
+        server_2 = nodes[1].full_node.server
+
+        capabilities = default_capabilities[NodeType.FULL_NODE] + [
+            (uint16(Capability.HARD_FORK_2.value), "1"),
+        ]
+        handshake = Handshake(
+            server_1._network_id,
+            protocol_version[NodeType.FULL_NODE],
+            "test",
+            uint16(0),
+            uint8(NodeType.FULL_NODE.value),
+            capabilities,
+        )
+        # Binary that should fail Message.from_bytes(): Message is (uint8 type, optional uint16 id, bytes data).
+        # - bytes: 4-byte big-endian length then payload. Optional: 1 byte 0/1, if 1 then uint16.
+        invalid_payloads = [
+            b"",  # EOF reading type (uint8)
+            b"\x01\x02",  # type=1, optional prefix 0x02 invalid (must be 0 or 1)
+            b"\x01\x01",  # type=1, id present, EOF reading uint16
+            b"\x01\x00\x00\x00\x00\x00\x00\x05\x11\x22",  # type=1, id=None, data len=5 but only 2 bytes
+            b"\xff\xff\xff",  # type=255, optional prefix 0xff invalid
+        ]
+        timeout = ClientTimeout(total=10)
+        url = f"wss://{self_hostname}:{server_1._port}/ws"
+        async with ClientSession(timeout=timeout) as session:
+            for invalid_payload in invalid_payloads:
+                async with session.ws_connect(
+                    url,
+                    autoclose=True,
+                    autoping=True,
+                    ssl=server_2.ssl_client_context,
+                    max_msg_size=50 * 1024 * 1024,
+                ) as ws:
+                    await ws.send_bytes(
+                        bytes(Message(uint8(ProtocolMessageTypes.handshake.value), None, bytes(handshake)))
+                    )
+                    first = await ws.receive()
+                    assert first.type == WSMsgType.BINARY, "Expected handshake response"
+
+                    assert len(server_1.all_connections) == 1
+                    ws_con = next(iter(server_1.all_connections.values()))
+                    ws_con.peer_info = PeerInfo("1.2.3.4", ws_con.peer_info.port)
+
+                    await ws.send_bytes(invalid_payload)
+
+                    response = await ws.receive()
+                    while response.type != WSMsgType.CLOSE:
+                        response = await ws.receive()
+                    assert response.type == WSMsgType.CLOSE
+                    assert response.data == WSCloseCode.PROTOCOL_ERROR
+
+                def is_banned() -> bool:
+                    return "1.2.3.4" in server_1.banned_peers
+
+                await time_out_assert(10, is_banned)
+
+        # Final check that peer remained banned after all iterations
+        assert "1.2.3.4" in server_1.banned_peers

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -355,6 +355,16 @@ class WSChiaConnection:
     async def wait_until_closed(self) -> None:
         await self._close_event.wait()
 
+    async def _schedule_close_and_yield(
+        self,
+        ban_time: int = 0,
+        ws_close_code: WSCloseCode = WSCloseCode.OK,
+        error: Err | None = None,
+    ) -> None:
+        """Schedule close() in another task and yield so it can run (avoids self-cancel)."""
+        create_referenced_task(self.close(ban_time, ws_close_code, error), known_unreferenced=True)
+        await asyncio.sleep(3)
+
     async def ban_peer_bad_protocol(self, log_err_msg: str) -> None:
         """Ban peer for protocol violation"""
         ban_seconds = INTERNAL_PROTOCOL_ERROR_BAN_SECONDS
@@ -536,13 +546,14 @@ class WSChiaConnection:
             self.log.debug("Inbound_handler task cancelled")
         except ProtocolError as e:
             self.log.error(f"Disconnecting peer: {e}")
-            await self.close(INTERNAL_PROTOCOL_ERROR_BAN_SECONDS, WSCloseCode.PROTOCOL_ERROR, e.code)
+            await self._schedule_close_and_yield(
+                INTERNAL_PROTOCOL_ERROR_BAN_SECONDS, WSCloseCode.PROTOCOL_ERROR, e.code
+            )
         except Exception as e:
             error_stack = traceback.format_exc()
             self.log.error(f"Exception: {e}")
             self.log.error(f"Exception Stack: {error_stack}")
-            # Close (no ban) so the connection is not left as a zombie
-            await self.close(0, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
+            await self._schedule_close_and_yield(0, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
 
     async def send_message(self, message: Message) -> bool:
         """Send message sends a message with no tracking / callback."""
@@ -698,23 +709,17 @@ class WSChiaConnection:
                 f"{self.peer_server_port}/"
                 f"{self.peer_info.port}"
             )
-            create_referenced_task(self.close(), known_unreferenced=True)
-            # Yield so we let the close task cancel us
-            await asyncio.sleep(3)
+            await self._schedule_close_and_yield()
         elif message.type == WSMsgType.CLOSE:
             self.log.debug(
                 f"Peer closed connection {connection_type_str} {self.peer_info.host}:"
                 f"{self.peer_server_port}/"
                 f"{self.peer_info.port}"
             )
-            create_referenced_task(self.close(), known_unreferenced=True)
-            # Yield so we let the close task cancel us
-            await asyncio.sleep(3)
+            await self._schedule_close_and_yield()
         elif message.type == WSMsgType.CLOSED:
             if not self.closed:
-                create_referenced_task(self.close(), known_unreferenced=True)
-                # Yield so we let the close task cancel us
-                await asyncio.sleep(3)
+                await self._schedule_close_and_yield()
                 return None
         elif message.type == WSMsgType.BINARY:
             data = message.data
@@ -742,9 +747,7 @@ class WSChiaConnection:
                     details = ", ".join([f"{self.peer_info.host}", f"message: {message_type.name}", limiter_msg])
                     self.log.error(f"Peer has been rate limited and will be disconnected: {details}")
                     # Only full node disconnects peers, to prevent abuse and crashing timelords, farmers, etc
-                    create_referenced_task(self.close(RATE_LIMITER_BAN_SECONDS), known_unreferenced=True)
-                    # Yield so we let the close task cancel us
-                    await asyncio.sleep(3)
+                    await self._schedule_close_and_yield(RATE_LIMITER_BAN_SECONDS)
                     return None
                 else:
                     self.log.debug(
@@ -756,17 +759,12 @@ class WSChiaConnection:
         elif message.type == WSMsgType.ERROR:
             self.log.error(f"WebSocket Error: {message}")
             if isinstance(message.data, WebSocketError) and message.data.code == WSCloseCode.MESSAGE_TOO_BIG:
-                create_referenced_task(self.close(RATE_LIMITER_BAN_SECONDS), known_unreferenced=True)
+                await self._schedule_close_and_yield(RATE_LIMITER_BAN_SECONDS)
             else:
-                create_referenced_task(self.close(), known_unreferenced=True)
-            # Yield so we let the close task cancel us
-            await asyncio.sleep(3)
-
+                await self._schedule_close_and_yield()
         else:
             self.log.error(f"Unexpected WebSocket message type: {message}")
-            create_referenced_task(self.close())
-            # Yield so we let the close task cancel us
-            await asyncio.sleep(3)
+            await self._schedule_close_and_yield()
         return None
 
     # Used by the Chia Seeder.

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -534,10 +534,15 @@ class WSChiaConnection:
                     continue
         except asyncio.CancelledError:
             self.log.debug("Inbound_handler task cancelled")
+        except ProtocolError as e:
+            self.log.error(f"Disconnecting peer: {e}")
+            await self.close(INTERNAL_PROTOCOL_ERROR_BAN_SECONDS, WSCloseCode.PROTOCOL_ERROR, e.code)
         except Exception as e:
             error_stack = traceback.format_exc()
             self.log.error(f"Exception: {e}")
             self.log.error(f"Exception Stack: {error_stack}")
+            # Close (no ban) so the connection is not left as a zombie
+            await self.close(0, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
 
     async def send_message(self, message: Message) -> bool:
         """Send message sends a message with no tracking / callback."""
@@ -713,24 +718,18 @@ class WSChiaConnection:
                 return None
         elif message.type == WSMsgType.BINARY:
             data = message.data
-            full_message_loaded: Message = Message.from_bytes(data)
             self.bytes_read += len(data)
             self.last_message_time = time.time()
+            full_message_loaded = None
             try:
+                full_message_loaded = Message.from_bytes(data)
                 message_type = ProtocolMessageTypes(full_message_loaded.type)
             except Exception:
-                self.log.error(
-                    f"Disconnecting peer for unknown message type {full_message_loaded.type}: {self.peer_info.host}"
-                )
-                create_referenced_task(
-                    self.close(
-                        INTERNAL_PROTOCOL_ERROR_BAN_SECONDS, WSCloseCode.PROTOCOL_ERROR, Err.INVALID_PROTOCOL_MESSAGE
-                    ),
-                    known_unreferenced=True,
-                )
-                # Yield so we let the close task cancel us
-                await asyncio.sleep(3)
-                return None
+                if full_message_loaded is not None:
+                    error_message = f"unknown message type {full_message_loaded.type}: {self.peer_info.host}"
+                else:
+                    error_message = f"invalid message format: {self.peer_info.host}"
+                raise ProtocolError(Err.INVALID_PROTOCOL_MESSAGE, [error_message])
             limiter_msg = self.inbound_rate_limiter.process_msg_and_check(
                 full_message_loaded, self.local_capabilities, self.peer_capabilities
             )

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -355,16 +355,6 @@ class WSChiaConnection:
     async def wait_until_closed(self) -> None:
         await self._close_event.wait()
 
-    async def _schedule_close_and_yield(
-        self,
-        ban_time: int = 0,
-        ws_close_code: WSCloseCode = WSCloseCode.OK,
-        error: Err | None = None,
-    ) -> None:
-        """Schedule close() in another task and yield so it can run (avoids self-cancel)."""
-        create_referenced_task(self.close(ban_time, ws_close_code, error), known_unreferenced=True)
-        await asyncio.sleep(3)
-
     async def ban_peer_bad_protocol(self, log_err_msg: str) -> None:
         """Ban peer for protocol violation"""
         ban_seconds = INTERNAL_PROTOCOL_ERROR_BAN_SECONDS
@@ -544,16 +534,10 @@ class WSChiaConnection:
                     continue
         except asyncio.CancelledError:
             self.log.debug("Inbound_handler task cancelled")
-        except ProtocolError as e:
-            self.log.error(f"Disconnecting peer: {e}")
-            await self._schedule_close_and_yield(
-                INTERNAL_PROTOCOL_ERROR_BAN_SECONDS, WSCloseCode.PROTOCOL_ERROR, e.code
-            )
         except Exception as e:
             error_stack = traceback.format_exc()
             self.log.error(f"Exception: {e}")
             self.log.error(f"Exception Stack: {error_stack}")
-            await self._schedule_close_and_yield(0, WSCloseCode.PROTOCOL_ERROR, Err.UNKNOWN)
 
     async def send_message(self, message: Message) -> bool:
         """Send message sends a message with no tracking / callback."""
@@ -709,17 +693,23 @@ class WSChiaConnection:
                 f"{self.peer_server_port}/"
                 f"{self.peer_info.port}"
             )
-            await self._schedule_close_and_yield()
+            create_referenced_task(self.close(), known_unreferenced=True)
+            # Yield so we let the close task cancel us
+            await asyncio.sleep(3)
         elif message.type == WSMsgType.CLOSE:
             self.log.debug(
                 f"Peer closed connection {connection_type_str} {self.peer_info.host}:"
                 f"{self.peer_server_port}/"
                 f"{self.peer_info.port}"
             )
-            await self._schedule_close_and_yield()
+            create_referenced_task(self.close(), known_unreferenced=True)
+            # Yield so we let the close task cancel us
+            await asyncio.sleep(3)
         elif message.type == WSMsgType.CLOSED:
             if not self.closed:
-                await self._schedule_close_and_yield()
+                create_referenced_task(self.close(), known_unreferenced=True)
+                # Yield so we let the close task cancel us
+                await asyncio.sleep(3)
                 return None
         elif message.type == WSMsgType.BINARY:
             data = message.data
@@ -730,11 +720,21 @@ class WSChiaConnection:
                 full_message_loaded = Message.from_bytes(data)
                 message_type = ProtocolMessageTypes(full_message_loaded.type)
             except Exception:
-                if full_message_loaded is not None:
-                    error_message = f"unknown message type {full_message_loaded.type}: {self.peer_info.host}"
-                else:
-                    error_message = f"invalid message format: {self.peer_info.host}"
-                raise ProtocolError(Err.INVALID_PROTOCOL_MESSAGE, [error_message])
+                reason = (
+                    "invalid message format"
+                    if full_message_loaded is None
+                    else f"unknown message type {full_message_loaded.type}"
+                )
+                self.log.error(f"Disconnecting peer for {reason}: {self.peer_info.host}")
+                create_referenced_task(
+                    self.close(
+                        INTERNAL_PROTOCOL_ERROR_BAN_SECONDS, WSCloseCode.PROTOCOL_ERROR, Err.INVALID_PROTOCOL_MESSAGE
+                    ),
+                    known_unreferenced=True,
+                )
+                # Yield so we let the close task cancel us
+                await asyncio.sleep(3)
+                return None
             limiter_msg = self.inbound_rate_limiter.process_msg_and_check(
                 full_message_loaded, self.local_capabilities, self.peer_capabilities
             )
@@ -747,7 +747,9 @@ class WSChiaConnection:
                     details = ", ".join([f"{self.peer_info.host}", f"message: {message_type.name}", limiter_msg])
                     self.log.error(f"Peer has been rate limited and will be disconnected: {details}")
                     # Only full node disconnects peers, to prevent abuse and crashing timelords, farmers, etc
-                    await self._schedule_close_and_yield(RATE_LIMITER_BAN_SECONDS)
+                    create_referenced_task(self.close(RATE_LIMITER_BAN_SECONDS), known_unreferenced=True)
+                    # Yield so we let the close task cancel us
+                    await asyncio.sleep(3)
                     return None
                 else:
                     self.log.debug(
@@ -759,12 +761,17 @@ class WSChiaConnection:
         elif message.type == WSMsgType.ERROR:
             self.log.error(f"WebSocket Error: {message}")
             if isinstance(message.data, WebSocketError) and message.data.code == WSCloseCode.MESSAGE_TOO_BIG:
-                await self._schedule_close_and_yield(RATE_LIMITER_BAN_SECONDS)
+                create_referenced_task(self.close(RATE_LIMITER_BAN_SECONDS), known_unreferenced=True)
             else:
-                await self._schedule_close_and_yield()
+                create_referenced_task(self.close(), known_unreferenced=True)
+            # Yield so we let the close task cancel us
+            await asyncio.sleep(3)
+
         else:
             self.log.error(f"Unexpected WebSocket message type: {message}")
-            await self._schedule_close_and_yield()
+            create_referenced_task(self.close())
+            # Yield so we let the close task cancel us
+            await asyncio.sleep(3)
         return None
 
     # Used by the Chia Seeder.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core websocket connection handling and error paths, which can affect peer connectivity and banning behavior if misclassified or triggered incorrectly.
> 
> **Overview**
> Ensures malformed or unparseable websocket `BINARY` frames reliably trigger a `PROTOCOL_ERROR` disconnect (and ban where appropriate) instead of potentially leaving the connection open.
> 
> Refactors close-on-error logic in `WSChiaConnection` by introducing `_schedule_close_and_yield()` and using it consistently across websocket close/error branches and rate-limit disconnects to avoid self-cancel during shutdown.
> 
> Updates DOS tests to align handshake failures with `Err.INVALID_HANDSHAKE`, and adds coverage that sending invalid message byte formats *after a successful handshake* results in `PROTOCOL_ERROR` and the peer being banned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9374f872c9cd22784e978837937bc2486f99341. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->