### PR TITLE
More precise tx selection in `test_create_signed_transaction`

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -651,11 +651,12 @@ async def test_create_signed_transaction(
         )
     ).transactions
     change_expected = not selected_coin or selected_coin.amount - amount_total > 0
-    assert_tx_amounts(txs[-1], outputs, amount_fee=amount_fee, change_expected=change_expected, is_cat=is_cat)
+
+    main_tx = next(tx for tx in txs if tx.amount > 0)
+    assert_tx_amounts(main_tx, outputs, amount_fee=amount_fee, change_expected=change_expected, is_cat=is_cat)
 
     # Farm the transaction and make sure the wallet balance reflects it correct
-    spend_bundle = txs[0].spend_bundle
-    assert spend_bundle is not None
+    spend_bundle = next(tx.spend_bundle for tx in txs if tx.spend_bundle is not None)
     xch_delta = amount_total if not is_cat else amount_fee
     cat_delta = amount_total if is_cat else 0
     await wallet_environments.process_pending_states(


### PR DESCRIPTION
This PR is in answer to a flake: https://github.com/Chia-Network/chia-blockchain/actions/runs/23295574326/job/67742008805?pr=20693#step:16:567

I couldn't reproduce the flake, so this is my best guess at what the cause is.  In either case, it's a good change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that makes assertions deterministic when RPC returns multiple transaction records, reducing flakiness without affecting production code paths.
> 
> **Overview**
> Updates `test_create_signed_transaction` to **stop assuming ordering** of the `create_signed_transactions` response.
> 
> The test now explicitly selects the *main* transaction (`tx.amount > 0`) for `assert_tx_amounts`, and grabs the first non-`None` `spend_bundle` from the returned list, making the test resilient to extra/fee-only transaction records and avoiding flakes caused by nondeterministic ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6cbb6e633bb283065de32777b0a56d1163f935b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->