### PR TITLE
Streamable.from_bytes()

### DIFF
--- a/chia/_tests/core/util/test_streamable.py
+++ b/chia/_tests/core/util/test_streamable.py
@@ -780,8 +780,23 @@ def test_ambiguous_deserialization_program() -> None:
 
     TestClassProgram.from_bytes(bytes(program))
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         TestClassProgram.from_bytes(bytes(program) + b"9")
+
+
+def test_from_bytes_rejects_trailing_bytes_rust_types() -> None:
+    from chia_rs import G2Element, SpendBundle
+
+    coin = Coin(bytes32(bytes(32)), bytes32(bytes(32)), uint64(0))
+    valid_coin = bytes(coin)
+    Coin.from_bytes(valid_coin)
+    with pytest.raises(ValueError):
+        Coin.from_bytes(valid_coin + b"\x00")
+
+    valid_sb = bytes(4) + bytes(G2Element())
+    SpendBundle.from_bytes(valid_sb)
+    with pytest.raises(ValueError):
+        SpendBundle.from_bytes(valid_sb + b"\x00")
 
 
 def test_streamable_empty() -> None:

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -683,7 +683,9 @@ class Streamable:
     def from_bytes(cls, blob: bytes) -> Self:
         f = io.BytesIO(blob)
         parsed = cls.parse(f)
-        assert f.read() == b""
+        remainder = f.read()
+        if remainder != b"":
+            raise ValueError(f"{cls.__name__}: {len(remainder)} bytes not consumed")
         return parsed
 
     def stream_to_bytes(self) -> bytes:

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -292,7 +292,7 @@ class CATWallet:
         try:
             self.cat_info = cls.wallet_info_type.from_bytes(hexstr_to_bytes(self.wallet_info.data))
             self.lineage_store = await CATLineageStore.create(self.wallet_state_manager.db_wrapper, self.get_asset_id())
-        except AssertionError:
+        except (AssertionError, ValueError):
             # Do a migration of the lineage proofs
             cat_info = LegacyCATInfo.from_bytes(hexstr_to_bytes(self.wallet_info.data))
             self.cat_info = cls.wallet_info_type(cat_info.limitations_program_hash, cat_info.my_tail)


### PR DESCRIPTION
This function is currently failing with an `assert` when not all bytes are consumed.
Promote it to a proper run-time error (it's not a programmer error).

The unit test also makes sure to cover rust types that implement `Streamable`. To ensure they also fail in this case.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `Streamable.from_bytes()` to raise `ValueError` instead of asserting, which can affect any callers relying on the previous `AssertionError`/assert-stripping behavior and may surface new runtime errors when extra bytes are present.
> 
> **Overview**
> **Tightens deserialization validation for `Streamable.from_bytes()`.** Instead of `assert`ing that all input bytes were consumed, it now checks for leftover bytes and raises a `ValueError` with the remaining-byte count.
> 
> Tests were updated/added to ensure trailing bytes are rejected (including for Rust-backed `Streamable` types like `Coin` and `SpendBundle`), and `CATWallet.create()` now treats `ValueError` the same as the prior assertion failure to trigger the legacy `CATInfo` migration path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 874b68425aa919cc3834fbe7f4db83c58a480b06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->