### PR TITLE
Replace assert with explicit check for unknown parent block

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3720,6 +3720,25 @@ async def test_request_header_blocks_non_tx_block(
     assert len(response.header_blocks) == 2
 
 
+@pytest.mark.limit_consensus_modes(reason="save time")
+@pytest.mark.anyio
+async def test_add_block_missing_prev_record_raises_value_error(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    full_node_api, _server, bt = one_node_one_block
+    blocks = bt.get_consecutive_blocks(1, await full_node_api.get_all_full_blocks())
+    block = blocks[-1]
+
+    async def missing_block_record(_header_hash: bytes32) -> None:
+        return None
+
+    monkeypatch.setattr(full_node_api.full_node.blockchain, "get_block_record_from_db", missing_block_record)
+
+    with pytest.raises(ValueError, match="Previous block record not found"):
+        await full_node_api.full_node.add_block(block)
+
+
 @pytest.mark.anyio
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
 @pytest.mark.parametrize(

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2158,7 +2158,8 @@ class FullNode:
             prev_ses_block = None
             if block.height > 0:
                 prev_b = await self.blockchain.get_block_record_from_db(block.prev_header_hash)
-                assert prev_b is not None
+                if prev_b is None:
+                    raise ValueError(f"Previous block record not found for {block.prev_header_hash}")
                 curr = prev_b
                 while curr.height > 0 and curr.sub_epoch_summary_included is None:
                     curr = self.blockchain.block_record(curr.prev_hash)


### PR DESCRIPTION
### Purpose:

Replace a naked assert in `FullNode.add_block()` with explicit validation for missing parent records.

### Current Behavior:

`add_block()` used `assert prev_b is not None` after fetching a parent block record from DB. On malformed/invalid state this raised `AssertionError` (or was optimized out under `-O`).

### New Behavior:

`add_block()` now raises `ValueError` with a clear message when a non-genesis block's parent record is missing.

Invariants unchanged:
- Genesis (`height == 0`) behavior is unchanged.
- No consensus/difficulty/precision rules changed.
- Caller contract around invalid/disconnected block handling remains the same.
- Invalid parent state is still rejected; now via explicit check instead of assert.

### Testing Notes:

- `ruff check chia/full_node/full_node.py chia/_tests/core/full_node/test_full_node.py`
- `ruff format --check chia/full_node/full_node.py chia/_tests/core/full_node/test_full_node.py`
- `mypy chia/full_node/full_node.py chia/_tests/core/full_node/test_full_node.py`
- `unset CI && pytest --cov=chia --cov-config=.coveragerc --cov-report= chia/_tests/core/full_node/test_full_node.py -v -k "sync_no_farmer or wallet_sync_task_failure or request_blocks or missing_prev_record" --override-ini="addopts=--verbose --tb=short"`
- `unset CI && pytest -m benchmark -n 0 --capture no --ignore=chia/_tests/tools/test_legacy_keyring.py chia/_tests/`
- `coverage xml --rcfile=.coveragerc -o coverage.xml`
- `diff-cover --config-file=.diffcover.toml --compare-branch=origin/main --fail-under=100 coverage.xml`
- `pre-commit run --all-files`