### PR TITLE
Fix flaky test_harvester_restart timing assertion

### DIFF
--- a/chia/_tests/plot_sync/test_plot_sync.py
+++ b/chia/_tests/plot_sync/test_plot_sync.py
@@ -516,9 +516,9 @@ async def test_harvester_restart(environment: Environment) -> None:
     env: Environment = environment
     # Load all directories for both harvesters
     await add_and_validate_all_directories(env)
-    # Stop the harvester and make sure the receiver gets dropped on the farmer and refreshing gets stopped
+    # Stop the harvester and wait for the receiver to be dropped on the farmer (async via on_disconnect)
     await env.split_harvester_managers[0].exit()
-    assert len(env.farmer.plot_sync_receivers) == 1
+    await time_out_assert(5, lambda: len(env.farmer.plot_sync_receivers), 1)
     assert not env.harvesters[0].plot_manager._refreshing_enabled
     assert not env.harvesters[0].plot_manager.needs_refresh()
     # Start the harvester, wait for the handshake and make sure the receiver comes back


### PR DESCRIPTION
### Purpose:

Fix a flaky timing assertion in `test_harvester_restart` that intermittently
fails on slower CI runners (observed on macOS-intel `plot_sync` job).

### Current Behavior:

After stopping harvester 0, the test immediately asserts
`len(env.farmer.plot_sync_receivers) == 1`. The farmer removes the receiver in
its `on_disconnect` callback, which runs asynchronously when the network layer
processes the peer disconnection. On slower runners the callback hasn't fired
yet, so the assertion finds 2 receivers instead of 1.

### New Behavior:

The bare `assert` is replaced with `await time_out_assert(5, ...)`, which polls
every 50 ms for up to 5 seconds until the farmer processes the disconnection.
This matches the pattern already used elsewhere in the same file (e.g.
`test_farmer_restart` lines 554-556).

Invariants unchanged — the test still validates the same condition, just with
tolerance for async processing delay.

### Testing Notes:

- `test_harvester_restart` passes locally
- All pre-commit hooks pass
- ruff, ruff format, mypy all clean on the changed file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that replaces a timing-sensitive assertion with a bounded wait, reducing CI flakiness without changing production behavior.
> 
> **Overview**
> Fixes a flaky `test_harvester_restart` assertion by replacing the immediate receiver-count check after stopping a harvester with `time_out_assert(...)` to wait for the farmer’s async disconnect handling.
> 
> This keeps the same invariant (`plot_sync_receivers` drops to 1) but makes the test tolerant of slower runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec936abddb3474b0d10c9be652549bfd4ac1075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->