### PR TITLE
checkpoint: into main from release/2.6.1  @ 8a64bfc1e2bfbd9c586e9c8e32b5295de576f6d5

### DIFF
--- a/build_scripts/build_linux_deb-1-gui.sh
+++ b/build_scripts/build_linux_deb-1-gui.sh
@@ -19,6 +19,17 @@ if [ "$LAST_EXIT_CODE" -ne 0 ]; then
   exit $LAST_EXIT_CODE
 fi
 
+# Webpack already bundled all JS into build/. Clear production dependencies from
+# package.json so electron-builder v26's node module collector doesn't fail when
+# it can't find workspace packages that are removed below for cache optimization.
+echo "Clearing dependencies from packages/gui/package.json for electron-builder"
+node -e "
+  const fs = require('fs');
+  const p = JSON.parse(fs.readFileSync('./packages/gui/package.json', 'utf8'));
+  p.dependencies = {};
+  fs.writeFileSync('./packages/gui/package.json', JSON.stringify(p, null, 2) + '\n');
+"
+
 # Remove unused packages
 rm -rf node_modules
 
@@ -39,5 +50,5 @@ rm -rf electron/dist # ~186MB
 rm -rf "@mui"        # ~71MB
 rm -rf typescript    # ~63MB
 
-# Remove `packages/gui/node_modules/@chia-network` because it causes an error on later `electron-packager` command
+# Remove `packages/gui/node_modules/@chia-network` to save cache space
 rm -rf "@chia-network"

--- a/build_scripts/build_linux_rpm-1-gui.sh
+++ b/build_scripts/build_linux_rpm-1-gui.sh
@@ -18,6 +18,17 @@ if [ "$LAST_EXIT_CODE" -ne 0 ]; then
   exit $LAST_EXIT_CODE
 fi
 
+# Webpack already bundled all JS into build/. Clear production dependencies from
+# package.json so electron-builder v26's node module collector doesn't fail when
+# it can't find workspace packages that are removed below for cache optimization.
+echo "Clearing dependencies from packages/gui/package.json for electron-builder"
+node -e "
+  const fs = require('fs');
+  const p = JSON.parse(fs.readFileSync('./packages/gui/package.json', 'utf8'));
+  p.dependencies = {};
+  fs.writeFileSync('./packages/gui/package.json', JSON.stringify(p, null, 2) + '\n');
+"
+
 # Remove unused packages
 rm -rf node_modules
 
@@ -38,5 +49,5 @@ rm -rf electron/dist # ~186MB
 rm -rf "@mui"        # ~71MB
 rm -rf typescript    # ~63MB
 
-# Remove `packages/gui/node_modules/@chia-network` because it causes an error on later `electron-packager` command
+# Remove `packages/gui/node_modules/@chia-network` to save cache space
 rm -rf "@chia-network"

--- a/build_scripts/build_macos-1-gui.sh
+++ b/build_scripts/build_macos-1-gui.sh
@@ -20,6 +20,17 @@ if [ "$LAST_EXIT_CODE" -ne 0 ]; then
   exit $LAST_EXIT_CODE
 fi
 
+# Webpack already bundled all JS into build/. Clear production dependencies from
+# package.json so electron-builder v26's node module collector doesn't fail when
+# it can't find workspace packages that are removed below for cache optimization.
+echo "Clearing dependencies from packages/gui/package.json for electron-builder"
+node -e "
+  const fs = require('fs');
+  const p = JSON.parse(fs.readFileSync('./packages/gui/package.json', 'utf8'));
+  p.dependencies = {};
+  fs.writeFileSync('./packages/gui/package.json', JSON.stringify(p, null, 2) + '\n');
+"
+
 # Remove unused packages
 rm -rf node_modules
 
@@ -40,5 +51,5 @@ rm -rf electron/dist # ~186MB
 rm -rf "@mui"        # ~71MB
 rm -rf typescript    # ~63MB
 
-# Remove `packages/gui/node_modules/@chia-network` because it causes an error on later `electron-packager` command
+# Remove `packages/gui/node_modules/@chia-network` to save cache space
 rm -rf "@chia-network"

--- a/build_scripts/build_windows-1-gui.ps1
+++ b/build_scripts/build_windows-1-gui.ps1
@@ -29,6 +29,15 @@ If ($LastExitCode -gt 0){
     Throw "npm run build failed!"
 }
 
+# Webpack already bundled all JS into build/. Clear production dependencies from
+# package.json so electron-builder v26's node module collector doesn't fail when
+# it can't find workspace packages that are removed below for cache optimization.
+Write-Output "Clearing dependencies from packages/gui/package.json for electron-builder"
+node -e "const fs = require('fs'); const p = JSON.parse(fs.readFileSync('./packages/gui/package.json', 'utf8')); p.dependencies = {}; fs.writeFileSync('./packages/gui/package.json', JSON.stringify(p, null, 2) + '\n');"
+If ($LastExitCode -gt 0){
+    Throw "Failed to clear dependencies from packages/gui/package.json"
+}
+
 # Remove unused packages
 Remove-Item node_modules -Recurse -Force
 
@@ -48,5 +57,5 @@ Remove-Item packages\wallets -Recurse -Force
 #Remove-Item "@mui" -Recurse -Force # ~71MB
 #Remove-Item typescript -Recurse -Force # ~63MB
 
-# Remove `packages/gui/node_modules/@chia-network` because it causes an error on later `electron-packager` command
+# Remove `packages/gui/node_modules/@chia-network` to save cache space
 #Remove-Item "@chia-network" -Recurse -Force


### PR DESCRIPTION
Source hash: 8a64bfc1e2bfbd9c586e9c8e32b5295de576f6d5
Remaining commits: 4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build/packaging scripts now mutate `packages/gui/package.json` during CI to work around electron-builder v26 dependency collection, which could affect packaging behavior if the build relies on runtime node modules.
> 
> **Overview**
> After `npm run build`, the Linux/macOS/Windows GUI packaging scripts now **rewrite `packages/gui/package.json` to clear `dependencies`**, preventing electron-builder v26’s node-module collector from failing once workspace packages are removed for cache slimming.
> 
> Comments were updated to reflect that removing `packages/gui/node_modules/@chia-network` is for cache size (and Windows adds an explicit failure check if the dependency-clearing step errors).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ed4f051c0ca505f88099369a38d92fc318fd0e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->