### PR TITLE
checkpoint: into main from release/2.7.0  @ 39f8bec886f4ad42ec24b4d14cd9f78ba5539ee0

### DIFF
--- a/chia/_tests/core/data_layer/test_data_store.py
+++ b/chia/_tests/core/data_layer/test_data_store.py
@@ -40,6 +40,7 @@ from chia.data_layer.data_layer_util import (
     _debug_dump,
     get_delta_filename_path,
     get_full_tree_filename_path,
+    internal_hash,
     leaf_hash,
 )
 from chia.data_layer.data_store import DataStore
@@ -1227,6 +1228,7 @@ async def test_server_http_ban(
         server_info: ServerInfo,
         timeout: aiohttp.ClientTimeout,
         log: logging.Logger,
+        max_delta_file_size: int,
     ) -> None:
         if error:
             raise aiohttp.ClientConnectionError
@@ -1336,6 +1338,142 @@ async def write_tree_to_file_old_format(
     writer.write(to_write)
 
 
+def create_graph_util(path: Path, edges: list[tuple[int, int]]) -> bytes32:
+    """
+    Utility for tests: write a *full tree* file that `insert_into_data_store_from_file()` can consume.
+
+    This is a low-level writer which generates `SerializedNode` entries directly from `edges`
+    without relying on `DataStore.write_tree_to_file()`.
+    """
+
+    if len(edges) == 0:
+        raise ValueError("edges must be non-empty")
+
+    # `edges` define a binary Merkle DAG: each internal node id has exactly 2 outgoing edges
+    # which define the left/right child ordering (the edge list order is preserved).
+    normalized_edges: list[tuple[int, int]] = [(int(u), int(v)) for (u, v) in edges]
+
+    children_by_parent: dict[int, list[int]] = {}
+    all_children: set[int] = set()
+    for u, v in normalized_edges:
+        children_by_parent.setdefault(u, []).append(v)
+        all_children.add(v)
+
+    if len(children_by_parent) == 0:
+        raise ValueError("edges must contain at least one parent->child relationship")
+    if not all(len(vs) == 2 for vs in children_by_parent.values()):
+        raise ValueError("each parent must have exactly 2 children (binary Merkle DAG)")
+
+    roots = sorted(set(children_by_parent.keys()) - all_children)
+    if len(roots) != 1:
+        raise ValueError(f"expected exactly one root, found {len(roots)}")
+    root_id = roots[0]
+
+    # Leaves are nodes with no outgoing edges.
+    all_nodes: set[int] = set(children_by_parent.keys()) | all_children
+    leaf_ids = sorted(all_nodes - set(children_by_parent.keys()))
+    if len(leaf_ids) == 0:
+        raise ValueError("graph has no leaves")
+
+    # Depth-first, postorder write (children first, then parent), de-duplicating nodes.
+    # Implemented iteratively to avoid Python recursion limits for deep graphs (e.g. line graphs).
+    serialized_nodes: list[SerializedNode] = []
+    node_hashes: dict[int, bytes32] = {}
+
+    def leaf_key_value(node_id: int) -> tuple[bytes, bytes]:
+        key = int(node_id).to_bytes(4, byteorder="big", signed=False)
+        value = b""
+        return key, value
+
+    # Stack holds (node_id, state) where state 0=enter, 1=exit.
+    stack: list[tuple[int, int]] = [(root_id, 0)]
+    while stack:
+        node_id, state = stack.pop()
+        if state == 0:
+            if node_id in node_hashes:
+                continue
+            stack.append((node_id, 1))
+            children = children_by_parent.get(node_id)
+            if children is None:
+                continue
+            left_child, right_child = children
+            # Push in reverse order so left is processed first.
+            stack.append((right_child, 0))
+            stack.append((left_child, 0))
+        else:
+            if node_id in node_hashes:
+                continue
+            children = children_by_parent.get(node_id)
+            if children is None:
+                key, value = leaf_key_value(node_id)
+                h = leaf_hash(key=key, value=value)
+                serialized_nodes.append(SerializedNode(True, key, value))
+                node_hashes[node_id] = h
+                continue
+
+            left_child, right_child = children
+            left_hash = node_hashes[left_child]
+            right_hash = node_hashes[right_child]
+            h = internal_hash(left_hash=left_hash, right_hash=right_hash)
+            serialized_nodes.append(SerializedNode(False, bytes(left_hash), bytes(right_hash)))
+            node_hashes[node_id] = h
+
+    root_hash = node_hashes[root_id]
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as writer:
+        for node in serialized_nodes:
+            to_write = bytes(node)
+            writer.write(len(to_write).to_bytes(4, byteorder="big"))
+            writer.write(to_write)
+
+    return root_hash
+
+
+def create_dag_edges(levels: int) -> list[tuple[int, int]]:
+    """
+    Create a directed acyclic graph with 3 nodes per level and branching factor 2
+    Expect number of paths in the graph to be 2^levels.
+    On the second level, the three nodes are aggregated into two, then finally the top level contains the root.
+    The returned edges are intended to be fed into `create_graph_util(path, edges)`.
+    """
+    per_level = 3
+
+    def node_id(level: int, idx: int) -> int:
+        return 1 + level * per_level + idx
+
+    # We'll add a dedicated root node above the top level, and two aggregator nodes so the
+    # overall structure remains strictly binary (each parent has exactly 2 children).
+    root_node = 1 + levels * per_level
+    top_ab_agg = root_node + 1
+    top_c_agg = root_node + 2
+
+    edges: list[tuple[int, int]] = []
+
+    # Inter-level edges.
+    for level in range(1, levels):
+        # 3 internal nodes per level, each consuming 2 distinct children from the previous level,
+        # in a rotated pattern to guarantee distinct internal hashes.
+        for idx in range(per_level):
+            parent = node_id(level, idx)
+            left = node_id(level - 1, idx)
+            right = node_id(level - 1, (idx + 1) % per_level)
+            edges.append((parent, left))
+            edges.append((parent, right))
+
+    # Aggregate top A/B and top C separately, then root combines those two.
+    edges.append((top_ab_agg, node_id(levels - 1, 0)))
+    edges.append((top_ab_agg, node_id(levels - 1, 1)))
+
+    edges.append((top_c_agg, node_id(levels - 1, 2)))
+    edges.append((top_c_agg, node_id(levels - 1, 0)))
+
+    edges.append((root_node, top_ab_agg))
+    edges.append((root_node, top_c_agg))
+
+    return edges
+
+
 @pytest.mark.parametrize(argnames="test_delta", argvalues=["full", "delta", "old"])
 @boolean_datacases(name="group_files_by_store", false="group by singleton", true="don't group by singleton")
 @pytest.mark.anyio
@@ -1418,6 +1556,91 @@ async def test_data_server_files(
         current_root = await data_store.get_tree_root(store_id=store_id)
         assert current_root.node_hash == root.node_hash
         generation += 1
+
+
+@pytest.mark.anyio
+async def test_insert_into_data_store_from_file_graph_util(
+    data_store: DataStore, store_id: bytes32, tmp_path: Path
+) -> None:
+    # Simple binary tree:
+    #   1
+    #  / \
+    # 2   3
+    # / \
+    # 4  5
+    edges: list[tuple[int, int]] = [(1, 2), (1, 3), (2, 4), (2, 5)]
+    filename = tmp_path / "graph_full_v1.dat"
+
+    root_hash = create_graph_util(filename, edges)
+
+    await data_store.insert_into_data_store_from_file(store_id, root_hash, filename)
+    current_root = await data_store.get_tree_root(store_id=store_id)
+    assert current_root.node_hash == root_hash
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("depth", [1000, 100_000])
+async def test_insert_into_data_store_from_file_line_graph_depth(
+    data_store: DataStore,
+    store_id: bytes32,
+    tmp_path: Path,
+    depth: int,
+) -> None:
+    # Binary "line graph":
+    #   1 -> leaf_1, 2
+    #   2 -> leaf_2, 3
+    #   ...
+    #   depth -> leaf_depth, leaf_end
+    #
+    # This stresses depth/stack handling while staying strictly binary.
+    #
+    # Node IDs:
+    # - internal nodes: 1..depth
+    # - per-level leaf nodes: (depth+1)..(2*depth)
+    # - final leaf: (2*depth+1)
+    internal_first = 1
+    internal_last = depth
+    leaf_base = internal_last + 1
+    leaf_end = (2 * depth) + 1
+
+    edges: list[tuple[int, int]] = []
+    for i in range(internal_first, internal_last):
+        # Order matters: first edge is left child, second edge is right child.
+        edges.append((i, leaf_base + (i - internal_first)))  # unique leaf for this internal node
+        edges.append((i, i + 1))  # next internal node
+
+    # last internal points to its leaf and a final leaf
+    edges.append((internal_last, leaf_base + (internal_last - internal_first)))
+    edges.append((internal_last, leaf_end))
+
+    filename = tmp_path / f"line_graph_depth_{depth}.dat"
+    root_hash = create_graph_util(filename, edges)
+
+    with pytest.raises(chia_rs.datalayer.RecursionDepthExceededError):
+        await data_store.insert_into_data_store_from_file(store_id, root_hash, filename)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "levels",
+    [
+        10,
+        25,
+        50,
+    ],
+)
+async def test_insert_into_data_store_from_file_fails_for_dag(
+    data_store: DataStore,
+    store_id: bytes32,
+    tmp_path: Path,
+    levels: int,
+) -> None:
+    edges = create_dag_edges(levels=levels)
+    filename = tmp_path / f"merkle_dag_{levels}_levels_full_v1.dat"
+
+    root_hash = create_graph_util(filename, edges)
+    with pytest.raises(chia_rs.datalayer.CycleFoundError):
+        await data_store.insert_into_data_store_from_file(store_id, root_hash, filename)
 
 
 @pytest.mark.anyio
@@ -1762,8 +1985,9 @@ async def test_insert_from_delta_file(
         filename: str,
         proxy_url: str | None,
         server_info: ServerInfo,
-        timeout: int,
+        timeout: aiohttp.ClientTimeout,
         log: logging.Logger,
+        max_delta_file_size: int,
     ) -> None:
         pass
 
@@ -1772,8 +1996,9 @@ async def test_insert_from_delta_file(
         filename: str,
         proxy_url: str | None,
         server_info: ServerInfo,
-        timeout: int,
+        timeout: aiohttp.ClientTimeout,
         log: logging.Logger,
+        max_delta_file_size: int,
     ) -> None:
         try:
             os.rmdir(store_path)
@@ -2002,6 +2227,141 @@ async def test_insert_from_delta_file_incorrect_file_exists(
     with os.scandir(store_path) as entries:
         filenames = [entry.name for entry in entries if entry.name.endswith(".dat")]
         assert len(filenames) == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "max_delta_file_size_mib,value_size_mib,use_default_limit,expected_success",
+    [
+        (250, 200, True, False),
+        (100, 75, False, False),
+        (250, 100, True, True),
+        (100, 25, False, True),
+    ],
+)
+async def test_insert_from_delta_file_exceeds_max_limit(
+    data_store: DataStore,
+    store_id: bytes32,
+    tmp_path: Path,
+    max_delta_file_size_mib: int,
+    value_size_mib: int,
+    use_default_limit: bool,
+    expected_success: bool,
+) -> None:
+    key_a = b"\x00"
+    key_b = b"\x01"
+    large_value = b"\xaa" * value_size_mib * 1024 * 1024
+    leaf_a_hash = leaf_hash(key=key_a, value=large_value)
+    leaf_b_hash = leaf_hash(key=key_b, value=large_value)
+    root_hash = internal_hash(left_hash=leaf_a_hash, right_hash=leaf_b_hash)
+
+    delta_file_path = get_delta_filename_path(tmp_path, store_id, root_hash, 1)
+    with open(delta_file_path, "wb") as writer:
+        for serialized_node in (
+            SerializedNode(True, key_a, large_value),
+            SerializedNode(True, key_b, large_value),
+            SerializedNode(False, bytes(leaf_a_hash), bytes(leaf_b_hash)),
+        ):
+            serialized_node_bytes = bytes(serialized_node)
+            writer.write(len(serialized_node_bytes).to_bytes(4, byteorder="big"))
+            writer.write(serialized_node_bytes)
+
+    assert (await data_store.get_tree_root(store_id=store_id)).generation == 0
+
+    insert_kwargs: dict[str, Any] = {}
+    if not use_default_limit:
+        insert_kwargs["max_delta_file_size"] = max_delta_file_size_mib
+
+    success = await insert_from_delta_file(
+        data_store=data_store,
+        store_id=store_id,
+        existing_generation=0,
+        target_generation=1,
+        root_hashes=[root_hash],
+        server_info=ServerInfo("http://127.0.0.1/8003", 0, 0),
+        client_foldername=tmp_path,
+        timeout=aiohttp.ClientTimeout(total=15, sock_connect=5),
+        log=log,
+        proxy_url="",
+        downloader=None,
+        **insert_kwargs,
+    )
+
+    assert success is expected_success
+
+    root = await data_store.get_tree_root(store_id=store_id)
+    if expected_success:
+        assert root.generation == 1
+        assert root.node_hash == root_hash
+        node_a = await data_store.get_node_by_key(store_id=store_id, key=key_a)
+        node_b = await data_store.get_node_by_key(store_id=store_id, key=key_b)
+        assert node_a.value == large_value
+        assert node_b.value == large_value
+        assert delta_file_path.exists()
+    else:
+        assert root.generation == 0
+        assert not delta_file_path.exists()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "expected_file_size_bytes,expected_success",
+    [
+        (1_048_576, True),  # 1 MiB
+        (1_048_577, False),  # 1 MiB + 1 byte
+    ],
+)
+async def test_insert_from_delta_file_limit_boundary(
+    data_store: DataStore,
+    store_id: bytes32,
+    tmp_path: Path,
+    expected_file_size_bytes: int,
+    expected_success: bool,
+) -> None:
+    max_delta_file_size_mib = 1
+    # 4-byte length prefix + 10-byte SerializedNode terminal framing overhead.
+    delta_file_overhead_bytes = 14
+
+    key = b"\x42"
+    value_size_bytes = expected_file_size_bytes - delta_file_overhead_bytes
+    assert value_size_bytes >= 0
+    value = b"\xcc" * value_size_bytes
+    serialized_leaf = bytes(SerializedNode(True, key, value))
+    assert len(serialized_leaf) == expected_file_size_bytes - 4
+
+    root_hash = leaf_hash(key=key, value=value)
+    delta_file_path = get_delta_filename_path(tmp_path, store_id, root_hash, 1)
+    with open(delta_file_path, "wb") as writer:
+        writer.write(len(serialized_leaf).to_bytes(4, byteorder="big"))
+        writer.write(serialized_leaf)
+    assert delta_file_path.stat().st_size == expected_file_size_bytes
+
+    success = await insert_from_delta_file(
+        data_store=data_store,
+        store_id=store_id,
+        existing_generation=0,
+        target_generation=1,
+        root_hashes=[root_hash],
+        server_info=ServerInfo("http://127.0.0.1/8003", 0, 0),
+        client_foldername=tmp_path,
+        timeout=aiohttp.ClientTimeout(total=15, sock_connect=5),
+        log=log,
+        proxy_url="",
+        downloader=None,
+        max_delta_file_size=max_delta_file_size_mib,
+    )
+
+    assert success is expected_success
+    root = await data_store.get_tree_root(store_id=store_id)
+    if expected_success:
+        assert root.generation == 1
+        assert root.node_hash == root_hash
+        node = await data_store.get_node_by_key(store_id=store_id, key=key)
+        assert node.value == value
+        assert delta_file_path.exists()
+    else:
+        assert root.generation == 0
+        assert not delta_file_path.exists()
 
 
 @pytest.mark.anyio

--- a/chia/_tests/core/data_layer/test_plugin.py
+++ b/chia/_tests/core/data_layer/test_plugin.py
@@ -214,6 +214,7 @@ async def test_download_file_plugin_success(tmp_path: Path) -> None:
             log=log,
             grouped_by_store=False,
             group_downloaded_files_by_store=False,
+            max_delta_file_size=10 * 1024 * 1024,  # 10 MB
         )
 
     assert result is True
@@ -246,6 +247,7 @@ async def test_download_file_plugin_timeout(tmp_path: Path) -> None:
             log=log,
             grouped_by_store=False,
             group_downloaded_files_by_store=False,
+            max_delta_file_size=10 * 1024 * 1024,  # 10 MB
         )
 
     assert result is False
@@ -278,6 +280,7 @@ async def test_download_file_plugin_client_error(tmp_path: Path) -> None:
             log=log,
             grouped_by_store=False,
             group_downloaded_files_by_store=False,
+            max_delta_file_size=10 * 1024 * 1024,  # 10 MB
         )
 
     assert result is False

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -38,7 +38,7 @@ from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
 from packaging.version import Version
 
 from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block, _validate_and_add_block_no_error
-from chia._tests.conftest import ConsensusMode
+from chia._tests.conftest import ConsensusMode, make_old_setup_simulators_and_wallets
 from chia._tests.connection_utils import add_dummy_connection, add_dummy_connection_wsc, connect_and_get_peer
 from chia._tests.core.full_node.stores.test_coin_store import get_future_reward_coins
 from chia._tests.core.make_block_generator import make_spend_bundle
@@ -3821,3 +3821,68 @@ async def test_register_for_coin_updates(
     assert {cs.coin.name() for cs in response_data.coin_states} == set(first_coin)
     for coin_id in remaining_coins:
         assert coin_id not in response_data.coin_ids
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_request_puzzle_state_rejects_before_peak(
+    blockchain_constants: ConsensusConstants, self_hostname: str
+) -> None:
+    """
+    SEC-410: request_puzzle_state must return RejectPuzzleState instead of crashing
+    when the node has no peak (before any blocks are synced).
+    """
+    async with setup_simulators_and_wallets(1, 0, blockchain_constants) as new:
+        (nodes, _, _bt) = make_old_setup_simulators_and_wallets(new=new)
+        full_node_api = nodes[0]
+        server = full_node_api.full_node.server
+
+        assert full_node_api.full_node.blockchain.get_peak_height() is None
+
+        dummy_peer, _ = await add_dummy_connection_wsc(server, self_hostname, 1338, NodeType.WALLET)
+
+        request = wallet_protocol.RequestPuzzleState(
+            puzzle_hashes=[bytes32.random()],
+            previous_height=None,
+            header_hash=blockchain_constants.GENESIS_CHALLENGE,
+            filters=wallet_protocol.CoinStateFilters(True, True, True, uint64(0)),
+            subscribe_when_finished=False,
+        )
+        response = await full_node_api.request_puzzle_state(request, dummy_peer)
+
+        assert response is not None
+        assert response.type == ProtocolMessageTypes.reject_puzzle_state.value
+        reject = wallet_protocol.RejectPuzzleState.from_bytes(response.data)
+        assert reject.reason == uint8(wallet_protocol.RejectStateReason.REORG)
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_request_puzzle_state_responds_normally(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools], self_hostname: str
+) -> None:
+    """
+    Happy-path: request_puzzle_state returns RespondPuzzleState on a synced node.
+    """
+    full_node_api, server, _bt = one_node_one_block
+
+    assert full_node_api.full_node.blockchain.get_peak_height() is not None
+
+    dummy_peer, _ = await add_dummy_connection_wsc(server, self_hostname, 1339, NodeType.WALLET)
+
+    peak_height = full_node_api.full_node.blockchain.get_peak_height()
+    assert peak_height is not None
+    header_hash = full_node_api.full_node.blockchain.height_to_hash(peak_height)
+    assert header_hash is not None
+
+    request = wallet_protocol.RequestPuzzleState(
+        puzzle_hashes=[bytes32.random()],
+        previous_height=peak_height,
+        header_hash=header_hash,
+        filters=wallet_protocol.CoinStateFilters(True, True, True, uint64(0)),
+        subscribe_when_finished=False,
+    )
+    response = await full_node_api.request_puzzle_state(request, dummy_peer)
+
+    assert response is not None
+    assert response.type == ProtocolMessageTypes.respond_puzzle_state.value

--- a/chia/_tests/core/server/test_server.py
+++ b/chia/_tests/core/server/test_server.py
@@ -25,7 +25,7 @@ from chia.protocols.wallet_protocol import RejectHeaderRequest
 from chia.server.api_protocol import ApiMetadata
 from chia.server.server import ChiaServer
 from chia.server.ssl_context import chia_ssl_ca_paths, private_ssl_ca_paths
-from chia.server.ws_connection import WSChiaConnection, error_response_version
+from chia.server.ws_connection import WSChiaConnection, error_response_version, sanitize_version_string
 from chia.simulator.block_tools import BlockTools
 from chia.types.peer_info import PeerInfo
 from chia.util.errors import ApiError, Err
@@ -87,6 +87,24 @@ async def test_connection_versions(
         assert connection.protocol_version == Version(protocol_version[NodeType.WALLET])
         assert connection.version == __version__
         assert connection.get_version() == connection.version
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("2.5.0", "2.5.0"),
+        ("", ""),
+        ("2.5.0\nERROR fake log line", "2.5.0ERROR fake log line"),
+        ("2.5.0\r\nINJECTED", "2.5.0INJECTED"),
+        ("2.5.0\x00hidden", "2.5.0hidden"),
+        ("\x1b[31mred\x1b[0m", "[31mred[0m"),
+        ("valid-version_1.2.3+build.42", "valid-version_1.2.3+build.42"),
+        ("a" * 128, "a" * 128),
+        ("\u200b\u200czero-width", "zero-width"),
+    ],
+)
+def test_sanitize_version_string(raw: str, expected: str) -> None:
+    assert sanitize_version_string(raw) == expected
 
 
 @pytest.mark.anyio

--- a/chia/_tests/util/test_limited_semaphore.py
+++ b/chia/_tests/util/test_limited_semaphore.py
@@ -9,6 +9,67 @@ from chia.util.task_referencer import create_referenced_task
 
 
 @pytest.mark.anyio
+async def test_tracking_set_cleanup_on_semaphore_full() -> None:
+    """Verify that a tracking set entry is not leaked when LimitedSemaphoreFullError is raised.
+
+    Reproduces the pattern in new_compact_vdf / respond_compact_proof_of_time
+    where a name is added to compact_vdf_requests before acquiring the semaphore.
+    Without cleanup in the except block, the entry would be permanently leaked.
+    """
+    semaphore = LimitedSemaphore.create(active_limit=1, waiting_limit=0)
+    tracking_set: set[str] = set()
+    finish_event = asyncio.Event()
+
+    async def hold_semaphore() -> None:
+        async with semaphore.acquire():
+            await finish_event.wait()
+
+    holder = create_referenced_task(hold_semaphore())
+    await asyncio.sleep(0)
+
+    for i in range(5):
+        name = f"entry-{i}"
+        tracking_set.add(name)
+        try:
+            async with semaphore.acquire():
+                try:
+                    pass
+                finally:
+                    tracking_set.discard(name)
+        except LimitedSemaphoreFullError:
+            tracking_set.discard(name)
+
+    assert len(tracking_set) == 0, f"Leaked entries: {tracking_set}"
+
+    finish_event.set()
+    await holder
+
+    # Verify semaphore is fully released
+    assert semaphore._available_count == 1
+
+
+@pytest.mark.anyio
+async def test_tracking_set_cleanup_on_success() -> None:
+    """Verify the tracking set is cleaned up on the normal (successful acquire) path."""
+    semaphore = LimitedSemaphore.create(active_limit=2, waiting_limit=2)
+    tracking_set: set[str] = set()
+
+    for i in range(4):
+        name = f"entry-{i}"
+        tracking_set.add(name)
+        try:
+            async with semaphore.acquire():
+                try:
+                    pass
+                finally:
+                    tracking_set.discard(name)
+        except LimitedSemaphoreFullError:
+            tracking_set.discard(name)
+
+    assert len(tracking_set) == 0, f"Leaked entries: {tracking_set}"
+
+
+@pytest.mark.anyio
 async def test_stuff() -> None:
     active_limit = 2
     waiting_limit = 4

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -151,6 +151,7 @@ class DataLayer:
         default_factory=functools.partial(aiohttp.ClientTimeout, total=45, sock_connect=5)
     )
     group_files_by_store: bool = False
+    max_delta_file_size: int = 250
 
     @property
     def server(self) -> ChiaServer:
@@ -222,6 +223,7 @@ class DataLayer:
                 total=config.get("client_timeout", 45), sock_connect=config.get("connect_timeout", 5)
             ),
             group_files_by_store=config.get("group_files_by_store", False),
+            max_delta_file_size=config.get("max_delta_file_size", 250),
         )
 
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -665,6 +667,7 @@ class DataLayer:
                     downloader=await self.get_downloader(store_id, url),
                     group_files_by_store=self.group_files_by_store,
                     maximum_full_file_count=self.maximum_full_file_count,
+                    max_delta_file_size=self.max_delta_file_size,
                 )
                 if success:
                     self.log.info(

--- a/chia/data_layer/data_layer_errors.py
+++ b/chia/data_layer/data_layer_errors.py
@@ -53,3 +53,7 @@ class ProofIntegrityError(Exception):
 
 class LauncherCoinNotFoundError(Exception):
     pass
+
+
+class MaxDeltaFileSizeExceededError(Exception):
+    pass

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -31,7 +31,12 @@ from chia_rs.datalayer import (
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import int64
 
-from chia.data_layer.data_layer_errors import KeyNotFoundError, MerkleBlobNotFoundError, TreeGenerationIncrementingError
+from chia.data_layer.data_layer_errors import (
+    KeyNotFoundError,
+    MaxDeltaFileSizeExceededError,
+    MerkleBlobNotFoundError,
+    TreeGenerationIncrementingError,
+)
 from chia.data_layer.data_layer_util import (
     DiffData,
     InsertResult,
@@ -205,6 +210,7 @@ class DataStore:
         root_hash: bytes32 | None,
         filename: Path,
         delta_reader: DeltaReader | None = None,
+        max_delta_file_size: int = 250,
     ) -> DeltaReader | None:
         async with self.db_wrapper.writer():
             with self.manage_kv_files(store_id):
@@ -220,7 +226,7 @@ class DataStore:
                                 indexes=[TreeIndex(0)],
                             )
 
-                    internal_nodes, terminal_nodes = await self.read_from_file(filename, store_id)
+                    internal_nodes, terminal_nodes = await self.read_from_file(filename, store_id, max_delta_file_size)
                     delta_reader.add_internal_nodes(internal_nodes)
                     delta_reader.add_leaf_nodes(terminal_nodes)
 
@@ -242,7 +248,12 @@ class DataStore:
                     merkle_blob = delta_reader.create_merkle_blob_and_filter_unused_nodes(root_hash, set())
 
                 # Don't store these blob objects into cache, since their data structures are not calculated yet.
-                await self.insert_root_from_merkle_blob(merkle_blob, store_id, Status.COMMITTED, update_cache=False)
+                new_root = await self.insert_root_from_merkle_blob(
+                    merkle_blob, store_id, Status.COMMITTED, update_cache=False
+                )
+                # Double-check that the MerkleBlob is correct by loading it into memory.
+                if new_root.node_hash is not None:
+                    await self.get_merkle_blob(store_id=store_id, root_hash=new_root.node_hash, read_only=True)
                 return delta_reader
 
     async def build_merkle_blob_queries_for_missing_hashes(
@@ -346,12 +357,15 @@ class DataStore:
             log.info(f"Missing hashes: added old hashes from generation {current_generation}")
 
     async def read_from_file(
-        self, filename: Path, store_id: bytes32
+        self, filename: Path, store_id: bytes32, max_delta_file_size: int
     ) -> tuple[dict[bytes32, tuple[bytes32, bytes32]], dict[bytes32, tuple[KeyId, ValueId]]]:
         internal_nodes: dict[bytes32, tuple[bytes32, bytes32]] = {}
         terminal_nodes: dict[bytes32, tuple[KeyId, ValueId]] = {}
 
         with open(filename, "rb") as reader:
+            file_size = filename.stat().st_size
+            if file_size > max_delta_file_size * 1024 * 1024:
+                raise MaxDeltaFileSizeExceededError(f"Maximum delta file size exceeded: {max_delta_file_size} MiB.")
             async with self.db_wrapper.writer() as writer:
                 while True:
                     chunk = b""

--- a/chia/data_layer/download_data.py
+++ b/chia/data_layer/download_data.py
@@ -11,6 +11,7 @@ import aiohttp
 from chia_rs.datalayer import DeltaReader
 from chia_rs.sized_bytes import bytes32
 
+from chia.data_layer.data_layer_errors import MaxDeltaFileSizeExceededError
 from chia.data_layer.data_layer_util import (
     PluginRemote,
     Root,
@@ -121,6 +122,7 @@ async def download_file(
     log: logging.Logger,
     grouped_by_store: bool,
     group_downloaded_files_by_store: bool,
+    max_delta_file_size: int,
 ) -> bool:
     if target_filename_path.exists():
         return True
@@ -129,8 +131,10 @@ async def download_file(
     if downloader is None:
         # use http downloader - this raises on any error
         try:
-            await http_download(target_filename_path, filename, proxy_url, server_info, timeout, log)
-        except (asyncio.TimeoutError, aiohttp.ClientError):
+            await http_download(
+                target_filename_path, filename, proxy_url, server_info, timeout, log, max_delta_file_size
+            )
+        except (asyncio.TimeoutError, aiohttp.ClientError, MaxDeltaFileSizeExceededError):
             new_server_info = await data_store.server_misses_file(store_id, server_info, timestamp)
             log.info(
                 f"Failed to download {filename} from {new_server_info.url}."
@@ -146,6 +150,7 @@ async def download_file(
         "client_folder": str(client_foldername),
         "filename": filename,
         "group_files_by_store": group_downloaded_files_by_store,
+        "max_delta_file_size": max_delta_file_size,
     }
     try:
         async with aiohttp.ClientSession() as session:
@@ -177,6 +182,7 @@ async def insert_from_delta_file(
     downloader: PluginRemote | None,
     group_files_by_store: bool = False,
     maximum_full_file_count: int = 1,
+    max_delta_file_size: int = 250,
 ) -> bool:
     if group_files_by_store:
         client_foldername.joinpath(f"{store_id}").mkdir(parents=True, exist_ok=True)
@@ -206,6 +212,7 @@ async def insert_from_delta_file(
                 log=log,
                 grouped_by_store=grouped_by_store,
                 group_downloaded_files_by_store=group_files_by_store,
+                max_delta_file_size=max_delta_file_size,
             )
             if success:
                 break
@@ -227,6 +234,7 @@ async def insert_from_delta_file(
                     None if root_hash == bytes32.zeros else root_hash,
                     target_filename_path,
                     delta_reader=delta_reader,
+                    max_delta_file_size=max_delta_file_size,
                 )
                 log.info(
                     f"Successfully inserted hash {root_hash} from delta file. "
@@ -294,6 +302,7 @@ async def http_download(
     server_info: ServerInfo,
     timeout: aiohttp.ClientTimeout,
     log: logging.Logger,
+    max_delta_file_size: int,
 ) -> None:
     """
     Download a file from a server using aiohttp.
@@ -309,14 +318,28 @@ async def http_download(
         ) as resp:
             resp.raise_for_status()
             size = int(resp.headers.get("content-length", 0))
+            max_delta_file_size_bytes = max_delta_file_size * 1024 * 1024
+            if size > max_delta_file_size_bytes:
+                raise MaxDeltaFileSizeExceededError(f"Maximum delta file size exceeded: {max_delta_file_size} MiB.")
             log.debug(f"Downloading delta file {filename}. Size {size} bytes.")
             progress_byte = 0
             progress_percentage = f"{0:.0%}"
-            with target_filename_path.open(mode="wb") as f:
-                async for chunk, _ in resp.content.iter_chunks():
-                    f.write(chunk)
-                    progress_byte += len(chunk)
-                    new_percentage = f"{progress_byte / size:.0%}"
-                    if new_percentage != progress_percentage:
-                        progress_percentage = new_percentage
-                        log.info(f"Downloading delta file {filename}. {progress_percentage} of {size} bytes.")
+            success = False
+            try:
+                with target_filename_path.open(mode="wb") as f:
+                    async for chunk, _ in resp.content.iter_chunks():
+                        f.write(chunk)
+                        progress_byte += len(chunk)
+                        if progress_byte > max_delta_file_size_bytes:
+                            raise MaxDeltaFileSizeExceededError(
+                                f"Maximum delta file size exceeded: {max_delta_file_size} MiB."
+                            )
+                        if size > 0:
+                            new_percentage = f"{progress_byte / size:.0%}"
+                            if new_percentage != progress_percentage:
+                                progress_percentage = new_percentage
+                                log.info(f"Downloading delta file {filename}. {progress_percentage} of {size} bytes.")
+                success = True
+            finally:
+                if not success:
+                    target_filename_path.unlink(missing_ok=True)

--- a/chia/data_layer/s3_plugin_service.py
+++ b/chia/data_layer/s3_plugin_service.py
@@ -256,6 +256,9 @@ class S3Plugin:
             url = data["url"]
             filename = data["filename"]
             group_files_by_store = data.get("group_files_by_store", False)
+            max_delta_file_size = data.get("max_delta_file_size")
+            if not isinstance(max_delta_file_size, int) or max_delta_file_size <= 0:
+                max_delta_file_size = 250
 
             # filename must follow the DataLayer naming convention
             if not is_filename_valid(filename, group_files_by_store):
@@ -279,6 +282,16 @@ class S3Plugin:
             target_filename = self.get_path_for_filename(filename_store_id, trimmed_filename, group_files_by_store)
             # Create folder for parent directory
             target_filename.parent.mkdir(parents=True, exist_ok=True)
+            max_delta_file_size_bytes = max_delta_file_size * 1024 * 1024
+            remote_file_size = my_bucket.ObjectSummary(filename).size
+            if remote_file_size > max_delta_file_size_bytes:
+                log.warning(
+                    "Skipping %s, size %s bytes exceeds max delta size %s MiB",
+                    filename,
+                    remote_file_size,
+                    max_delta_file_size,
+                )
+                return web.json_response({"downloaded": False})
             log.info(f"downloading {url} to {target_filename}...")
             with concurrent.futures.ThreadPoolExecutor(thread_name_prefix="s3-download-") as pool:
                 await asyncio.get_running_loop().run_in_executor(

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1644,6 +1644,7 @@ class FullNodeAPI:
                 finally:
                     self.full_node.compact_vdf_requests.remove(name)
         except LimitedSemaphoreFullError:
+            self.full_node.compact_vdf_requests.discard(name)
             self.log.debug(f"Ignoring CompactProofOfTime: {request}, _waiters")
 
         return None
@@ -1670,6 +1671,7 @@ class FullNodeAPI:
                 finally:
                     self.full_node.compact_vdf_requests.remove(name)
         except LimitedSemaphoreFullError:
+            self.full_node.compact_vdf_requests.discard(name)
             self.log.debug("Ignoring NewCompactVDF, limited semaphore full: %s %s", peer.get_peer_logging(), request)
             return None
 
@@ -1945,11 +1947,15 @@ class FullNodeAPI:
         is_done = next_min_height is None
 
         peak_height = self.full_node.blockchain.get_peak_height()
-        assert peak_height is not None
+        if peak_height is None:
+            reject = wallet_protocol.RejectPuzzleState(uint8(wallet_protocol.RejectStateReason.REORG))
+            return make_msg(ProtocolMessageTypes.reject_puzzle_state, reject)
 
         height = uint32(next_min_height - 1) if next_min_height is not None else peak_height
         header_hash = self.full_node.blockchain.height_to_hash(height)
-        assert header_hash is not None
+        if header_hash is None:
+            reject = wallet_protocol.RejectPuzzleState(uint8(wallet_protocol.RejectStateReason.REORG))
+            return make_msg(ProtocolMessageTypes.reject_puzzle_state, reject)
 
         # Check if the request would exceed the subscription limit.
         # We do this again since we've crossed an `await` point, to prevent a race condition.

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -5,6 +5,7 @@ import logging
 import math
 import time
 import traceback
+import unicodedata
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from ipaddress import IPv4Network, IPv6Network
@@ -55,6 +56,11 @@ WebSocket = WebSocketResponse | ClientWebSocketResponse
 ConnectionCallback = Callable[["WSChiaConnection"], Awaitable[None]]
 
 error_response_version = Version("0.0.35")
+
+
+def sanitize_version_string(version: str) -> str:
+    """Strip Unicode control characters (Cc) and format characters (Cf) to prevent log injection."""
+    return "".join(c for c in version if unicodedata.category(c) not in {"Cc", "Cf"})
 
 
 def create_default_last_message_time_dict() -> dict[ProtocolMessageTypes, float]:
@@ -298,7 +304,7 @@ class WSChiaConnection:
             )
             await self._send_message(outbound_handshake)
 
-        self.version = inbound_handshake.software_version
+        self.version = sanitize_version_string(inbound_handshake.software_version)
         self.protocol_version = Version(inbound_handshake.protocol_version)
         self.peer_server_port = inbound_handshake.server_port
         self.connection_type = remote_node_type

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -706,6 +706,8 @@ data_layer:
 
   # Speeds up autoinserts. Disable to perform inserts one by one instead of in a batch.
   enable_batch_autoinsert: True
+  # Maximum allowed delta file size (in MiB)
+  max_delta_file_size: 250
 
   logging: *logging
 


### PR DESCRIPTION
Source hash: 39f8bec886f4ad42ec24b4d14cd9f78ba5539ee0
Remaining commits: 1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new size-limit enforcement and cleanup paths in the data-layer download/insert pipeline, which can change sync behavior by rejecting/aborting large deltas. Also adjusts full node wallet API behavior and connection handshake string handling, affecting network-facing code paths.
> 
> **Overview**
> Adds a configurable `max_delta_file_size` (default **250 MiB**) to the data layer and enforces it end-to-end: `http_download()`/S3 plugin now reject oversized files, `DataStore.read_from_file()` raises `MaxDeltaFileSizeExceededError`, and partial downloads are deleted; this limit is also passed through downloader plugins.
> 
> Hardens a few network-facing edge cases: `request_puzzle_state` now returns `RejectPuzzleState` (REORG) instead of asserting when the node has no peak/header hash, handshake `software_version` is sanitized via `sanitize_version_string()` to prevent log/control-character injection, and compact VDF request tracking uses `discard()` on semaphore-full to avoid leaking entries. Tests are expanded to cover these cases, plus file-import recursion/DAG failure scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f95fa1278c824b2c70ca3dd78ffc4bf159d506a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->