### PR TITLE
don't ban peers for transactions that fail mempool checks

### DIFF
--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -2912,9 +2912,9 @@ class TestMaliciousGenerators:
         coin_spend_0 = make_spend(coin_0, cs.puzzle_reveal, cs.solution)
         new_bundle = recursive_replace(spend_bundle, "coin_spends", [coin_spend_0, *spend_bundle.coin_spends[1:]])
         assert spend_bundle is not None
-        with pytest.raises(ValidationError) as e:
-            await full_node_1.full_node.add_transaction(new_bundle, new_bundle.name(), test=True)
-        assert e.value.code == Err.WRONG_PUZZLE_HASH
+        status, error = await full_node_1.full_node.add_transaction(new_bundle, new_bundle.name(), test=True)
+        assert status == MempoolInclusionStatus.FAILED
+        assert error == Err.WRONG_PUZZLE_HASH
 
 
 coins = make_test_coins()

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2815,6 +2815,10 @@ class FullNode:
             # ban the peer
             self.log.info(f"Rejecting transaction {spend_name}: {e}")
             return MempoolInclusionStatus.FAILED, Err.INVALID_SPEND_BUNDLE
+        except ValidationError as e:
+            self.log.info(f"Rejecting transaction {spend_name}: {e.code}")
+            self.mempool_manager.add_and_maybe_pop_seen(spend_name)
+            return MempoolInclusionStatus.FAILED, e.code
 
         self.mempool_manager.add_and_maybe_pop_seen(spend_name)
 


### PR DESCRIPTION
but may be valid otherwise

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how invalid transactions are surfaced to callers/peers, which can affect network behavior and transaction propagation, but it’s a small, localized error-handling change with test coverage.
> 
> **Overview**
> Pre-validation failures from mempool checks (`ValidationError`) are now handled as a **soft reject** in `FullNode.add_transaction`, returning `(FAILED, err_code)` and recording the transaction as seen instead of letting the exception propagate (which could trigger peer bans upstream).
> 
> Updates the mempool test for an invalid coin spend to assert the returned `MempoolInclusionStatus.FAILED` and `Err.WRONG_PUZZLE_HASH` rather than expecting a raised `ValidationError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06f0f9b3a05ade649a7fff3dee03507414384bdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->