### PR TITLE
message too large unit test

### DIFF
--- a/chia/_tests/core/server/test_dos.py
+++ b/chia/_tests/core/server/test_dos.py
@@ -94,17 +94,59 @@ class TestDos:
             )
 
     @pytest.mark.anyio
-    async def test_large_message_disconnect_and_ban(
+    async def test_large_message_disconnect(
+        self,
+        setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+        self_hostname: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # The max_message_size (50MB) is enforced at the aiohttp websocket
+        # layer for all connections, including localhost. Verify that a message
+        # exceeding this limit is rejected even without the is_localhost
+        # monkeypatch.
+        nodes, _, _ = setup_two_nodes_fixture
+        server_1 = nodes[0].full_node.server
+        server_2 = nodes[1].full_node.server
+
+        timeout = ClientTimeout(total=10)
+        session = ClientSession(timeout=timeout)
+        url = f"wss://{self_hostname}:{server_1._port}/ws"
+
+        ssl_context = server_2.ssl_client_context
+        ws = await session.ws_connect(
+            url, autoclose=True, autoping=True, ssl=ssl_context, max_msg_size=100 * 1024 * 1024
+        )
+        assert not ws.closed
+
+        large_msg: bytes = bytes([0] * (60 * 1024 * 1024))
+        with caplog.at_level(logging.ERROR):
+            await ws.send_bytes(large_msg)
+
+            response: WSMessage = await ws.receive()
+            assert response.type == WSMsgType.CLOSE
+            assert response.data == WSCloseCode.MESSAGE_TOO_BIG
+
+        assert "WebSocket Error" in caplog.text
+        assert "WSCloseCode.MESSAGE_TOO_BIG: 1009" in caplog.text
+        assert "Message size 62914560 exceeds limit 52428800" in caplog.text
+
+        await ws.close()
+        await session.close()
+
+    @pytest.mark.anyio
+    async def test_large_message_ban(
         self,
         setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
         self_hostname: str,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        # Localhost peers are never banned (they may be our own farmer,
+        # harvester, etc.). Pretend we're not localhost to verify that
+        # remote peers get banned after sending an oversized message.
         nodes, _, _ = setup_two_nodes_fixture
         server_1 = nodes[0].full_node.server
         server_2 = nodes[1].full_node.server
 
-        # Use the server_2 ssl information to connect to server_1, and send a huge message
         timeout = ClientTimeout(total=10)
         session = ClientSession(timeout=timeout)
         url = f"wss://{self_hostname}:{server_1._port}/ws"
@@ -123,10 +165,10 @@ class TestDos:
             response: WSMessage = await ws.receive()
             await time_out_assert(10, lambda: self_hostname in server_1.banned_peers)
 
-        print(response)
         assert response.type == WSMsgType.CLOSE
         assert response.data == WSCloseCode.MESSAGE_TOO_BIG
         await ws.close()
+        await session.close()
 
     @pytest.mark.anyio
     async def test_bad_handshake_and_ban(


### PR DESCRIPTION
we have a test that sends a message that's too large and pretends not to be localhost and ensures we get banned. This adds another, similar, test that doesn't pretned to be local host, just to ensure we still have the connection closed

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add coverage for oversized websocket messages and adjust assertions/cleanup without affecting production logic.
> 
> **Overview**
> Adds a new DoS regression test to verify that sending a websocket message over the 50MB limit reliably closes the connection with `WSCloseCode.MESSAGE_TOO_BIG` even for localhost connections, and asserts the expected error logs via `caplog`.
> 
> Splits the prior oversized-message test into a dedicated *disconnect* test and a *ban* test that explicitly monkeypatches `is_localhost` to ensure remote peers are banned; also tightens test cleanup by closing the `ClientSession` and removes debug output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02dde332f1b3f4b8618f2c89bf08c1f05e0ed5b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->