### PR TITLE
[ASB-128] Fix SyncStore handling of stale peaks and empty peer entries

### DIFF
--- a/chia/_tests/core/full_node/stores/test_sync_store.py
+++ b/chia/_tests/core/full_node/stores/test_sync_store.py
@@ -142,3 +142,50 @@ async def test_backtrack_syncing_removes_on_disconnect(seeded_random: random.Ran
 
     store.peer_disconnected(node_id=node_id)
     assert node_id not in store._backtrack_syncing
+
+
+@pytest.mark.anyio
+async def test_get_heaviest_peak_returns_none_when_peaks_evicted() -> None:
+    """get_heaviest_peak() returns None (not AssertionError) when all peaks are evicted from peak_to_peer."""
+    store = SyncStore()
+    legit_peer = std_hash(b"legit")
+    legit_hash = std_hash(b"legit_block")
+    store.peer_has_block(legit_hash, legit_peer, uint128(1000), uint32(100), True)
+
+    # Flood peak_to_peer with unique hashes to evict the legitimate entry
+    attacker = std_hash(b"attacker")
+    for i in range(300):
+        store.peer_has_block(std_hash(i.to_bytes(4, "big")), attacker, uint128(500), uint32(50), i == 299)
+
+    # Attacker disconnects — their peer_to_peak entry is removed but
+    # empty-set entries in peak_to_peer persist (before the cleanup fix)
+    store.peer_disconnected(attacker)
+
+    # Legitimate peer is still in peer_to_peak but their hash was evicted from peak_to_peer
+    assert legit_peer in store.peer_to_peak
+    assert legit_hash not in store.peak_to_peer
+
+    # Should return None, not raise AssertionError
+    assert store.get_heaviest_peak() is None
+
+
+@pytest.mark.anyio
+async def test_peer_disconnected_cleans_empty_peak_to_peer_entries() -> None:
+    """peer_disconnected() removes peak_to_peer entries that have no remaining peers."""
+    store = SyncStore()
+    peer_a = std_hash(b"peer_a")
+    peer_b = std_hash(b"peer_b")
+    block_hash = std_hash(b"shared_block")
+
+    store.peer_has_block(block_hash, peer_a, uint128(100), uint32(10), True)
+    store.peer_has_block(block_hash, peer_b, uint128(100), uint32(10), True)
+    assert block_hash in store.peak_to_peer
+    assert store.peak_to_peer[block_hash] == {peer_a, peer_b}
+
+    store.peer_disconnected(peer_a)
+    assert block_hash in store.peak_to_peer
+    assert store.peak_to_peer[block_hash] == {peer_b}
+
+    store.peer_disconnected(peer_b)
+    # After both peers disconnect, the empty entry should be cleaned up
+    assert block_hash not in store.peak_to_peer

--- a/chia/full_node/sync_store.py
+++ b/chia/full_node/sync_store.py
@@ -116,17 +116,19 @@ class SyncStore:
                 continue
             if heaviest_peak is None or peak.weight > heaviest_peak.weight:
                 heaviest_peak = peak
-        assert heaviest_peak is not None
         return heaviest_peak
 
     def peer_disconnected(self, node_id: bytes32) -> None:
         if node_id in self.peer_to_peak:
             del self.peer_to_peak[node_id]
 
+        empty_hashes: list[bytes32] = []
         for peak, peers in self.peak_to_peer.items():
-            if node_id in peers:
-                self.peak_to_peer[peak].remove(node_id)
-            assert node_id not in self.peak_to_peer[peak]
+            peers.discard(node_id)
+            if not peers:
+                empty_hashes.append(peak)
+        for h in empty_hashes:
+            del self.peak_to_peer[h]
 
         self._backtrack_syncing.pop(node_id, None)
 


### PR DESCRIPTION
### Purpose:

Fix two edge cases in `SyncStore` that could cause assertion failures or stale data accumulation:
- `get_heaviest_peak()` could `AssertionError` when all tracked peer peaks had been evicted from `peak_to_peer` (LRU overflow).
- `peer_disconnected()` left empty sets in `peak_to_peer` after removing the last peer for a given hash.

Split from #20759 per reviewer feedback (unrelated to the flaky test fix in that PR).

### Current Behavior:

- `get_heaviest_peak()` asserts `heaviest_peak is not None` even when eviction has removed all referenced hashes from `peak_to_peer`, causing an `AssertionError`.
- `peer_disconnected()` uses `remove()` + a post-condition `assert` instead of `discard()`, and never cleans up empty sets from `peak_to_peer`.

### New Behavior:

- `get_heaviest_peak()` returns `None` when no valid tracked peak remains (the caller already handles `None`).
- `peer_disconnected()` uses `discard()` and removes empty `peak_to_peer` entries, keeping the map clean.

Invariants unchanged: caller contracts for `get_heaviest_peak()` already handle `None`; no new error paths introduced.

### Testing Notes:

- Added `test_get_heaviest_peak_returns_none_when_peaks_evicted` — verifies `None` return instead of `AssertionError` after LRU eviction.
- Added `test_peer_disconnected_cleans_empty_peak_to_peer_entries` — verifies empty-set cleanup on disconnect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches full-node sync state bookkeeping: returning `None` for heaviest peak and pruning `peak_to_peer` entries changes behavior during peer churn/evictions and could affect sync peer selection if assumptions elsewhere are wrong.
> 
> **Overview**
> Prevents `SyncStore.get_heaviest_peak()` from asserting when all `peer_to_peak` entries reference peaks that have been evicted from `peak_to_peer`; it now returns `None` in that case.
> 
> Updates `SyncStore.peer_disconnected()` to use `discard()` and to delete `peak_to_peer` entries whose peer sets become empty, avoiding accumulation of stale empty mappings. Adds tests covering LRU-eviction + disconnect behavior and empty-set cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff93190982ce1cd0acfb116bca388bcaab8878d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->