### PR TITLE
checkpoint: into main from release/2.7.0  @ cb82283cf65a535b6b63ee07c31b4e50774bfd5a

### DIFF
--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -2912,9 +2912,9 @@ class TestMaliciousGenerators:
         coin_spend_0 = make_spend(coin_0, cs.puzzle_reveal, cs.solution)
         new_bundle = recursive_replace(spend_bundle, "coin_spends", [coin_spend_0, *spend_bundle.coin_spends[1:]])
         assert spend_bundle is not None
-        with pytest.raises(ValidationError) as e:
-            await full_node_1.full_node.add_transaction(new_bundle, new_bundle.name(), test=True)
-        assert e.value.code == Err.WRONG_PUZZLE_HASH
+        status, error = await full_node_1.full_node.add_transaction(new_bundle, new_bundle.name(), test=True)
+        assert status == MempoolInclusionStatus.FAILED
+        assert error == Err.WRONG_PUZZLE_HASH
 
 
 coins = make_test_coins()

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2815,6 +2815,10 @@ class FullNode:
             # ban the peer
             self.log.info(f"Rejecting transaction {spend_name}: {e}")
             return MempoolInclusionStatus.FAILED, Err.INVALID_SPEND_BUNDLE
+        except ValidationError as e:
+            self.log.info(f"Rejecting transaction {spend_name}: {e.code}")
+            self.mempool_manager.add_and_maybe_pop_seen(spend_name)
+            return MempoolInclusionStatus.FAILED, e.code
 
         self.mempool_manager.add_and_maybe_pop_seen(spend_name)
 


### PR DESCRIPTION
Source hash: cb82283cf65a535b6b63ee07c31b4e50774bfd5a
Remaining commits: 1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `FullNode.add_transaction()` error-handling to catch and convert `ValidationError` into a `(FAILED, Err)` return, which affects transaction rejection behavior and seen-tx bookkeeping in a consensus-adjacent path.
> 
> **Overview**
> `FullNode.add_transaction()` now catches `ValidationError` from `mempool_manager.pre_validate_spendbundle()`, logs the specific `Err` code, records the tx as seen via `add_and_maybe_pop_seen()`, and returns `(MempoolInclusionStatus.FAILED, e.code)` instead of letting the exception propagate.
> 
> Mempool tests were updated to assert the returned `FAILED` status and `Err.WRONG_PUZZLE_HASH` for an invalid coin spend, rather than expecting a raised `ValidationError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82091f5adfba722ba1814790f381e29149d48678. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->