### PR TITLE
Mempool spend limit

### DIFF
--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -3041,32 +3041,47 @@ def test_full_mempool(items: list[int], add: int, expected: list[int]) -> None:
         assert mi.cost == expected_cost
 
 
+SCALE = 1_000_000
+
+
 @pytest.mark.parametrize("height", [True, False])
 @pytest.mark.parametrize(
     "items,expected,increase_fee",
     [
-        # the max size is 100
-        # the max block size is 50
+        # the max size is 100 * SCALE
+        # the max block size is 50 * SCALE
         # which is also the max size for expiring transactions
         # the increasing fee will order the transactions in the reverse
         # insertion order
-        ([10, 11, 12, 13, 14], [14, 13, 12, 11], True),
+        (
+            [10 * SCALE, 11 * SCALE, 12 * SCALE, 13 * SCALE, 14 * SCALE],
+            [14 * SCALE, 13 * SCALE, 12 * SCALE, 11 * SCALE],
+            True,
+        ),
         # decreasing fee rate will make the last one fail to be inserted
-        ([10, 11, 12, 13, 14], [10, 11, 12, 13], False),
+        (
+            [10 * SCALE, 11 * SCALE, 12 * SCALE, 13 * SCALE, 14 * SCALE],
+            [10 * SCALE, 11 * SCALE, 12 * SCALE, 13 * SCALE],
+            False,
+        ),
         # the last is big enough to evict all previous ones
-        ([10, 11, 12, 13, 50], [50], True),
+        ([10 * SCALE, 11 * SCALE, 12 * SCALE, 13 * SCALE, 50 * SCALE], [50 * SCALE], True),
         # the last one will not evict any earlier ones, because the fee rate is
         # lower
-        ([10, 11, 12, 13, 50], [10, 11, 12, 13], False),
+        (
+            [10 * SCALE, 11 * SCALE, 12 * SCALE, 13 * SCALE, 50 * SCALE],
+            [10 * SCALE, 11 * SCALE, 12 * SCALE, 13 * SCALE],
+            False,
+        ),
     ],
 )
 def test_limit_expiring_transactions(height: bool, items: list[int], expected: list[int], increase_fee: bool) -> None:
     fee_estimator = create_bitcoin_fee_estimator(uint64(11000000000))
 
     mempool_info = MempoolInfo(
-        CLVMCost(uint64(100)),
+        CLVMCost(uint64(100 * SCALE)),
         FeeRate(uint64(1000000)),
-        CLVMCost(uint64(50)),
+        CLVMCost(uint64(50 * SCALE)),
     )
     mempool = Mempool(mempool_info, fee_estimator)
     mempool.new_tx_block(uint32(10), uint64(100000))
@@ -3075,7 +3090,7 @@ def test_limit_expiring_transactions(height: bool, items: list[int], expected: l
     # fill the mempool with regular transactions (without expiration)
     fee_rate: float = 3.0
     for i in range(1, 20):
-        mempool.add_to_pool(item_cost(i, fee_rate))
+        mempool.add_to_pool(item_cost(i * SCALE, fee_rate))
         fee_rate -= 0.1
         invariant_check_mempool(mempool)
 
@@ -3112,7 +3127,7 @@ def test_limit_expiring_transactions(height: bool, items: list[int], expected: l
             ttl = "No"
         print(f"- cost: {item.cost} TTL: {ttl}")
 
-    assert mempool.total_mempool_cost() > 90
+    assert mempool.total_mempool_cost() > 90 * SCALE
     invariant_check_mempool(mempool)
 
 

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -416,8 +416,8 @@ class Mempool:
             cursor = self._db_conn.execute(
                 """
                 SELECT name,
-                    fee_per_cost,
-                    SUM(cost) OVER (ORDER BY fee_per_cost DESC, seq ASC) AS cumulative_cost
+                    priority,
+                    SUM(cost) OVER (ORDER BY priority DESC, seq ASC) AS cumulative_cost
                 FROM tx
                 WHERE assert_before_seconds IS NOT NULL AND assert_before_seconds < ?
                     OR assert_before_height IS NOT NULL AND assert_before_height < ?
@@ -427,7 +427,7 @@ class Mempool:
             )
             to_remove: list[bytes32] = []
             for row in cursor:
-                name, fee_per_cost, cumulative_cost = row
+                name, priority, cumulative_cost = row
 
                 # there's space for us, stop pruning
                 if cumulative_cost + item.cost <= self.mempool_info.max_block_clvm_cost:
@@ -435,7 +435,7 @@ class Mempool:
 
                 # we can't evict any more transactions, abort (and don't
                 # evict what we put aside in "to_remove" list)
-                if fee_per_cost > item.fee_per_cost:
+                if priority > item.fee_per_virtual_cost:
                     return MempoolAddInfo([], Err.INVALID_FEE_LOW_FEE)
                 to_remove.append(name)
 
@@ -444,13 +444,13 @@ class Mempool:
             # if we don't find any entries, it's OK to add this entry
 
         if self._total_cost + item.cost > self.mempool_info.max_size_in_cost:
-            # pick the items with the lowest fee per virtual cost to remove
+            # pick the items with the lowest priority to remove
             cursor = self._db_conn.execute(
                 """SELECT name FROM tx
                 WHERE name NOT IN (
                     SELECT name FROM (
                         SELECT name,
-                        SUM(cost) OVER (ORDER BY fee_per_cost DESC, seq ASC) AS total_cost
+                        SUM(cost) OVER (ORDER BY priority DESC, seq ASC) AS total_cost
                         FROM tx) AS tx_with_cost
                     WHERE total_cost <= ?)
                 """,

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -129,11 +129,13 @@ class Mempool:
                 assert_before_height INT,
                 assert_before_seconds INT,
                 fee_per_cost REAL,
+                priority REAL,
                 seq INTEGER PRIMARY KEY AUTOINCREMENT)
                 """
             )
             self._db_conn.execute("CREATE INDEX name_idx ON tx(name)")
             self._db_conn.execute("CREATE INDEX feerate ON tx(fee_per_cost)")
+            self._db_conn.execute("CREATE INDEX priority_idx ON tx(priority)")
             self._db_conn.execute(
                 "CREATE INDEX assert_before ON tx(assert_before_height, assert_before_seconds) "
                 "WHERE assert_before_height IS NOT NULL OR assert_before_seconds IS NOT NULL"
@@ -307,7 +309,7 @@ class Mempool:
         # TODO: make MempoolItem.cost be CLVMCost
         current_cost = self._total_cost
 
-        # Iterates through all spends in increasing fee per cost
+        # Iterates through all spends in increasing fee per virtual cost
         with self._db_conn:
             cursor = self._db_conn.execute("SELECT cost,fee_per_cost FROM tx ORDER BY fee_per_cost ASC, seq DESC")
 
@@ -442,7 +444,7 @@ class Mempool:
             # if we don't find any entries, it's OK to add this entry
 
         if self._total_cost + item.cost > self.mempool_info.max_size_in_cost:
-            # pick the items with the lowest fee per cost to remove
+            # pick the items with the lowest fee per virtual cost to remove
             cursor = self._db_conn.execute(
                 """SELECT name FROM tx
                 WHERE name NOT IN (
@@ -462,8 +464,9 @@ class Mempool:
             # "GENERATED ALWAYS AS (CAST(fee AS REAL) / cost) VIRTUAL"
             conn.execute(
                 "INSERT INTO "
-                "tx(name,cost,fee,assert_height,assert_before_height,assert_before_seconds,fee_per_cost) "
-                "VALUES(?, ?, ?, ?, ?, ?, ?)",
+                "tx(name,cost,fee,assert_height,assert_before_height,assert_before_seconds,"
+                "fee_per_cost,priority) "
+                "VALUES(?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     item.name,
                     item.cost,
@@ -471,7 +474,8 @@ class Mempool:
                     item.assert_height,
                     item.assert_before_height,
                     item.assert_before_seconds,
-                    item.fee / item.cost,
+                    item.fee_per_cost,
+                    item.fee_per_virtual_cost,
                 ),
             )
             all_coin_spends = []
@@ -598,7 +602,7 @@ class Mempool:
         sigs: list[G2Element] = []
         log.info(f"Starting to make block, max cost: {self.mempool_info.max_block_clvm_cost}")
         bundle_creation_start = monotonic()
-        cursor = self._db_conn.execute("SELECT name, fee FROM tx ORDER BY fee_per_cost DESC, seq ASC")
+        cursor = self._db_conn.execute("SELECT name, fee FROM tx ORDER BY priority DESC, seq ASC")
         skipped_items = 0
         for row in cursor:
             name = bytes32(row[0])
@@ -710,7 +714,7 @@ class Mempool:
         singleton_ff = SingletonFastForward()
         log.info(f"Starting to make block, max cost: {self.mempool_info.max_block_clvm_cost}")
         generator_creation_start = monotonic()
-        cursor = self._db_conn.execute("SELECT name, fee FROM tx ORDER BY fee_per_cost DESC, seq ASC")
+        cursor = self._db_conn.execute("SELECT name, fee FROM tx ORDER BY priority DESC, seq ASC")
         builder = BlockBuilder()
         skipped_items = 0
         # the total (estimated) cost of the transactions added so far

--- a/chia/types/mempool_item.py
+++ b/chia/types/mempool_item.py
@@ -10,6 +10,10 @@ from chia_rs.sized_ints import uint32, uint64
 from chia.types.blockchain_format.coin import Coin
 from chia.util.streamable import recurse_jsonify
 
+# Per-spend penalty added to CLVM cost when computing virtual cost.
+# Virtual cost = CLVM cost + num_spends * SPEND_PENALTY_COST
+SPEND_PENALTY_COST = 500_000
+
 
 @dataclass(frozen=True)
 class UnspentLineageInfo:
@@ -69,12 +73,24 @@ class MempoolItem:
         return int(self.fee) / int(self.cost)
 
     @property
+    def fee_per_virtual_cost(self) -> float:
+        return int(self.fee) / int(self.virtual_cost)
+
+    @property
     def name(self) -> bytes32:
         return self.spend_bundle_name
 
     @property
     def cost(self) -> uint64:
         return uint64(0 if self.conds is None else self.conds.cost)
+
+    @property
+    def num_spends(self) -> int:
+        return 0 if self.conds is None else len(self.conds.spends)
+
+    @property
+    def virtual_cost(self) -> uint64:
+        return uint64(self.cost + self.num_spends * SPEND_PENALTY_COST)
 
     @property
     def additions(self) -> list[Coin]:


### PR DESCRIPTION
### Purpose:

Now that we have a spend limit per block, the mempool needs to ascribe some cost to spends, to avoid including a transaction that has a lot of spends but low cost (therefore, a competitive fee/cost). If it uses up more than its fair share of the spend-budget, it's a loss for the farmer.

The long term fix for this will be to introduce a cost per spend, in the 3.0 hard fork. For now, add a "virtual cost" of 500'000 per spend.

### Current Behavior:

When building a block, pick transactions in order of highest fee per cost first.

### New Behavior:

When building a block, pick transactions in order of highest fee per *virtual* cost first.
The virtual cost is `cost + len(spends) * 500_000`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mempool eviction and block-assembly ordering from pure fee/CLVM-cost to a new fee/virtual-cost metric (penalizing high-spend bundles), which can alter transaction inclusion and farmer fee outcomes. It also adds new SQLite fields/indexes used in selection/pruning, so correctness depends on the new priority calculations being applied consistently.
> 
> **Overview**
> Updates mempool transaction *prioritization and eviction* to use a new **fee per virtual cost** metric that penalizes bundles with many spends (`virtual_cost = cost + num_spends * 500_000`).
> 
> This adds `SPEND_PENALTY_COST` plus `num_spends`/`virtual_cost`/`fee_per_virtual_cost` to `MempoolItem`, stores the computed value as `priority` in the mempool SQLite table, and switches block construction and mempool pruning/eviction queries to order/compare by `priority` instead of `fee_per_cost`.
> 
> Adjusts `test_limit_expiring_transactions` to scale costs/limits (`SCALE = 1_000_000`) so the test remains stable under the updated cost/priority behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3de57ed651adcddeac67c7e3302c9a90a60af588. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->