### PR TITLE
Update poetry.lock to fix pre-commit CI failures

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -953,6 +953,12 @@ optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
+    {file = "chialisp-0.4.1-cp310-abi3-macosx_15_0_arm64.whl", hash = "sha256:acfb22291189af9e8cdcf59c2618327e35f6cbb643f7d96d21b9f6488ae317c4"},
+    {file = "chialisp-0.4.1-cp310-abi3-macosx_15_0_x86_64.whl", hash = "sha256:b59dcca36571a4a06312f6b6955ff172794b27c7936d052dddc56a8a7f657059"},
+    {file = "chialisp-0.4.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:cd3a8ed6cab8e8cad76715c7b880b009a0895757d10b751549c3fbb8ce5b4cfe"},
+    {file = "chialisp-0.4.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0903d73f21e9a56243f6d1180a34c9385edc5369fe4909282beb567a8ae190bd"},
+    {file = "chialisp-0.4.1-cp310-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:0af3af4635cf1f14967a133180578361c236484010762741f0ee82360241e693"},
+    {file = "chialisp-0.4.1-cp310-abi3-win_amd64.whl", hash = "sha256:f7e2d264c5dd272890f477316b081431c72ca4b1b49dd6d2555f0fc6edddff09"},
     {file = "chialisp-0.4.1-cp39-abi3-macosx_13_0_arm64.whl", hash = "sha256:8f5847359869218053cdc2a326acd43b122e657bfa50de15af3a6b690f791444"},
     {file = "chialisp-0.4.1-cp39-abi3-macosx_13_0_x86_64.whl", hash = "sha256:c5a94ab4124d2d03416d9692d8e0542f547f8d27c3171811a90de6815db1f2f3"},
     {file = "chialisp-0.4.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ffb0e4627d64d160b6a49bdce356d2af16dae5c6eec818eba551aeb39525c830"},


### PR DESCRIPTION
### Purpose:

The `poetry` pre-commit hook is failing on every PR (all build-matrix cells) because
`poetry.lock` on `main` is stale. The hook runs `poetry lock` (without `--no-update`),
which re-resolves dependencies with a clean cache, discovers new wheel files for
`chialisp` 0.4.1 (cp310-abi3 platform builds published after the lock was committed
on April 2), writes an updated lock file, and fails with "files were modified by this hook."

This PR refreshes the lock file so `poetry lock` is idempotent again.

### Current Behavior:

The `poetry` pre-commit hook fails in CI on every PR with:
```
poetry...................................................................Failed
- hook id: poetry
- files were modified by this hook
```
`poetry lock` re-resolves and writes 6 new `chialisp` wheel hashes into `poetry.lock`.

### New Behavior:

`poetry lock` produces no changes — the lock file is already up to date.
All 18 pre-commit hooks pass.

**Invariants unchanged:** No dependency versions changed. No `pyproject.toml` changes.
Only newly-published wheel hashes for the existing `chialisp==0.4.1` are added to the lock.

### Testing Notes:

- `poetry check --strict` passes
- `pre-commit run poetry --all-files` passes (no "files were modified" failure)
- `pre-commit run --all-files` passes (all 18 hooks)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only change: no version bumps or code changes, just additional wheel hashes for an existing dependency to make CI deterministic.
> 
> **Overview**
> Updates `poetry.lock` to add the newly published `chialisp==0.4.1` `cp310-abi3` wheel entries (macOS, Linux, musllinux, Windows) so `poetry lock` is idempotent and the `poetry` pre-commit hook stops failing due to lockfile rewrites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa4fb58c7db08d14da8df574297e6252c34292a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->