### PR TITLE
speed up the long-reorg tests by disabling VDF- and signature validation

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -3434,7 +3434,10 @@ class TestReorgs:
         test_long_reorg_blocks: list[FullBlock],
         test_long_reorg_blocks_light: list[FullBlock],
         consensus_mode: ConsensusMode,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        monkeypatch.setattr("chia.consensus.block_header_validation.validate_vdf", lambda *a, **kw: True)
+        monkeypatch.setattr("chia.consensus.block_header_validation.AugSchemeMPL.verify", lambda *a, **kw: True)
         if light_blocks:
             reorg_blocks = test_long_reorg_blocks_light[:1650]
         elif consensus_mode >= ConsensusMode.HARD_FORK_3_0:
@@ -4052,7 +4055,9 @@ async def test_chain_failed_rollback(empty_blockchain: Blockchain, bt: BlockTool
 
 @pytest.mark.anyio
 @pytest.mark.skipif(_is_macos_intel(), reason="Slow on macOS Intel")
-async def test_reorg_flip_flop(empty_blockchain: Blockchain, bt: BlockTools) -> None:
+async def test_reorg_flip_flop(empty_blockchain: Blockchain, bt: BlockTools, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("chia.consensus.block_header_validation.validate_vdf", lambda *a, **kw: True)
+    monkeypatch.setattr("chia.consensus.block_header_validation.AugSchemeMPL.verify", lambda *a, **kw: True)
     b = empty_blockchain
     wallet_a = WalletTool(b.constants)
     WALLET_A_PUZZLE_HASHES = [wallet_a.get_new_puzzlehash() for _ in range(5)]


### PR DESCRIPTION
Current timings on `main`:

```
544.86s call     .venv/lib/python3.12/site-packages/chia/_tests/blockchain/test_blockchain.py::TestReorgs::test_long_reorg[ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT-False]
496.21s call     .venv/lib/python3.12/site-packages/chia/_tests/blockchain/test_blockchain.py::TestReorgs::test_long_reorg[ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT-True]
```
See [here](https://github.com/Chia-Network/chia-blockchain/actions/runs/23875198556/job/69625800734)

timings in this PR:

```
273.12s call     .venv/lib/python3.12/site-packages/chia/_tests/blockchain/test_blockchain.py::TestReorgs::test_long_reorg[ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT-False]
226.15s call     .venv/lib/python3.12/site-packages/chia/_tests/blockchain/test_blockchain.py::TestReorgs::test_long_reorg[ConsensusMode.HARD_FORK_3_0_AFTER_PHASE_OUT-True]
```

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

Waste less time and CPU in CI.

The long-reorg tests are primarily meant to exercise our chain state being done efficiently and correctly. Things like updating the coin store and running the CLVM generators.

We used to validate reorged blocks very inefficiently, where the cost of validating a generated was linear to how long the fork-chain is. That's the case these tests are exercising.

VDFs and block signatures are still validated in other tests, and already has good coverage.

### Current Behavior:

We validate block signatures and VDFs (in our test chains, from `test-cache`)

### New Behavior:

We disable validating signatures and VDFs, to speed up the tests.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to test code, but it reduces validation coverage within the affected reorg tests and could hide regressions specifically in header/VDF/signature verification for those scenarios.
> 
> **Overview**
> Speeds up the slow reorg-focused blockchain tests by **monkeypatching header validation** to always accept VDF proofs and BLS signature verification.
> 
> `test_long_reorg` and `test_reorg_flip_flop` now take a `monkeypatch` fixture and stub out `validate_vdf` and `AugSchemeMPL.verify`, keeping these tests focused on reorg/chain-state behavior rather than cryptographic validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb58f43bb656e002498c5f6ad578c1fafe99db3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->