### PR TITLE
Replace assert with explicit None check in get_heaviest_peak()

### DIFF
--- a/chia/full_node/sync_store.py
+++ b/chia/full_node/sync_store.py
@@ -116,7 +116,6 @@ class SyncStore:
                 continue
             if heaviest_peak is None or peak.weight > heaviest_peak.weight:
                 heaviest_peak = peak
-        assert heaviest_peak is not None
         return heaviest_peak
 
     def peer_disconnected(self, node_id: bytes32) -> None:


### PR DESCRIPTION
### Purpose:

Replace a naked `assert` used on peer-derived state in `SyncStore.get_heaviest_peak()` with explicit `None` handling.

### Current Behavior:

`get_heaviest_peak()` could raise `AssertionError` when `peer_to_peak` is non-empty but all entries are stale and filtered out by `peak_to_peer` membership. The caller already handles the no-peak case.

### New Behavior:

`get_heaviest_peak()` now returns `None` in that stale-filtered case instead of asserting.

Invariants unchanged:
- Caller contract remains `Peak | None` and caller-side `None` handling is unchanged.
- No rounding/precision behavior changed.
- No `None` vs falsy semantics changed outside this explicit return path.
- Invalid/stale peer state still does not produce a successful sync target.

### Testing Notes:

- `ruff check chia/full_node/sync_store.py`
- `ruff format --check chia/full_node/sync_store.py`
- `mypy chia/full_node/sync_store.py`
- `unset CI && pytest --cov=chia --cov-config=.coveragerc --cov-report= chia/_tests/core/full_node/stores/test_sync_store.py chia/_tests/core/full_node/test_full_node.py -v -k sync --override-ini="addopts=--verbose --tb=short"`
- `unset CI && pytest -m benchmark -n 0 --capture no --ignore=chia/_tests/tools/test_legacy_keyring.py chia/_tests/`
- `coverage xml --rcfile=.coveragerc -o coverage.xml`
- `diff-cover --config-file=.diffcover.toml --compare-branch=origin/main --fail-under=100 coverage.xml`
- `pre-commit run --all-files`