### PR TITLE
Update CHANGELOG.md for 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
+## 2.7.0 Chia blockchain 2026-3-26
+
+## What's Changed
+
+### Changed
+
+- Full nodes should only accept peer connections post hard fork 2 from nodes that signal support for it
+- Add Remote Wallet and new RPC calls
+- Make the mempool a bit more defensive on slow machines
+- Improve waiting for the connection to close in `WSChiaConnection`'s `_read_one_message`
+- Improve unknown protocol message type handling in `WSChiaConnection`'s `_read_one_message`
+- Simplify a peer check in `WSChiaConnection`'s `_read_one_message`
+- Improve `FullNodeAPI`'s `register_for_coin_updates`
+- Early check of proof of space in a few places
+- Ignore unsolicited `RespondTransaction`
+- Mempool spend limit
+- `Streamable.from_bytes()`
+- Optimise pre-commit `chialisp_pprint`
+- Remove deprecated Python `analyze-chain.py`
+- Add missing type annotations and remove mypy exclusions
+- Bump `chia_rs` to `0.41.1`
+
+### Fixed
+
+- Fix timelord to skip processing after failed VDF proof validation
+- Apply `client_timeout` to all DataLayer plugin HTTP calls
+- Don't ban peers for transactions that fail mempool checks
+
 ## 2.6.1 Chia blockchain 2026-3-18
 
 ## What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ for setuptools_scm/PEP 440 reasons.
 - Remote Wallet and new RPC calls
 
 ### Changed
+
 - Numerous hardening measures and soft fork: Please read our blog post for more information
   <url>
 - Make the mempool a bit more defensive on slow machines
@@ -31,7 +32,7 @@ for setuptools_scm/PEP 440 reasons.
 - Fix timelord to skip processing after failed VDF proof validation
 - Apply `client_timeout` to all DataLayer plugin HTTP calls
 - DataLayer hardening related to DAT file downloading
-  
+
 ## 2.6.1 Chia blockchain 2026-3-18
 
 ## What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,7 @@ for setuptools_scm/PEP 440 reasons.
 - Early check of proof of space in a few places
 - Ignore unsolicited `RespondTransaction`
 - Mempool spend limit
-- `Streamable.from_bytes()`
-- Remove deprecated Python `analyze-chain.py`
+- Harden `Streamable.from_bytes()` to raise `ValueError` on unconsumed trailing bytes
 - Bump `chia_rs` to `0.41.1`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ for setuptools_scm/PEP 440 reasons.
 ### Changed
 
 - Numerous hardening measures and soft fork: Please read our blog post for more information
-  <url>
+  https://www.chia.net/blog/
 - Make the mempool a bit more defensive on slow machines
 - Harden connection handling and message validation in `WSChiaConnection`
 - Improve `register_for_coin_updates`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ for setuptools_scm/PEP 440 reasons.
 
 ## What's Changed
 
+### Added
+
+- Remote Wallet and new RPC calls
+
 ### Changed
 - Numerous hardening measures and soft fork: Please read our blog post for more information
   <url>
-- Add Remote Wallet and new RPC calls
 - Make the mempool a bit more defensive on slow machines
 - Harden connection handling and message validation in `WSChiaConnection`
 - Improve `register_for_coin_updates`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ for setuptools_scm/PEP 440 reasons.
 - Early check of proof of space in a few places
 - Ignore unsolicited `RespondTransaction`
 - Mempool spend limit
+- `Streamable.from_bytes()`
+- Remove deprecated Python `analyze-chain.py`
 - Bump `chia_rs` to `0.41.1`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,7 @@ for setuptools_scm/PEP 440 reasons.
   <url>
 - Add Remote Wallet and new RPC calls
 - Make the mempool a bit more defensive on slow machines
-- Improve waiting for the connection to close in `_read_one_message`
-- Improve unknown protocol message type handling in `_read_one_message`
-- Simplify a peer check in `WSChiaConnection`'s `_read_one_message`
+- Harden connection handling and message validation in `WSChiaConnection`
 - Improve `register_for_coin_updates`
 - Early check of proof of space in a few places
 - Ignore unsolicited `RespondTransaction`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,29 +11,25 @@ for setuptools_scm/PEP 440 reasons.
 ## What's Changed
 
 ### Changed
-
-- Full nodes should only accept peer connections post hard fork 2 from nodes that signal support for it
+- Numerous hardening measures and soft fork: Please read our blog post for more information
+  <url>
 - Add Remote Wallet and new RPC calls
 - Make the mempool a bit more defensive on slow machines
-- Improve waiting for the connection to close in `WSChiaConnection`'s `_read_one_message`
-- Improve unknown protocol message type handling in `WSChiaConnection`'s `_read_one_message`
+- Improve waiting for the connection to close in `_read_one_message`
+- Improve unknown protocol message type handling in `_read_one_message`
 - Simplify a peer check in `WSChiaConnection`'s `_read_one_message`
-- Improve `FullNodeAPI`'s `register_for_coin_updates`
+- Improve `register_for_coin_updates`
 - Early check of proof of space in a few places
 - Ignore unsolicited `RespondTransaction`
 - Mempool spend limit
-- `Streamable.from_bytes()`
-- Optimise pre-commit `chialisp_pprint`
-- Remove deprecated Python `analyze-chain.py`
-- Add missing type annotations and remove mypy exclusions
 - Bump `chia_rs` to `0.41.1`
 
 ### Fixed
 
 - Fix timelord to skip processing after failed VDF proof validation
 - Apply `client_timeout` to all DataLayer plugin HTTP calls
-- Don't ban peers for transactions that fail mempool checks
-
+- DataLayer hardening related to DAT file downloading
+  
 ## 2.6.1 Chia blockchain 2026-3-18
 
 ## What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ for setuptools_scm/PEP 440 reasons.
 ### Changed
 
 - Numerous hardening measures and soft fork: Please read our blog post for more information
-  https://www.chia.net/blog/
+  https://www.chia.net/2026/03/26/chia-2-7-0-combatting-the-ai-siege/
 - Make the mempool a bit more defensive on slow machines
 - Harden connection handling and message validation in `WSChiaConnection`
 - Improve `register_for_coin_updates`


### PR DESCRIPTION
Update CHANGELOG.md with entries for the 2.7.0 release (2026-03-26).

Categorized per `.github/release.yml`:
- **Changed:** networking hardening, Remote Wallet, mempool improvements, `chia_rs` 0.41.1, mypy cleanup, misc
- **Fixed:** timelord VDF validation, DataLayer plugin timeout, peer banning on mempool failures

Excludes: checkpoint merges, CI, Tests, Cleanup, dependabot bumps, Exclude_Notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `CHANGELOG.md` with release notes and no functional code changes.
> 
> **Overview**
> Adds a new `2.7.0` section to `CHANGELOG.md`, documenting the release’s *Added/Changed/Fixed* items (e.g., Remote Wallet/RPC additions, networking/mempool hardening notes, `chia_rs` bump, and several timelord/DataLayer fixes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b76485ea7047924fe026c05d602dc4cab0948e2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->