### PR TITLE
[CHIA-3957] ignore unsolicited RespondTransaction

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1234,6 +1234,47 @@ async def test_respond_transaction_fail(
 
 
 @pytest.mark.anyio
+async def test_unsolicited_transaction_ignored(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+) -> None:
+    full_node_1, server_1, _bt = one_node_one_block
+
+    _incoming_queue, dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12312)
+    peer = server_1.all_connections[dummy_node_id]
+
+    spend_bundle = make_spend_bundle(1)
+    assert peer.expected_mempool_responses == 0
+    res = await full_node_1.respond_transaction(fnp.RespondTransaction(spend_bundle), peer)
+    assert res is None
+    assert full_node_1.full_node.mempool_manager.get_spendbundle(spend_bundle.name()) is None
+
+
+@pytest.mark.anyio
+async def test_malformed_peer_version_on_connect(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+) -> None:
+    full_node_1, server_1, _bt = one_node_one_block
+
+    _incoming_queue, dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12312)
+    peer = server_1.all_connections[dummy_node_id]
+
+    # Make synced() return True so on_connect reaches the version check
+    original_network = full_node_1.full_node.config.get("selected_network")
+    full_node_1.full_node.config["selected_network"] = "simulator0"
+    try:
+        peer.version = "2.7.0-custom"
+        peer.expected_mempool_responses = 0
+        await full_node_1.full_node.on_connect(peer)
+
+        # Unparseable version should be treated as old, so the counter is incremented
+        assert peer.expected_mempool_responses == 100
+    finally:
+        full_node_1.full_node.config["selected_network"] = original_network
+
+
+@pytest.mark.anyio
 async def test_request_block(
     wallet_nodes: tuple[
         FullNodeSimulator, FullNodeSimulator, ChiaServer, ChiaServer, WalletTool, WalletTool, BlockTools

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1169,6 +1169,7 @@ async def test_request_respond_transaction(
     spend_bundle = wallet_a.generate_signed_transaction(uint64(100), receiver_puzzlehash, coin)
     assert spend_bundle is not None
     respond_transaction = fnp.RespondTransaction(spend_bundle)
+    peer.expected_mempool_responses += 1
     res = await full_node_1.respond_transaction(respond_transaction, peer)
     assert res is None
 
@@ -1224,6 +1225,7 @@ async def test_respond_transaction_fail(
 
     assert spend_bundle is not None
     respond_transaction = fnp.RespondTransaction(spend_bundle)
+    peer.expected_mempool_responses += 1
     msg = await full_node_1.respond_transaction(respond_transaction, peer)
     assert msg is None
 

--- a/chia/_tests/core/full_node/test_performance.py
+++ b/chia/_tests/core/full_node/test_performance.py
@@ -51,6 +51,7 @@ class TestPerformance:
         start_height = peak_record.height if peak_record is not None else -1
         _incoming_queue, node_id = await add_dummy_connection(server_1, self_hostname, 12312)
         fake_peer = server_1.all_connections[node_id]
+        fake_peer.expected_mempool_responses = 10000
         # Mempool has capacity of 100, make 110 unspents that we can use
         puzzle_hashes = []
 

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -426,6 +426,7 @@ class TestMempoolManager:
         spend_bundle = generate_test_spend_bundle(wallet_a, coin)
         assert spend_bundle is not None
         tx: full_node_protocol.RespondTransaction = full_node_protocol.RespondTransaction(spend_bundle)
+        peer.expected_mempool_responses += 1
         await full_node_1.respond_transaction(tx, peer, test=True)
 
         await time_out_assert(

--- a/chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py
+++ b/chia/_tests/wallet/simple_sync/test_simple_sync_protocol.py
@@ -506,6 +506,7 @@ async def test_subscribe_for_hint(simulator_and_wallet: OldSimulatorsAndWallets,
     await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
     tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin_spent, condition_dic=condition_dict)
+    fake_wallet_peer.expected_mempool_responses += 1
     await full_node_api.respond_transaction(RespondTransaction(tx), fake_wallet_peer)
 
     await full_node_api.process_spend_bundles(bundles=[tx])
@@ -557,6 +558,7 @@ async def test_subscribe_for_puzzle_hash_coin_hint_duplicates(
             ConditionOpcode.CREATE_COIN: [ConditionWithArgs(ConditionOpcode.CREATE_COIN, [ph, int_to_bytes(1), ph])]
         },
     )
+    wallet_connection.expected_mempool_responses += 1
     await full_node_api.respond_transaction(RespondTransaction(tx), wallet_connection)
     await full_node_api.process_spend_bundles(bundles=[tx])
     # Query the coin states and make sure it doesn't contain duplicated entries
@@ -615,6 +617,7 @@ async def test_subscribe_for_hint_long_sync(
     await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=20)
 
     tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin_spent, condition_dic=condition_dict)
+    fake_wallet_peer.expected_mempool_responses += 1
     await full_node_api.respond_transaction(RespondTransaction(tx), fake_wallet_peer)
 
     await full_node_api.process_spend_bundles(bundles=[tx])

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -942,6 +942,14 @@ class FullNode:
 
                 msg = make_msg(ProtocolMessageTypes.request_mempool_transactions, mempool_request)
                 await connection.send_message(msg)
+                # Old peers (< 2.6.0) respond to RequestMempoolTransactions with
+                # RespondTransaction directly. New peers send NewTransaction instead.
+                try:
+                    old_peer = Version(connection.version) < Version("2.6.0")
+                except Exception:
+                    old_peer = True
+                if old_peer:
+                    connection.expected_mempool_responses += 100
 
         peak_full: FullBlock | None = await self.blockchain.get_full_peak()
 

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -314,6 +314,11 @@ class FullNodeAPI:
         spend_name = std_hash(tx_bytes)
         if spend_name in self.full_node.full_node_store.pending_tx_request:
             self.full_node.full_node_store.pending_tx_request.pop(spend_name)
+        elif peer.expected_mempool_responses > 0:
+            peer.expected_mempool_responses -= 1
+        else:
+            self.log.warning(f"Received unsolicited transaction from peer {peer.peer_node_id}")
+            return None
         peers_with_tx = {}
         if spend_name in self.full_node.full_node_store.peers_with_tx:
             peers_with_tx = self.full_node.full_node_store.peers_with_tx.pop(spend_name)

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -137,6 +137,11 @@ class WSChiaConnection:
     # Used to reject unsolicited RespondCompactVDF messages.
     pending_compact_vdfs: LRUSet[bytes32] = field(default_factory=lambda: LRUSet(MAX_PENDING_COMPACT_VDFS), repr=False)
 
+    # Tracks expected RespondTransaction messages from old peers (< 2.6.0) that
+    # respond to RequestMempoolTransactions with RespondTransaction directly.
+    # Decremented on each such response; if 0, the message is unsolicited.
+    expected_mempool_responses: int = 0
+
     exempt_peer_networks: list[IPv4Network | IPv6Network] = field(
         default_factory=list,
         repr=False,


### PR DESCRIPTION
As part of improving the network protocol. Unsolicited `RespondTransaction` messages are ignored. But previous versions of the client would send an unknown number of `RespondTransaction` in response to a single `RequestMempoolTransactions`, which was a quirk in the protocol.

When connecting to old peers, we must still tolerate this behavior. But to make it tighter, only allow 100 "unsolicited" messages after we send `RequestMempoolTransactions` and only from old peers.

If we get a message we think is unsolicited, ignore it rather than banning, to be more conservative, avoiding too drastic effects on the network.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches full-node transaction ingestion and peer-compatibility logic; miscounting expected responses could drop legitimate transactions from older peers or noisy networks.
> 
> **Overview**
> **Full nodes now ignore `RespondTransaction` messages that were not requested.** `FullNodeAPI.respond_transaction()` only accepts a transaction if it matches a pending tx request *or* the peer has outstanding `expected_mempool_responses`; otherwise it logs and drops the message.
> 
> **Adds backward-compat handling for pre-2.6.0 peers.** On connect, `FullNode.on_connect()` detects old/unparseable peer versions and pre-allocates an `expected_mempool_responses` budget to allow legacy `RequestMempoolTransactions` behavior.
> 
> Tests are updated to account for the new gating and add coverage for ignoring unsolicited transactions and handling malformed peer version strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f2b6ffc089eeb76255d4ab22897749c92ad4591. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->