### PR TITLE
Fix DEB and RPM package compression for smaller installer sizes

### DIFF
--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -69,7 +69,7 @@ cp assets/systemd/*.service "dist/$CLI_DEB_BASE/etc/systemd/system/"
 cp -r dist/daemon/* "dist/$CLI_DEB_BASE/opt/chia/"
 
 ln -s ../../opt/chia/chia "dist/$CLI_DEB_BASE/usr/bin/chia"
-dpkg-deb -Zxz -z6 --build --root-owner-group "dist/$CLI_DEB_BASE"
+dpkg-deb -Zxz -z9 --build --root-owner-group "dist/$CLI_DEB_BASE"
 # CLI only .deb done
 
 cp -r dist/daemon ../chia-blockchain-gui/packages/gui

--- a/build_scripts/build_linux_deb-2-installer.sh
+++ b/build_scripts/build_linux_deb-2-installer.sh
@@ -69,7 +69,7 @@ cp assets/systemd/*.service "dist/$CLI_DEB_BASE/etc/systemd/system/"
 cp -r dist/daemon/* "dist/$CLI_DEB_BASE/opt/chia/"
 
 ln -s ../../opt/chia/chia "dist/$CLI_DEB_BASE/usr/bin/chia"
-dpkg-deb --build --root-owner-group "dist/$CLI_DEB_BASE"
+dpkg-deb -Zxz -z6 --build --root-owner-group "dist/$CLI_DEB_BASE"
 # CLI only .deb done
 
 cp -r dist/daemon ../chia-blockchain-gui/packages/gui

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -88,7 +88,7 @@ fpm -s dir -t rpm \
   --before-install=assets/rpm/before-install.sh \
   --rpm-tag 'Requires(pre): findutils' \
   --rpm-compression xz \
-  --rpm-compression-level 6 \
+  --rpm-compression-level 9 \
   .
 # CLI only rpm done
 cp -r dist/daemon ../chia-blockchain-gui/packages/gui

--- a/build_scripts/build_linux_rpm-2-installer.sh
+++ b/build_scripts/build_linux_rpm-2-installer.sh
@@ -87,7 +87,7 @@ fpm -s dir -t rpm \
   --rpm-tag '%undefine _missing_build_ids_terminate_build' \
   --before-install=assets/rpm/before-install.sh \
   --rpm-tag 'Requires(pre): findutils' \
-  --rpm-compression xzmt \
+  --rpm-compression xz \
   --rpm-compression-level 6 \
   .
 # CLI only rpm done

--- a/build_scripts/electron-builder.json
+++ b/build_scripts/electron-builder.json
@@ -78,6 +78,7 @@
   "deb": {
     "afterInstall": "../../../build_scripts/assets/deb/postinst.sh",
     "afterRemove": "../../../build_scripts/assets/deb/prerm.sh",
+    "fpm": ["--deb-compression", "xz", "--deb-compression-level", "6"],
     "depends": [
       "libgbm1",
       "libgtk-3-0",
@@ -103,7 +104,9 @@
       "--rpm-tag=Recommends: libxcrypt-compat",
       "--directories=/opt/chia",
       "--rpm-tag=Requires(pre): findutils",
-      "--before-install=../../../build_scripts/assets/rpm/before-install.sh"
+      "--before-install=../../../build_scripts/assets/rpm/before-install.sh",
+      "--rpm-compression=xz",
+      "--rpm-compression-level=6"
     ]
   }
 }

--- a/build_scripts/electron-builder.json
+++ b/build_scripts/electron-builder.json
@@ -78,7 +78,7 @@
   "deb": {
     "afterInstall": "../../../build_scripts/assets/deb/postinst.sh",
     "afterRemove": "../../../build_scripts/assets/deb/prerm.sh",
-    "fpm": ["--deb-compression", "xz", "--deb-compression-level", "6"],
+    "fpm": ["--deb-compression", "xz", "--deb-compression-level", "9"],
     "depends": [
       "libgbm1",
       "libgtk-3-0",
@@ -106,7 +106,7 @@
       "--rpm-tag=Requires(pre): findutils",
       "--before-install=../../../build_scripts/assets/rpm/before-install.sh",
       "--rpm-compression=xz",
-      "--rpm-compression-level=6"
+      "--rpm-compression-level=9"
     ]
   }
 }


### PR DESCRIPTION
## Summary

- CLI DEB: added `-Zxz -z9` to `dpkg-deb` (was using build host default zstd level 3)
- GUI DEB: added `--deb-compression xz --deb-compression-level 9` to electron-builder fpm options (was using electron-builder's 7-Zip xz with a 4 MiB dictionary)
- CLI RPM: changed `--rpm-compression xzmt` to `--rpm-compression xz` and level from 6 to 9 (single-threaded for better cross-file deduplication, 64 MiB dictionary)
- GUI RPM: added explicit `--rpm-compression=xz --rpm-compression-level=9` to electron-builder fpm options (was relying on fpm/rpmbuild defaults)

All four Linux packages now explicitly use single-threaded xz at level 9 (64 MiB LZMA2 dictionary).

### Results

| Package | 2.6.1 Release | With fix | Reduction |
|---------|--------------|----------|-----------|
| GUI DEB | 401 MB | 175 MB | 56% smaller |
| CLI DEB | 306 MB | 96 MB | 69% smaller |
| GUI RPM | 178 MB | 162 MB | 9% smaller |
| CLI RPM | 301 MB | 80 MB | 73% smaller |
| **Total** | **1,186 MB** | **513 MB** | **57% smaller** |

### Root cause

- **GUI DEB**: electron-builder's app-builder delegates xz compression to 7-Zip, which defaults to a 4 MiB LZMA2 dictionary regardless of compression level
- **CLI DEB**: `dpkg-deb` on the Ubuntu 22.04 build host defaults to zstd level 3, not xz
- **CLI RPM**: `xzmt` (multi-threaded xz) splits the payload into small 24 MB blocks, preventing effective deduplication of the 15 near-identical ~16 MB PyInstaller executables
- **GUI RPM**: was already compressing well by accident (rpmbuild defaulting to level 9), now made explicit

## Test plan

- [x] Build DEB packages and verify `data.tar.xz` uses xz with 64 MiB dictionary
- [x] Build RPM packages and verify payload uses xz with 64 MiB dictionary
- [x] Compare package sizes against 2.6.1 release
- [x] Verify packages install and run correctly on Ubuntu and Fedora/RHEL