### PR TITLE
[CHIA-3963 CHIA-3964 CHIA-3955] early check of proof of space in a few places

### DIFF
--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -703,6 +703,9 @@ class Blockchain:
     async def validate_unfinished_block_header(
         self, block: UnfinishedBlock, skip_overflow_ss_validation: bool = True
     ) -> tuple[uint64 | None, Err | None]:
+        if len(block.reward_chain_block.proof_of_space.proof) >= 2000:
+            return None, Err.INVALID_POSPACE
+
         if len(block.transactions_generator_ref_list) > self.constants.MAX_GENERATOR_REF_LIST_SIZE:
             return None, Err.TOO_MANY_GENERATOR_REFS
 

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2062,6 +2062,9 @@ class FullNode:
         ):
             # This is the case where we already had the unfinished block, and asked for this block without
             # the transactions (since we already had them). Therefore, here we add the transactions.
+            pos = block.reward_chain_block.proof_of_space
+            if pos.version == 1 and pos.quality_string() is None:
+                raise ConsensusError(Err.INVALID_POSPACE)
             unfinished_rh: bytes32 = block.reward_chain_block.get_unfinished().get_hash()
             foliage_hash: bytes32 | None = block.foliage.foliage_transaction_block_hash
             assert foliage_hash is not None
@@ -2326,6 +2329,10 @@ class FullNode:
             # No need to request the parent, since the peer will send it to us anyway, via NewPeak
             self.log.debug("Received a disconnected unfinished block")
             return None
+
+        pos = block.reward_chain_block.proof_of_space
+        if pos.version == 1 and pos.quality_string() is None:
+            raise ConsensusError(Err.INVALID_POSPACE)
 
         # Adds the unfinished block to seen, and check if it's seen before, to prevent
         # processing it twice. This searches for the exact version of the unfinished block (there can be many different

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1231,6 +1231,11 @@ def validate_recent_blocks(
     adjusted = False
     validated_block_count = 0
     for idx, block in enumerate(recent_chain.recent_chain_data):
+        pos = block.reward_chain_block.proof_of_space
+        if pos.version == 1 and pos.quality_string() is None:
+            log.info(f"invalid proof of space in weight proof recent chain block {block.height}")
+            return False, []
+
         required_iters = uint64(0)
         overflow = False
         ses = False

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -168,6 +168,11 @@ def verify_and_get_quality_string(
         # === V1 plots ===
         assert plot_param.strength_v2 is None
 
+        if not height_agnostic and prev_transaction_block_height >= constants.SOFT_FORK9_HEIGHT:
+            if len(pos.proof) >= 2000:
+                log.error(f"Proof of space too large: {len(pos.proof)} bytes")
+                return None
+
         quality_str = Verifier().validate_proof(plot_id, plot_param.size_v1, pos.challenge, bytes(pos.proof))
         if not quality_str:
             return None


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-critical block and weight-proof validation paths; although the checks are simple, they can change block acceptance and sync behavior if misapplied (e.g., around soft-fork heights or plot versions).
> 
> **Overview**
> **Adds earlier rejection of malformed/abusive Proof of Space data.** Unfinished block header validation now immediately rejects oversized PoS proofs (>= 2000 bytes) with `Err.INVALID_POSPACE`.
> 
> The full node and weight-proof verification paths add an early v1 PoS sanity check (`quality_string()` must be present) to fail fast on invalid blocks/weight proofs before doing heavier processing.
> 
> `validate_pospace()` additionally enforces the PoS size limit for v1 proofs *after* `SOFT_FORK9_HEIGHT`, logging and returning `None` when exceeded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0af2526a6e04b629b30d849597660198abb63e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->