### PR TITLE
[ASB-203] [ASB-202] [CHIA-4004] [CHIA-4005] Fix wallet tx inflight tracking

### DIFF
--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -13,6 +13,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64, uint128
 
 from chia._tests.conftest import ConsensusMode
+from chia._tests.environments.wallet import WalletTestFramework
 from chia._tests.util.misc import CoinGenerator, patch_request_handler
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
 from chia._tests.util.time_out_assert import time_out_assert
@@ -691,16 +692,25 @@ async def test_transaction_send_cache(self_hostname: str, simulator_and_wallet: 
     await time_out_assert(5, check_wallet_cache_empty, True)
 
 
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [
+        {
+            "num_environments": 1,
+            "blocks_needed": [1],
+        }
+    ],
+    indirect=True,
+)
 @pytest.mark.limit_consensus_modes(reason="consensus rules irrelevant")
 @pytest.mark.anyio
 async def test_transaction_ack_duplicate_without_resend_ignored(
-    self_hostname: str, simulator_and_wallet: OldSimulatorsAndWallets, caplog: pytest.LogCaptureFixture
+    wallet_environments: WalletTestFramework, caplog: pytest.LogCaptureFixture
 ) -> None:
-    [full_node_api], [(wallet_node, wallet_server)], _ = simulator_and_wallet
-
-    await wallet_server.start_client(PeerInfo(self_hostname, full_node_api.server.get_port()), None)
-    wallet = wallet_node.wallet_state_manager.main_wallet
-    await full_node_api.farm_rewards_to_wallet(1, wallet)
+    env = wallet_environments.environments[0]
+    full_node_api = wallet_environments.full_node
+    wallet_node = env.node
+    wallet = env.xch_wallet
 
     logged_spends = []
 
@@ -712,7 +722,9 @@ async def test_transaction_ack_duplicate_without_resend_ignored(
 
     assert full_node_api.full_node._server is not None
     with patch_request_handler(api=full_node_api.full_node._server.get_connections()[0].api, handler=send_transaction):
-        async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+        async with wallet.wallet_state_manager.new_action_scope(
+            wallet.wallet_state_manager.tx_config, push=True
+        ) as action_scope:
             await wallet.generate_signed_transaction([uint64(0)], [bytes32.zeros], action_scope)
         [tx] = action_scope.side_effects.transactions
 
@@ -725,8 +737,7 @@ async def test_transaction_ack_duplicate_without_resend_ignored(
                 tx.name, uint8(MempoolInclusionStatus.FAILED), Err.GENERATOR_RUNTIME_ERROR.name
             ),
         )
-        assert simulator_and_wallet[1][0][0]._server is not None
-        conn = simulator_and_wallet[1][0][0]._server.get_connections()[0]
+        conn = env.peer_server.get_connections()[0]
         await conn.incoming_queue.put(msg)
 
         def check_wallet_cache_empty() -> bool:

--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -6,7 +6,6 @@ import time
 import types
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from chia_rs import CoinState, FullBlock, G1Element, PrivateKey
@@ -691,45 +690,6 @@ async def test_transaction_send_cache(self_hostname: str, simulator_and_wallet: 
     # Disconnect from the peer to make sure their entry in the cache is also deleted
     await simulator_and_wallet[1][0][0]._server.get_connections()[0].close(120)
     await time_out_assert(5, check_wallet_cache_empty, True)
-
-
-@pytest.mark.anyio
-async def test_send_transaction_message_cleans_up_on_closed_connection(
-    root_path_populated_with_config: Path,
-) -> None:
-    """
-    When peer.send_message returns False (connection closed),
-    _send_transaction_message should roll back the in-flight marker.
-    """
-    config = load_config(root_path_populated_with_config, "config.yaml", "wallet")
-    wallet_node = WalletNode(config, root_path_populated_with_config, test_constants)
-
-    peer_id = bytes32(b"\x01" * 32)
-    msg_name_a = bytes32(b"\x0a" * 32)
-    msg_name_b = bytes32(b"\x0b" * 32)
-
-    peer = MagicMock(spec=WSChiaConnection)
-    peer.peer_node_id = peer_id
-    peer.send_message = AsyncMock(return_value=False)
-    mock_msg: Any = object()
-
-    async def send_and_check(
-        initial_state: dict[bytes32, list[bytes32]],
-        expected_state: dict[bytes32, list[bytes32]],
-    ) -> None:
-        wallet_node._tx_messages_in_progress = initial_state
-        await wallet_node._send_transaction_message(peer, mock_msg, msg_name_a)
-        assert wallet_node._tx_messages_in_progress == expected_state
-
-    # Only message in-flight for this peer — peer entry is fully removed
-    await send_and_check({}, {})
-
-    # Another message already in-flight — only the failed one is removed
-    await send_and_check({peer_id: [msg_name_b]}, {peer_id: [msg_name_b]})
-
-    # Successful send — marker stays in-flight
-    peer.send_message = AsyncMock(return_value=True)
-    await send_and_check({}, {peer_id: [msg_name_a]})
 
 
 @pytest.mark.parametrize(

--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -622,9 +622,7 @@ async def test_add_states_from_peer_untrusted_shutdown(
 
 @pytest.mark.limit_consensus_modes(reason="consensus rules irrelevant")
 @pytest.mark.anyio
-async def test_transaction_send_cache(
-    self_hostname: str, simulator_and_wallet: OldSimulatorsAndWallets, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_transaction_send_cache(self_hostname: str, simulator_and_wallet: OldSimulatorsAndWallets) -> None:
     """
     The purpose of this test is to test that calling _resend_queue on the wallet node does not result in resending a
     spend to a peer that has already received that spend and is currently processing it. It also tests that once we
@@ -691,6 +689,72 @@ async def test_transaction_send_cache(
     # Disconnect from the peer to make sure their entry in the cache is also deleted
     await simulator_and_wallet[1][0][0]._server.get_connections()[0].close(120)
     await time_out_assert(5, check_wallet_cache_empty, True)
+
+
+@pytest.mark.limit_consensus_modes(reason="consensus rules irrelevant")
+@pytest.mark.anyio
+async def test_transaction_ack_duplicate_without_resend_ignored(
+    self_hostname: str, simulator_and_wallet: OldSimulatorsAndWallets, caplog: pytest.LogCaptureFixture
+) -> None:
+    [full_node_api], [(wallet_node, wallet_server)], _ = simulator_and_wallet
+
+    await wallet_server.start_client(PeerInfo(self_hostname, full_node_api.server.get_port()), None)
+    wallet = wallet_node.wallet_state_manager.main_wallet
+    await full_node_api.farm_rewards_to_wallet(1, wallet)
+
+    logged_spends = []
+
+    async def send_transaction(
+        self: Self, request: wallet_protocol.SendTransaction, peer: WSChiaConnection, *, test: bool = False
+    ) -> Message | None:
+        logged_spends.append(request.transaction.name())
+        return None
+
+    assert full_node_api.full_node._server is not None
+    with patch_request_handler(api=full_node_api.full_node._server.get_connections()[0].api, handler=send_transaction):
+        async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
+            await wallet.generate_signed_transaction([uint64(0)], [bytes32.zeros], action_scope)
+        [tx] = action_scope.side_effects.transactions
+
+        await wallet_node._resend_queue()
+        await time_out_assert(5, lambda: len(logged_spends), 1)
+
+        msg = make_msg(
+            ProtocolMessageTypes.transaction_ack,
+            wallet_protocol.TransactionAck(
+                tx.name, uint8(MempoolInclusionStatus.FAILED), Err.GENERATOR_RUNTIME_ERROR.name
+            ),
+        )
+        assert simulator_and_wallet[1][0][0]._server is not None
+        conn = simulator_and_wallet[1][0][0]._server.get_connections()[0]
+        await conn.incoming_queue.put(msg)
+
+        def check_wallet_cache_empty() -> bool:
+            return wallet_node._tx_messages_in_progress == {}
+
+        def incoming_queue_empty() -> bool:
+            return conn.incoming_queue.qsize() == 0
+
+        await time_out_assert(5, check_wallet_cache_empty, True)
+        first_tx_record = await wallet_node.wallet_state_manager.get_transaction(tx.name)
+        assert first_tx_record is not None
+        first_sent = first_tx_record.sent
+        first_sent_to = first_tx_record.sent_to.copy()
+        first_confirmed = first_tx_record.confirmed
+
+        # Duplicate acks without another send should all be ignored.
+        with caplog.at_level(logging.DEBUG, logger="chia.wallet.wallet_node"):
+            for _ in range(10):
+                await conn.incoming_queue.put(msg)
+                await time_out_assert(5, incoming_queue_empty, True)
+                await time_out_assert(5, check_wallet_cache_empty, True)
+
+        second_tx_record = await wallet_node.wallet_state_manager.get_transaction(tx.name)
+        assert second_tx_record is not None
+        assert second_tx_record.sent == first_sent
+        assert second_tx_record.sent_to == first_sent_to
+        assert second_tx_record.confirmed == first_confirmed
+        assert sum("Ignoring unsolicited transaction ack" in record.getMessage() for record in caplog.records) >= 10
 
 
 @pytest.mark.limit_consensus_modes(reason="consensus rules irrelevant")

--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -6,6 +6,7 @@ import time
 import types
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from chia_rs import CoinState, FullBlock, G1Element, PrivateKey
@@ -690,6 +691,45 @@ async def test_transaction_send_cache(self_hostname: str, simulator_and_wallet: 
     # Disconnect from the peer to make sure their entry in the cache is also deleted
     await simulator_and_wallet[1][0][0]._server.get_connections()[0].close(120)
     await time_out_assert(5, check_wallet_cache_empty, True)
+
+
+@pytest.mark.anyio
+async def test_send_transaction_message_cleans_up_on_closed_connection(
+    root_path_populated_with_config: Path,
+) -> None:
+    """
+    When peer.send_message returns False (connection closed),
+    _send_transaction_message should roll back the in-flight marker.
+    """
+    config = load_config(root_path_populated_with_config, "config.yaml", "wallet")
+    wallet_node = WalletNode(config, root_path_populated_with_config, test_constants)
+
+    peer_id = bytes32(b"\x01" * 32)
+    msg_name_a = bytes32(b"\x0a" * 32)
+    msg_name_b = bytes32(b"\x0b" * 32)
+
+    peer = MagicMock(spec=WSChiaConnection)
+    peer.peer_node_id = peer_id
+    peer.send_message = AsyncMock(return_value=False)
+    mock_msg: Any = object()
+
+    async def send_and_check(
+        initial_state: dict[bytes32, list[bytes32]],
+        expected_state: dict[bytes32, list[bytes32]],
+    ) -> None:
+        wallet_node._tx_messages_in_progress = initial_state
+        await wallet_node._send_transaction_message(peer, mock_msg, msg_name_a)
+        assert wallet_node._tx_messages_in_progress == expected_state
+
+    # Only message in-flight for this peer — peer entry is fully removed
+    await send_and_check({}, {})
+
+    # Another message already in-flight — only the failed one is removed
+    await send_and_check({peer_id: [msg_name_b]}, {peer_id: [msg_name_b]})
+
+    # Successful send — marker stays in-flight
+    peer.send_message = AsyncMock(return_value=True)
+    await send_and_check({}, {peer_id: [msg_name_a]})
 
 
 @pytest.mark.parametrize(

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -520,12 +520,12 @@ class WalletNode:
     async def _send_transaction_message(self, peer: WSChiaConnection, msg: Message, msg_name: bytes32) -> None:
         in_progress = self._tx_messages_in_progress.setdefault(peer.peer_node_id, [])
         in_progress.append(msg_name)
-        # send_message returns False when the connection is closed; it does not raise.
-        if not await peer.send_message(msg):
-            # Connection was closed; roll back the in-flight marker.
-            in_progress.remove(msg_name)
-            if not in_progress:
-                del self._tx_messages_in_progress[peer.peer_node_id]
+        # send_message returns False (never raises) when the connection is
+        # closed.  No rollback of the in-flight marker is needed here because
+        # on_disconnect already deletes the entire peer entry from
+        # _tx_messages_in_progress.  Attempting to roll back here would race
+        # with on_disconnect and risk a KeyError.
+        await peer.send_message(msg)
 
     async def _resend_queue(self) -> None:
         if self._shut_down or self._server is None or self._wallet_state_manager is None:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -517,12 +517,16 @@ class WalletNode:
     def _tx_message_in_flight(self, peer_id: bytes32, msg_name: bytes32) -> bool:
         return peer_id in self._tx_messages_in_progress and msg_name in self._tx_messages_in_progress[peer_id]
 
-    async def _send_transaction_message(self, peer: WSChiaConnection, msg: Message, msg_name: bytes32) -> None:
+    async def _send_transaction_message(
+        self, peer: WSChiaConnection, msg: Message, msg_name: bytes32 | None = None
+    ) -> None:
         # Bail out before touching _tx_messages_in_progress so we never
         # create an in-flight marker that on_disconnect has already passed
         # and therefore will never clean up.
         if peer.closed:
             return
+        if msg_name is None:
+            msg_name = std_hash(msg.data)
         in_progress = self._tx_messages_in_progress.setdefault(peer.peer_node_id, [])
         in_progress.append(msg_name)
         await peer.send_message(msg)
@@ -759,10 +763,9 @@ class WalletNode:
         for msg, peer_ids in messages_peer_ids:
             if peer.peer_node_id in peer_ids:
                 continue
-            msg_name: bytes32 = std_hash(msg.data)
-            if self._tx_message_in_flight(peer.peer_node_id, msg_name):
-                continue
-            await self._send_transaction_message(peer, msg, msg_name)
+            # if we are connecting to this peer, _tx_messages_in_progress is empty,
+            # so we don't need to check if the message is already in flight.
+            await self._send_transaction_message(peer, msg)
 
         if self.wallet_peers is not None:
             await self.wallet_peers.on_connect(peer)
@@ -1723,10 +1726,9 @@ class WalletNode:
     # For RPC only. You should use wallet_state_manager.add_pending_transaction for normal wallet business.
     async def push_tx(self, spend_bundle: WalletSpendBundle) -> None:
         msg = make_msg(ProtocolMessageTypes.send_transaction, SendTransaction(spend_bundle))
-        msg_name: bytes32 = std_hash(msg.data)
         full_nodes = self.server.get_connections(NodeType.FULL_NODE)
         for peer in full_nodes:
-            await self._send_transaction_message(peer, msg, msg_name)
+            await self._send_transaction_message(peer, msg)
 
     async def _update_balance_cache(self, wallet_id: uint32) -> None:
         assert self.wallet_state_manager.lock.locked(), "WalletStateManager.lock required"

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -532,9 +532,19 @@ class WalletNode:
                 ):
                     continue
                 self.log.debug(f"sending: {msg}")
-                await peer.send_message(msg)
-                self._tx_messages_in_progress.setdefault(peer.peer_node_id, [])
-                self._tx_messages_in_progress[peer.peer_node_id].append(msg_name)
+                in_progress = self._tx_messages_in_progress.setdefault(peer.peer_node_id, [])
+                in_progress.append(msg_name)
+                try:
+                    await peer.send_message(msg)
+                except Exception:
+                    # Roll back in-flight marker if send fails.
+                    if peer.peer_node_id in self._tx_messages_in_progress:
+                        in_progress = self._tx_messages_in_progress[peer.peer_node_id]
+                        if msg_name in in_progress:
+                            in_progress.remove(msg_name)
+                        if in_progress == []:
+                            del self._tx_messages_in_progress[peer.peer_node_id]
+                    raise
 
     async def _messages_to_resend(self) -> list[tuple[Message, set[bytes32]]]:
         if self._wallet_state_manager is None or self._shut_down:
@@ -751,7 +761,25 @@ class WalletNode:
         for msg, peer_ids in messages_peer_ids:
             if peer.peer_node_id in peer_ids:
                 continue
-            await peer.send_message(msg)
+            msg_name: bytes32 = std_hash(msg.data)
+            if (
+                peer.peer_node_id in self._tx_messages_in_progress
+                and msg_name in self._tx_messages_in_progress[peer.peer_node_id]
+            ):
+                continue
+            in_progress = self._tx_messages_in_progress.setdefault(peer.peer_node_id, [])
+            in_progress.append(msg_name)
+            try:
+                await peer.send_message(msg)
+            except Exception:
+                # Roll back in-flight marker if send fails.
+                if peer.peer_node_id in self._tx_messages_in_progress:
+                    in_progress = self._tx_messages_in_progress[peer.peer_node_id]
+                    if msg_name in in_progress:
+                        in_progress.remove(msg_name)
+                    if in_progress == []:
+                        del self._tx_messages_in_progress[peer.peer_node_id]
+                raise
 
         if self.wallet_peers is not None:
             await self.wallet_peers.on_connect(peer)
@@ -1712,9 +1740,22 @@ class WalletNode:
     # For RPC only. You should use wallet_state_manager.add_pending_transaction for normal wallet business.
     async def push_tx(self, spend_bundle: WalletSpendBundle) -> None:
         msg = make_msg(ProtocolMessageTypes.send_transaction, SendTransaction(spend_bundle))
+        msg_name: bytes32 = std_hash(msg.data)
         full_nodes = self.server.get_connections(NodeType.FULL_NODE)
         for peer in full_nodes:
-            await peer.send_message(msg)
+            in_progress = self._tx_messages_in_progress.setdefault(peer.peer_node_id, [])
+            in_progress.append(msg_name)
+            try:
+                await peer.send_message(msg)
+            except Exception:
+                # Roll back in-flight marker if send fails.
+                if peer.peer_node_id in self._tx_messages_in_progress:
+                    in_progress = self._tx_messages_in_progress[peer.peer_node_id]
+                    if msg_name in in_progress:
+                        in_progress.remove(msg_name)
+                    if in_progress == []:
+                        del self._tx_messages_in_progress[peer.peer_node_id]
+                raise
 
     async def _update_balance_cache(self, wallet_id: uint32) -> None:
         assert self.wallet_state_manager.lock.locked(), "WalletStateManager.lock required"

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -518,13 +518,13 @@ class WalletNode:
         return peer_id in self._tx_messages_in_progress and msg_name in self._tx_messages_in_progress[peer_id]
 
     async def _send_transaction_message(self, peer: WSChiaConnection, msg: Message, msg_name: bytes32) -> None:
+        # Bail out before touching _tx_messages_in_progress so we never
+        # create an in-flight marker that on_disconnect has already passed
+        # and therefore will never clean up.
+        if peer.closed:
+            return
         in_progress = self._tx_messages_in_progress.setdefault(peer.peer_node_id, [])
         in_progress.append(msg_name)
-        # send_message returns False (never raises) when the connection is
-        # closed.  No rollback of the in-flight marker is needed here because
-        # on_disconnect already deletes the entire peer entry from
-        # _tx_messages_in_progress.  Attempting to roll back here would race
-        # with on_disconnect and risk a KeyError.
         await peer.send_message(msg)
 
     async def _resend_queue(self) -> None:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -520,17 +520,12 @@ class WalletNode:
     async def _send_transaction_message(self, peer: WSChiaConnection, msg: Message, msg_name: bytes32) -> None:
         in_progress = self._tx_messages_in_progress.setdefault(peer.peer_node_id, [])
         in_progress.append(msg_name)
-        try:
-            await peer.send_message(msg)
-        except Exception:
-            # Roll back in-flight marker if send fails.
-            if peer.peer_node_id in self._tx_messages_in_progress:
-                in_progress = self._tx_messages_in_progress[peer.peer_node_id]
-                if msg_name in in_progress:
-                    in_progress.remove(msg_name)
-                if in_progress == []:
-                    del self._tx_messages_in_progress[peer.peer_node_id]
-            raise
+        # send_message returns False when the connection is closed; it does not raise.
+        if not await peer.send_message(msg):
+            # Connection was closed; roll back the in-flight marker.
+            in_progress.remove(msg_name)
+            if not in_progress:
+                del self._tx_messages_in_progress[peer.peer_node_id]
 
     async def _resend_queue(self) -> None:
         if self._shut_down or self._server is None or self._wallet_state_manager is None:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -514,6 +514,24 @@ class WalletNode:
             return None
         create_referenced_task(self._resend_queue(), known_unreferenced=True)
 
+    def _tx_message_in_flight(self, peer_id: bytes32, msg_name: bytes32) -> bool:
+        return peer_id in self._tx_messages_in_progress and msg_name in self._tx_messages_in_progress[peer_id]
+
+    async def _send_transaction_message(self, peer: WSChiaConnection, msg: Message, msg_name: bytes32) -> None:
+        in_progress = self._tx_messages_in_progress.setdefault(peer.peer_node_id, [])
+        in_progress.append(msg_name)
+        try:
+            await peer.send_message(msg)
+        except Exception:
+            # Roll back in-flight marker if send fails.
+            if peer.peer_node_id in self._tx_messages_in_progress:
+                in_progress = self._tx_messages_in_progress[peer.peer_node_id]
+                if msg_name in in_progress:
+                    in_progress.remove(msg_name)
+                if in_progress == []:
+                    del self._tx_messages_in_progress[peer.peer_node_id]
+            raise
+
     async def _resend_queue(self) -> None:
         if self._shut_down or self._server is None or self._wallet_state_manager is None:
             return None
@@ -526,25 +544,10 @@ class WalletNode:
                 if peer.peer_node_id in sent_peers:
                     continue
                 msg_name: bytes32 = std_hash(msg.data)
-                if (
-                    peer.peer_node_id in self._tx_messages_in_progress
-                    and msg_name in self._tx_messages_in_progress[peer.peer_node_id]
-                ):
+                if self._tx_message_in_flight(peer.peer_node_id, msg_name):
                     continue
                 self.log.debug(f"sending: {msg}")
-                in_progress = self._tx_messages_in_progress.setdefault(peer.peer_node_id, [])
-                in_progress.append(msg_name)
-                try:
-                    await peer.send_message(msg)
-                except Exception:
-                    # Roll back in-flight marker if send fails.
-                    if peer.peer_node_id in self._tx_messages_in_progress:
-                        in_progress = self._tx_messages_in_progress[peer.peer_node_id]
-                        if msg_name in in_progress:
-                            in_progress.remove(msg_name)
-                        if in_progress == []:
-                            del self._tx_messages_in_progress[peer.peer_node_id]
-                    raise
+                await self._send_transaction_message(peer, msg, msg_name)
 
     async def _messages_to_resend(self) -> list[tuple[Message, set[bytes32]]]:
         if self._wallet_state_manager is None or self._shut_down:
@@ -762,24 +765,9 @@ class WalletNode:
             if peer.peer_node_id in peer_ids:
                 continue
             msg_name: bytes32 = std_hash(msg.data)
-            if (
-                peer.peer_node_id in self._tx_messages_in_progress
-                and msg_name in self._tx_messages_in_progress[peer.peer_node_id]
-            ):
+            if self._tx_message_in_flight(peer.peer_node_id, msg_name):
                 continue
-            in_progress = self._tx_messages_in_progress.setdefault(peer.peer_node_id, [])
-            in_progress.append(msg_name)
-            try:
-                await peer.send_message(msg)
-            except Exception:
-                # Roll back in-flight marker if send fails.
-                if peer.peer_node_id in self._tx_messages_in_progress:
-                    in_progress = self._tx_messages_in_progress[peer.peer_node_id]
-                    if msg_name in in_progress:
-                        in_progress.remove(msg_name)
-                    if in_progress == []:
-                        del self._tx_messages_in_progress[peer.peer_node_id]
-                raise
+            await self._send_transaction_message(peer, msg, msg_name)
 
         if self.wallet_peers is not None:
             await self.wallet_peers.on_connect(peer)
@@ -1743,19 +1731,7 @@ class WalletNode:
         msg_name: bytes32 = std_hash(msg.data)
         full_nodes = self.server.get_connections(NodeType.FULL_NODE)
         for peer in full_nodes:
-            in_progress = self._tx_messages_in_progress.setdefault(peer.peer_node_id, [])
-            in_progress.append(msg_name)
-            try:
-                await peer.send_message(msg)
-            except Exception:
-                # Roll back in-flight marker if send fails.
-                if peer.peer_node_id in self._tx_messages_in_progress:
-                    in_progress = self._tx_messages_in_progress[peer.peer_node_id]
-                    if msg_name in in_progress:
-                        in_progress.remove(msg_name)
-                    if in_progress == []:
-                        del self._tx_messages_in_progress[peer.peer_node_id]
-                raise
+            await self._send_transaction_message(peer, msg, msg_name)
 
     async def _update_balance_cache(self, wallet_id: uint32) -> None:
         assert self.wallet_state_manager.lock.locked(), "WalletStateManager.lock required"

--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -106,12 +106,22 @@ class WalletNodeAPI:
         async with self.wallet_node.wallet_state_manager.lock:
             assert peer.peer_node_id is not None
             name = peer.peer_node_id.hex()
+            matched_in_flight_send = False
             if peer.peer_node_id in self.wallet_node._tx_messages_in_progress:
-                self.wallet_node._tx_messages_in_progress[peer.peer_node_id] = [
-                    txid for txid in self.wallet_node._tx_messages_in_progress[peer.peer_node_id] if txid != ack.txid
-                ]
-                if self.wallet_node._tx_messages_in_progress[peer.peer_node_id] == []:
+                in_progress = self.wallet_node._tx_messages_in_progress[peer.peer_node_id]
+                if ack.txid in in_progress:
+                    matched_in_flight_send = True
+                    in_progress.remove(ack.txid)
+                if in_progress == []:
                     del self.wallet_node._tx_messages_in_progress[peer.peer_node_id]
+
+            # Ignore stale/unsolicited acknowledgements that don't correspond to an in-flight send.
+            if not matched_in_flight_send:
+                self.wallet_node.log.debug(
+                    "Ignoring unsolicited transaction ack from peer %s for tx %s", name, ack.txid
+                )
+                return None
+
             status = MempoolInclusionStatus(ack.status)
             try:
                 wallet_state_manager = self.wallet_node.wallet_state_manager


### PR DESCRIPTION
Use in-flight progress cache as a way to ignore unsolicited TransactionAck responses from a full node

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes wallet transaction send/ack bookkeeping to avoid marking messages in-flight for closed peers and to drop acks that don’t match an active send, which could affect transaction propagation/resend behavior. Covered by new/updated tests but touches wallet networking flow.
> 
> **Overview**
> Improves wallet transaction in-flight tracking by centralizing send+tracking in `WalletNode._send_transaction_message()`, reusing it for resend processing, initial peer connect resends, and RPC `push_tx`, and avoiding creating in-flight markers for already-closed peers.
> 
> Tightens `transaction_ack` handling to **only** clear resend state and update transaction records when the ack matches an actually in-flight tx; otherwise it logs and ignores the ack.
> 
> Adds/updates tests around resend caching and introduces a new test ensuring duplicate/unsolicited `transaction_ack` messages don’t mutate wallet transaction state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e9f2355f345cfa65fc3087497fc82f41ba18498. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->