### PR TITLE
Update chia_rs dependency.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
         python-version: ["3.12"]
     env:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
-      BLOCKS_AND_PLOTS_VERSION: 0.45.7
+      BLOCKS_AND_PLOTS_VERSION: 0.45.8
 
     steps:
       - name: Clean workspace

--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -130,7 +130,7 @@ jobs:
       CHIA_ROOT: ${{ github.workspace }}/.chia/mainnet
       CHIA_SIMULATOR_ROOT: ${{ github.workspace }}/.chia/simulator
       JOB_FILE_NAME: tests_${{ matrix.os.file_name }}_python-${{ matrix.python.file_name }}_${{ matrix.configuration.module_import_path }}${{ matrix.configuration.file_name_index }}
-      BLOCKS_AND_PLOTS_VERSION: 0.45.7
+      BLOCKS_AND_PLOTS_VERSION: 0.45.8
 
     steps:
       - name: Checkout code

--- a/chia/_tests/core/full_node/test_conditions.py
+++ b/chia/_tests/core/full_node/test_conditions.py
@@ -16,6 +16,7 @@ from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from chia._tests.conftest import ConsensusMode
 from chia._tests.core.full_node.ram_db import create_ram_blockchain
 from chia._tests.core.full_node.test_full_node import find_reward_coin
+from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.condition_tools import agg_sig_additional_data
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.keyring import TempKeyring
@@ -145,8 +146,14 @@ class TestConditions:
             block_base_cost = 756064 - 12000
         else:
             block_base_cost = 761056 - 12000
+
+        if consensus_mode >= ConsensusMode.HARD_FORK_3_0:
+            condition_cost = ConditionCost.GENERIC_CONDITION_COST.value
+        else:
+            condition_cost = 0
+
         assert new_block.transactions_info is not None
-        assert new_block.transactions_info.cost - block_base_cost == expected_cost
+        assert new_block.transactions_info.cost - block_base_cost - condition_cost == expected_cost
 
     @pytest.mark.anyio
     @pytest.mark.parametrize(
@@ -169,11 +176,16 @@ class TestConditions:
             # generator (which includes hashing all puzzles).
             block_base_cost = 732064 - 12000
 
+        if consensus_mode >= ConsensusMode.HARD_FORK_3_0:
+            condition_cost = ConditionCost.GENERIC_CONDITION_COST.value
+        else:
+            condition_cost = 0
+
         # the block_base_cost includes the cost of the bytes for the condition
         # with 2 bytes argument. This test works as long as the conditions it's
         # parameterized on has the same size
         assert new_block.transactions_info is not None
-        assert new_block.transactions_info.cost - block_base_cost == expected_cost
+        assert new_block.transactions_info.cost - block_base_cost - condition_cost == expected_cost
 
     @pytest.mark.anyio
     @pytest.mark.parametrize(

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -3412,18 +3412,39 @@ def test_max_spends_per_block(old: bool) -> None:
     )
     mempool = Mempool(mempool_info, fee_estimator)
 
-    num_items = MAX_SPENDS_PER_BLOCK + 500
-    for i in range(num_items):
-        item = mk_item([make_coin(i)], cost=1_000_000, fee=100)
+    # Fill up to MAX_SPENDS_PER_BLOCK - 1 with single-coin items.
+    coin_idx = 0
+    for i in range(MAX_SPENDS_PER_BLOCK - 1):
+        item = mk_item([make_coin(coin_idx)], cost=1_000_000, fee=100)
+        coin_idx += 1
         info = mempool.add_to_pool(item)
         assert info.error is None
 
-    assert mempool.size() == num_items
+    # Add 2-coin items. These are processed next (same fee_per_cost, higher
+    # seq) and each would push new_spend_count to
+    # MAX_SPENDS_PER_BLOCK - 1 + 2 = MAX_SPENDS_PER_BLOCK + 1, which must
+    # trigger the > MAX_SPENDS_PER_BLOCK skip path.
+    num_two_coin_items = 5
+    for i in range(num_two_coin_items):
+        item = mk_item([make_coin(coin_idx), make_coin(coin_idx + 1)], cost=1_000_000, fee=100)
+        coin_idx += 2
+        info = mempool.add_to_pool(item)
+        assert info.error is None
+
+    # Add a final single-coin item that fits in the remaining slot.
+    item = mk_item([make_coin(coin_idx)], cost=1_000_000, fee=100)
+    coin_idx += 1
+    info = mempool.add_to_pool(item)
+    assert info.error is None
+
+    total_items = MAX_SPENDS_PER_BLOCK - 1 + num_two_coin_items + 1
+    assert mempool.size() == total_items
 
     create_block = mempool.create_block_generator if old else mempool.create_block_generator2
     generator = create_block(test_constants, uint32(0), 30.0)
     assert generator is not None
-    assert len(generator.removals) <= MAX_SPENDS_PER_BLOCK
+    # The 2-coin items were skipped but the final 1-coin item fits.
+    assert len(generator.removals) == MAX_SPENDS_PER_BLOCK
 
 
 @pytest.mark.parametrize("old", [True, False])

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -47,7 +47,7 @@ from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
 from chia.full_node.fee_estimation import EmptyMempoolInfo, MempoolInfo
 from chia.full_node.full_node_api import FullNodeAPI
-from chia.full_node.mempool import Mempool
+from chia.full_node.mempool import MAX_SPENDS_PER_BLOCK, Mempool
 from chia.full_node.mempool_manager import MEMPOOL_MIN_FEE_INCREASE, LineageInfoCache
 from chia.full_node.pending_tx_cache import ConflictTxCache, PendingTxCache
 from chia.protocols import full_node_protocol, wallet_protocol
@@ -3399,6 +3399,74 @@ def test_create_block_generator(old: bool) -> None:
 
     assert num_additions == len(generator.additions)
     invariant_check_mempool(mempool)
+
+
+@pytest.mark.parametrize("old", [True, False])
+def test_max_spends_per_block(old: bool) -> None:
+    max_cost = uint64(11_000_000_000)
+    fee_estimator = create_bitcoin_fee_estimator(max_cost)
+    mempool_info = MempoolInfo(
+        CLVMCost(uint64(max_cost * 10)),
+        FeeRate(uint64(1000000)),
+        CLVMCost(max_cost),
+    )
+    mempool = Mempool(mempool_info, fee_estimator)
+
+    num_items = MAX_SPENDS_PER_BLOCK + 500
+    for i in range(num_items):
+        item = mk_item([make_coin(i)], cost=1_000_000, fee=100)
+        info = mempool.add_to_pool(item)
+        assert info.error is None
+
+    assert mempool.size() == num_items
+
+    create_block = mempool.create_block_generator if old else mempool.create_block_generator2
+    generator = create_block(test_constants, uint32(0), 30.0)
+    assert generator is not None
+    assert len(generator.removals) <= MAX_SPENDS_PER_BLOCK
+
+
+@pytest.mark.parametrize("old", [True, False])
+def test_max_spends_per_block_with_dedup(old: bool) -> None:
+    from chia_rs import ELIGIBLE_FOR_DEDUP
+
+    max_cost = uint64(11_000_000_000)
+    fee_estimator = create_bitcoin_fee_estimator(max_cost)
+    mempool_info = MempoolInfo(
+        CLVMCost(uint64(max_cost * 10)),
+        FeeRate(uint64(1000000)),
+        CLVMCost(max_cost),
+    )
+    mempool = Mempool(mempool_info, fee_estimator)
+
+    shared_coin = make_coin(0)
+
+    num_items = MAX_SPENDS_PER_BLOCK + 500
+    for i in range(num_items):
+        unique_coin = make_coin(i + 1)
+        item = mk_item(
+            [shared_coin, unique_coin],
+            cost=1_000_000,
+            fee=100,
+            flags=[ELIGIBLE_FOR_DEDUP, 0],
+        )
+        info = mempool.add_to_pool(item)
+        assert info.error is None
+
+    assert mempool.size() == num_items
+
+    create_block = mempool.create_block_generator if old else mempool.create_block_generator2
+    generator = create_block(test_constants, uint32(0), 30.0)
+    assert generator is not None
+
+    # With dedup, the shared coin is only counted once. Each item contributes
+    # 1 unique spend (after the first which contributes 2), so more items fit
+    # than without dedup, but we must still respect the limit.
+    assert len(generator.removals) <= MAX_SPENDS_PER_BLOCK
+
+    # Verify dedup actually helped: without dedup each item would need 2 spend
+    # slots, limiting us to 3000 items. With dedup we should fit more.
+    assert len(generator.removals) > MAX_SPENDS_PER_BLOCK // 2
 
 
 def test_keccak() -> None:

--- a/chia/_tests/core/test_cost_calculation.py
+++ b/chia/_tests/core/test_cost_calculation.py
@@ -97,22 +97,20 @@ async def test_basics(softfork_height: int, bt: BlockTools) -> None:
     assert puzzle == coin_spend.puzzle_reveal
     assert solution == coin_spend.solution
 
-    if softfork_height >= bt.constants.HARD_FORK_HEIGHT:
+    condition_cost = ConditionCost.CREATE_COIN.value + ConditionCost.AGG_SIG.value
+    if softfork_height >= bt.constants.HARD_FORK2_HEIGHT:
+        condition_cost += ConditionCost.MESSAGE_CONDITION_COST.value
+        clvm_cost = 27360
+    elif softfork_height >= bt.constants.HARD_FORK_HEIGHT:
         clvm_cost = 27360
     else:
         clvm_cost = 404560
     byte_cost = len(bytes(program.program)) * bt.constants.COST_PER_BYTE
-    assert (
-        npc_result.conds.cost == ConditionCost.CREATE_COIN.value + ConditionCost.AGG_SIG.value + clvm_cost + byte_cost
-    )
+    assert npc_result.conds.cost == condition_cost + clvm_cost + byte_cost
 
     # Create condition + agg_sig_condition + length + cpu_cost
     assert (
-        npc_result.conds.cost
-        == ConditionCost.CREATE_COIN.value
-        + ConditionCost.AGG_SIG.value
-        + len(bytes(program.program)) * bt.constants.COST_PER_BYTE
-        + clvm_cost
+        npc_result.conds.cost == condition_cost + len(bytes(program.program)) * bt.constants.COST_PER_BYTE + clvm_cost
     )
 
 

--- a/chia/consensus/condition_costs.py
+++ b/chia/consensus/condition_costs.py
@@ -8,6 +8,8 @@ class ConditionCost(Enum):
     AGG_SIG = 1200000  # the cost of one G1 subgroup check + aggregated signature validation
     CREATE_COIN = 1800000
 
-    # with hard fork 2 (Chia 3.0) all conditions past the first 100 (per spend)
-    # has an additional cost of 500
-    GENERIC_CONDITION_COST = 500
+    # with hard fork 2 (Chia 3.0) all conditions have a cost
+    # SEND/RECEIVE MESSAGE and CREATE/ASSERT ANNOUNCEMENT
+    MESSAGE_CONDITION_COST = 700
+    # all other conditions
+    GENERIC_CONDITION_COST = 200

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -62,6 +62,15 @@ MIN_COST_THRESHOLD = 6_000_000
 # integers, which we rely on for computing fee per cost as well as the fee sum
 MEMPOOL_ITEM_FEE_LIMIT = 2**50
 
+# After soft_fork9_height, blocks are limited to 6000 spends in addition to the
+# CLVM cost limit. To prevent low-cost, many-spend transactions from exhausting
+# the spend limit and crowding out higher-value transactions, the mempool
+# prioritizes by fee per "virtual cost" rather than fee per CLVM cost.
+# Virtual cost is defined as: cost + num_spends * 500_000
+# This penalizes transactions that consume a disproportionate number of spend
+# slots relative to their CLVM cost.
+MAX_SPENDS_PER_BLOCK = 6000
+
 
 @dataclass
 class MempoolRemoveInfo:
@@ -572,6 +581,7 @@ class Mempool:
     ) -> tuple[SpendBundle, list[Coin]] | None:
         cost_sum = 0  # Checks that total cost does not exceed block maximum
         fee_sum = 0  # Checks that total fees don't exceed 64 bits
+        spend_count = 0  # Checks that total spends do not exceed MAX_SPENDS_PER_BLOCK
         processed_spend_bundles = 0
         additions: list[Coin] = []
         # This contains a map of coin ID to a coin spend solution and its
@@ -637,29 +647,34 @@ class Mempool:
                     # accounting for it
                     break  # pragma: no cover
                 new_cost_sum = cost_sum + item_cost
-                if new_cost_sum > self.mempool_info.max_block_clvm_cost:
-                    # Let's skip this item
+                new_spend_count = spend_count + len(unique_coin_spends)
+                if new_cost_sum > self.mempool_info.max_block_clvm_cost or new_spend_count > MAX_SPENDS_PER_BLOCK:
                     log.info(
-                        "Skipping mempool item. Cumulative cost %d exceeds maximum block cost %d",
+                        "Skipping mempool item. Cumulative cost %d (max %d) spends %d (max %d)",
                         new_cost_sum,
                         self.mempool_info.max_block_clvm_cost,
+                        new_spend_count,
+                        MAX_SPENDS_PER_BLOCK,
                     )
                     skipped_items += 1
                     if skipped_items < MAX_SKIPPED_ITEMS:
                         continue
-                    # Let's stop taking more items if we skipped `MAX_SKIPPED_ITEMS`
                     break
                 coin_spends.extend(unique_coin_spends)
                 additions.extend(unique_additions)
                 sigs.append(item.aggregated_signature)
                 cost_sum = new_cost_sum
                 fee_sum = new_fee_sum
+                spend_count = new_spend_count
                 processed_spend_bundles += 1
                 # Let's stop taking more items if we don't have enough cost left
                 # for at least `MIN_COST_THRESHOLD` because that would mean we're
                 # getting very close to the limit anyway and *probably* won't
                 # find transactions small enough to fit at this point
-                if self.mempool_info.max_block_clvm_cost - cost_sum < MIN_COST_THRESHOLD:
+                if (
+                    self.mempool_info.max_block_clvm_cost - cost_sum < MIN_COST_THRESHOLD
+                    or spend_count >= MAX_SPENDS_PER_BLOCK
+                ):
                     break
             except SkipDedup as e:
                 log.info(f"{e}")
@@ -732,6 +747,16 @@ class Mempool:
                     # accounting for it
                     break  # pragma: no cover
 
+                new_spend_count = added_spends + batch_spends + len(unique_coin_spends)
+                if new_spend_count > MAX_SPENDS_PER_BLOCK:
+                    log.info(
+                        "Skipping mempool item. Cumulative spends %d exceeds limit %d",
+                        new_spend_count,
+                        MAX_SPENDS_PER_BLOCK,
+                    )
+                    skipped_items += 1
+                    continue
+
                 # if adding item would make us exceed the block cost, commit the
                 # batch we've built up first, to see if more space may be freed
                 # up by the compression
@@ -764,6 +789,8 @@ class Mempool:
                 batch_additions.extend(unique_additions)
                 fee_sum = new_fee_sum
                 block_cost += item.conds.cost - cost_saving
+                if added_spends + batch_spends >= MAX_SPENDS_PER_BLOCK:
+                    break
             except SkipDedup as e:
                 log.info(f"{e}")
                 continue

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -2184,17 +2184,11 @@ CONDITION_COSTS = compute_cost_table()
 
 
 def conditions_cost(conds: Program, *, charge_for_conditions: bool) -> uint64:
-    free_conditions = 100
-
     condition_cost = 0
     for cond in conds.as_iter():
         condition = cond.first().as_atom()
 
         # this is new in hard fork 2
-        if free_conditions > 0:
-            free_conditions -= 1
-        elif charge_for_conditions:
-            condition_cost += ConditionCost.GENERIC_CONDITION_COST.value
 
         if condition == ConditionOpcode.CREATE_COIN:
             condition_cost += ConditionCost.CREATE_COIN.value
@@ -2202,9 +2196,13 @@ def conditions_cost(conds: Program, *, charge_for_conditions: bool) -> uint64:
         # have costs. Account for that.
         elif len(condition) == 2 and condition[0] != 0:
             condition_cost += CONDITION_COSTS[condition[1]]
+            if charge_for_conditions:
+                condition_cost += ConditionCost.GENERIC_CONDITION_COST.value
         elif condition == ConditionOpcode.SOFTFORK.value:
             arg = cond.rest().first().as_int()
             condition_cost += arg * 10000
+            if charge_for_conditions:
+                condition_cost += ConditionCost.GENERIC_CONDITION_COST.value
         elif condition in {
             ConditionOpcode.AGG_SIG_UNSAFE,
             ConditionOpcode.AGG_SIG_ME,
@@ -2216,6 +2214,23 @@ def conditions_cost(conds: Program, *, charge_for_conditions: bool) -> uint64:
             ConditionOpcode.AGG_SIG_PARENT_PUZZLE,
         }:
             condition_cost += ConditionCost.AGG_SIG.value
+        elif (
+            condition
+            in {
+                ConditionOpcode.SEND_MESSAGE,
+                ConditionOpcode.RECEIVE_MESSAGE,
+                ConditionOpcode.CREATE_COIN_ANNOUNCEMENT,
+                ConditionOpcode.CREATE_PUZZLE_ANNOUNCEMENT,
+                ConditionOpcode.ASSERT_COIN_ANNOUNCEMENT,
+                ConditionOpcode.ASSERT_PUZZLE_ANNOUNCEMENT,
+                ConditionOpcode.ASSERT_CONCURRENT_SPEND,
+                ConditionOpcode.ASSERT_CONCURRENT_PUZZLE,
+            }
+            and charge_for_conditions
+        ):
+            condition_cost += ConditionCost.MESSAGE_CONDITION_COST.value
+        elif charge_for_conditions:
+            condition_cost += ConditionCost.GENERIC_CONDITION_COST.value
     return uint64(condition_cost)
 
 

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -197,6 +197,8 @@ class Err(Enum):
     # the transactions generator uses overlong encoding of CLVM atoms in its
     # serialization
     INVALID_TRANSACTIONS_GENERATOR_ENCODING = 148
+    # block or spendbundle had too many spends
+    TOO_MANY_SPENDS = 149
 
 
 class ValidationError(Exception):

--- a/poetry.lock
+++ b/poetry.lock
@@ -872,38 +872,38 @@ pytest = ">=8.3.3,<9.0.0"
 
 [[package]]
 name = "chia-rs"
-version = "0.40.0"
+version = "0.41.0"
 description = ""
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "chia_rs-0.40.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:8d2b5755cb9ba90cda9161669277fe911459d3e6a192e5b24e9b5f5349a143bc"},
-    {file = "chia_rs-0.40.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:f218cb3eb08277369a58ca5c2bac21cc703061dba10b1f8a7590d352988ed5de"},
-    {file = "chia_rs-0.40.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:bdc5a0c2538caa8c08b0577bd511914b813858b0db585490ea2292fadead7789"},
-    {file = "chia_rs-0.40.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:37eaa559cb62e42ebc4c05f13ef1cdd8a5130d46a32a47db8ae344a17ed92ee3"},
-    {file = "chia_rs-0.40.0-cp310-cp310-win_amd64.whl", hash = "sha256:73efdbaef520ab201814a6f0110ab3ebc0fc261882683ec7d4ac1575b4dccb70"},
-    {file = "chia_rs-0.40.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:034f4662fcf67e80817b4770d121821586de3846746991ea75678e120ecb45df"},
-    {file = "chia_rs-0.40.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:c5ed5803999d9ab71ddb24f96d937d1bc4e7a2a16b5101b86f9bc14569052ca2"},
-    {file = "chia_rs-0.40.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:538f7b64716d085ff824b1e4c9e4b0966b81a17263871778ae55cb443e61822a"},
-    {file = "chia_rs-0.40.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a906ee80a5b3ac01d849886d4645ca2e5cdaecf6721bb3f18fe80757699a59a2"},
-    {file = "chia_rs-0.40.0-cp311-cp311-win_amd64.whl", hash = "sha256:cab83f0504bba55af28517fa12c8f6dd6c2e57578b6bd564d88c34ba49521966"},
-    {file = "chia_rs-0.40.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:2fd9b388c0e8315b9c63d6d69bbb3e3d318921af6d65a35168cb45a28ab4b138"},
-    {file = "chia_rs-0.40.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:4f9b1d3a73d9f73cac6379d784f6e3155cae38ad11bc7dd319e26a31bf3851e9"},
-    {file = "chia_rs-0.40.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:102366a85bd03af43b21c420eda0fe64deb95215a09a44a5c4942558649977f3"},
-    {file = "chia_rs-0.40.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:3cf4759bd0d6a26008cc27f50802a9022f27dd92610ef4ad9ed048e9b5957a18"},
-    {file = "chia_rs-0.40.0-cp312-cp312-win_amd64.whl", hash = "sha256:75c0c68da95b108baa858a923ed1e38a9d8b7f0867084043f764393fd44e6b76"},
-    {file = "chia_rs-0.40.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:8d86bd686f0226c6b480b22d44441157864446ea45200ae2b827c1c95efbee22"},
-    {file = "chia_rs-0.40.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:86bd6251b3838e8b0d88854ea8379cb0abddc2acf59836e1045d9b7a2e952c79"},
-    {file = "chia_rs-0.40.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:21253c2623a0501493f77b88d17bceb5a754c9640e5418b1ae59d2fb1afdff7f"},
-    {file = "chia_rs-0.40.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1ef03714bcfcdc2a74acaa1f6a8efb3a6e8477f8c0c106a15e55a4ed12e38143"},
-    {file = "chia_rs-0.40.0-cp313-cp313-win_amd64.whl", hash = "sha256:20be413ad23a3b569a3ec60443d0d14ad32ac2b6b0b44c4d8eea1f4f1e71e99e"},
-    {file = "chia_rs-0.40.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:183159babaa5bfd305c072438283ea54e5f4e908c5d4989049bd2c34f6cba3d6"},
-    {file = "chia_rs-0.40.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:6b2c357b881a20181d48fd6981eebb1edaa8a18334343e5611ede7212d9fa097"},
-    {file = "chia_rs-0.40.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:34eff9227ab58796986163229ca7c0b6b5cdb23861fe8d41264af422409fc912"},
-    {file = "chia_rs-0.40.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5b855da9eda135ce82ee8b33ac9934ffc9dc66d7dca54cc804e1e08a8d7d2d77"},
-    {file = "chia_rs-0.40.0-cp314-cp314-win_amd64.whl", hash = "sha256:7fbe140788c981df56dfd03bbdf0fe0fe442de9312ba0822b9d5fbc3a95ae6b7"},
-    {file = "chia_rs-0.40.0.tar.gz", hash = "sha256:1460b6c74318ec71554583bd66de3f4087bb7a1c46e877b183c986c05900dea5"},
+    {file = "chia_rs-0.41.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:778dce0cc5ed1d5f5f118cd862268733c4dfb80fb4f83d84e641c48529c23030"},
+    {file = "chia_rs-0.41.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:419df38ff3fa19422cef2a5f20dc786f997c98fa76ff698e9ffab9be500ee19a"},
+    {file = "chia_rs-0.41.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:dbff87a2142367db4bc6c45369d1f0127bf328fc86016d4d171097db78da3bc0"},
+    {file = "chia_rs-0.41.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:8ea4ce4d60d6e9049ddff8fa0ccd66f8485ce35de53b21fed0d888ee51670d85"},
+    {file = "chia_rs-0.41.0-cp310-cp310-win_amd64.whl", hash = "sha256:edeb1f23b938e65a92b0e3e43657c6e198a4d4d87e0406e126b0c4c8a6f14d88"},
+    {file = "chia_rs-0.41.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:575dbf026da39a67a228183faaa797b10941cc0c72f1ce27ee55e85cf6585d68"},
+    {file = "chia_rs-0.41.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:2ca5d58810b358d5ab9eb8a70391cf35b7feecbba6515a32afa91ddf146d4da9"},
+    {file = "chia_rs-0.41.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:6267c7baba0caba5b3a4d91e7b3abc2c993c3364087cffe7db67d9b0774d1486"},
+    {file = "chia_rs-0.41.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:be947da8f104bac0a1cdb7ec99b04dac1bf0edfe7bcea388d3968faaeafdb711"},
+    {file = "chia_rs-0.41.0-cp311-cp311-win_amd64.whl", hash = "sha256:cc1f3403378119d6be3973c467e8853beee53088ed2854ac78bc0a764b2ef5cb"},
+    {file = "chia_rs-0.41.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:5a65a5193fb261dfe78e96bdc7b8596587e9db5991fc7b56c0a8b32e853f491f"},
+    {file = "chia_rs-0.41.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:194f53e79b27333d956de5836444af54599ee9d86d233e7f9b4684f013e7c972"},
+    {file = "chia_rs-0.41.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9e4fc81142e10c3f55e4f843802ec649b3880e4e106eceab150bbd0b02c45438"},
+    {file = "chia_rs-0.41.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f773e3908879e782352045a6bab4636cae566deee971d9de220c133ea9f7dcc6"},
+    {file = "chia_rs-0.41.0-cp312-cp312-win_amd64.whl", hash = "sha256:3305248a7b64386ce6eecad6e4875d1b526addffe7392ad0bc90cc429ac269e9"},
+    {file = "chia_rs-0.41.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:73393d6c0bdece9ed742f0057e9ae347a8b5a9e080ce322832f64ee3b000053e"},
+    {file = "chia_rs-0.41.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:2bca42c29364f00a7d20602403686a68eb69b0f4ec8ea0bd9b315e728572b57b"},
+    {file = "chia_rs-0.41.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:8c7fce718ed95b456ad174e5f2a02ce56260c08e85a72570a98504907741f87e"},
+    {file = "chia_rs-0.41.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0f18aa3cdbcd07af38cc008f1f22a908bdf231d8f74fb1de9f5769d839d87cf1"},
+    {file = "chia_rs-0.41.0-cp313-cp313-win_amd64.whl", hash = "sha256:f153a90135f3cf397adf022212193d07db62af7e33ce9313c0a7f71d5d5fe7b1"},
+    {file = "chia_rs-0.41.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:53add2b466fd0518844a0556426fc04e2e130205cb792e84bad308abbd8c5dbc"},
+    {file = "chia_rs-0.41.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:331fb7e7cf4b0c2ffa8008826c16921773256decea5b8335d3a58fe23811bc8f"},
+    {file = "chia_rs-0.41.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:19e13f94ebe1a1b83129c0431404bc465eb72febdb9e696d2e40d6a3272f5c6f"},
+    {file = "chia_rs-0.41.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4948ad58cababaac1d7098b2ecdfb3e5fc475e13294440847e8664dce1aa82d9"},
+    {file = "chia_rs-0.41.0-cp314-cp314-win_amd64.whl", hash = "sha256:8ca59ae438671a33bb466cf4b1b10aadf85abafb6688660d5e3b2b712925621b"},
+    {file = "chia_rs-0.41.0.tar.gz", hash = "sha256:6210df932d1b7da84cc7dc2787a134b9a51c22d470d85e8305bba8b24d7b76e1"},
 ]
 
 [package.dependencies]
@@ -4104,4 +4104,4 @@ upnp = ["miniupnpc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <4"
-content-hash = "38d9ce7f97511e9fb43cea7228e21d01bdd02b3982d16c9a0d1d0263937608b8"
+content-hash = "e2c95ab55327becafdddd19bc77907c61cd00906af4ed7592e46a8f5a0e79fba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ boto3 = ">=1.35.43"  # AWS S3 for Data Layer S3 plugin
 chiabip158 = ">=1.5.2"  # bip158-style wallet filters
 chiapos = ">=2.0.10"  # proof of space
 chia-puzzles-py = ">=0.20.1"
-chia_rs = ">=0.40.0, <0.41"
+chia_rs = ">=0.41.0, <0.42"
 chiavdf = ">=1.1.10"  # timelord and vdf verification
 click = ">=8.1.7"  # For the CLI
 clvm = ">=0.9.14"


### PR DESCRIPTION
### Purpose:

Bump chia_rs to the latest version.

### Current Behavior:

* Blocks have no limit on the number of spends

* Conditions have no cost

### New Behavior:

* After hard fork 2.7.0, Blocks may not have more than 6000 spends. The mempool implements this limit immediately though.

* After hard fork 3.0, Conditions have cost. This requires the test block chains for 3.0 and later to be re-generated.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Medium-to-high risk because it changes mempool block assembly constraints (new 6000-spend cap) and condition cost accounting, which affects fee prioritization, block creation, and consensus-related test expectations.
> 
> **Overview**
> Bumps `chia_rs` to `0.41.0` (and updates CI test-cache ref to `0.45.8`) and adjusts tests to match new cost semantics.
> 
> Updates condition costing to charge for conditions after hard fork 3.0 (`MESSAGE_CONDITION_COST` vs `GENERIC_CONDITION_COST`) and updates simulator cost calculation and cost-related tests accordingly.
> 
> Adds a new `MAX_SPENDS_PER_BLOCK = 6000` constraint in `Mempool` block assembly (both generator paths), including dedup-aware spend counting, plus new mempool tests covering skip/fit behavior around the spend cap and a new `Err.TOO_MANY_SPENDS` error code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90359cbb784137b039c57b023f243e606e69fbfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->