### PR TITLE
[CHIA-3985] PriorityThreadPoolExecutor

### DIFF
--- a/benchmarks/block_ref.py
+++ b/benchmarks/block_ref.py
@@ -19,8 +19,10 @@ from chia.consensus.get_block_generator import get_block_generator
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.types.blockchain_format.serialized_program import SerializedProgram
+from chia.util.cpu import available_logical_cores
 from chia.util.db_version import lookup_db_version
 from chia.util.db_wrapper import DBWrapper2
+from chia.util.priority_thread_pool_executor import PriorityThreadPoolExecutor
 
 # the first transaction block. Each byte in transaction_height_delta is the
 # number of blocks to skip forward to get to the next transaction block
@@ -66,10 +68,12 @@ async def main(db_path: Path) -> None:
         coin_store = await CoinStore.create(db_wrapper)
 
         start_time = monotonic()
-        # make configurable
         reserved_cores = 4
+        cpu_count = available_logical_cores()
+        num_workers = max(cpu_count - reserved_cores, 1)
+        pool = PriorityThreadPoolExecutor(max_workers=num_workers, thread_name_prefix="validation-")
         height_map = await BlockHeightMap.create(db_path.parent, db_wrapper)
-        blockchain = await Blockchain.create(coin_store, block_store, height_map, DEFAULT_CONSTANTS, reserved_cores)
+        blockchain = await Blockchain.create(coin_store, block_store, height_map, DEFAULT_CONSTANTS, pool)
 
         peak = blockchain.get_peak()
         assert peak is not None
@@ -90,6 +94,7 @@ async def main(db_path: Path) -> None:
         print(f"get_block_generator(): {timing / REPETITIONS:0.3f}s")
 
         blockchain.shut_down()
+        pool.shutdown()
 
 
 @click.command()

--- a/benchmarks/mempool-long-lived.py
+++ b/benchmarks/mempool-long-lived.py
@@ -16,6 +16,7 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.mempool_item import UnspentLineageInfo
 from chia.util.casts import int_to_bytes
+from chia.util.inline_executor import InlineExecutor
 
 # this is one week worth of blocks
 NUM_ITERS = 32256
@@ -97,8 +98,8 @@ async def run_mempool_benchmark() -> None:
         get_coin_record,
         get_unspent_lineage_info_for_puzzle_hash,
         DEFAULT_CONSTANTS,
+        InlineExecutor(),
         validation_timeout=2,
-        single_threaded=True,
     ) as mempool:
         print("\nrunning add_spend_bundle() + new_peak()")
 

--- a/benchmarks/mempool.py
+++ b/benchmarks/mempool.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import cProfile
 from collections.abc import Collection, Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from subprocess import check_call
 from time import monotonic
@@ -20,6 +20,8 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.mempool_item import UnspentLineageInfo
 from chia.util.batches import to_batches
+from chia.util.inline_executor import InlineExecutor
+from chia.util.priority_thread_pool_executor import Executor, PriorityThreadPoolExecutor
 from chia.util.task_referencer import create_referenced_task
 
 NUM_ITERS = 200
@@ -169,18 +171,26 @@ async def run_mempool_benchmark() -> None:
 
     start_height = height
     for single_threaded in [False, True]:
+        pool: Executor
         if single_threaded:
             print("\n== Single-threaded")
+            pool = InlineExecutor()
         else:
             print("\n== Multi-threaded")
+            pool = PriorityThreadPoolExecutor(max_workers=2, thread_name_prefix="mempool-")
 
-        with MempoolManager(
-            get_coin_records,
-            get_unspent_lineage_info_for_puzzle_hash,
-            DEFAULT_CONSTANTS,
-            single_threaded=single_threaded,
-            validation_timeout=2,
-        ) as mempool:
+        with ExitStack() as stack:
+            stack.enter_context(pool)
+
+            mempool = stack.enter_context(
+                MempoolManager(
+                    get_coin_records,
+                    get_unspent_lineage_info_for_puzzle_hash,
+                    DEFAULT_CONSTANTS,
+                    pool,
+                    validation_timeout=2,
+                )
+            )
             height = start_height
             rec = fake_block_record(height, timestamp)
             await mempool.new_peak(rec, None)
@@ -200,13 +210,16 @@ async def run_mempool_benchmark() -> None:
             print(f"  time: {stop - start:0.4f}s")
             print(f"  per call: {(stop - start) / total_bundles * 1000:0.2f}ms")
 
-        with MempoolManager(
-            get_coin_records,
-            get_unspent_lineage_info_for_puzzle_hash,
-            DEFAULT_CONSTANTS,
-            single_threaded=single_threaded,
-            validation_timeout=2,
-        ) as mempool:
+            mempool.shut_down()
+            mempool = stack.enter_context(
+                MempoolManager(
+                    get_coin_records,
+                    get_unspent_lineage_info_for_puzzle_hash,
+                    DEFAULT_CONSTANTS,
+                    pool,
+                    validation_timeout=2,
+                )
+            )
             height = start_height
             rec = fake_block_record(height, timestamp)
             await mempool.new_peak(rec, None)

--- a/chia/_tests/core/full_node/ram_db.py
+++ b/chia/_tests/core/full_node/ram_db.py
@@ -12,6 +12,7 @@ from chia.consensus.blockchain import Blockchain
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.util.db_wrapper import DBWrapper2
+from chia.util.inline_executor import InlineExecutor
 
 
 @contextlib.asynccontextmanager
@@ -23,7 +24,7 @@ async def create_ram_blockchain(
         block_store = await BlockStore.create(db_wrapper)
         coin_store = await CoinStore.create(db_wrapper)
         height_map = await BlockHeightMap.create(Path("."), db_wrapper)
-        blockchain = await Blockchain.create(coin_store, block_store, height_map, consensus_constants, 2)
+        blockchain = await Blockchain.create(coin_store, block_store, height_map, consensus_constants, InlineExecutor())
         try:
             yield db_wrapper, blockchain
         finally:

--- a/chia/_tests/core/full_node/stores/test_block_store.py
+++ b/chia/_tests/core/full_node/stores/test_block_store.py
@@ -32,6 +32,7 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 from chia.types.blockchain_format.vdf import VDFProof
 from chia.util.casts import int_to_bytes
 from chia.util.db_wrapper import get_host_parameter_limit
+from chia.util.inline_executor import InlineExecutor
 from chia.util.task_referencer import create_referenced_task
 
 log = logging.getLogger(__name__)
@@ -75,7 +76,7 @@ async def test_block_store(tmp_dir: Path, db_version: int, bt: BlockTools, use_c
         coin_store_2 = await CoinStore.create(db_wrapper_2)
         store_2 = await BlockStore.create(db_wrapper_2, use_cache=use_cache)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, height_map, bt.constants, 2)
+        bc = await Blockchain.create(coin_store_2, store_2, height_map, bt.constants, InlineExecutor())
 
         store = await BlockStore.create(db_wrapper, use_cache=use_cache)
         await BlockStore.create(db_wrapper_2)
@@ -151,7 +152,7 @@ async def test_get_full_blocks_at(
         coin_store = await CoinStore.create(db_wrapper)
         block_store = await BlockStore.create(db_wrapper, use_cache=use_cache)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
-        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, 2)
+        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, InlineExecutor())
 
         count = 0
         fork_info = ForkInfo(-1, -1, bt.constants.GENESIS_CHALLENGE)
@@ -179,7 +180,7 @@ async def test_get_block_records_in_range(
         coin_store = await CoinStore.create(db_wrapper)
         block_store = await BlockStore.create(db_wrapper, use_cache=use_cache)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
-        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, 2)
+        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, InlineExecutor())
 
         count = 0
         fork_info = ForkInfo(-1, -1, bt.constants.GENESIS_CHALLENGE)
@@ -209,7 +210,7 @@ async def test_get_block_bytes_in_range_in_main_chain(
         coin_store = await CoinStore.create(db_wrapper)
         block_store = await BlockStore.create(db_wrapper, use_cache=use_cache)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
-        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, 2)
+        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, InlineExecutor())
         count = 0
         fork_info = ForkInfo(-1, -1, bt.constants.GENESIS_CHALLENGE)
         for b1, b2 in zip(blocks, alt_blocks):
@@ -238,7 +239,7 @@ async def test_deadlock(tmp_dir: Path, db_version: int, bt: BlockTools, use_cach
         coin_store_2 = await CoinStore.create(wrapper_2)
         store_2 = await BlockStore.create(wrapper_2)
         height_map = await BlockHeightMap.create(tmp_dir, wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, height_map, bt.constants, 2)
+        bc = await Blockchain.create(coin_store_2, store_2, height_map, bt.constants, InlineExecutor())
         block_records = []
         for block in blocks:
             await _validate_and_add_block(bc, block)
@@ -269,7 +270,7 @@ async def test_rollback(bt: BlockTools, tmp_dir: Path, use_cache: bool, default_
         coin_store = await CoinStore.create(db_wrapper)
         block_store = await BlockStore.create(db_wrapper, use_cache=use_cache)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
-        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, 2)
+        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, InlineExecutor())
 
         # insert all blocks
         count = 0
@@ -332,7 +333,7 @@ async def test_count_compactified_blocks(bt: BlockTools, tmp_dir: Path, db_versi
         coin_store = await CoinStore.create(db_wrapper)
         block_store = await BlockStore.create(db_wrapper, use_cache=use_cache)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
-        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, 2)
+        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, InlineExecutor())
 
         count = await block_store.count_compactified_blocks()
         assert count == 0
@@ -353,7 +354,7 @@ async def test_count_uncompactified_blocks(bt: BlockTools, tmp_dir: Path, db_ver
         coin_store = await CoinStore.create(db_wrapper)
         block_store = await BlockStore.create(db_wrapper, use_cache=use_cache)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
-        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, 2)
+        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, InlineExecutor())
 
         count = await block_store.count_uncompactified_blocks()
         assert count == 0
@@ -381,7 +382,7 @@ async def test_replace_proof(bt: BlockTools, tmp_dir: Path, db_version: int, use
         coin_store = await CoinStore.create(db_wrapper)
         block_store = await BlockStore.create(db_wrapper, use_cache=use_cache)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
-        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, 2)
+        bc = await Blockchain.create(coin_store, block_store, height_map, bt.constants, InlineExecutor())
         for block in blocks:
             await _validate_and_add_block(bc, block)
 
@@ -462,7 +463,7 @@ async def test_get_blocks_by_hash(tmp_dir: Path, bt: BlockTools, db_version: int
         coin_store_2 = await CoinStore.create(db_wrapper_2)
         store_2 = await BlockStore.create(db_wrapper_2, use_cache=use_cache)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, height_map, bt.constants, 2)
+        bc = await Blockchain.create(coin_store_2, store_2, height_map, bt.constants, InlineExecutor())
 
         store = await BlockStore.create(db_wrapper, use_cache=use_cache)
         await BlockStore.create(db_wrapper_2)
@@ -502,7 +503,7 @@ async def test_get_block_bytes_in_range(tmp_dir: Path, bt: BlockTools, db_versio
         coin_store_2 = await CoinStore.create(db_wrapper_2)
         store_2 = await BlockStore.create(db_wrapper_2, use_cache=use_cache)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, height_map, bt.constants, 2)
+        bc = await Blockchain.create(coin_store_2, store_2, height_map, bt.constants, InlineExecutor())
 
         await BlockStore.create(db_wrapper_2)
 
@@ -575,7 +576,7 @@ async def test_get_prev_hash(tmp_dir: Path, bt: BlockTools, db_version: int, use
         coin_store_2 = await CoinStore.create(db_wrapper_2)
         store_2 = await BlockStore.create(db_wrapper_2, use_cache=use_cache)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper_2)
-        bc = await Blockchain.create(coin_store_2, store_2, height_map, bt.constants, 2)
+        bc = await Blockchain.create(coin_store_2, store_2, height_map, bt.constants, InlineExecutor())
 
         store = await BlockStore.create(db_wrapper, use_cache=use_cache)
         await BlockStore.create(db_wrapper_2)

--- a/chia/_tests/core/full_node/stores/test_coin_store.py
+++ b/chia/_tests/core/full_node/stores/test_coin_store.py
@@ -29,6 +29,7 @@ from chia.types.mempool_item import UnspentLineageInfo
 from chia.util.casts import int_to_bytes
 from chia.util.db_wrapper import DBWrapper2
 from chia.util.hash import std_hash
+from chia.util.inline_executor import InlineExecutor
 
 constants = test_constants
 
@@ -314,7 +315,7 @@ async def test_basic_reorg(tmp_dir: Path, db_version: int, bt: BlockTools) -> No
         coin_store = await CoinStore.create(db_wrapper)
         store = await BlockStore.create(db_wrapper)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
-        b: Blockchain = await Blockchain.create(coin_store, store, height_map, bt.constants, 2)
+        b: Blockchain = await Blockchain.create(coin_store, store, height_map, bt.constants, InlineExecutor())
         try:
             records: list[CoinRecord | None] = []
 
@@ -379,7 +380,7 @@ async def test_get_puzzle_hash(tmp_dir: Path, db_version: int, bt: BlockTools) -
         coin_store = await CoinStore.create(db_wrapper)
         store = await BlockStore.create(db_wrapper)
         height_map = await BlockHeightMap.create(tmp_dir, db_wrapper)
-        b: Blockchain = await Blockchain.create(coin_store, store, height_map, bt.constants, 2)
+        b: Blockchain = await Blockchain.create(coin_store, store, height_map, bt.constants, InlineExecutor())
         for block in blocks:
             await _validate_and_add_block(b, block)
         peak = b.get_peak()

--- a/chia/_tests/core/mempool/test_mempool_fee_estimator.py
+++ b/chia/_tests/core/mempool/test_mempool_fee_estimator.py
@@ -14,6 +14,7 @@ from chia.full_node.fee_estimation import MempoolItemInfo
 from chia.full_node.fee_estimator import SmartFeeEstimator
 from chia.full_node.fee_tracker import FeeTracker
 from chia.full_node.mempool_manager import MempoolManager
+from chia.util.inline_executor import InlineExecutor
 
 
 @pytest.mark.anyio
@@ -66,6 +67,7 @@ async def test_fee_increase() -> None:
             coin_store.get_coin_records,
             coin_store.get_unspent_lineage_info_for_puzzle_hash,
             test_constants,
+            InlineExecutor(),
             validation_timeout=10,
         ) as mempool_manager:
             assert test_constants.MAX_BLOCK_COST_CLVM == mempool_manager.constants.MAX_BLOCK_COST_CLVM

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -2319,10 +2319,12 @@ async def test_fill_rate_block_validation(
         # Check for the peak change after farming the block
         assert peak.prev_hash == current_peak.header_hash
         # Check our coin(s)
+        _, peer_id = await add_dummy_connection(full_node_api.server, self_hostname, 12313)
+        peer = full_node_api.server.all_connections[peer_id]
         for i in range(expected_block_items):
             coin_name, puzzle, _ = sbs_info[i]
             rps_res = await full_node_api.request_puzzle_solution(
-                wallet_protocol.RequestPuzzleSolution(coin_name, peak.height)
+                wallet_protocol.RequestPuzzleSolution(coin_name, peak.height), peer
             )
             assert rps_res is not None
             rps_res_parsed = wallet_protocol.RespondPuzzleSolution.from_bytes(rps_res.data)

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -70,6 +70,7 @@ from chia.types.mempool_item import BundleCoinSpend, MempoolItem, UnspentLineage
 from chia.util.casts import int_to_bytes
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.errors import Err, ValidationError
+from chia.util.inline_executor import InlineExecutor
 from chia.wallet.conditions import AssertCoinAnnouncement
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
     DEFAULT_HIDDEN_PUZZLE_HASH,
@@ -265,6 +266,7 @@ async def instantiate_mempool_manager(
         get_coin_records,
         zero_calls_get_unspent_lineage_info_for_puzzle_hash,
         constants,
+        InlineExecutor(),
         max_tx_clvm_cost=max_tx_clvm_cost,
         validation_timeout=10,
     ) as mempool_manager:
@@ -718,6 +720,7 @@ async def test_validation_timeout() -> None:
         zero_calls_get_coin_records,
         zero_calls_get_unspent_lineage_info_for_puzzle_hash,
         DEFAULT_CONSTANTS,
+        InlineExecutor(),
         validation_timeout=0,
     ) as mempool_manager:
         await mempool_manager.new_peak(create_test_block_record(), None)
@@ -2448,6 +2451,7 @@ async def setup_mempool(coins: TestCoins) -> AsyncGenerator[MempoolManager, None
         coins.get_coin_records,
         coins.get_unspent_lineage_info,
         DEFAULT_CONSTANTS,
+        InlineExecutor(),
         validation_timeout=10,
     ) as mempool_manager:
         test_block_record = create_test_block_record(height=uint32(5000000), timestamp=uint64(12345678))
@@ -2702,6 +2706,7 @@ def test_no_peak(old: bool, transactions_1000: list[SpendBundle]) -> None:
         coins.get_coin_records,
         coins.get_unspent_lineage_info,
         DEFAULT_CONSTANTS,
+        InlineExecutor(),
         validation_timeout=10,
     ) as mempool_manager:
         create_block = mempool_manager.create_block_generator if old else mempool_manager.create_block_generator2

--- a/chia/_tests/core/test_db_conversion.py
+++ b/chia/_tests/core/test_db_conversion.py
@@ -19,6 +19,7 @@ from chia.full_node.coin_store import CoinStore
 from chia.full_node.hint_store import HintStore
 from chia.simulator.block_tools import test_constants
 from chia.util.db_wrapper import DBWrapper2
+from chia.util.inline_executor import InlineExecutor
 
 
 @pytest.mark.anyio
@@ -63,7 +64,7 @@ async def test_blocks(default_1000_blocks: list[FullBlock], with_hints: bool) ->
                     await hint_store1.add_hints([(h[0], h[1])])
 
             height_map = await BlockHeightMap.create(Path("."), db_wrapper1)
-            bc = await Blockchain.create(coin_store1, block_store1, height_map, test_constants, reserved_cores=0)
+            bc = await Blockchain.create(coin_store1, block_store1, height_map, test_constants, InlineExecutor())
             sub_slot_iters = test_constants.SUB_SLOT_ITERS_STARTING
             for block in blocks:
                 if block.height != 0 and len(block.finished_sub_slots) > 0:

--- a/chia/_tests/core/test_db_validation.py
+++ b/chia/_tests/core/test_db_validation.py
@@ -20,6 +20,7 @@ from chia.consensus.multiprocess_validation import PreValidationResult
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.util.db_wrapper import DBWrapper2
+from chia.util.inline_executor import InlineExecutor
 
 
 def rand_hash() -> bytes32:
@@ -141,7 +142,7 @@ async def make_db(db_file: Path, blocks: list[FullBlock], constants: ConsensusCo
         coin_store = await CoinStore.create(db_wrapper)
         height_map = await BlockHeightMap.create(Path("."), db_wrapper)
 
-        bc = await Blockchain.create(coin_store, block_store, height_map, constants, reserved_cores=0)
+        bc = await Blockchain.create(coin_store, block_store, height_map, constants, InlineExecutor())
         sub_slot_iters = constants.SUB_SLOT_ITERS_STARTING
         for block in blocks:
             if block.height != 0 and len(block.finished_sub_slots) > 0:

--- a/chia/_tests/util/blockchain.py
+++ b/chia/_tests/util/blockchain.py
@@ -17,6 +17,7 @@ from chia.full_node.coin_store import CoinStore
 from chia.simulator.block_tools import BlockTools
 from chia.util.db_wrapper import DBWrapper2, generate_in_memory_db_uri
 from chia.util.default_root import DEFAULT_ROOT_PATH
+from chia.util.inline_executor import InlineExecutor
 
 
 @contextlib.asynccontextmanager
@@ -29,7 +30,7 @@ async def create_blockchain(
         store = await BlockStore.create(wrapper)
         path = Path(".")
         height_map = await BlockHeightMap.create(path, wrapper)
-        bc1 = await Blockchain.create(coin_store, store, height_map, constants, 3, single_threaded=True, log_coins=True)
+        bc1 = await Blockchain.create(coin_store, store, height_map, constants, InlineExecutor(), log_coins=True)
         try:
             assert bc1.get_peak() is None
             yield bc1, wrapper

--- a/chia/_tests/util/spend_sim.py
+++ b/chia/_tests/util/spend_sim.py
@@ -41,6 +41,7 @@ from chia.types.mempool_item import MempoolItem
 from chia.util.db_wrapper import DBWrapper2
 from chia.util.errors import Err, ValidationError
 from chia.util.hash import std_hash
+from chia.util.inline_executor import InlineExecutor
 from chia.util.streamable import Streamable, streamable
 from chia.wallet.util.compute_hints import HintedCoin, compute_spend_hints_and_additions
 from chia.wallet.wallet_spend_bundle import T_SpendBundle
@@ -172,6 +173,7 @@ class SpendSim:
                 self.coin_store.get_coin_records,
                 self.coin_store.get_unspent_lineage_info_for_puzzle_hash,
                 defaults,
+                InlineExecutor(),
                 validation_timeout=10,
             ) as self.mempool_manager:
                 # Load the next data if there is any

--- a/chia/_tests/util/test_priority_thread_pool_executor.py
+++ b/chia/_tests/util/test_priority_thread_pool_executor.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from concurrent.futures import Future
+
+import pytest
+
+from chia.util.priority_thread_pool_executor import PriorityThreadPoolExecutor
+
+
+def test_basic_submit() -> None:
+    with PriorityThreadPoolExecutor(max_workers=2, thread_name_prefix="test-") as pool:
+        future = pool.submit(lambda x, y: x + y, 3, 4)
+        assert future.result(timeout=5) == 7
+
+
+def test_submit_exception() -> None:
+    with PriorityThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(int, "not_a_number")
+        with pytest.raises(ValueError):
+            future.result(timeout=5)
+
+
+def test_nice_ordering() -> None:
+    """Lower nice values should run before higher nice values."""
+    barrier = threading.Event()
+    results: list[int] = []
+    lock = threading.Lock()
+
+    def record(value: int) -> None:
+        barrier.wait()
+        with lock:
+            results.append(value)
+
+    with PriorityThreadPoolExecutor(max_workers=1, thread_name_prefix="prio-") as pool:
+        blocking: Future[None] = pool.submit(barrier.wait)
+
+        pool.submit(record, 99, nice=(10,))
+        pool.submit(record, 1, nice=(1,))
+        pool.submit(record, 50, nice=(5,))
+
+        time.sleep(0.05)
+
+        barrier.set()
+        blocking.result(timeout=5)
+
+        pool.shutdown()
+
+    assert results == [1, 50, 99]
+
+
+def test_fifo_within_same_nice() -> None:
+    """Jobs with the same nice value should execute in FIFO order."""
+    barrier = threading.Event()
+    results: list[int] = []
+    lock = threading.Lock()
+
+    def record(value: int) -> None:
+        barrier.wait()
+        with lock:
+            results.append(value)
+
+    with PriorityThreadPoolExecutor(max_workers=1) as pool:
+        blocking: Future[None] = pool.submit(barrier.wait)
+
+        for i in range(5):
+            pool.submit(record, i, nice=(5,))
+
+        time.sleep(0.05)
+        barrier.set()
+        blocking.result(timeout=5)
+
+        pool.shutdown()
+
+    assert results == [0, 1, 2, 3, 4]
+
+
+def test_shutdown_rejects_new_work() -> None:
+    pool = PriorityThreadPoolExecutor(max_workers=1)
+    pool.shutdown()
+    with pytest.raises(RuntimeError, match="shut-down"):
+        pool.submit(lambda: None)
+
+
+def test_max_workers_respected() -> None:
+    active = threading.Semaphore(0)
+    max_concurrent = 0
+    current = 0
+    lock = threading.Lock()
+
+    def track() -> None:
+        nonlocal max_concurrent, current
+        with lock:
+            current += 1
+            max_concurrent = max(max_concurrent, current)
+        active.release()
+        time.sleep(0.05)
+        with lock:
+            current -= 1
+
+    max_w = 3
+    with PriorityThreadPoolExecutor(max_workers=max_w, thread_name_prefix="max-") as pool:
+        n_jobs = 10
+        futures = [pool.submit(track) for _ in range(n_jobs)]
+        for f in futures:
+            f.result(timeout=10)
+
+    assert max_concurrent <= max_w
+
+
+@pytest.mark.anyio
+async def test_run_in_loop() -> None:
+    with PriorityThreadPoolExecutor(max_workers=2) as pool:
+        result = await pool.run_in_loop(lambda x: x * 2, 21)
+        assert result == 42
+
+
+@pytest.mark.anyio
+async def test_run_in_loop_exception() -> None:
+    with PriorityThreadPoolExecutor(max_workers=1) as pool:
+        with pytest.raises(ValueError):
+            await pool.run_in_loop(int, "bad")
+
+
+@pytest.mark.anyio
+async def test_run_in_loop_nice() -> None:
+    """Verify nice ordering works through the async interface."""
+    barrier = threading.Event()
+    results: list[int] = []
+    lock = threading.Lock()
+
+    def record(value: int) -> None:
+        barrier.wait()
+        with lock:
+            results.append(value)
+
+    with PriorityThreadPoolExecutor(max_workers=1) as pool:
+        blocking = pool.submit(barrier.wait)
+
+        f1 = pool.run_in_loop(record, 99, nice=(10,))
+        f2 = pool.run_in_loop(record, 1, nice=(1,))
+
+        await asyncio.sleep(0.05)
+        barrier.set()
+
+        await asyncio.gather(asyncio.wrap_future(blocking), f1, f2)
+
+    assert results == [1, 99]
+
+
+def test_nice_tuple_ordering() -> None:
+    """Verify that tuple nice values sort correctly, including secondary keys."""
+    barrier = threading.Event()
+    results: list[str] = []
+    lock = threading.Lock()
+
+    def record(value: str) -> None:
+        barrier.wait()
+        with lock:
+            results.append(value)
+
+    with PriorityThreadPoolExecutor(max_workers=1) as pool:
+        blocking = pool.submit(barrier.wait)
+
+        pool.submit(record, "low-fee", nice=(10, -1.0))
+        pool.submit(record, "high-fee", nice=(10, -100.0))
+        pool.submit(record, "block", nice=(0,))
+
+        time.sleep(0.05)
+        barrier.set()
+        blocking.result(timeout=5)
+        pool.shutdown()
+
+    assert results == ["block", "high-fee", "low-fee"]
+
+
+def test_context_manager() -> None:
+    with PriorityThreadPoolExecutor(max_workers=1) as pool:
+        f = pool.submit(lambda: 1)
+        assert f.result(timeout=5) == 1
+    with pytest.raises(RuntimeError):
+        pool.submit(lambda: 2)
+
+
+def test_invalid_max_workers() -> None:
+    with pytest.raises(ValueError, match="max_workers must be positive"):
+        PriorityThreadPoolExecutor(max_workers=0)
+
+
+def test_invalid_dedicated() -> None:
+    with pytest.raises(ValueError):
+        PriorityThreadPoolExecutor(max_workers=2, dedicated=2)
+    with pytest.raises(ValueError):
+        PriorityThreadPoolExecutor(max_workers=2, dedicated=-1)
+
+
+def test_dedicated_threads_run_dedicated_jobs() -> None:
+    """Dedicated threads should pick up dedicated=True jobs even when
+    general threads are fully occupied."""
+    general_barrier = threading.Event()
+    results: list[str] = []
+    lock = threading.Lock()
+
+    def block_general() -> str:
+        general_barrier.wait()
+        with lock:
+            results.append("general")
+        return "general"
+
+    def dedicated_job() -> str:
+        with lock:
+            results.append("dedicated")
+        return "dedicated"
+
+    with PriorityThreadPoolExecutor(max_workers=2, dedicated=1, thread_name_prefix="ded-") as pool:
+        general_future = pool.submit(block_general, nice=(10,))
+
+        time.sleep(0.05)
+
+        ded_future = pool.submit(dedicated_job, nice=(0,), dedicated=True)
+        assert ded_future.result(timeout=5) == "dedicated"
+
+        general_barrier.set()
+        assert general_future.result(timeout=5) == "general"
+
+    assert "dedicated" in results
+    assert "general" in results
+
+
+def test_dedicated_false_not_on_dedicated_queue() -> None:
+    """Jobs with dedicated=False should never be picked up by dedicated
+    threads, only by general threads."""
+    barrier = threading.Event()
+    thread_names: list[str | None] = []
+    lock = threading.Lock()
+
+    def record_thread() -> None:
+        barrier.wait()
+        with lock:
+            thread_names.append(threading.current_thread().name)
+
+    with PriorityThreadPoolExecutor(max_workers=2, dedicated=1, thread_name_prefix="t-") as pool:
+        ded_blocker = pool.submit(barrier.wait, dedicated=True)
+
+        time.sleep(0.05)
+
+        futures = [pool.submit(record_thread, nice=(5,)) for _ in range(3)]
+
+        time.sleep(0.05)
+        barrier.set()
+
+        ded_blocker.result(timeout=5)
+        for f in futures:
+            f.result(timeout=5)
+
+    for name in thread_names:
+        assert name is not None
+        assert "dedicated" not in name
+
+
+def test_dedicated_jobs_also_run_on_general_threads() -> None:
+    """When the dedicated thread is busy, general threads should also
+    be able to pick up dedicated=True jobs from the general queue."""
+    barrier = threading.Event()
+
+    with PriorityThreadPoolExecutor(max_workers=3, dedicated=1, thread_name_prefix="t-") as pool:
+        ded_blocker = pool.submit(barrier.wait, dedicated=True)
+        time.sleep(0.05)
+
+        futures = [pool.submit(lambda v: v, i, dedicated=True) for i in range(4)]
+
+        for f in futures:
+            assert f.result(timeout=5) is not None
+
+        barrier.set()
+        ded_blocker.result(timeout=5)
+
+
+def test_dedicated_and_general_race() -> None:
+    """When a dedicated=True job is posted to both queues, only one thread
+    runs it — the other hits RuntimeError on set_running_or_notify_cancel()
+    and skips it.  The job must complete exactly once."""
+    run_count = 0
+    lock = threading.Lock()
+    gate = threading.Barrier(3)
+
+    def counted_job(v: int) -> int:
+        nonlocal run_count
+        with lock:
+            run_count += 1
+        return v
+
+    n_jobs = 50
+    with PriorityThreadPoolExecutor(max_workers=2, dedicated=1, thread_name_prefix="race-") as pool:
+        # Both blockers are dedicated=True so each goes to both queues.
+        # Regardless of which thread claims the first blocker, the loser
+        # skips it (RuntimeError) and picks the second one from its queue.
+        pool.submit(gate.wait, dedicated=True)
+        pool.submit(gate.wait, dedicated=True)
+        time.sleep(0.05)
+
+        # Queue dedicated jobs while both threads are blocked
+        futures = [pool.submit(counted_job, i, dedicated=True) for i in range(n_jobs)]
+
+        # Release both threads — they race over the same items
+        gate.wait(timeout=5)
+
+        results = sorted(f.result(timeout=10) for f in futures)
+
+    assert results == list(range(n_jobs))
+    assert run_count == n_jobs
+
+
+def test_no_dedicated_threads() -> None:
+    """With dedicated=0 (default), dedicated=True on submit is a no-op."""
+    with PriorityThreadPoolExecutor(max_workers=2) as pool:
+        f = pool.submit(lambda: 42, dedicated=True)
+        assert f.result(timeout=5) == 42

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -146,7 +146,9 @@ async def test_request_block_headers_transactions_filter(
         `request_block_headers` in this regard, to `request_header_blocks` as
         well as `request_block_header`.
     """
-    full_node_api, _, bt = one_node_one_block
+    full_node_api, server, bt = one_node_one_block
+    _, peer_id = await add_dummy_connection(server, "127.0.0.1", 12312)
+    peer = server.all_connections[peer_id]
     ph = SerializedProgram.to(1).get_tree_hash()
     for _ in range(2):
         await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
@@ -200,7 +202,7 @@ async def test_request_block_headers_transactions_filter(
     assert block_headers_res.header_blocks == block_headers
     assert block_headers_res.header_blocks[0].transactions_filter == expected_transactions_filter
     # Go even further and compare this to the outcome of request_block_header
-    msg = await full_node_api.request_block_header(wallet_protocol.RequestBlockHeader(uint32(new_block.height)))
+    msg = await full_node_api.request_block_header(wallet_protocol.RequestBlockHeader(uint32(new_block.height)), peer)
     assert msg is not None
     block_header_res = RespondBlockHeader.from_bytes(msg.data)
     assert block_header_res.header_block == block_header
@@ -1524,10 +1526,14 @@ async def test_retry_store(
     request_puzzle_solution_failure_tested = False
 
     def flaky_request_puzzle_solution(
-        func: Callable[[FullNodeAPI, wallet_protocol.RequestPuzzleSolution], Awaitable[Message | None]],
-    ) -> Callable[[FullNodeAPI, wallet_protocol.RequestPuzzleSolution], Awaitable[Message | None]]:
+        func: Callable[
+            [FullNodeAPI, wallet_protocol.RequestPuzzleSolution, WSChiaConnection], Awaitable[Message | None]
+        ],
+    ) -> Callable[[FullNodeAPI, wallet_protocol.RequestPuzzleSolution, WSChiaConnection], Awaitable[Message | None]]:
         @functools.wraps(func)
-        async def new_func(self: FullNodeAPI, request: wallet_protocol.RequestPuzzleSolution) -> Message | None:
+        async def new_func(
+            self: FullNodeAPI, request: wallet_protocol.RequestPuzzleSolution, peer: WSChiaConnection
+        ) -> Message | None:
             nonlocal request_puzzle_solution_failure_tested
             if not request_puzzle_solution_failure_tested:
                 request_puzzle_solution_failure_tested = True
@@ -1535,7 +1541,7 @@ async def test_retry_store(
                 reject = wallet_protocol.RejectPuzzleSolution(bytes32.zeros, uint32(0))
                 return make_msg(ProtocolMessageTypes.reject_puzzle_solution, reject)
             else:
-                return await func(self, request)
+                return await func(self, request, peer)
 
         return new_func
 

--- a/chia/apis/full_node_stub.py
+++ b/chia/apis/full_node_stub.py
@@ -272,8 +272,10 @@ class FullNodeApiStub(ApiProtocol, Protocol):
         ...
 
     # WALLET PROTOCOL
-    @metadata.request()
-    async def request_block_header(self, request: wallet_protocol.RequestBlockHeader) -> Message | None:
+    @metadata.request(peer_required=True)
+    async def request_block_header(
+        self, request: wallet_protocol.RequestBlockHeader, peer: WSChiaConnection
+    ) -> Message | None:
         """Handle block header request from wallet."""
         ...
 
@@ -294,8 +296,10 @@ class FullNodeApiStub(ApiProtocol, Protocol):
         """Handle transaction send from wallet."""
         ...
 
-    @metadata.request()
-    async def request_puzzle_solution(self, request: wallet_protocol.RequestPuzzleSolution) -> Message | None:
+    @metadata.request(peer_required=True)
+    async def request_puzzle_solution(
+        self, request: wallet_protocol.RequestPuzzleSolution, peer: WSChiaConnection
+    ) -> Message | None:
         """Handle puzzle solution request from wallet."""
         ...
 

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -5,7 +5,6 @@ import dataclasses
 import enum
 import logging
 import traceback
-from concurrent.futures import Executor, ThreadPoolExecutor
 from enum import Enum
 from typing import TYPE_CHECKING, ClassVar, cast
 
@@ -43,11 +42,10 @@ from chia.types.blockchain_format.vdf import VDFInfo
 from chia.types.generator_types import BlockGenerator
 from chia.types.unfinished_header_block import UnfinishedHeaderBlock
 from chia.types.validation_state import ValidationState
-from chia.util.cpu import available_logical_cores
 from chia.util.errors import Err
 from chia.util.hash import std_hash
-from chia.util.inline_executor import InlineExecutor
 from chia.util.priority_mutex import PriorityMutex
+from chia.util.priority_thread_pool_executor import Executor
 
 log = logging.getLogger(__name__)
 
@@ -126,9 +124,8 @@ class Blockchain:
         block_store: BlockStore,
         height_map: BlockHeightMap,
         consensus_constants: ConsensusConstants,
-        reserved_cores: int,
+        pool: Executor,
         *,
-        single_threaded: bool = False,
         log_coins: bool = False,
     ) -> Blockchain:
         """
@@ -142,17 +139,7 @@ class Blockchain:
         # be validated first.
         self.priority_mutex = PriorityMutex.create(priority_type=BlockchainMutexPriority)
         self.compact_proof_lock = asyncio.Lock()
-        if single_threaded:
-            self.pool = InlineExecutor()
-        else:
-            cpu_count = available_logical_cores()
-            num_workers = max(cpu_count - reserved_cores, 1)
-            self.pool = ThreadPoolExecutor(
-                max_workers=num_workers,
-                thread_name_prefix="block-validation-",
-            )
-            log.info(f"Started {num_workers} processes for block validation")
-
+        self.pool = pool
         self.constants = consensus_constants
         self.coin_store = coin_store
         self.block_store = block_store
@@ -163,7 +150,6 @@ class Blockchain:
 
     def shut_down(self) -> None:
         self._shut_down = True
-        self.pool.shutdown(wait=True)
 
     async def _load_chain_from_store(self, height_map: BlockHeightMap) -> None:
         """

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 import copy
 import logging
 import time
 import traceback
 from collections.abc import Awaitable, Collection
-from concurrent.futures import Executor
 from dataclasses import dataclass
 
 from chia_rs import (
@@ -37,6 +35,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.generator_types import BlockGenerator
 from chia.types.validation_state import ValidationState
 from chia.util.errors import Err
+from chia.util.priority_thread_pool_executor import Executor, _SupportsLessThan
 from chia.util.streamable import Streamable, streamable
 
 log = logging.getLogger(__name__)
@@ -170,6 +169,8 @@ async def pre_validate_block(
     vs: ValidationState,
     *,
     wp_summaries: list[SubEpochSummary] | None = None,
+    nice: _SupportsLessThan = (0,),
+    dedicated: bool = True,
 ) -> Awaitable[PreValidationResult]:
     """
     This method must be called under the blockchain lock
@@ -268,8 +269,7 @@ async def pre_validate_block(
     except ValueError:
         return return_error(Err.FAILED_GETTING_GENERATOR_MULTIPROCESSING)
 
-    future = asyncio.get_running_loop().run_in_executor(
-        pool,
+    future = pool.run_in_loop(
         _pre_validate_block,
         constants,
         blockchain.read_only_snapshot(),
@@ -277,6 +277,8 @@ async def pre_validate_block(
         previous_generators,
         conds,
         copy.copy(vs),
+        nice=nice,
+        dedicated=dedicated,
     )
 
     if block_rec.sub_epoch_summary_included is not None:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -282,6 +282,7 @@ class FullNode:
                     max_workers=num_workers,
                     dedicated=dedicated,
                     thread_name_prefix="validation-",
+                    instrument=bool(self.config.get("instrument_thread_pool", 0)),
                 )
                 self.log.info(f"Started {num_workers} threads for validation ({dedicated} dedicated)")
             selected_network = self.config.get("selected_network")

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -299,7 +299,7 @@ class FullNode:
                 get_coin_records=self.coin_store.get_coin_records,
                 get_unspent_lineage_info_for_puzzle_hash=self.coin_store.get_unspent_lineage_info_for_puzzle_hash,
                 consensus_constants=self.constants,
-                single_threaded=single_threaded,
+                pool=self.pool,
                 validation_timeout=self.config.get("block_creation_timeout", 2.0),
             ) as self._mempool_manager:
                 # Transactions go into this queue from the server, and get sent to respond_transaction
@@ -2836,8 +2836,15 @@ class FullNode:
         if self.sync_store.get_sync_mode() or self.mempool_manager.peak is None:
             return MempoolInclusionStatus.FAILED, Err.NO_TRANSACTIONS_WHILE_SYNCING
 
+        fee_per_cost = 0.0
+        for peer_info in peers_with_tx.values():
+            if peer_info.advertised_cost > 0:
+                fee_per_cost = max(fee_per_cost, peer_info.advertised_fee / peer_info.advertised_cost)
+
         try:
-            cost_result = await self.mempool_manager.pre_validate_spendbundle(transaction, spend_name, self._bls_cache)
+            cost_result = await self.mempool_manager.pre_validate_spendbundle(
+                transaction, spend_name, self._bls_cache, fee_per_cost=fee_per_cost
+            )
         except ValueError as e:
             # ValueError is used to indicate a soft failure. We don't want to
             # ban the peer

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -86,13 +86,16 @@ from chia.types.validation_state import ValidationState
 from chia.types.weight_proof import WeightProof
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.config import process_config_start_method
+from chia.util.cpu import available_logical_cores
 from chia.util.db_synchronous import db_synchronous_on
 from chia.util.db_version import lookup_db_version, set_db_version_async
 from chia.util.db_wrapper import DBWrapper2, manage_connection
 from chia.util.errors import ConsensusError, Err, TimestampError, ValidationError
+from chia.util.inline_executor import InlineExecutor
 from chia.util.limited_semaphore import LimitedSemaphore
 from chia.util.network import is_localhost
 from chia.util.path import path_from_root
+from chia.util.priority_thread_pool_executor import Executor, PriorityThreadPoolExecutor
 from chia.util.profiler import enable_profiler, mem_profile_task, profile_task
 from chia.util.safe_cancel_task import cancel_task_safe
 from chia.util.task_referencer import create_referenced_task
@@ -164,6 +167,7 @@ class FullNode:
     _mempool_manager: MempoolManager | None = None
     _init_weight_proof: asyncio.Task[None] | None = None
     _blockchain: Blockchain | None = None
+    _pool: Executor | None = None
     _timelord_lock: asyncio.Lock | None = None
     weight_proof_handler: WeightProofHandler | None = None
     # hashes of peaks that failed long sync on chip13 Validation
@@ -263,11 +267,23 @@ class FullNode:
             self._coin_store = await CoinStore.create(self.db_wrapper)
             self.log.info("Initializing blockchain from disk")
             start_time = time.monotonic()
-            reserved_cores = self.config.get("reserved_cores", 0)
             single_threaded = self.config.get("single_threaded", False)
             log_coins = self.config.get("log_coins", False)
             multiprocessing_start_method = process_config_start_method(config=self.config, log=self.log)
             self.multiprocessing_context = multiprocessing.get_context(method=multiprocessing_start_method)
+            if single_threaded:
+                self._pool = InlineExecutor()
+            else:
+                reserved_cores = self.config.get("reserved_cores", 0)
+                cpu_count = available_logical_cores()
+                num_workers = max(cpu_count - reserved_cores, 1)
+                dedicated = 1 if num_workers > 1 else 0
+                self._pool = PriorityThreadPoolExecutor(
+                    max_workers=num_workers,
+                    dedicated=dedicated,
+                    thread_name_prefix="validation-",
+                )
+                self.log.info(f"Started {num_workers} threads for validation ({dedicated} dedicated)")
             selected_network = self.config.get("selected_network")
             height_map = await BlockHeightMap.create(self.db_path.parent, self._db_wrapper, selected_network)
             self._blockchain = await Blockchain.create(
@@ -275,8 +291,7 @@ class FullNode:
                 block_store=self.block_store,
                 consensus_constants=self.constants,
                 height_map=height_map,
-                reserved_cores=reserved_cores,
-                single_threaded=single_threaded,
+                pool=self.pool,
                 log_coins=log_coins,
             )
 
@@ -357,6 +372,7 @@ class FullNode:
 
                 try:
                     async with contextlib.AsyncExitStack() as aexit_stack:
+                        aexit_stack.enter_context(self.pool)
                         if self.full_node_peers is not None:
                             await aexit_stack.enter_async_context(self.full_node_peers.manage())
                         yield
@@ -420,6 +436,11 @@ class FullNode:
     def blockchain(self) -> Blockchain:
         assert self._blockchain is not None
         return self._blockchain
+
+    @property
+    def pool(self) -> Executor:
+        assert self._pool is not None
+        return self._pool
 
     @property
     def coin_store(self) -> CoinStoreProtocol:
@@ -1615,10 +1636,11 @@ class FullNode:
                     self.constants,
                     blockchain,
                     block,
-                    self.blockchain.pool,
+                    self.pool,
                     None,
                     vs,
                     wp_summaries=wp_summaries,
+                    nice=(20,),
                 )
             )
         return ret
@@ -2170,7 +2192,7 @@ class FullNode:
                 self.blockchain.constants,
                 AugmentedBlockchain(self.blockchain),
                 block,
-                self.blockchain.pool,
+                self.pool,
                 conds,
                 ValidationState(ssi, diff, prev_ses_block),
             )
@@ -2364,7 +2386,7 @@ class FullNode:
 
         # If we have already added the block with this reward block hash and
         # foliage hash, return
-        existing, _, has_better = self.full_node_store.get_unfinished_block2(block_hash, foliage_tx_hash)
+        existing, unfinished_count, has_better = self.full_node_store.get_unfinished_block2(block_hash, foliage_tx_hash)
         if existing is not None or has_better:
             return None
 
@@ -2436,8 +2458,10 @@ class FullNode:
                 run_block = run_block_generator
 
             # run_block() also validates the signature
-            err, conditions = await asyncio.get_running_loop().run_in_executor(
-                self.blockchain.pool,
+            # bump nice for each unfinished block we already have for this
+            # reward hash, so a burst of duplicates doesn't starve mempool
+            # transaction validation
+            err, conditions = await self.pool.run_in_loop(
                 run_block,
                 bytes(block.transactions_generator),
                 generator_args,
@@ -2446,6 +2470,7 @@ class FullNode:
                 block.transactions_info.aggregated_signature,
                 self._bls_cache,
                 self.constants,
+                nice=(5 + unfinished_count,),
             )
 
             if err is not None:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -5,7 +5,6 @@ import logging
 import time
 import traceback
 from collections.abc import Collection
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, ClassVar, cast
 
@@ -158,13 +157,11 @@ class FullNodeAPI:
 
     log: logging.Logger
     full_node: FullNode
-    executor: ThreadPoolExecutor
     metadata: ClassVar[ApiMetadata] = ApiMetadata()
 
     def __init__(self, full_node: FullNode) -> None:
         self.log = logging.getLogger(__name__)
         self.full_node = full_node
-        self.executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="node-api-")
 
     @property
     def server(self) -> ChiaServer:
@@ -1283,8 +1280,10 @@ class FullNodeAPI:
         else:
             return msg
 
-    @metadata.request()
-    async def request_block_header(self, request: wallet_protocol.RequestBlockHeader) -> Message | None:
+    @metadata.request(peer_required=True)
+    async def request_block_header(
+        self, request: wallet_protocol.RequestBlockHeader, peer: WSChiaConnection
+    ) -> Message | None:
         header_hash = self.full_node.blockchain.height_to_hash(request.height)
         if header_hash is None:
             msg = make_msg(ProtocolMessageTypes.reject_header_request, RejectHeaderRequest(request.height))
@@ -1305,13 +1304,17 @@ class FullNodeAPI:
             # transactions_generator, so the block_generator should always be set
             assert block_generator is not None, "failed to get block_generator for tx-block"
             flags = await get_flags(constants=self.full_node.constants, blocks=self.full_node.blockchain, block=block)
-            additions, removals = await asyncio.get_running_loop().run_in_executor(
-                self.executor,
+            # trusted peers use dedicated threads at high priority;
+            # untrusted peers are deprioritized
+            trusted = self.is_trusted(peer)
+            additions, removals = await self.full_node.pool.run_in_loop(
                 additions_and_removals,
                 bytes(block.transactions_generator),
                 block_generator.generator_refs,
                 flags,
                 self.full_node.constants,
+                nice=(5,) if trusted else (15,),
+                dedicated=trusted,
             )
             # strip the hint from additions, and compute the puzzle hash for
             # removals
@@ -1509,8 +1512,10 @@ class FullNodeAPI:
                 response = wallet_protocol.TransactionAck(spend_name, uint8(status.value), error_name)
         return make_msg(ProtocolMessageTypes.transaction_ack, response)
 
-    @metadata.request()
-    async def request_puzzle_solution(self, request: wallet_protocol.RequestPuzzleSolution) -> Message | None:
+    @metadata.request(peer_required=True)
+    async def request_puzzle_solution(
+        self, request: wallet_protocol.RequestPuzzleSolution, peer: WSChiaConnection
+    ) -> Message | None:
         coin_name = request.coin_name
         height = request.height
         coin_record = await self.full_node.coin_store.get_coin_record(coin_name)
@@ -1532,15 +1537,19 @@ class FullNodeAPI:
             self.full_node.blockchain.lookup_block_generators, block
         )
         assert block_generator is not None
+        # trusted peers use dedicated threads at high priority;
+        # untrusted peers are deprioritized
+        trusted = self.is_trusted(peer)
         try:
-            puzzle, solution = await asyncio.get_running_loop().run_in_executor(
-                self.executor,
+            puzzle, solution = await self.full_node.pool.run_in_loop(
                 get_puzzle_and_solution_for_coin,
                 block_generator.program,
                 block_generator.generator_refs,
                 self.full_node.constants.MAX_BLOCK_COST_CLVM,
                 coin_record.coin,
                 get_flags_for_height_and_constants(height, self.full_node.constants),
+                nice=(5,) if trusted else (15,),
+                dedicated=trusted,
             )
         except ValueError:
             return reject_msg

--- a/chia/full_node/full_node_rpc_api.py
+++ b/chia/full_node/full_node_rpc_api.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import asyncio
 import time
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
@@ -91,8 +89,6 @@ async def get_average_block_time(
 
 
 class FullNodeRpcApi:
-    executor: ThreadPoolExecutor
-
     if TYPE_CHECKING:
         from chia.rpc.rpc_server import RpcApiProtocol
 
@@ -102,7 +98,6 @@ class FullNodeRpcApi:
         self.service = service
         self.service_name = "chia_full_node"
         self.cached_blockchain_state: dict[str, Any] | None = None
-        self.executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="node-rpc-")
 
     def get_routes(self) -> dict[str, Endpoint]:
         return {
@@ -522,16 +517,17 @@ class FullNodeRpcApi:
 
         flags = await get_flags(constants=self.service.constants, blocks=self.service.blockchain, block=full_block)
 
-        spends = await asyncio.get_running_loop().run_in_executor(
-            self.executor,
+        spends = await self.service.pool.run_in_loop(
             get_spends_for_trusted_block,
             self.service.constants,
             block_generator.program,
             block_generator.generator_refs,
             flags,
+            nice=(5,),
+            dedicated=True,
         )
 
-        return spends
+        return cast(EndpointResult, spends)
 
     async def get_block_spends_with_conditions(self, request: dict[str, Any]) -> EndpointResult:
         if "header_hash" not in request:
@@ -551,13 +547,14 @@ class FullNodeRpcApi:
             return {"block_spends_with_conditions": []}
 
         flags = await get_flags(constants=self.service.constants, blocks=self.service.blockchain, block=full_block)
-        spends_with_conditions = await asyncio.get_running_loop().run_in_executor(
-            self.executor,
+        spends_with_conditions = await self.service.pool.run_in_loop(
             get_spends_for_trusted_block_with_conditions,
             self.service.constants,
             block_generator.program,
             block_generator.generator_refs,
             flags,
+            nice=(5,),
+            dedicated=True,
         )
         return {"block_spends_with_conditions": spends_with_conditions}
 
@@ -1000,8 +997,7 @@ class FullNodeRpcApi:
 
             if maybe_gen is not None:
                 # this also validates the signature
-                err, conds = await asyncio.get_running_loop().run_in_executor(
-                    self.executor,
+                err, conds = await self.service.pool.run_in_loop(
                     run_block_generator2,
                     bytes(gen.program),
                     gen.generator_refs,
@@ -1010,6 +1006,8 @@ class FullNodeRpcApi:
                     gen.signature,
                     None,
                     self.service.constants,
+                    nice=(5,),
+                    dedicated=True,
                 )
                 if err is not None:
                     self.service.log.error(f"failed to validate block: {err}")

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import logging
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Collection
-from concurrent.futures import Executor, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from types import TracebackType
 from typing import TypeVar
@@ -43,7 +41,7 @@ from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.mempool_item import BundleCoinSpend, MempoolItem, UnspentLineageInfo
 from chia.util.db_wrapper import SQLITE_INT_MAX
 from chia.util.errors import Err, ValidationError
-from chia.util.inline_executor import InlineExecutor
+from chia.util.priority_thread_pool_executor import Executor
 
 log = logging.getLogger(__name__)
 
@@ -319,9 +317,9 @@ class MempoolManager:
         get_coin_records: Callable[[Collection[bytes32]], Awaitable[list[CoinRecord]]],
         get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[UnspentLineageInfo | None]],
         consensus_constants: ConsensusConstants,
+        pool: Executor,
         *,
         validation_timeout: float,
-        single_threaded: bool = False,
         max_tx_clvm_cost: uint64 | None = None,
     ):
         self.constants: ConsensusConstants = consensus_constants
@@ -353,10 +351,7 @@ class MempoolManager:
         self.seen_cache_size = 10000
         self._worker_queue_size = 0
         self.validation_timeout = validation_timeout
-        if single_threaded:
-            self.pool = InlineExecutor()
-        else:
-            self.pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="mempool-")
+        self.pool = pool
 
         # The mempool will correspond to a certain peak
         self.peak: BlockRecordProtocol | None = None
@@ -375,16 +370,16 @@ class MempoolManager:
         get_coin_records: Callable[[Collection[bytes32]], Awaitable[list[CoinRecord]]],
         get_unspent_lineage_info_for_puzzle_hash: Callable[[bytes32], Awaitable[UnspentLineageInfo | None]],
         consensus_constants: ConsensusConstants,
+        pool: Executor,
         *,
         validation_timeout: float,
-        single_threaded: bool = False,
         max_tx_clvm_cost: uint64 | None = None,
     ) -> AsyncIterator[Self]:
         self = cls(
             get_coin_records,
             get_unspent_lineage_info_for_puzzle_hash,
             consensus_constants,
-            single_threaded=single_threaded,
+            pool,
             max_tx_clvm_cost=max_tx_clvm_cost,
             validation_timeout=validation_timeout,
         )
@@ -394,7 +389,6 @@ class MempoolManager:
             self.shut_down()
 
     def shut_down(self) -> None:
-        self.pool.shutdown(wait=True)
         self.mempool.close()
 
     def __enter__(self) -> Self:
@@ -475,7 +469,12 @@ class MempoolManager:
             self.seen_bundle_hashes.pop(bundle_hash)
 
     async def pre_validate_spendbundle(
-        self, spend_bundle: SpendBundle, spend_bundle_id: bytes32 | None = None, bls_cache: BLSCache | None = None
+        self,
+        spend_bundle: SpendBundle,
+        spend_bundle_id: bytes32 | None = None,
+        bls_cache: BLSCache | None = None,
+        *,
+        fee_per_cost: float = 0.0,
     ) -> SpendBundleConditions:
         """
         Errors are included within the cached_result.
@@ -490,13 +489,14 @@ class MempoolManager:
         self._worker_queue_size += 1
         try:
             flags = get_flags_for_height_and_constants(self.peak.height, self.constants)
-            sbc, new_cache_entries, duration = await asyncio.get_running_loop().run_in_executor(
-                self.pool,
+            sbc: SpendBundleConditions
+            sbc, new_cache_entries, duration = await self.pool.run_in_loop(
                 validate_clvm_and_signature,
                 spend_bundle,
                 self.max_tx_clvm_cost,
                 self.constants,
                 flags | MEMPOOL_MODE,
+                nice=(5, -fee_per_cost),
             )
         # validate_clvm_and_signature raises a ValueError with an error code
         except ValueError as e:

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -202,7 +202,7 @@ class FullNodeSimulator(FullNodeAPI):
                     self.full_node.blockchain.constants,
                     AugmentedBlockchain(self.full_node.blockchain),
                     genesis,
-                    self.full_node.blockchain.pool,
+                    self.full_node.pool,
                     None,
                     ValidationState(ssi, diff, None),
                 )
@@ -261,7 +261,7 @@ class FullNodeSimulator(FullNodeAPI):
                     self.full_node.blockchain.constants,
                     AugmentedBlockchain(self.full_node.blockchain),
                     genesis,
-                    self.full_node.blockchain.pool,
+                    self.full_node.pool,
                     None,
                     ValidationState(ssi, diff, None),
                 )

--- a/chia/simulator/setup_services.py
+++ b/chia/simulator/setup_services.py
@@ -46,6 +46,7 @@ from chia.timelord.timelord_service import TimelordService
 from chia.types.peer_info import UnresolvedPeerInfo
 from chia.util.bech32m import encode_puzzle_hash
 from chia.util.config import config_path_for_filename, load_config, lock_and_load_config, save_config
+from chia.util.cpu import available_logical_cores
 from chia.util.db_wrapper import generate_in_memory_db_uri
 from chia.util.keychain import bytes_to_mnemonic
 from chia.util.lock import Lockfile
@@ -139,6 +140,7 @@ async def setup_full_node(
     else:
         service_config["introducer_peer"] = None
     service_config["dns_servers"] = []
+    service_config["reserved_cores"] = available_logical_cores() - 1
     service_config["port"] = 0
     service_config["rpc_port"] = 0
     config["simulator"]["auto_farm"] = False  # Disable Auto Farm for tests

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -373,6 +373,10 @@ full_node:
   # profiled.
   single_threaded: False
 
+  # set to 1 to log thread pool statistics (queue lengths, max wait times,
+  # jobs retired) every 10 seconds at INFO level.
+  # instrument_thread_pool: 0
+
   # when enabled, logs coins additions, removals and reorgs at INFO level.
   # Requires the log level to be INFO or DEBUG as well.
   log_coins: False

--- a/chia/util/inline_executor.py
+++ b/chia/util/inline_executor.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from concurrent.futures import Executor, Future
-from typing import TypeVar
+from typing import Any, TypeVar
 
 _T = TypeVar("_T")
 
@@ -12,7 +13,7 @@ _T = TypeVar("_T")
 class InlineExecutor(Executor):
     _closing: bool = False
 
-    def submit(self, fn: Callable[..., _T], *args, **kwargs) -> Future[_T]:  # type: ignore
+    def submit(self, fn: Callable[..., _T], *args: Any, **kwargs: Any) -> Future[_T]:  # type: ignore
         if self._closing:
             raise RuntimeError("executor shutting down")
 
@@ -23,5 +24,13 @@ class InlineExecutor(Executor):
             f.set_exception(e)
         return f
 
-    def close(self) -> None:
+    def run_in_loop(
+        self, fn: Callable[..., Any], /, *args: Any, nice: Any = (0,), dedicated: bool = False, **kwargs: Any
+    ) -> asyncio.Future[Any]:
+        return asyncio.wrap_future(self.submit(fn, *args, **kwargs))
+
+    def shutdown(self, wait: bool = True) -> None:  # type: ignore[override]
         self._closing = True
+
+    def close(self) -> None:
+        self.shutdown()

--- a/chia/util/priority_thread_pool_executor.py
+++ b/chia/util/priority_thread_pool_executor.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import queue
 import threading
+import time
 from collections.abc import Callable
 from concurrent.futures import Future
 from dataclasses import dataclass, field
@@ -10,6 +12,8 @@ from types import TracebackType
 from typing import Any, Protocol, runtime_checkable
 
 from typing_extensions import Self
+
+log = logging.getLogger(__name__)
 
 
 class _SupportsLessThan(Protocol):
@@ -58,6 +62,7 @@ class _WorkItem:
     args: tuple[Any, ...] = field(compare=False, default=())
     kwargs: dict[str, Any] = field(compare=False, default_factory=dict)
     future: Future[Any] | None = field(compare=False, default=None)
+    enqueue_time: float = field(compare=False, default=0.0)
     _claim: threading.Lock = field(compare=False, default_factory=threading.Lock)
 
 
@@ -87,7 +92,9 @@ class PriorityThreadPoolExecutor:
     threads to contribute to dedicated work.
     """
 
-    def __init__(self, max_workers: int, *, dedicated: int = 0, thread_name_prefix: str = "") -> None:
+    def __init__(
+        self, max_workers: int, *, dedicated: int = 0, thread_name_prefix: str = "", instrument: bool = False
+    ) -> None:
         if max_workers <= 0:
             raise ValueError("max_workers must be positive")
         if dedicated < 0 or dedicated >= max_workers:
@@ -99,14 +106,28 @@ class PriorityThreadPoolExecutor:
         self._shutdown = False
         self._lock = threading.Lock()
         self._threads: list[threading.Thread] = []
+
+        self._instrument = instrument
+        self._stats_lock = threading.Lock()
+        self._retired_dedicated = 0
+        self._retired_general = 0
+        self._stop_instrument = threading.Event()
+
         for i in range(dedicated):
             name = f"{thread_name_prefix}dedicated-{i}" if thread_name_prefix else None
-            t = threading.Thread(target=self._worker, args=(self._dedicated_queue,), name=name)
+            t = threading.Thread(target=self._worker, args=(self._dedicated_queue, True), name=name)
             t.start()
             self._threads.append(t)
         for i in range(max_workers - dedicated):
             name = f"{thread_name_prefix}{i}" if thread_name_prefix else None
-            t = threading.Thread(target=self._worker, args=(self._general_queue,), name=name)
+            t = threading.Thread(target=self._worker, args=(self._general_queue, False), name=name)
+            t.start()
+            self._threads.append(t)
+
+        if instrument:
+            t = threading.Thread(
+                target=self._instrument_loop, name=f"{thread_name_prefix}instrument" if thread_name_prefix else None
+            )
             t.start()
             self._threads.append(t)
 
@@ -125,7 +146,8 @@ class PriorityThreadPoolExecutor:
             future: Future[Any] = Future()
             seq = self._seq
             self._seq += 1
-            item = _WorkItem(False, nice, seq, fn, args, kwargs, future)
+            now = time.monotonic() if self._instrument else 0.0
+            item = _WorkItem(False, nice, seq, fn, args, kwargs, future, now)
             self._general_queue.put(item)
             if dedicated and self._dedicated_count > 0:
                 self._dedicated_queue.put(item)
@@ -145,19 +167,19 @@ class PriorityThreadPoolExecutor:
     def shutdown(self, wait: bool = True) -> None:
         with self._lock:
             self._shutdown = True
+            self._stop_instrument.set()
             for _ in range(self._dedicated_count):
                 seq = self._seq
                 self._seq += 1
                 self._dedicated_queue.put(_WorkItem(_sentinel=True, nice=(0,), seq=seq))
-            for _ in range(len(self._threads) - self._dedicated_count):
+            for _ in range(len(self._threads) - self._dedicated_count - (1 if self._instrument else 0)):
                 seq = self._seq
                 self._seq += 1
                 self._general_queue.put(_WorkItem(_sentinel=True, nice=(0,), seq=seq))
         for t in self._threads:
             t.join()
 
-    @staticmethod
-    def _worker(q: queue.PriorityQueue[_WorkItem]) -> None:
+    def _worker(self, q: queue.PriorityQueue[_WorkItem], is_dedicated: bool) -> None:
         while True:
             item = q.get()
             if item.fn is None:
@@ -167,11 +189,51 @@ class PriorityThreadPoolExecutor:
             assert item.future is not None
             if not item.future.set_running_or_notify_cancel():
                 continue
+            if self._instrument:
+                with self._stats_lock:
+                    if is_dedicated:
+                        self._retired_dedicated += 1
+                    else:
+                        self._retired_general += 1
             try:
                 result = item.fn(*item.args, **item.kwargs)
                 item.future.set_result(result)
             except BaseException as e:
                 item.future.set_exception(e)
+
+    @staticmethod
+    def _oldest_pending_wait(q: queue.PriorityQueue[_WorkItem], now: float) -> float:
+        """Return the wait time of the oldest still-pending item in *q*."""
+        max_wait = 0.0
+        with q.mutex:
+            for item in q.queue:
+                if item._sentinel or item.enqueue_time == 0.0:
+                    continue
+                assert item.future is not None
+                if not item.future.running() and not item.future.done():
+                    max_wait = max(max_wait, now - item.enqueue_time)
+        return max_wait
+
+    def _instrument_loop(self) -> None:
+        prev_retired_ded = 0
+        prev_retired_gen = 0
+        while not self._stop_instrument.wait(10):
+            now = time.monotonic()
+            with self._stats_lock:
+                retired_ded = self._retired_dedicated
+                retired_gen = self._retired_general
+            if retired_ded == prev_retired_ded and retired_gen == prev_retired_gen:
+                continue
+            prev_retired_ded = retired_ded
+            prev_retired_gen = retired_gen
+            pending_ded = self._oldest_pending_wait(self._dedicated_queue, now)
+            pending_gen = self._oldest_pending_wait(self._general_queue, now)
+            log.info(
+                f"thread pool: "
+                f"Queue: {self._dedicated_queue.qsize()}, {self._general_queue.qsize()} "
+                f"Retired: {retired_ded}, {retired_gen} "
+                f"Pending: {pending_ded:.1f}s, {pending_gen:.1f}s"
+            )
 
     def __enter__(self) -> Self:
         return self

--- a/chia/util/priority_thread_pool_executor.py
+++ b/chia/util/priority_thread_pool_executor.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+import queue
+import threading
+from collections.abc import Callable
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from types import TracebackType
+from typing import Any, Protocol, runtime_checkable
+
+from typing_extensions import Self
+
+
+class _SupportsLessThan(Protocol):
+    def __lt__(self, other: Self, /) -> bool: ...
+
+
+@runtime_checkable
+class Executor(Protocol):
+    def run_in_loop(
+        self,
+        fn: Callable[..., Any],
+        /,
+        *args: Any,
+        nice: _SupportsLessThan = (0,),
+        dedicated: bool = False,
+        **kwargs: Any,
+    ) -> asyncio.Future[Any]: ...
+
+    def shutdown(self, wait: bool = True) -> None: ...
+
+    def __enter__(self) -> Self: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None: ...
+
+
+@dataclass(order=True)
+class _WorkItem:
+    """Wraps a callable for priority queue ordering.
+
+    Fields participate in comparison in declaration order.  ``_sentinel``
+    sorts first: since ``False < True``, real work items always come before
+    shutdown sentinels regardless of ``nice`` values.  Among real items,
+    lower ``nice`` runs first (like Unix niceness), with ``seq`` breaking
+    ties in FIFO order.  A sentinel is represented by ``fn is None``.
+    """
+
+    _sentinel: bool
+    nice: _SupportsLessThan
+    seq: int
+    fn: Callable[..., Any] | None = field(compare=False, default=None)
+    args: tuple[Any, ...] = field(compare=False, default=())
+    kwargs: dict[str, Any] = field(compare=False, default_factory=dict)
+    future: Future[Any] | None = field(compare=False, default=None)
+    _claim: threading.Lock = field(compare=False, default_factory=threading.Lock)
+
+
+class PriorityThreadPoolExecutor:
+    """Thread pool with priority ordering and optional dedicated threads.
+
+    Dedicated threads only pull from the dedicated queue and are never
+    occupied by non-dedicated work, guaranteeing they are available (or
+    will be shortly) when dedicated work arrives.
+
+    Jobs submitted with ``dedicated=True`` are posted to *both* queues
+    so that general threads can also help with dedicated work.  This is
+    important during long sync where multiple FullBlocks are validated
+    in parallel and we want to utilize all cores.  The duplicate queue
+    entry is resolved cheaply: each thread calls
+    ``set_running_or_notify_cancel()`` on the shared Future, and only the
+    first thread to claim it runs the job; the other skips it.
+
+    We considered alternatives (condition variables, semaphores, separate
+    queues without cross-posting) but they all have drawbacks.  A shared
+    condition variable with ``notify_all()`` causes thundering herd wake-ups,
+    and a dedicated thread woken for a non-dedicated job must re-signal
+    without a clean way to target a general thread.  Separate queues
+    without cross-posting would prevent general threads from helping with
+    dedicated work.  The dual-post approach lets every thread sleep
+    efficiently on a blocking ``queue.get()`` while still allowing all
+    threads to contribute to dedicated work.
+    """
+
+    def __init__(self, max_workers: int, *, dedicated: int = 0, thread_name_prefix: str = "") -> None:
+        if max_workers <= 0:
+            raise ValueError("max_workers must be positive")
+        if dedicated < 0 or dedicated >= max_workers:
+            raise ValueError("dedicated must be >= 0 and < max_workers")
+        self._general_queue: queue.PriorityQueue[_WorkItem] = queue.PriorityQueue()
+        self._dedicated_queue: queue.PriorityQueue[_WorkItem] = queue.PriorityQueue()
+        self._dedicated_count = dedicated
+        self._seq = 0
+        self._shutdown = False
+        self._lock = threading.Lock()
+        self._threads: list[threading.Thread] = []
+        for i in range(dedicated):
+            name = f"{thread_name_prefix}dedicated-{i}" if thread_name_prefix else None
+            t = threading.Thread(target=self._worker, args=(self._dedicated_queue,), name=name)
+            t.start()
+            self._threads.append(t)
+        for i in range(max_workers - dedicated):
+            name = f"{thread_name_prefix}{i}" if thread_name_prefix else None
+            t = threading.Thread(target=self._worker, args=(self._general_queue,), name=name)
+            t.start()
+            self._threads.append(t)
+
+    def submit(
+        self,
+        fn: Callable[..., Any],
+        /,
+        *args: Any,
+        nice: _SupportsLessThan = (0,),
+        dedicated: bool = False,
+        **kwargs: Any,
+    ) -> Future[Any]:
+        with self._lock:
+            if self._shutdown:
+                raise RuntimeError("cannot submit to a shut-down pool")
+            future: Future[Any] = Future()
+            seq = self._seq
+            self._seq += 1
+            item = _WorkItem(False, nice, seq, fn, args, kwargs, future)
+            self._general_queue.put(item)
+            if dedicated and self._dedicated_count > 0:
+                self._dedicated_queue.put(item)
+            return future
+
+    def run_in_loop(
+        self,
+        fn: Callable[..., Any],
+        /,
+        *args: Any,
+        nice: _SupportsLessThan = (0,),
+        dedicated: bool = False,
+        **kwargs: Any,
+    ) -> asyncio.Future[Any]:
+        return asyncio.wrap_future(self.submit(fn, *args, nice=nice, dedicated=dedicated, **kwargs))
+
+    def shutdown(self, wait: bool = True) -> None:
+        with self._lock:
+            self._shutdown = True
+            for _ in range(self._dedicated_count):
+                seq = self._seq
+                self._seq += 1
+                self._dedicated_queue.put(_WorkItem(_sentinel=True, nice=(0,), seq=seq))
+            for _ in range(len(self._threads) - self._dedicated_count):
+                seq = self._seq
+                self._seq += 1
+                self._general_queue.put(_WorkItem(_sentinel=True, nice=(0,), seq=seq))
+        for t in self._threads:
+            t.join()
+
+    @staticmethod
+    def _worker(q: queue.PriorityQueue[_WorkItem]) -> None:
+        while True:
+            item = q.get()
+            if item.fn is None:
+                return
+            if not item._claim.acquire(blocking=False):
+                continue
+            assert item.future is not None
+            if not item.future.set_running_or_notify_cancel():
+                continue
+            try:
+                result = item.fn(*item.args, **item.kwargs)
+                item.future.set_result(result)
+            except BaseException as e:
+                item.future.set_exception(e)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.shutdown()


### PR DESCRIPTION
This PR is best reviewed one commit at a time.

### Purpose:

Improve CPU utilization and mitigate abuse. Specifically to prevent less important work preepmt important work.

### Current Behavior

The following classes have `ThreadPoolExecutor` to run CPU heavy background work.

* Blockchain (`FullBlock` and `UnfinishedBlock` validation)
* MempoolManager (transactions validation)
* FullNodeAPI (servicing the Wallet protocol when block needs to be run)
* FullNodeRPC (servicing RPC calls when blocks need to be run)

These thread pools are independent and their combined thread limits may exceed the number of cores on the machine. This makes it oversubscribed where, sometimes, less important work can interfere with important work.

### New Behavior

`FullNode` has a single thread pool (`PriorityThreadPoolExecutor`) that different systems post their job into, and they are run strictly ordered by priority.

This means it's possible to starve low priority work by having a steady stream of high priority work.

#### Thread pool

The new thread pool has a priority queue, where each job is ordered by its "nice" value. It also has "dedicated" threads, workers that are dedicated to certain kinds of jobs. The main reason for this is to keep latency low. We don't want to wait for lower priority work to finish before starting to execute some types of jobs.

When we post a job with `dedicated=True`, it will be posted to both the dedicated job queue and the generic job queue. Whichever thread picks it up first cancels the other.

#### priority

Priority is inverted, so it's called `nice`. Lower `nice`-value means higher priority.

We use a tuple for nice, to allow prioritizing transactions among themselves. We order them by fee per cost.


#### Starvation

Since the thread pool uses a strict priority queue, it's possible to starve low priority work by having an endless stream of high priority work. Some care has to be taken to mitigate abuse.

`UnfinishedBlocks` gets lower priority each time we get another version of a block for the same reward hash. This prevents `UnfinishedBlocks` from starving other lower priority work.

#### job priorities

  | Job | `nice` | `dedicated` | Description |
  |---|---|---|---|
  | FullBlock validation (add_block) | `(0,)` | `True` | Chain progression - highest priority |
  | Trusted wallet: `request_block_header` | `(5,)` | `True` | Block header + additions/removals for trusted peer |
  | Trusted wallet: `request_puzzle_solution` | `(5,)` | `True` | Puzzle/solution lookup for trusted peer |
  | RPC: `get_block_spends` | `(5,)` | `True` | Authenticated RPC |
  | RPC: `get_block_spends_with_conditions` | `(5,)` | `True` | Authenticated RPC |
  | RPC: `run_block_generator2` (fee estimates) | `(5,)` | `True` | Authenticated RPC |
  | UnfinishedBlock validation | `(5 + N,)` | `False` | N = existing unfinished blocks for same reward hash |
  | Mempool transaction validation | `(5, -fee_per_cost)` | `False` | Higher fee-per-cost = lower nice = higher priority |
  | Untrusted wallet: `request_block_header` | `(15,)` | `False` | Untrusted peer - lowest priority |
  | Untrusted wallet: `request_puzzle_solution` | `(15,)` | `False` | Untrusted peer - lowest priority |
  | FullBlock validation (long sync) | `(20,)` | `True` | Chain sync - lowest priority |

## testing

There's some missing test coverage of the instrumentation code. This is a debug facility though.

I've been running my testnet 11 node with this patch and logging enabled.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core full-node concurrency and validation scheduling (block, mempool, wallet, RPC) and introduces a new custom thread-pool implementation; subtle priority, shutdown, or starvation bugs could affect sync/validation latency or correctness under load.
> 
> **Overview**
> Replaces multiple independent `ThreadPoolExecutor`s (block validation, mempool validation, wallet protocol heavy calls, and RPC block-processing calls) with a single shared `PriorityThreadPoolExecutor` owned by `FullNode`, enabling global prioritization via tuple-based `nice` values and optional dedicated worker threads.
> 
> Updates `Blockchain.create()` and `MempoolManager`/`pre_validate_block()` APIs to accept an injected `Executor` (with `run_in_loop(nice=..., dedicated=...)`) and adds priority-aware scheduling: fee-per-cost influences mempool validation ordering, wallet/RPC block-running is prioritized for trusted peers, long-sync block validation is deprioritized, and unfinished-block processing increases `nice` based on duplicate counts.
> 
> Adds the new `chia/util/priority_thread_pool_executor.py`, extends `InlineExecutor` to match the new executor interface, wires pool lifecycle management into services/config (`instrument_thread_pool`), and updates benchmarks and extensive tests to pass the executor and peer where now required for wallet requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e166339d3fe3ce87421e95fac275ce00a5ffd1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->