### PR TITLE
[SEC-615] Reject malformed weight proof segments with overflow block at index 0

### DIFF
--- a/chia/_tests/weight_proof/test_weight_proof.py
+++ b/chia/_tests/weight_proof/test_weight_proof.py
@@ -1,16 +1,32 @@
 from __future__ import annotations
 
 import pytest
-from chia_rs import BlockRecord, ConsensusConstants, FullBlock, HeaderBlock, SubEpochSummary
+from chia_rs import (
+    BlockRecord,
+    ConsensusConstants,
+    FullBlock,
+    HeaderBlock,
+    SubEpochChallengeSegment,
+    SubEpochSummary,
+    SubSlotData,
+)
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint32
+from chia_rs.sized_ints import uint8, uint32, uint64
 
 from chia._tests.conftest import ConsensusMode
 from chia._tests.util.blockchain_mock import BlockchainMock
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.generator_tools import get_block_header
 from chia.consensus.pot_iterations import validate_pospace_and_get_required_iters
-from chia.full_node.weight_proof import WeightProofHandler, _map_sub_epoch_summaries, _validate_summaries_weight
+from chia.full_node.weight_proof import (
+    WeightProofHandler,
+    _map_sub_epoch_summaries,
+    _validate_summaries_weight,
+)
+from chia.full_node.weight_proof import (
+    __validate_pospace as _validate_pospace_impl,
+)
 from chia.simulator.block_tools import BlockTools
 
 
@@ -516,3 +532,33 @@ class TestWeightProof:
         valid, fork_point, _ = await wpf.validate_weight_proof(new_wp)
         assert valid
         assert fork_point != 0
+
+    def test_validate_pospace_rejects_overflow_at_idx_0(self) -> None:
+        constants = DEFAULT_CONSTANTS
+        overflow_spi = uint8(constants.NUM_SPS_SUB_SLOT - 1)
+        overflow_sub_slot = SubSlotData(
+            None,  # proof_of_space
+            None,  # cc_signage_point
+            None,  # cc_infusion_point
+            None,  # icc_infusion_point
+            None,  # cc_sp_vdf_info
+            overflow_spi,  # signage_point_index
+            None,  # cc_slot_end
+            None,  # icc_slot_end
+            None,  # cc_slot_end_info
+            None,  # icc_slot_end_info
+            None,  # cc_ip_vdf_info
+            None,  # icc_ip_vdf_info
+            None,  # total_iters
+        )
+        segment = SubEpochChallengeSegment(uint32(0), [overflow_sub_slot], None)
+        result = _validate_pospace_impl(
+            constants,
+            segment,
+            0,
+            uint64(constants.DIFFICULTY_STARTING),
+            None,
+            True,
+            uint32(0),
+        )
+        assert result is None

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1371,6 +1371,9 @@ def __validate_pospace(
     sub_slot_data: SubSlotData = segment.sub_slots[idx]
 
     if sub_slot_data.signage_point_index and is_overflow_block(constants, sub_slot_data.signage_point_index):
+        if idx < 1:
+            log.error("overflow block at index 0 has no previous sub slot")
+            return None
         curr_slot = segment.sub_slots[idx - 1]
         assert curr_slot.cc_slot_end_info
         challenge = curr_slot.cc_slot_end_info.challenge


### PR DESCRIPTION
### Purpose:

Defensive hardening of `__validate_pospace` in the weight proof validation path.

When `idx == 0` and the sub-slot contains an overflow block, the code accesses `segment.sub_slots[idx - 1]`, which in Python silently resolves to `sub_slots[-1]` (the *last* element) rather than a predecessor slot. This is not currently exploitable because exceptions are caught upstream, but it is semantically incorrect and should be explicitly rejected.

The sister function `_get_challenge_block_vdfs` already has this exact guard (`sub_slot_idx >= 1` before accessing `sub_slots[sub_slot_idx - 1]`). This PR applies the same pattern to `__validate_pospace` for consistency.

### Current Behavior:

When `idx == 0` and the sub-slot is an overflow block, `segment.sub_slots[-1]` is read. This silently returns the wrong slot. In practice the subsequent `assert` on `cc_slot_end_info` or the PoSpace validation would fail, and the exception is caught by the caller — but the root cause is masked.

### New Behavior:

An explicit `idx < 1` guard now precedes the `segment.sub_slots[idx - 1]` access. If triggered, an error is logged and `None` is returned — the same rejection pattern used by all other validation failures in this function.

**Invariants unchanged:**

- No new error paths for well-formed weight proofs (overflow blocks at `idx >= 1` are unaffected)
- Return type and caller contract unchanged (`uint64 | None`)
- Logging level and message style consistent with adjacent error paths

### Testing Notes:

- Added `test_validate_pospace_rejects_overflow_at_idx_0` — directly constructs a `SubEpochChallengeSegment` with an overflow sub-slot at index 0 and verifies `__validate_pospace` returns `None`
- All 66 weight proof tests pass (65 original + 1 new, 5 skipped same as baseline)
- `ruff check`, `ruff format --check`, and `mypy` pass clean on both changed files
- `diff-cover --fail-under=100` passes (100% coverage on all changed lines)