### PR TITLE
[ASB-128] Fix flaky test_server_http_ban by freezing time.time()

### DIFF
--- a/chia/_tests/core/data_layer/test_data_store.py
+++ b/chia/_tests/core/data_layer/test_data_store.py
@@ -1233,8 +1233,10 @@ async def test_server_http_ban(
         if error:
             raise aiohttp.ClientConnectionError
 
-    start_timestamp = int(time.time())
+    frozen_time = time.time()
+    start_timestamp = int(frozen_time)
     with monkeypatch.context() as m:
+        m.setattr(time, "time", lambda: frozen_time)
         m.setattr("chia.data_layer.download_data.http_download", mock_http_download)
         success = await insert_from_delta_file(
             data_store=data_store,
@@ -1255,10 +1257,11 @@ async def test_server_http_ban(
     subscriptions = await data_store.get_subscriptions()
     sinfo = subscriptions[0].servers_info[0]
     assert sinfo.num_consecutive_failures == 1
-    assert sinfo.ignore_till >= start_timestamp + 5 * 60  # ban for 5 minutes
+    assert sinfo.ignore_till == start_timestamp + 5 * 60  # ban for 5 minutes
     start_timestamp = sinfo.ignore_till
 
     with monkeypatch.context() as m:
+        m.setattr(time, "time", lambda: frozen_time)
         m.setattr("chia.data_layer.download_data.http_download", mock_http_download)
         success = await insert_from_delta_file(
             data_store=data_store,


### PR DESCRIPTION
### Purpose:

Fix intermittent failure in `test_data_store.py`'s HTTP-ban test caused by wall-clock drift between sequential `insert_from_delta_file()` calls.

SyncStore changes have been split into a separate PR: #20769

### Current Behavior:

`insert_from_delta_file()` captures a fresh `int(time.time())` on each call. When the wall clock advances between two sequential calls, `max(old_ignore_till, new_timestamp + ban)` picks the newer value, breaking the strict `==` assertion. This causes intermittent test failures.

### New Behavior:

Freeze `time.time()` via `monkeypatch` so both calls see the same timestamp, making the `max()` computation deterministic. Tightened the first ban assertion from `>=` to `==` since the frozen clock guarantees an exact value.

Invariants unchanged: no production code modified; test-only change.

### Testing Notes:

- The patched test (`test_data_store.py`) now uses a frozen time source for deterministic assertions.
- No production code changes.