### PR TITLE
CHIA-3984 Give callers of SingletonFastForward's process_fast_forward_spends control over the state update

### DIFF
--- a/chia/_tests/core/mempool/test_singleton_fast_forward.py
+++ b/chia/_tests/core/mempool/test_singleton_fast_forward.py
@@ -58,9 +58,10 @@ def test_process_fast_forward_spends_nothing_to_do() -> None:
     )
     original_version = dataclasses.replace(internal_mempool_item)
     singleton_ff = SingletonFastForward()
-    bundle_coin_spends = singleton_ff.process_fast_forward_spends(
+    bundle_coin_spends, ff_state_update = singleton_ff.process_fast_forward_spends(
         mempool_item=internal_mempool_item, prev_tx_height=TEST_HEIGHT, constants=DEFAULT_CONSTANTS
     )
+    assert ff_state_update == {}
     assert singleton_ff == SingletonFastForward()
     assert bundle_coin_spends == original_version.bundle_coin_spends
 
@@ -90,7 +91,7 @@ def test_process_fast_forward_spends_latest_unspent() -> None:
     )
     original_version = dataclasses.replace(internal_mempool_item)
     singleton_ff = SingletonFastForward()
-    bundle_coin_spends = singleton_ff.process_fast_forward_spends(
+    bundle_coin_spends, ff_state_update = singleton_ff.process_fast_forward_spends(
         mempool_item=internal_mempool_item, prev_tx_height=TEST_HEIGHT, constants=DEFAULT_CONSTANTS
     )
     child_coin = item.bundle_coin_spends[test_coin.name()].additions[0]
@@ -99,6 +100,9 @@ def test_process_fast_forward_spends_latest_unspent() -> None:
             coin_id=child_coin.name(), parent_id=test_coin.name(), parent_parent_id=test_coin.parent_coin_info
         )
     }
+    assert singleton_ff.fast_forward_spends == {}
+    assert ff_state_update == expected_fast_forward_spends
+    singleton_ff.update_fast_forward_spends(ff_state_update)
     # We have set the next version from our additions to chain ff spends
     assert singleton_ff.fast_forward_spends == expected_fast_forward_spends
     # We didn't need to fast forward the item so it stays as is

--- a/chia/full_node/eligible_coin_spends.py
+++ b/chia/full_node/eligible_coin_spends.py
@@ -173,11 +173,14 @@ class SingletonFastForward:
 
     def process_fast_forward_spends(
         self, *, mempool_item: InternalMempoolItem, prev_tx_height: uint32, constants: ConsensusConstants
-    ) -> dict[bytes32, BundleCoinSpend]:
+    ) -> tuple[dict[bytes32, BundleCoinSpend], dict[bytes32, UnspentLineageInfo]]:
         """
-        Provides the caller with a `bundle_coin_spends` map that has a proper
-        state of fast forwarded coin spends and additions starting from
-        the most recent unspent versions of the related singleton spends.
+        Provides the caller with a map that has a proper state of fast
+        forwarded coin spends and additions starting from the most recent
+        unspent versions of the related singleton spends, along with fast
+        forward state update that must be explicitly committed by the caller
+        via `commit_fast_forward_state` after confirming the item will be
+        included.
 
         Args:
             mempool_item: The internal mempool item to process
@@ -185,8 +188,9 @@ class SingletonFastForward:
             prev_tx_height: needed in order to refresh the mempool item if needed
 
         Returns:
-            The resulting `bundle_coin_spends` map of coin IDs to coin spends
-            and metadata, after fast forwarding
+            A tuple of: map of coin IDs to coin spends and metadata after fast
+            forwarding, and the the fast forward state update to commit if the
+            item end up included.
 
         Raises:
             If a fast forward cannot proceed, to prevent potential double spends
@@ -266,9 +270,7 @@ class SingletonFastForward:
             new_coin_spends.append(new_coin_spend)
             fast_forwarded_spends += 1
         if fast_forwarded_spends == 0:
-            # Update the fast forward state with current chain
-            self.fast_forward_spends.update(ff_state_update)
-            return new_bundle_coin_spends
+            return new_bundle_coin_spends, ff_state_update
         # Update the mempool item after validating the new spend bundle
         new_sb = SpendBundle(coin_spends=new_coin_spends, aggregated_signature=mempool_item.aggregated_signature)
         assert mempool_item.conds is not None
@@ -286,5 +288,10 @@ class SingletonFastForward:
                 raise ValueError(
                     "Mempool item became invalid after singleton fast forward with an unspecified error."
                 )  # pragma: no cover
+        return new_bundle_coin_spends, ff_state_update
+
+    def update_fast_forward_spends(self, ff_state_update: dict[bytes32, UnspentLineageInfo]) -> None:
         self.fast_forward_spends.update(ff_state_update)
-        return new_bundle_coin_spends
+
+    def copy(self) -> SingletonFastForward:
+        return SingletonFastForward(fast_forward_spends=dict(self.fast_forward_spends))

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -36,7 +36,7 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.clvm_cost import CLVMCost
 from chia.types.generator_types import NewBlockGenerator
 from chia.types.internal_mempool_item import InternalMempoolItem
-from chia.types.mempool_item import MempoolItem
+from chia.types.mempool_item import MempoolItem, UnspentLineageInfo
 from chia.util.batches import to_batches
 from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER
 from chia.util.errors import Err
@@ -633,9 +633,10 @@ class Mempool:
                     for spend_data in item.bundle_coin_spends.values():
                         unique_coin_spends.append(spend_data.coin_spend)
                         unique_additions.extend(spend_data.additions)
+                    ff_state_update: dict[bytes32, UnspentLineageInfo] = {}
                     cost_saving = 0
                 else:
-                    bundle_coin_spends = singleton_ff.process_fast_forward_spends(
+                    bundle_coin_spends, ff_state_update = singleton_ff.process_fast_forward_spends(
                         mempool_item=item, prev_tx_height=prev_tx_height, constants=constants
                     )
                     unique_coin_spends, cost_saving, unique_additions = dedup_coin_spends.get_deduplication_info(
@@ -664,6 +665,7 @@ class Mempool:
                     if skipped_items < MAX_SKIPPED_ITEMS:
                         continue
                     break
+                singleton_ff.update_fast_forward_spends(ff_state_update)
                 coin_spends.extend(unique_coin_spends)
                 additions.extend(unique_additions)
                 sigs.append(item.aggregated_signature)
@@ -712,6 +714,9 @@ class Mempool:
 
         dedup_coin_spends = IdenticalSpendDedup()
         singleton_ff = SingletonFastForward()
+        # Fast forward state committed so far from accepted batches, used to
+        # rollback on batch rejection.
+        committed_ff = singleton_ff.copy()
         log.info(f"Starting to make block, max cost: {self.mempool_info.max_block_clvm_cost}")
         generator_creation_start = monotonic()
         cursor = self._db_conn.execute("SELECT name, fee FROM tx ORDER BY priority DESC, seq ASC")
@@ -739,7 +744,9 @@ class Mempool:
             try:
                 assert item.conds is not None
                 cost = item.conds.condition_cost + item.conds.execution_cost
-                bundle_coin_spends = singleton_ff.process_fast_forward_spends(
+                # This `ff_state_update` is only committed later on via
+                # `update_fast_forward_spends` if the item gets batched.
+                bundle_coin_spends, ff_state_update = singleton_ff.process_fast_forward_spends(
                     mempool_item=item, prev_tx_height=prev_tx_height, constants=constants
                 )
                 unique_coin_spends, cost_saving, unique_additions = dedup_coin_spends.get_deduplication_info(
@@ -769,6 +776,9 @@ class Mempool:
 
                     block_cost = builder.cost()
                     if added:
+                        # Update the checkpoint to include the fast forward
+                        # state from all the items in this accepted batch.
+                        committed_ff = singleton_ff.copy()
                         added_spends += batch_spends
                         additions.extend(batch_additions)
                         removals.extend([cs.coin for sb in batch_transactions for cs in sb.coin_spends])
@@ -776,17 +786,36 @@ class Mempool:
                             f"adding TX batch, additions: {len(batch_additions)} removals: {batch_spends} "
                             f"cost: {batch_cost} total cost: {block_cost}"
                         )
+                        batch_cost = 0
+                        batch_transactions = []
+                        batch_additions = []
+                        batch_spends = 0
                     else:
                         log.info(f"Skipping transaction batch cumulative cost: {block_cost} batch cost: {batch_cost}")
                         skipped_items += 1
+                        # Restore FF state
+                        singleton_ff = committed_ff.copy()
+                        # Reset the batch
+                        batch_cost = 0
+                        batch_transactions = []
+                        batch_additions = []
+                        batch_spends = 0
+                        # Reprocess the current item against the correct fast
+                        # forward state.
+                        bundle_coin_spends, ff_state_update = singleton_ff.process_fast_forward_spends(
+                            mempool_item=item, prev_tx_height=prev_tx_height, constants=constants
+                        )
+                        unique_coin_spends = []
+                        unique_additions = []
+                        for spend_data in bundle_coin_spends.values():
+                            unique_coin_spends.append(spend_data.coin_spend)
+                            unique_additions.extend(spend_data.additions)
+                        cost_saving = uint64(0)
 
-                    batch_cost = 0
-                    batch_transactions = []
-                    batch_additions = []
-                    batch_spends = 0
                     if done:
                         break
 
+                singleton_ff.update_fast_forward_spends(ff_state_update)
                 batch_cost += cost - cost_saving
                 batch_transactions.append(SpendBundle(unique_coin_spends, item.aggregated_signature))
                 batch_spends += len(unique_coin_spends)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches block assembly logic by changing how singleton fast-forward state is committed and rolled back, which could affect transaction selection/validity if state updates are missed or applied out of order.
> 
> **Overview**
> **Singleton fast-forward state is no longer mutated implicitly.** `SingletonFastForward.process_fast_forward_spends()` now returns both the rewritten `bundle_coin_spends` *and* an `ff_state_update` map, and callers must explicitly apply it via a new `update_fast_forward_spends()` method.
> 
> Block construction paths (`create_bundle_from_mempool_items` and `create_block_generator2`) are updated to commit the returned fast-forward state only after an item/batch is accepted, including adding a fast-forward-state checkpoint/rollback in `create_block_generator2` when a batch is rejected.
> 
> Tests are adjusted to assert the returned state update and to verify no state is applied unless explicitly committed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 438499e1cd7fb204f3a649da8cd5c52e4d58dd57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->