### PR TITLE
[CHIA-4180] Detect spend bundle rejections early in wallet test framework

### DIFF
--- a/chia/_tests/environments/wallet.py
+++ b/chia/_tests/environments/wallet.py
@@ -278,7 +278,7 @@ class WalletEnvironment:
             if tx.type not in CLAWBACK_INCOMING_TRANSACTION_TYPES and tx.name not in _exclude_from_mempool_check
         ]
         # Ensure txs enter mempool and are marked as such locally
-        await full_node_api.wait_transaction_records_entered_mempool(pending_txs)
+        await full_node_api.wait_transaction_records_entered_mempool(pending_txs, wallet_node=self.node)
         await full_node_api.wait_transaction_records_marked_as_in_mempool([tx.name for tx in pending_txs], self.node)
 
         return pending_txs
@@ -383,8 +383,8 @@ class WalletTestFramework:
                         await env.check_balances(transition.pre_block_additional_balance_info)
                 except Exception:
                     raise ValueError(f"Error with env index {i}")
-        except Exception:
-            raise ValueError("Error before block was farmed")
+        except Exception as e:
+            raise ValueError(f"Error before block was farmed: {e}") from e
 
         # Farm block
         await self.full_node.farm_blocks_to_puzzlehash(count=1, guarantee_transaction_blocks=True)
@@ -409,8 +409,8 @@ class WalletTestFramework:
                         await env.check_balances(transition.post_block_additional_balance_info)
                 except Exception:
                     raise ValueError(f"Error with env {i}")
-        except Exception:
-            raise ValueError("Error after block was farmed")
+        except Exception as e:
+            raise ValueError(f"Error after block was farmed: {e}") from e
 
         # Make sure all pending txs from before the block are now confirmed
         for i, (env, txs) in enumerate(zip(self.environments, pending_txs)):

--- a/chia/_tests/simulation/test_simulator.py
+++ b/chia/_tests/simulation/test_simulator.py
@@ -14,6 +14,7 @@ from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.peer_info import PeerInfo
 from chia.util.errors import Err
+from chia.wallet.transaction_record import minimum_send_attempts
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.wallet_node import WalletNode
 
@@ -311,9 +312,12 @@ async def test_wait_mempool_skips_in_mempool_wallet_records(
 
 
 @pytest.mark.anyio
-async def test_wait_mempool_fast_fail_on_rejection(
+async def test_wait_mempool_allows_retries_before_giving_up(
     simulator_and_wallet: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
 ) -> None:
+    """A transaction that has been rejected fewer than minimum_send_attempts
+    times is still considered valid by the wallet.  The mempool wait should
+    keep polling (not fast-fail) so the wallet's retry mechanism can succeed."""
     [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
     await wallet_server.start_client(PeerInfo("127.0.0.1", full_node_api.server.get_port()), None)
     assert wallet_node.wallet_state_manager is not None
@@ -330,16 +334,66 @@ async def test_wait_mempool_fast_fail_on_rejection(
     [tx] = action_scope.side_effects.transactions
     assert tx.spend_bundle is not None
 
-    failed_record = dataclasses.replace(
+    few_failures_record = dataclasses.replace(
         tx,
         sent_to=[("peer1", uint8(MempoolInclusionStatus.FAILED.value), Err.INVALID_SPEND_BUNDLE.name)],
     )
+    assert few_failures_record.is_valid()
+
+    # Iteration 1: mempool empty, wallet record still valid → keep polling
+    # Iteration 2: mempool returns the bundle → success
+    with (
+        patch.object(
+            full_node_api.full_node.mempool_manager,
+            "get_spendbundle",
+            side_effect=[None, tx.spend_bundle],
+        ),
+        patch.object(
+            wallet_node.wallet_state_manager.tx_store,
+            "get_transaction_record",
+            return_value=few_failures_record,
+        ),
+    ):
+        await full_node_api.wait_transaction_records_entered_mempool(records=[tx], wallet_node=wallet_node)
+
+
+@pytest.mark.anyio
+async def test_wait_mempool_fast_fail_after_retries_exhausted(
+    simulator_and_wallet: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+) -> None:
+    """Once the wallet has exhausted its retry attempts (is_valid() returns
+    False), the mempool wait should fail fast with the rejection error instead
+    of silently waiting for the timeout."""
+    [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
+    await wallet_server.start_client(PeerInfo("127.0.0.1", full_node_api.server.get_port()), None)
+    assert wallet_node.wallet_state_manager is not None
+    wallet = wallet_node.wallet_state_manager.main_wallet
+    await full_node_api.farm_rewards_to_wallet(amount=1, wallet=wallet)
+
+    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=False) as action_scope:
+        await wallet.generate_signed_transaction(
+            amounts=[uint64(1)],
+            puzzle_hashes=[await action_scope.get_puzzle_hash(wallet.wallet_state_manager)],
+            action_scope=action_scope,
+        )
+
+    [tx] = action_scope.side_effects.transactions
+    assert tx.spend_bundle is not None
+
+    exhausted_record = dataclasses.replace(
+        tx,
+        sent_to=[
+            (f"peer{i}", uint8(MempoolInclusionStatus.FAILED.value), Err.INVALID_SPEND_BUNDLE.name)
+            for i in range(minimum_send_attempts)
+        ],
+    )
+    assert not exhausted_record.is_valid()
 
     with (
         patch.object(
             wallet_node.wallet_state_manager.tx_store,
             "get_transaction_record",
-            return_value=failed_record,
+            return_value=exhausted_record,
         ),
         pytest.raises(RuntimeError, match="was rejected"),
     ):

--- a/chia/_tests/simulation/test_simulator.py
+++ b/chia/_tests/simulation/test_simulator.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import dataclasses
+from unittest.mock import patch
+
 import pytest
-from chia_rs.sized_ints import uint64
+from chia_rs.sized_ints import uint8, uint64
 
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
 from chia.cmds.units import units
 from chia.server.server import ChiaServer
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator
+from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.peer_info import PeerInfo
+from chia.util.errors import Err
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.wallet_node import WalletNode
 
@@ -230,3 +235,112 @@ async def test_create_coins_with_invalid_amounts_raises(
             amounts=amounts,  # type: ignore[arg-type]
             wallet=wallet,
         )
+
+
+@pytest.mark.anyio
+async def test_add_transaction_value_error_returns_failed(
+    simulator_and_wallet: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+) -> None:
+    [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
+    await wallet_server.start_client(PeerInfo("127.0.0.1", full_node_api.server.get_port()), None)
+    assert wallet_node.wallet_state_manager is not None
+    wallet = wallet_node.wallet_state_manager.main_wallet
+    await full_node_api.farm_rewards_to_wallet(amount=1, wallet=wallet)
+
+    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=False) as action_scope:
+        await wallet.generate_signed_transaction(
+            amounts=[uint64(1)],
+            puzzle_hashes=[await action_scope.get_puzzle_hash(wallet.wallet_state_manager)],
+            action_scope=action_scope,
+        )
+
+    [tx] = action_scope.side_effects.transactions
+    assert tx.spend_bundle is not None
+
+    with patch.object(
+        full_node_api.full_node.mempool_manager,
+        "pre_validate_spendbundle",
+        side_effect=ValueError("too many pairs"),
+    ):
+        status, err = await full_node_api.full_node.add_transaction(tx.spend_bundle, tx.spend_bundle.name())
+
+    assert status == MempoolInclusionStatus.FAILED
+    assert err == Err.INVALID_SPEND_BUNDLE
+
+
+@pytest.mark.anyio
+async def test_wait_mempool_skips_in_mempool_wallet_records(
+    simulator_and_wallet: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+) -> None:
+    [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
+    await wallet_server.start_client(PeerInfo("127.0.0.1", full_node_api.server.get_port()), None)
+    assert wallet_node.wallet_state_manager is not None
+    wallet = wallet_node.wallet_state_manager.main_wallet
+    await full_node_api.farm_rewards_to_wallet(amount=1, wallet=wallet)
+
+    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=False) as action_scope:
+        await wallet.generate_signed_transaction(
+            amounts=[uint64(1)],
+            puzzle_hashes=[await action_scope.get_puzzle_hash(wallet.wallet_state_manager)],
+            action_scope=action_scope,
+        )
+
+    [tx] = action_scope.side_effects.transactions
+    assert tx.spend_bundle is not None
+
+    in_mempool_record = dataclasses.replace(
+        tx,
+        sent_to=[("peer1", uint8(MempoolInclusionStatus.SUCCESS.value), None)],
+    )
+
+    # Iteration 1: mempool has no bundle → wallet reports in_mempool → continue (skip)
+    # Iteration 2: mempool returns bundle → ids_to_check empty → return
+    with (
+        patch.object(
+            full_node_api.full_node.mempool_manager,
+            "get_spendbundle",
+            side_effect=[None, tx.spend_bundle],
+        ),
+        patch.object(
+            wallet_node.wallet_state_manager.tx_store,
+            "get_transaction_record",
+            return_value=in_mempool_record,
+        ),
+    ):
+        await full_node_api.wait_transaction_records_entered_mempool(records=[tx], wallet_node=wallet_node)
+
+
+@pytest.mark.anyio
+async def test_wait_mempool_fast_fail_on_rejection(
+    simulator_and_wallet: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+) -> None:
+    [[full_node_api], [[wallet_node, wallet_server]], _] = simulator_and_wallet
+    await wallet_server.start_client(PeerInfo("127.0.0.1", full_node_api.server.get_port()), None)
+    assert wallet_node.wallet_state_manager is not None
+    wallet = wallet_node.wallet_state_manager.main_wallet
+    await full_node_api.farm_rewards_to_wallet(amount=1, wallet=wallet)
+
+    async with wallet.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=False) as action_scope:
+        await wallet.generate_signed_transaction(
+            amounts=[uint64(1)],
+            puzzle_hashes=[await action_scope.get_puzzle_hash(wallet.wallet_state_manager)],
+            action_scope=action_scope,
+        )
+
+    [tx] = action_scope.side_effects.transactions
+    assert tx.spend_bundle is not None
+
+    failed_record = dataclasses.replace(
+        tx,
+        sent_to=[("peer1", uint8(MempoolInclusionStatus.FAILED.value), Err.INVALID_SPEND_BUNDLE.name)],
+    )
+
+    with (
+        patch.object(
+            wallet_node.wallet_state_manager.tx_store,
+            "get_transaction_record",
+            return_value=failed_record,
+        ),
+        pytest.raises(RuntimeError, match="was rejected"),
+    ):
+        await full_node_api.wait_transaction_records_entered_mempool(records=[tx], wallet_node=wallet_node)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2815,10 +2815,10 @@ class FullNode:
         except ValueError as e:
             # ValueError is used to indicate a soft failure. We don't want to
             # ban the peer
-            self.log.warning(f"Rejecting transaction {spend_name}: {e}")
+            self.log.info(f"Rejecting transaction {spend_name}: {e}")
             return MempoolInclusionStatus.FAILED, Err.INVALID_SPEND_BUNDLE
         except ValidationError as e:
-            self.log.warning(f"Rejecting transaction {spend_name}: {e.code}")
+            self.log.info(f"Rejecting transaction {spend_name}: {e.code}")
             self.mempool_manager.add_and_maybe_pop_seen(spend_name)
             return MempoolInclusionStatus.FAILED, e.code
 

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2815,10 +2815,10 @@ class FullNode:
         except ValueError as e:
             # ValueError is used to indicate a soft failure. We don't want to
             # ban the peer
-            self.log.info(f"Rejecting transaction {spend_name}: {e}")
+            self.log.warning(f"Rejecting transaction {spend_name}: {e}")
             return MempoolInclusionStatus.FAILED, Err.INVALID_SPEND_BUNDLE
         except ValidationError as e:
-            self.log.info(f"Rejecting transaction {spend_name}: {e.code}")
+            self.log.warning(f"Rejecting transaction {spend_name}: {e.code}")
             self.mempool_manager.add_and_maybe_pop_seen(spend_name)
             return MempoolInclusionStatus.FAILED, e.code
 

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -27,7 +27,6 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.validation_state import ValidationState
 from chia.util.config import lock_and_load_config, save_config
-from chia.util.errors import Err
 from chia.util.timing import adjusted_timeout, backoff_times
 from chia.wallet.conditions import CreateCoin
 from chia.wallet.transaction_record import LightTransactionRecord, TransactionRecord
@@ -484,10 +483,6 @@ class FullNodeSimulator(FullNodeAPI):
             await self.farm_blocks_to_wallet(count=count, wallet=wallet, timeout=None)
             return rewards
 
-    _TEMPORARY_MEMPOOL_ERRORS: frozenset[str] = frozenset(
-        {Err.INVALID_FEE_LOW_FEE.name, Err.INVALID_FEE_TOO_CLOSE_TO_ZERO.name}
-    )
-
     async def wait_transaction_records_entered_mempool(
         self,
         records: Collection[TransactionRecord | LightTransactionRecord],
@@ -500,8 +495,10 @@ class FullNodeSimulator(FullNodeAPI):
         Arguments:
             records: The transaction records to wait for.
             wallet_node: If provided, the wallet's transaction store is polled
-                for non-recoverable rejection errors so the wait can fail fast
-                instead of running until the timeout.
+                so that once the wallet has exhausted its retry attempts for a
+                transaction (``tx_record.is_valid()`` returns ``False``), the
+                wait fails fast with the last rejection error instead of running
+                until the timeout.
         """
         with anyio.fail_after(delay=adjusted_timeout(timeout)):
             ids_to_check: set[bytes32] = set()
@@ -534,16 +531,19 @@ class FullNodeSimulator(FullNodeAPI):
                         tx_record = await wallet_node.wallet_state_manager.tx_store.get_transaction_record(tx_name)
                         if tx_record is None or tx_record.is_in_mempool():
                             continue
-                        for _, status, error in tx_record.sent_to:
-                            if (
-                                status == MempoolInclusionStatus.FAILED.value
-                                and error is not None
-                                and error not in self._TEMPORARY_MEMPOOL_ERRORS
-                            ):
-                                raise RuntimeError(
-                                    f"Transaction {tx_name.hex()} was rejected: {error}. "
-                                    f"Failing fast instead of waiting for mempool timeout."
-                                )
+                        if not tx_record.is_valid():
+                            last_error = next(
+                                (
+                                    error
+                                    for _, status, error in reversed(tx_record.sent_to)
+                                    if status == MempoolInclusionStatus.FAILED.value and error is not None
+                                ),
+                                "unknown",
+                            )
+                            raise RuntimeError(
+                                f"Transaction {tx_name.hex()} was rejected: {last_error}. "
+                                f"Failing fast — wallet exhausted retries."
+                            )
 
                 await asyncio.sleep(backoff)
 

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -505,13 +505,16 @@ class FullNodeSimulator(FullNodeAPI):
         """
         with anyio.fail_after(delay=adjusted_timeout(timeout)):
             ids_to_check: set[bytes32] = set()
-            tx_names: set[bytes32] = set()
+            bundle_to_tx_names: dict[bytes32, set[bytes32]] = {}
             for record in records:
                 if record.spend_bundle is None:
                     continue
 
-                ids_to_check.add(record.spend_bundle.name())
-                tx_names.add(record.name)
+                bundle_id = record.spend_bundle.name()
+                ids_to_check.add(bundle_id)
+                bundle_to_tx_names.setdefault(bundle_id, set()).add(record.name)
+
+            pending_tx_names: set[bytes32] = {n for names in bundle_to_tx_names.values() for n in names}
 
             for backoff in backoff_times():
                 found = set()
@@ -519,15 +522,17 @@ class FullNodeSimulator(FullNodeAPI):
                     tx = self.full_node.mempool_manager.get_spendbundle(spend_bundle_name)
                     if tx is not None:
                         found.add(spend_bundle_name)
-                ids_to_check = ids_to_check.difference(found)
+                ids_to_check -= found
+                for bundle_id in found:
+                    pending_tx_names -= bundle_to_tx_names.get(bundle_id, set())
 
                 if len(ids_to_check) == 0:
                     return
 
                 if wallet_node is not None:
-                    for tx_name in tx_names:
+                    for tx_name in pending_tx_names:
                         tx_record = await wallet_node.wallet_state_manager.tx_store.get_transaction_record(tx_name)
-                        if tx_record is None:
+                        if tx_record is None or tx_record.is_in_mempool():
                             continue
                         for _, status, error in tx_record.sent_to:
                             if (

--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -24,8 +24,10 @@ from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol, GetAllCoinsProtocol, ReorgProtocol
 from chia.types.blockchain_format.coin import Coin
+from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.validation_state import ValidationState
 from chia.util.config import lock_and_load_config, save_config
+from chia.util.errors import Err
 from chia.util.timing import adjusted_timeout, backoff_times
 from chia.wallet.conditions import CreateCoin
 from chia.wallet.transaction_record import LightTransactionRecord, TransactionRecord
@@ -482,24 +484,34 @@ class FullNodeSimulator(FullNodeAPI):
             await self.farm_blocks_to_wallet(count=count, wallet=wallet, timeout=None)
             return rewards
 
+    _TEMPORARY_MEMPOOL_ERRORS: frozenset[str] = frozenset(
+        {Err.INVALID_FEE_LOW_FEE.name, Err.INVALID_FEE_TOO_CLOSE_TO_ZERO.name}
+    )
+
     async def wait_transaction_records_entered_mempool(
         self,
         records: Collection[TransactionRecord | LightTransactionRecord],
         timeout: float | None = 5,
+        wallet_node: WalletNode | None = None,
     ) -> None:
         """Wait until the transaction records have entered the mempool.  Transaction
         records with no spend bundle are ignored.
 
         Arguments:
             records: The transaction records to wait for.
+            wallet_node: If provided, the wallet's transaction store is polled
+                for non-recoverable rejection errors so the wait can fail fast
+                instead of running until the timeout.
         """
         with anyio.fail_after(delay=adjusted_timeout(timeout)):
             ids_to_check: set[bytes32] = set()
+            tx_names: set[bytes32] = set()
             for record in records:
                 if record.spend_bundle is None:
                     continue
 
                 ids_to_check.add(record.spend_bundle.name())
+                tx_names.add(record.name)
 
             for backoff in backoff_times():
                 found = set()
@@ -511,6 +523,22 @@ class FullNodeSimulator(FullNodeAPI):
 
                 if len(ids_to_check) == 0:
                     return
+
+                if wallet_node is not None:
+                    for tx_name in tx_names:
+                        tx_record = await wallet_node.wallet_state_manager.tx_store.get_transaction_record(tx_name)
+                        if tx_record is None:
+                            continue
+                        for _, status, error in tx_record.sent_to:
+                            if (
+                                status == MempoolInclusionStatus.FAILED.value
+                                and error is not None
+                                and error not in self._TEMPORARY_MEMPOOL_ERRORS
+                            ):
+                                raise RuntimeError(
+                                    f"Transaction {tx_name.hex()} was rejected: {error}. "
+                                    f"Failing fast instead of waiting for mempool timeout."
+                                )
 
                 await asyncio.sleep(backoff)
 


### PR DESCRIPTION
### Purpose:

Wallet tests that use `process_pending_states` silently wait the full 5-second
mempool timeout when a spend bundle is rejected by the full node. The test then
fails with a generic `ValueError("Error before block was farmed")`, losing the
actual rejection reason. This makes CI flake investigations difficult — you have
to dig through captured log output to find the real cause.

### Current Behavior:

`wait_transaction_records_entered_mempool` polls only the mempool. If a spend
bundle is permanently rejected (e.g. coins already spent, invalid puzzle), it
never enters the mempool. The wallet retries up to `minimum_send_attempts` (6)
times, but the test framework doesn't observe this — it just loops until the
5-second `anyio.fail_after` fires with a generic timeout error.

`process_pending_states` then wraps that timeout in:

```
ValueError("Error before block was farmed")
```

The actual rejection reason (e.g. `INVALID_SPEND_BUNDLE`) is only visible in
captured log output, requiring manual investigation.

### New Behavior:

When a `wallet_node` is provided to `wait_transaction_records_entered_mempool`,
the method now polls the wallet's transaction store on each iteration. It uses
the wallet's own `tx_record.is_valid()` to determine whether to fast-fail:

- **While `is_valid()` is True** (fewer than 6 failed attempts, or any SUCCESS,
  or only fee-related errors): keep polling. The wallet's retry mechanism may
  still recover the transaction (e.g. transient validation timeouts on loaded
  CI runners).
- **Once `is_valid()` returns False** (wallet has exhausted retries): raise
  `RuntimeError` immediately with the last rejection error, e.g.:

```
RuntimeError: Transaction abc123... was rejected: INVALID_SPEND_BUNDLE. Failing fast — wallet exhausted retries.
```

This is then wrapped by `process_pending_states` into:

```
ValueError: Error before block was farmed: Transaction abc123... was rejected: INVALID_SPEND_BUNDLE. Failing fast — wallet exhausted retries.
```

This approach delegates retry/give-up policy to the wallet's existing
`TransactionRecord.is_valid()` logic rather than maintaining a separate error
classification list in the test framework. The wallet already knows which errors
are temporary (fee-related) and how many retries to attempt — the test framework
just observes the verdict.

**Invariants unchanged:**
- `wait_transaction_records_entered_mempool` without `wallet_node` behaves
  exactly as before (pure mempool polling with timeout)
- The 5-second timeout still applies as an outer bound
- `process_pending_states` error wrapping behavior is unchanged (propagates
  the exception message via `from e`)
- `ValueError` return type from `process_pending_states` is unchanged

### Testing Notes:

Three new/updated tests in `test_simulator.py`:

- `test_add_transaction_value_error_returns_failed` — verifies `ValueError`
  from `pre_validate_spendbundle` maps to `INVALID_SPEND_BUNDLE`
- `test_wait_mempool_allows_retries_before_giving_up` — a transaction with
  one FAILED entry is still `is_valid()`, so the wait keeps polling and
  succeeds when the bundle appears in the mempool on the next iteration
- `test_wait_mempool_fast_fail_after_retries_exhausted` — a transaction with
  `minimum_send_attempts` FAILED entries is not `is_valid()`, triggering
  immediate RuntimeError with the rejection reason