### PR TITLE
CHIA-3977 Simplify a peer check in WSChiaConnection's _read_one_message

### DIFF
--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -735,10 +735,8 @@ class WSChiaConnection:
                 full_message_loaded, self.local_capabilities, self.peer_capabilities
             )
             if limiter_msg is not None:
-                if (
-                    self.local_type == NodeType.FULL_NODE
-                    and not is_localhost(self.peer_info.host)
-                    and not is_in_network(self.peer_info.host, self.exempt_peer_networks)
+                if not is_localhost(self.peer_info.host) and not is_in_network(
+                    self.peer_info.host, self.exempt_peer_networks
                 ):
                     details = ", ".join([f"{self.peer_info.host}", f"message: {message_type.name}", limiter_msg])
                     self.log.error(f"Peer has been rate limited and will be disconnected: {details}")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes peer-disconnect behavior in `WSChiaConnection._read_one_message` by removing the `FULL_NODE` gate, so more node types may now disconnect/ban rate-limited non-exempt peers. This could impact network stability/peer connectivity if other services (e.g., farmers/timelords) start enforcing bans unexpectedly.
> 
> **Overview**
> Simplifies the inbound rate-limit handling in `WSChiaConnection._read_one_message` by removing the `local_type == NodeType.FULL_NODE` condition and only exempting `localhost` and configured `exempt_peer_networks`.
> 
> As a result, any node type using this connection will now disconnect/ban rate-limited peers unless they are exempt, rather than limiting disconnections to full nodes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d86394088237300b94cd49536126b8062984d021. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->