### PR TITLE
Restore DL wallet launcher entry after rollback

### DIFF
--- a/chia/_tests/wallet/db_wallet/test_dl_wallet.py
+++ b/chia/_tests/wallet/db_wallet/test_dl_wallet.py
@@ -870,3 +870,123 @@ async def test_datalayer_reorgs(wallet_environments: WalletTestFramework) -> Non
         ]
     )
     assert len(await dl_wallet.get_mirrors_for_launcher(launcher_id)) == 1
+
+
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [
+        {
+            "num_environments": 1,
+            "blocks_needed": [1],
+            "reuse_puzhash": True,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
+@pytest.mark.anyio
+async def test_datalayer_ownership_survives_rollback(wallet_environments: WalletTestFramework) -> None:
+    """Verify that store ownership is preserved after a wallet rollback to block 0.
+
+    Regression test: a rollback deletes launcher entries from the DB while
+    singleton_records survive (unconfirmed).  During re-sync the wallet must
+    restore the launcher entry so that get_owned_singletons still reports the
+    store as owned.
+    """
+    env = wallet_environments.environments[0]
+    wallet_node = env.node
+
+    env.wallet_aliases = {
+        "xch": 1,
+        "dl": 2,
+    }
+
+    async with env.wallet_state_manager.lock:
+        dl_wallet = await DataLayerWallet.create_new_dl_wallet(env.wallet_state_manager)
+
+    # --- Create a store (generation 0) ---
+    async with dl_wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        launcher_id = await dl_wallet.generate_new_reporter(bytes32.zeros, action_scope)
+
+    await wallet_environments.process_pending_states(
+        [
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "xch": {
+                        "unconfirmed_wallet_balance": -1,
+                        "<=#spendable_balance": -1,
+                        "<=#max_send_amount": -1,
+                        ">=#pending_change": 1,
+                        "pending_coin_removal_count": 1,
+                    },
+                    "dl": {"init": True},
+                },
+                post_block_balance_updates={
+                    "xch": {
+                        "confirmed_wallet_balance": -1,
+                        ">=#spendable_balance": 1,
+                        ">=#max_send_amount": 1,
+                        "<=#pending_change": -1,
+                        "pending_coin_removal_count": -1,
+                    },
+                    "dl": {"unspent_coin_count": 1},
+                },
+            )
+        ]
+    )
+    await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet, launcher_id, bytes32.zeros)
+
+    owned = await dl_wallet.get_owned_singletons()
+    assert any(s.launcher_id == launcher_id for s in owned)
+
+    # --- Update the store so the singleton advances to generation > 0 ---
+    new_root = bytes32([2] * 32)
+    async with dl_wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        await dl_wallet.create_update_state_spend(launcher_id, new_root, action_scope)
+
+    await wallet_environments.process_pending_states(
+        [
+            WalletStateTransition(
+                pre_block_balance_updates={
+                    "xch": {},
+                    "dl": {"pending_coin_removal_count": 1},
+                },
+                post_block_balance_updates={
+                    "xch": {},
+                    "dl": {"pending_coin_removal_count": -1},
+                },
+            )
+        ]
+    )
+    await time_out_assert(15, is_singleton_confirmed_and_root, True, dl_wallet, launcher_id, new_root)
+
+    owned = await dl_wallet.get_owned_singletons()
+    assert any(s.launcher_id == launcher_id for s in owned)
+
+    # --- Simulate a wallet rollback to block 0 (e.g. peer trust flip) ---
+    await wallet_node.perform_atomic_rollback(0)
+
+    # The launcher entry should be gone after rollback
+    assert await env.wallet_state_manager.dl_store.get_launcher(launcher_id) is None
+
+    # The singleton record should still exist (unconfirmed, generation > 0)
+    rec = await env.wallet_state_manager.dl_store.get_latest_singleton(launcher_id)
+    assert rec is not None
+    assert not rec.confirmed
+    assert rec.generation > 0
+
+    # Ownership is lost because the launchers row was deleted
+    owned = await dl_wallet.get_owned_singletons()
+    assert not any(s.launcher_id == launcher_id for s in owned)
+
+    # --- Re-track the launcher (simulates what the wallet sync does on resync) ---
+    peer = wallet_node.get_full_node_peer()
+    assert peer is not None
+    await dl_wallet.track_new_launcher_id(launcher_id, peer)
+
+    # --- Ownership must be restored ---
+    launcher = await env.wallet_state_manager.dl_store.get_launcher(launcher_id)
+    assert launcher is not None, "Launcher entry not restored after re-track"
+
+    owned = await dl_wallet.get_owned_singletons()
+    assert any(s.launcher_id == launcher_id for s in owned), "Store ownership lost after rollback + re-track"

--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -243,8 +243,14 @@ class DataLayerWallet:
                 timestamp = await self.wallet_state_manager.wallet_node.get_timestamp_for_height(height)
                 await self.wallet_state_manager.dl_store.set_confirmed(singleton_record.coin_id, height, timestamp)
             else:
-                self.log.info(f"Spend of launcher {launcher_id} has already been processed")
-                return None
+                # Singleton has advanced beyond generation 0 but the launcher entry
+                # is missing (already verified at the top of this function). This
+                # happens after a wallet rollback deletes the launchers row while
+                # the singleton_records survive.  Fall through to restore it.
+                self.log.info(
+                    f"Singleton {launcher_id} already tracked at generation "
+                    f"{singleton_record.generation}, restoring launcher entry"
+                )
         else:
             timestamp = await self.wallet_state_manager.wallet_node.get_timestamp_for_height(height)
             await self.wallet_state_manager.dl_store.add_singleton_record(


### PR DESCRIPTION
### Purpose:

Fix a bug where the DataLayer wallet permanently loses ownership of its stores after a wallet rollback to block 0.

When a wallet rollback occurs (triggered by peer trust flips, sync failures, or reconnections), `rollback_to_block()` in `dl_wallet_store.py` correctly deletes launcher entries from the `launchers` table for generation-0 singletons confirmed above the rollback height. However, during re-sync, `_track_new_launcher_id()` in `data_layer_wallet.py` fails to restore the launcher entry when the singleton has advanced beyond generation 0. It finds the existing singleton record (at generation > 0), determines the coin ID doesn't match the generation-0 launcher spend, and returns early without calling `add_launcher()`.

This permanently orphans the store — `get_owned_singletons()` no longer returns it because the `launchers` table entry is missing, and all subsequent `batch_update`/`batch_insert` calls fail with `ValueError: Singleton with launcher ID ... is not owned by DL Wallet`.

Discovered via CADT CI failure: https://github.com/Chia-Network/cadt/actions/runs/23617621559/job/68789023179?pr=1554

### Current Behavior:

1. Store is created (generation 0) and updated (generation > 0) — normal operation
2. Wallet rollback to block 0 occurs (e.g. peer trust flip triggers `perform_atomic_rollback(0)`)
3. `rollback_to_block(0)` deletes the `launchers` row, unconfirms all `singleton_records`
4. During re-sync, `_track_new_launcher_id()` is called with the launcher spend (generation 0)
5. It finds the latest `singleton_record` (generation > 0, unconfirmed) — coin ID doesn't match the generation-0 coin
6. Hits the `else` branch, logs "Spend of launcher has already been processed", returns early
7. `add_launcher()` is never called — the `launchers` row is never restored
8. `get_owned_singletons()` returns empty — store is permanently orphaned
9. All `batch_update`/`batch_insert` calls fail

### New Behavior:

The `else` branch in `_track_new_launcher_id()` no longer returns early. Instead, it logs an informative message and falls through to `add_launcher()`, restoring the `launchers` table entry. The function then continues with the normal registration flow (interested puzzle hashes, coin IDs, and the singleton resync loop), ensuring the wallet fully recovers its DL state after a rollback.

After the fix:
- Steps 1-4 remain the same (rollback behavior is unchanged)
- Step 5: Same detection of the generation > 0 singleton record
- Step 6: Logs "Singleton X already tracked at generation N, restoring launcher entry"
- Step 7: Falls through to `add_launcher()` — launcher row is restored
- Step 8: `get_owned_singletons()` returns the store — ownership preserved
- Step 9: `batch_update`/`batch_insert` work normally

### Testing Notes:

- Added `test_datalayer_ownership_survives_rollback` regression test that:
  1. Creates a store (generation 0)
  2. Updates the store (advances to generation > 0)
  3. Verifies ownership via `get_owned_singletons()`
  4. Calls `perform_atomic_rollback(0)` to simulate wallet resync
  5. Verifies the launcher entry was deleted and ownership is lost (pre-condition)
  6. Calls `track_new_launcher_id()` to simulate re-sync discovering the launcher
  7. Asserts the launcher entry is restored and ownership is preserved
- All existing DL wallet tests pass (24 passed, 4 skipped)
- All 158 benchmark tests pass
- 100% diff-coverage on all changed lines
- Pre-commit hooks pass (ruff, mypy, tach, formatting)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches DataLayer wallet sync/rollback recovery logic; while small, it affects ownership tracking and DB state during resync, so regressions could orphan or mis-track stores.
> 
> **Overview**
> Ensures the DataLayer wallet can recover store ownership after a wallet rollback that deletes `launchers` rows while leaving later-generation `singleton_records` unconfirmed.
> 
> Updates `_track_new_launcher_id()` to **no longer early-return** when a newer singleton record exists; it now logs and falls through to re-add the launcher entry. Adds a regression test (`test_datalayer_ownership_survives_rollback`) that simulates rollback-to-0 and verifies `track_new_launcher_id()` restores the launcher row and `get_owned_singletons()` ownership.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de92534dc9940cba1c6ed4154cb3156f05b36629. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->