### PR TITLE
optimize handling of unfinished blocks

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1845,30 +1845,27 @@ async def test_request_unfinished_block2(
 
     peer = await connect_and_get_peer(server_1, server_2, self_hostname)
 
-    # the "best" unfinished block according to the metric we use to pick one
-    # deterministically
-    best_unf: UnfinishedBlock | None = None
-
+    # Generate all unfinished blocks up front, each with a different
+    # transaction (different foliage) but the same reward block (same plot).
+    unfinished_blocks: list[UnfinishedBlock] = []
     for idx in range(6):
-        # we include a different transaction in each block. This makes the
-        # foliage different in each of them, but the reward block (plot) the same
         tx = wallet_a.generate_signed_transaction(uint64(100 * (idx + 1)), puzzle_hash, coin)
-
-        # note that we use the same chain to build the new block on top of every time
         block = bt.get_consecutive_blocks(
             1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
         )[-1]
         unf = make_unfinished_block(block, bt.constants)
         assert unf.foliage.foliage_transaction_block_hash is not None
+        unfinished_blocks.append(unf)
 
-        if best_unf is None:
-            best_unf = unf
-        elif (
-            best_unf.foliage.foliage_transaction_block_hash is not None
-            and unf.foliage.foliage_transaction_block_hash < best_unf.foliage.foliage_transaction_block_hash
-        ):
-            best_unf = unf
+    # Sort worst-to-best (descending foliage hash), so every block we send is
+    # strictly better than what the node already has and will be accepted.
+    def foliage_tx_hash(b: UnfinishedBlock) -> bytes32:
+        assert b.foliage.foliage_transaction_block_hash is not None
+        return b.foliage.foliage_transaction_block_hash
 
+    unfinished_blocks.sort(key=foliage_tx_hash, reverse=True)
+
+    for unf in unfinished_blocks:
         # Don't have
         res = await full_node_1.request_unfinished_block2(
             fnp.RequestUnfinishedBlock2(unf.partial_hash, unf.foliage.foliage_transaction_block_hash)
@@ -1876,6 +1873,7 @@ async def test_request_unfinished_block2(
         assert res is None
 
         await full_node_1.full_node.add_unfinished_block(unf, peer)
+
         # Have
         res = await full_node_1.request_unfinished_block2(
             fnp.RequestUnfinishedBlock2(unf.partial_hash, unf.foliage.foliage_transaction_block_hash)
@@ -1883,13 +1881,14 @@ async def test_request_unfinished_block2(
         assert res is not None
         assert res.data == bytes(fnp.RespondUnfinishedBlock(unf))
 
+        # The current block is always the best so far
         res = await full_node_1.request_unfinished_block(fnp.RequestUnfinishedBlock(unf.partial_hash))
         assert res is not None
-        assert res.data == bytes(fnp.RespondUnfinishedBlock(best_unf))
+        assert res.data == bytes(fnp.RespondUnfinishedBlock(unf))
 
         res = await full_node_1.request_unfinished_block2(fnp.RequestUnfinishedBlock2(unf.partial_hash, None))
         assert res is not None
-        assert res.data == bytes(fnp.RespondUnfinishedBlock(best_unf))
+        assert res.data == bytes(fnp.RespondUnfinishedBlock(unf))
 
 
 @pytest.mark.anyio

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2363,7 +2363,8 @@ class FullNode:
 
         # If we have already added the block with this reward block hash and
         # foliage hash, return
-        if self.full_node_store.get_unfinished_block2(block_hash, foliage_tx_hash)[0] is not None:
+        existing, _, has_better = self.full_node_store.get_unfinished_block2(block_hash, foliage_tx_hash)
+        if existing is not None or has_better:
             return None
 
         peak: BlockRecord | None = self.blockchain.get_peak()
@@ -2464,7 +2465,8 @@ class FullNode:
         assert validate_result.required_iters is not None
 
         # Perform another check, in case we have already concurrently added the same unfinished block
-        if self.full_node_store.get_unfinished_block2(block_hash, foliage_tx_hash)[0] is not None:
+        existing, _, has_better = self.full_node_store.get_unfinished_block2(block_hash, foliage_tx_hash)
+        if existing is not None or has_better:
             return None
 
         if block.prev_header_hash == self.constants.GENESIS_CHALLENGE:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

Reject more unfinished blocks earlier.

relevant context: https://github.com/Chia-Network/chia-blockchain/blob/main/chia/full_node/full_node_store.py#L283

### Current Behavior:

Let through UnfinishedBlocks that we don't really need

### New Behavior:

Reject more UnfinishedBlocks that we don't need

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches full-node unfinished-block acceptance logic, which can affect propagation and fork responsiveness; the change is small but in a consensus-adjacent, DOS-sensitive path.
> 
> **Overview**
> **Optimizes unfinished-block intake** by rejecting an `UnfinishedBlock` not only when the exact `(reward_hash, foliage_hash)` is already stored, but also when the node already has a *better* candidate for the same reward block (via `get_unfinished_block2(...).has_better`). This check is applied both before and after validation to avoid wasted work under concurrency.
> 
> Updates `test_request_unfinished_block2` to generate multiple unfinished blocks for the same reward hash, send them *worst-to-best*, and assert that `request_unfinished_block`/`request_unfinished_block2(..., None)` always returns the best block seen so far (i.e., the latest accepted one).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff1218cf581e26d3e1c58a7a6a79ec51448311e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->