### PR TITLE
Add outbound handshake timeout in start_client

### DIFF
--- a/chia/_tests/core/server/test_server.py
+++ b/chia/_tests/core/server/test_server.py
@@ -79,6 +79,31 @@ async def test_start_client_handshake_timeout(
 
 
 @pytest.mark.anyio
+async def test_start_client_handshake_timeout_configurable(
+    two_nodes: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _, _, server_1, server_2, _ = two_nodes
+
+    recorded_timeouts: list[float | None] = []
+    original_wait_for = asyncio.wait_for
+
+    async def capturing_wait_for(fut: object, *, timeout: float | None = None) -> object:
+        recorded_timeouts.append(timeout)
+        return await original_wait_for(fut, timeout=timeout)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(asyncio, "wait_for", capturing_wait_for)
+    monkeypatch.setattr("chia.server.server.is_localhost", lambda _host: False)
+    server_1.config["outbound_handshake_timeout"] = 42
+    target_peer = PeerInfo(self_hostname, server_2.get_port())
+    with caplog.at_level(logging.DEBUG):
+        await server_1.start_client(target_peer, None)
+    assert 42.0 in recorded_timeouts
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize("method", [repr, str])
 async def test_connection_string_conversion(
     two_nodes_one_block: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],

--- a/chia/_tests/core/server/test_server.py
+++ b/chia/_tests/core/server/test_server.py
@@ -58,6 +58,27 @@ async def test_duplicate_client_connection(
 
 
 @pytest.mark.anyio
+async def test_start_client_handshake_timeout(
+    two_nodes: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _, _, server_1, server_2, _ = two_nodes
+
+    async def timeout_handshake(
+        self: WSChiaConnection, network_id: str, server_port: uint16, local_type: NodeType
+    ) -> None:
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(WSChiaConnection, "perform_handshake", timeout_handshake)
+    target_peer = PeerInfo(self_hostname, server_2.get_port())
+    with caplog.at_level(logging.DEBUG):
+        assert not await server_1.start_client(target_peer, None)
+    assert f"Handshake timeout connecting to {target_peer}" in caplog.text
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize("method", [repr, str])
 async def test_connection_string_conversion(
     two_nodes_one_block: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -506,7 +506,15 @@ class ChiaServer:
                 session=session,
                 exempt_peer_networks=self.exempt_peer_networks,
             )
-            await connection.perform_handshake(self._network_id, server_port, self._local_type)
+            handshake_timeout: float | None = (
+                None
+                if is_localhost(target_node.host) or is_in_network(target_node.host, self.exempt_peer_networks)
+                else 120.0
+            )
+            await asyncio.wait_for(
+                connection.perform_handshake(self._network_id, server_port, self._local_type),
+                timeout=handshake_timeout,
+            )
             await self.connection_added(connection, on_connect)
             # the session has been adopted by the connection, don't close it at
             # the end of the function
@@ -525,6 +533,10 @@ class ChiaServer:
                 self.log.debug(f"Feeler connection error. {e}")
             else:
                 self.log.info(f"{e}")
+        except asyncio.TimeoutError:
+            if connection is not None:
+                await connection.close()
+            self.log.debug(f"Handshake timeout connecting to {target_node}")
         except ProtocolError as e:
             if connection is not None:
                 await connection.close(self.invalid_protocol_ban_seconds, WSCloseCode.PROTOCOL_ERROR, e.code)

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -509,7 +509,7 @@ class ChiaServer:
             handshake_timeout: float | None = (
                 None
                 if is_localhost(target_node.host) or is_in_network(target_node.host, self.exempt_peer_networks)
-                else 120.0
+                else float(self.config.get("outbound_handshake_timeout", 120))
             )
             await asyncio.wait_for(
                 connection.perform_handshake(self._network_id, server_port, self._local_type),


### PR DESCRIPTION
### Purpose:

Prevent outbound connections from hanging indefinitely during the post-connect handshake window while keeping localhost and exempt-network behavior unchanged.

### Current Behavior:

`start_client()` performs `perform_handshake()` without an outbound-specific timeout. If that path stalls, it can linger until broader error handling catches it as a generic exception.

### New Behavior:

`start_client()` now wraps outbound `perform_handshake()` in `asyncio.wait_for()` with a `120.0` second timeout for non-localhost, non-exempt peers.

Localhost and exempt-network peers use `timeout=None` (no timeout), preserving current trusted/local behavior.

Handshake timeout failures are handled explicitly via `except asyncio.TimeoutError`, closing the connection cleanly and logging at debug level without protocol-ban semantics.

Invariants unchanged:
- Connection setup still uses existing TLS/session and duplicate/self checks.
- Protocol and network-id validation behavior remains in existing handlers.
- Localhost/exempt peers remain unbounded during handshake.
- Successful handshakes follow the same `connection_added()` flow and feeler behavior.

### Testing Notes:

- Added regression test: `chia/_tests/core/server/test_server.py::test_start_client_handshake_timeout`
- Ran Phase 1 checks: `ruff check`, `ruff format --check`, `mypy`
- Ran Phase 2 targets:
  - `pytest --cov=chia --cov-config=.coveragerc --cov-report= chia/_tests/core/server/test_server.py`
  - `pytest --cov=chia --cov-config=.coveragerc --cov-report= chia/_tests/farmer_harvester/test_third_party_harvesters.py::test_harvester_receive_source_signing_data`
  - Combined coverage run for diff-cover:
    - `pytest --cov=chia --cov-config=.coveragerc --cov-report= chia/_tests/core/server/test_server.py chia/_tests/farmer_harvester/test_third_party_harvesters.py::test_harvester_receive_source_signing_data`
- Ran Phase 3 benchmarks:
  - `pytest -m benchmark -n 0 --capture no --ignore=chia/_tests/tools/test_legacy_keyring.py chia/_tests/`
- Ran Phase 4 diff coverage:
  - `coverage xml --rcfile=.coveragerc -o coverage.xml`
  - `diff-cover --config-file=.diffcover.toml --compare-branch=origin/main --fail-under=100 coverage.xml` (100%)
- Ran Phase 5 pre-push gate:
  - `pre-commit run --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound connection establishment by enforcing a handshake timeout and explicitly handling `asyncio.TimeoutError`, which could affect peer connectivity and retry behavior if misconfigured or in slow networks.
> 
> **Overview**
> Prevents outbound peer connections from hanging during `start_client()` by wrapping `WSChiaConnection.perform_handshake()` in `asyncio.wait_for()` with a configurable `outbound_handshake_timeout` (default `120s`), while keeping localhost and `exempt_peer_networks` unbounded (`timeout=None`).
> 
> Adds explicit timeout handling to close the connection cleanly and log a debug message, plus new tests covering handshake timeout behavior and verifying the timeout value is configurable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00766da7925e3415bad9febc1d79d1b4e589af6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->