### PR TITLE
Fix Windows gui install

### DIFF
--- a/Install-gui.ps1
+++ b/Install-gui.ps1
@@ -32,7 +32,6 @@ try {
 
     $ErrorActionPreference = "SilentlyContinue"
     npm ci --loglevel=error
-    npm audit fix
     npm run build
     py ..\installhelper.py
 


### PR DESCRIPTION

### Purpose:

The shell install script `install-gui.sh` will skip `npm audit` if there's an issue, but the powershell script `install-gui.ps1` will not.
`npm audit` is not strictly necessary for the GUI to run and in fact can cause issues, so this PR removes it as a step from the Powershell install script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to the Windows install script; it only removes a non-essential dependency remediation step that could previously break installs.
> 
> **Overview**
> Stops running `npm audit fix` during `Install-gui.ps1` GUI builds, so Windows installs no longer fail or hang on audit issues and proceed directly from `npm ci` to `npm run build`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04ea0a064a3aa1a12f898f4b72b706eb2e3903bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->