### PR TITLE
test parameterization cleanup

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -3361,7 +3361,6 @@ class TestReorgs:
 
         if consensus_mode not in {
             ConsensusMode.HARD_FORK_2_0,
-            ConsensusMode.SOFT_FORK_2_6,
             ConsensusMode.SOFT_FORK_2_7,
         }:
             reorg_point = 13

--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -209,15 +209,13 @@ class ConsensusMode(ComparableEnum):
     PLAIN = 0
     # the hard fork introduced in Chia 2.0 (but really in 2.1)
     HARD_FORK_2_0 = 1
-    # the soft fork introduced in Chia 2.6
-    SOFT_FORK_2_6 = 2
     # the soft fork introduced in Chia 2.7
-    SOFT_FORK_2_7 = 3
+    SOFT_FORK_2_7 = 2
     # the hard fork introduced in Chia 3.0
-    HARD_FORK_3_0 = 4
+    HARD_FORK_3_0 = 3
     # the hard fork introduced in Chia 3.0 but after v1 plots have been
     # phased-out, and no longer valid
-    HARD_FORK_3_0_AFTER_PHASE_OUT = 5
+    HARD_FORK_3_0_AFTER_PHASE_OUT = 4
 
 
 @pytest.fixture(
@@ -225,7 +223,6 @@ class ConsensusMode(ComparableEnum):
     params=[
         ConsensusMode.PLAIN,
         ConsensusMode.HARD_FORK_2_0,
-        ConsensusMode.SOFT_FORK_2_6,
         ConsensusMode.SOFT_FORK_2_7,
         ConsensusMode.HARD_FORK_3_0,
         ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT,
@@ -242,11 +239,6 @@ def blockchain_constants(consensus_mode: ConsensusMode) -> ConsensusConstants:
     if consensus_mode >= ConsensusMode.HARD_FORK_2_0:
         ret = ret.replace(
             HARD_FORK_HEIGHT=uint32(2),
-        )
-
-    if consensus_mode >= ConsensusMode.SOFT_FORK_2_6:
-        ret = ret.replace(
-            SOFT_FORK8_HEIGHT=uint32(2),
         )
 
     if consensus_mode >= ConsensusMode.SOFT_FORK_2_7:

--- a/chia/_tests/timelord/test_new_peak.py
+++ b/chia/_tests/timelord/test_new_peak.py
@@ -157,7 +157,7 @@ class TestNewPeak:
         allowed=[
             ConsensusMode.PLAIN,
             ConsensusMode.HARD_FORK_2_0,
-            ConsensusMode.SOFT_FORK_2_6,
+            ConsensusMode.SOFT_FORK_2_7,
         ],
         reason="test builds a synthetic unfinished block for HF3.0",
     )

--- a/chia/_tests/weight_proof/test_weight_proof.py
+++ b/chia/_tests/weight_proof/test_weight_proof.py
@@ -317,7 +317,7 @@ class TestWeightProof:
         allowed=[
             ConsensusMode.PLAIN,
             ConsensusMode.HARD_FORK_2_0,
-            ConsensusMode.SOFT_FORK_2_6,
+            ConsensusMode.SOFT_FORK_2_7,
             ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT,
         ],
         reason="investigate test failure",


### PR DESCRIPTION
since 2.6.0 and 2.7.0 will be the same soft-fork now, we don't need to test them separately

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test parametrization and constants setup, with no production logic affected. Main risk is accidental gaps in coverage or changed expectations due to removing the separate `SOFT_FORK_2_6` mode.
> 
> **Overview**
> Collapses the test consensus-mode matrix by **removing `ConsensusMode.SOFT_FORK_2_6`** and renumbering `ConsensusMode` values, so tests no longer run a separate 2.6 soft-fork scenario.
> 
> Updates the session-scoped `consensus_mode` and `blockchain_constants` fixtures accordingly (dropping the 2.6-only constants overrides), and adjusts a few tests/markers to reference `SOFT_FORK_2_7` instead of `SOFT_FORK_2_6` (including the reorg-point selection in `test_get_tx_peak_reorg`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 242510a7c79be21614feae53da883373581b36d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->