### PR TITLE
Increase timelord test job timeout from 30m to 40m

### DIFF
--- a/chia/_tests/timelord/config.py
+++ b/chia/_tests/timelord/config.py
@@ -1,3 +1,4 @@
 from __future__ import annotations
 
 checkout_blocks_and_plots = True
+job_timeout = 40


### PR DESCRIPTION
### Purpose:

The timelord CI job on macOS Intel is hitting the default 30-minute `job_timeout`, causing the job to be cancelled during post-test coverage processing — even though the tests themselves pass.

Example failure: https://github.com/Chia-Network/chia-blockchain/actions/runs/23656830463/job/68916319761?pr=20735

In that run, setup took ~4 minutes and the pytest step took ~25.5 minutes (completing successfully), leaving no time for coverage data processing before the 30-minute wall clock expired.

Even on a recent successful `main` run, the macOS Intel timelord job took ~19.8 minutes total — already 66% of the budget, leaving it vulnerable to any runner variance.

### Current Behavior:

The timelord test directory (`chia/_tests/timelord/config.py`) does not override `job_timeout`, so it inherits the default of 30 minutes from `testconfig.py`. This is too tight for macOS Intel where setup + tests + coverage processing can exceed 30 minutes.

### New Behavior:

Sets `job_timeout = 40` in `chia/_tests/timelord/config.py`, giving ~10 minutes of headroom beyond the current worst case. This matches the timeout used by other similarly-timed test directories (e.g. `wallet/config.py`, `core/full_node/stores/config.py`).

### Testing Notes:

- Config-only change; no product code or test logic affected
- `chia/_tests/*/config.py` files are excluded from diff-cover (`.diffcover.toml`)
- Verified with ruff lint, ruff format, and mypy locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that just increases the CI timeout for timelord tests, with no product code or test logic modifications.
> 
> **Overview**
> Increases the timelord test directory CI `job_timeout` override to `40` minutes in `chia/_tests/timelord/config.py` (from the default `30`) to reduce macOS Intel job cancellations during post-test/coverage processing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49516cd6d1e9f809f3cfe8e84d381992c65bc53a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->