### PR TITLE
CHIA-3997 Improve compact vdf request handling

### DIFF
--- a/chia/apis/full_node_stub.py
+++ b/chia/apis/full_node_stub.py
@@ -260,7 +260,9 @@ class FullNodeApiStub(ApiProtocol, Protocol):
         ...
 
     @metadata.request(peer_required=True, reply_types=[ProtocolMessageTypes.respond_compact_vdf])
-    async def request_compact_vdf(self, request: full_node_protocol.RequestCompactVDF, peer: WSChiaConnection) -> None:
+    async def request_compact_vdf(
+        self, request: full_node_protocol.RequestCompactVDF, peer: WSChiaConnection
+    ) -> Message | None:
         """Handle compact VDF request."""
         ...
 

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -3195,7 +3195,9 @@ class FullNode:
                 peer.pending_compact_vdfs.remove(vdf_req_key)
                 await self.add_compact_vdf(response, peer)
 
-    async def request_compact_vdf(self, request: full_node_protocol.RequestCompactVDF, peer: WSChiaConnection) -> None:
+    async def request_compact_vdf(
+        self, request: full_node_protocol.RequestCompactVDF, peer_id: bytes32
+    ) -> VDFProof | None:
         header_block = await self.blockchain.get_header_block_by_height(
             request.height, request.header_hash, tx_filter=False
         )
@@ -3227,17 +3229,9 @@ class FullNode:
         ):
             vdf_proof = header_block.challenge_chain_ip_proof
         if vdf_proof is None or vdf_proof.witness_type > 0 or not vdf_proof.normalized_to_identity:
-            self.log.info(f"{peer.peer_node_id} requested compact vdf we don't have, height: {request.height}.")
+            self.log.info(f"{peer_id} requested compact vdf we don't have, height: {request.height}.")
             return None
-        compact_vdf = full_node_protocol.RespondCompactVDF(
-            request.height,
-            request.header_hash,
-            request.field_vdf,
-            request.vdf_info,
-            vdf_proof,
-        )
-        msg = make_msg(ProtocolMessageTypes.respond_compact_vdf, compact_vdf)
-        await peer.send_message(msg)
+        return vdf_proof
 
     async def add_compact_vdf(self, request: full_node_protocol.RespondCompactVDF, peer: WSChiaConnection) -> None:
         field_vdf = CompressibleVDFField(int(request.field_vdf))

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1676,11 +1676,24 @@ class FullNodeAPI:
         return None
 
     @metadata.request(peer_required=True, reply_types=[ProtocolMessageTypes.respond_compact_vdf])
-    async def request_compact_vdf(self, request: full_node_protocol.RequestCompactVDF, peer: WSChiaConnection) -> None:
+    async def request_compact_vdf(
+        self, request: full_node_protocol.RequestCompactVDF, peer: WSChiaConnection
+    ) -> Message | None:
         if self.full_node.sync_store.get_sync_mode():
             return None
-        await self.full_node.request_compact_vdf(request, peer)
-        return None
+        vdf_proof = await self.full_node.request_compact_vdf(request, peer.peer_node_id)
+        if vdf_proof is None:
+            return None
+        return make_msg(
+            ProtocolMessageTypes.respond_compact_vdf,
+            full_node_protocol.RespondCompactVDF(
+                height=request.height,
+                header_hash=request.header_hash,
+                field_vdf=request.field_vdf,
+                vdf_info=request.vdf_info,
+                vdf_proof=vdf_proof,
+            ),
+        )
 
     @metadata.request(peer_required=True)
     async def respond_compact_vdf(self, request: full_node_protocol.RespondCompactVDF, peer: WSChiaConnection) -> None:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the full-node networking response path for `RequestCompactVDF`, which could impact peer interoperability or lead to missing responses if return types/metadata are mis-handled. Scope is small and limited to compact VDF request/response flow.
> 
> **Overview**
> **Improves compact VDF request handling** by converting `request_compact_vdf` to a request/reply style handler that *returns* a `respond_compact_vdf` `Message` instead of constructing and sending the response directly.
> 
> `FullNode.request_compact_vdf` now returns a `VDFProof | None` (and accepts `peer_id` for logging), while `FullNodeAPI.request_compact_vdf` wraps that proof into `RespondCompactVDF` via `make_msg`; the API stub signature is updated to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8f663c9ce8d253018239dcfa9d9181c2b7ba1de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->