### PR TITLE
Fix flaky test_maximum_full_file_count data layer test timeouts on macOS CI

### DIFF
--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -182,9 +182,9 @@ async def init_wallet_and_node(
 async def farm_block_check_singleton(
     data_layer: DataLayer, full_node_api: FullNodeSimulator, ph: bytes32, store_id: bytes32, wallet: WalletNode
 ) -> None:
-    await time_out_assert(10, check_mempool_spend_count, True, full_node_api, 1)
+    await time_out_assert(30, check_mempool_spend_count, True, full_node_api, 1)
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-    await time_out_assert(10, check_singleton_confirmed, True, data_layer, store_id)
+    await time_out_assert(30, check_singleton_confirmed, True, data_layer, store_id)
     await full_node_api.wait_for_wallet_synced(wallet_node=wallet, timeout=20)
 
 
@@ -215,9 +215,9 @@ async def check_mempool_spend_count_or_fail(
 async def farm_block_with_spend(
     full_node_api: FullNodeSimulator, ph: bytes32, tx_rec: bytes32, wallet_rpc_api: WalletRpcApi
 ) -> None:
-    await time_out_assert(10, check_mempool_spend_count_or_fail, True, full_node_api, 1, wallet_rpc_api, tx_rec)
+    await time_out_assert(30, check_mempool_spend_count_or_fail, True, full_node_api, 1, wallet_rpc_api, tx_rec)
     await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
-    await time_out_assert(10, is_transaction_confirmed, True, wallet_rpc_api, tx_rec)
+    await time_out_assert(30, is_transaction_confirmed, True, wallet_rpc_api, tx_rec)
     await full_node_api.wait_for_wallet_synced(wallet_node=wallet_rpc_api.service, timeout=20)
 
 


### PR DESCRIPTION
### Purpose:

`test_maximum_full_file_count` fails intermittently on macOS CI because `adjusted_timeout()` in `chia/util/timing.py` adds +20 s on Darwin. The 10 s nominal values in `farm_block_check_singleton` and `farm_block_with_spend` gave only a 30 s effective window — too tight for slow GitHub Actions runners where the DataLayerWallet can be slow to initialize and submit spends to the mempool.

### Current Behavior:

Both `time_out_assert` calls in `farm_block_check_singleton` and both in `farm_block_with_spend` use a 10 s timeout, giving a 30 s effective window on macOS CI. This is occasionally exceeded, causing intermittent `asyncio.TimeoutError` failures.

### New Behavior:

All four calls are bumped to 30 s, giving a 50 s effective window on macOS CI (30 + 20 s platform adjustment). No test logic, assertions, or parametrization is changed — only the four timeout integer arguments.

### Testing Notes:

- Only `chia/_tests/core/data_layer/test_data_rpc.py` is modified.
- `ruff check`, `ruff format --check`, and `mypy` all pass on the changed file.
- Change is intentionally minimal: four integer literals changed from `10` to `30`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that increases `time_out_assert` windows to avoid intermittent timing failures on slower CI runners, without altering functional assertions or production code.
> 
> **Overview**
> Raises the `time_out_assert` timeouts from 10s to 30s in `test_data_rpc.py` for `farm_block_check_singleton` and `farm_block_with_spend`, giving the DataLayer/wallet/mempool flow more time to initialize, submit spends, and confirm transactions.
> 
> No test logic changes beyond extending these wait windows to reduce intermittent macOS CI timeouts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e535c9540334893712ca6940428a0ea81ad99587. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->