### PR TITLE
[CHIA-3995] Update inbound timelord connection handling

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -553,6 +553,25 @@ async def test_inbound_connection_limit(setup_four_nodes: OldSimulatorsAndWallet
 
 
 @pytest.mark.anyio
+async def test_timelord_inbound_connection(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+) -> None:
+    _, server, _ = one_node_one_block
+    from ipaddress import ip_network
+
+    # Timelord from localhost should be accepted
+    assert server.should_accept_inbound(NodeType.TIMELORD, "127.0.0.1") is True
+    assert server.should_accept_inbound(NodeType.TIMELORD, "::1") is True
+
+    # Timelord from non-localhost, non-exempt should be rejected
+    assert server.should_accept_inbound(NodeType.TIMELORD, "8.8.8.8") is False
+
+    # Timelord from non-localhost, exempt network should be accepted
+    server.exempt_peer_networks = [ip_network("8.8.8.0/24")]
+    assert server.should_accept_inbound(NodeType.TIMELORD, "8.8.8.8") is True
+
+
+@pytest.mark.anyio
 async def test_request_peers(
     wallet_nodes: tuple[
         FullNodeSimulator, FullNodeSimulator, ChiaServer, ChiaServer, WalletTool, WalletTool, BlockTools

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3724,7 +3724,7 @@ async def test_node_type_message_typechecking(
     [
         (NodeType.HARVESTER, None),
         (NodeType.FARMER, "max_inbound_farmer"),
-        (NodeType.TIMELORD, "max_inbound_timelord"),
+        (NodeType.TIMELORD, None),
         (NodeType.INTRODUCER, None),
         (NodeType.WALLET, "max_inbound_wallet"),
         (NodeType.DATA_LAYER, None),

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -358,11 +358,7 @@ class ChiaServer:
                     raise ProtocolError(Err.INVALID_HANDSHAKE)
 
             # Limit inbound connections to config's specifications.
-            if (
-                not self.accept_inbound_connections(connection.connection_type)
-                and not is_in_network(connection.peer_info.host, self.exempt_peer_networks)
-                and not (connection.connection_type == NodeType.TIMELORD and is_localhost(connection.peer_info.host))
-            ):
+            if not self.should_accept_inbound(connection.connection_type, connection.peer_info.host):
                 self.log.info(
                     f"Not accepting inbound connection: {connection.get_peer_logging()} "
                     f"of type {connection.connection_type.name}. Inbound limit reached."
@@ -737,6 +733,7 @@ class ChiaServer:
         return uint16(self._port)
 
     def accept_inbound_connections(self, node_type: NodeType) -> bool:
+        """Check if there are available inbound slots for this node type per config.yaml limits."""
         if not self._local_type == NodeType.FULL_NODE:
             return True
         inbound_count = len(self.get_connections(node_type, outbound=False))
@@ -748,6 +745,17 @@ class ChiaServer:
             return inbound_count < cast(int, self.config.get("max_inbound_wallet", 20))
         if node_type == NodeType.FARMER:
             return inbound_count < cast(int, self.config.get("max_inbound_farmer", 10))
+        return False
+
+    def should_accept_inbound(self, connection_type: NodeType, peer_host: str) -> bool:
+        """Check if an inbound connection should be accepted, considering config limits,
+        exempt peer networks, and localhost exceptions for timelords."""
+        if self.accept_inbound_connections(connection_type):
+            return True
+        if is_in_network(peer_host, self.exempt_peer_networks):
+            return True
+        if connection_type == NodeType.TIMELORD and is_localhost(peer_host):
+            return True
         return False
 
     def is_trusted_peer(self, peer: WSChiaConnection, trusted_peers: dict[str, Any]) -> bool:

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -360,7 +360,7 @@ class ChiaServer:
             # Limit inbound connections to config's specifications.
             if not self.accept_inbound_connections(connection.connection_type) and not is_in_network(
                 connection.peer_info.host, self.exempt_peer_networks
-            ):
+            ) and not is_localhost(connection.peer_info.host):
                 self.log.info(
                     f"Not accepting inbound connection: {connection.get_peer_logging()} "
                     f"of type {connection.connection_type.name}. Inbound limit reached."
@@ -746,8 +746,6 @@ class ChiaServer:
             return inbound_count < cast(int, self.config.get("max_inbound_wallet", 20))
         if node_type == NodeType.FARMER:
             return inbound_count < cast(int, self.config.get("max_inbound_farmer", 10))
-        if node_type == NodeType.TIMELORD:
-            return inbound_count < cast(int, self.config.get("max_inbound_timelord", 5))
         return False
 
     def is_trusted_peer(self, peer: WSChiaConnection, trusted_peers: dict[str, Any]) -> bool:

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -361,7 +361,7 @@ class ChiaServer:
             if (
                 not self.accept_inbound_connections(connection.connection_type)
                 and not is_in_network(connection.peer_info.host, self.exempt_peer_networks)
-                and not is_localhost(connection.peer_info.host)
+                and not (connection.connection_type == NodeType.TIMELORD and is_localhost(connection.peer_info.host))
             ):
                 self.log.info(
                     f"Not accepting inbound connection: {connection.get_peer_logging()} "

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -358,9 +358,11 @@ class ChiaServer:
                     raise ProtocolError(Err.INVALID_HANDSHAKE)
 
             # Limit inbound connections to config's specifications.
-            if not self.accept_inbound_connections(connection.connection_type) and not is_in_network(
-                connection.peer_info.host, self.exempt_peer_networks
-            ) and not is_localhost(connection.peer_info.host):
+            if (
+                not self.accept_inbound_connections(connection.connection_type)
+                and not is_in_network(connection.peer_info.host, self.exempt_peer_networks)
+                and not is_localhost(connection.peer_info.host)
+            ):
                 self.log.info(
                     f"Not accepting inbound connection: {connection.get_peer_logging()} "
                     f"of type {connection.connection_type.name}. Inbound limit reached."

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -391,7 +391,6 @@ full_node:
   # Accept at most # of inbound connections for different node types.
   max_inbound_wallet: 20
   max_inbound_farmer: 10
-  max_inbound_timelord: 5
   # Only connect to peers who we have heard about in the last recent_peer_threshold seconds
   recent_peer_threshold: 6000
 


### PR DESCRIPTION
Remove the `max_inbound_timelord` config option; inbound timelord connections are now only accepted from localhost or `exempt_peer_networks`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inbound connection admission logic for `NodeType.TIMELORD`, which can affect network connectivity and timelord operation if deployments relied on the old `max_inbound_timelord` limit/config behavior.
> 
> **Overview**
> Updates full node inbound-connection gating to centralize decisions in `ChiaServer.should_accept_inbound()`, combining slot limits, `exempt_peer_networks`, and a new *localhost-only exception for timelords*.
> 
> Removes the `max_inbound_timelord` config option/default and adjusts tests to reflect that timelord inbound acceptance is now only allowed from localhost (or from `exempt_peer_networks`), rather than being governed by a per-type inbound limit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dadeb69f514f3416d2c88ba7b8dc3a0704d1ce23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->