### PR TITLE
Fix flaky test_dusted_wallet timeout on ARM runners

### DIFF
--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -1289,9 +1289,9 @@ async def test_dusted_wallet(
 
     # advance the chain and sync both wallets
     await full_node_api.wait_transaction_records_entered_mempool([tx])
-    await full_node_api.wait_for_wallets_synced(wallet_nodes=[farm_wallet_node, dust_wallet_node], timeout=20)
+    await full_node_api.wait_for_wallets_synced(wallet_nodes=[farm_wallet_node, dust_wallet_node], timeout=40)
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-    await full_node_api.wait_for_wallets_synced(wallet_nodes=[farm_wallet_node, dust_wallet_node], timeout=20)
+    await full_node_api.wait_for_wallets_synced(wallet_nodes=[farm_wallet_node, dust_wallet_node], timeout=40)
 
     # Obtain and log important values
     all_unspent = await dust_wallet_node.wallet_state_manager.coin_store.get_all_unspent_coins()
@@ -1357,9 +1357,9 @@ async def test_dusted_wallet(
 
     # advance the chain and sync both wallets
     await full_node_api.wait_transaction_records_entered_mempool([tx])
-    await full_node_api.wait_for_wallets_synced(wallet_nodes=[farm_wallet_node, dust_wallet_node], timeout=20)
+    await full_node_api.wait_for_wallets_synced(wallet_nodes=[farm_wallet_node, dust_wallet_node], timeout=40)
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-    await full_node_api.wait_for_wallets_synced(wallet_nodes=[farm_wallet_node, dust_wallet_node], timeout=20)
+    await full_node_api.wait_for_wallets_synced(wallet_nodes=[farm_wallet_node, dust_wallet_node], timeout=40)
 
     # Obtain and log important values
     all_unspent = await dust_wallet_node.wallet_state_manager.coin_store.get_all_unspent_coins()


### PR DESCRIPTION
### Purpose:

The wallet either needs to do it's work faster or we need longer timeouts on the test - this routinely fails on the CI hardware.

Fix flaky `test_dusted_wallet` failures in the `wallet.sync` test suite. The `(105, 1_000_000, 1)` parameterization intermittently fails with `TimeoutError` on ARM CI runners due to insufficient `wait_for_wallets_synced` timeouts in Part 6 of the test.  
### Current Behavior:

`test_dusted_wallet[True-ConsensusMode.HARD_FORK_2_0-105-1000000-1]` and `test_dusted_wallet[False-ConsensusMode.HARD_FORK_2_0-105-1000000-1]` intermittently fail with `TimeoutError` on `ubuntu-arm` runners. The 105-coin variant accumulates ~120+ coins across Parts 1–5, then Part 6 spends them all in a single transaction. Processing that many coin state changes during wallet sync exceeds the 20-second timeout (21s after `adjusted_timeout` on Linux), especially under load with 6 parallel pytest workers on slower ARM hardware.

The failure occurs at the `wait_for_wallets_synced` call after farming the block that clears the dust wallet, and the traceback shows the wallet was mid-SQLite query (`get_finished_sync_up_to`) when the anyio cancel scope fired — confirming the wallet was still syncing coin state changes.

### New Behavior:

Part 6 `wait_for_wallets_synced` timeouts are increased from 20s to 40s for the two operations that process large numbers of coins:
- Clearing all ~120+ coins from the dust wallet (lines 1292/1294)
- Re-creating ~99 coins in the final batch send (lines 1360/1362)

Other Part 6 operations that handle small numbers of coins (6-coin batch in the loop, 1-mojo send) are left at 20s since they are not at risk.

### Testing Notes:

This is a test-only change that increases sync timeouts. No production code is modified. The fix addresses the same flaky failure observed in chia-blockchain-private CI (ubuntu-arm, Python 3.12).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only timeout adjustments with no production logic changes. Main impact is slightly longer waits in failure scenarios, which could marginally increase CI runtime.
> 
> **Overview**
> Reduces flakiness in `test_dusted_wallet` by increasing Part 6 `wait_for_wallets_synced` timeouts from 20s to 40s for the two heavy-sync points: after spending/clearing the dust wallet and after farming the block that recreates the final batch of coins.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87be4cb036a15acdc77105dfe157c735d5df4873. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->