### PR TITLE
Add `fee` to WalletPushTX

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -441,6 +441,56 @@ async def test_push_transactions(wallet_environments: WalletTestFramework) -> No
 )
 @pytest.mark.limit_consensus_modes(reason="irrelevant")
 @pytest.mark.anyio
+async def test_push_tx_with_fee_persists_transactions(wallet_environments: WalletTestFramework) -> None:
+    env = wallet_environments.environments[0]
+
+    wallet: Wallet = env.xch_wallet
+    wallet_node: WalletNode = env.node
+    full_node_api: FullNodeSimulator = wallet_environments.full_node
+    client: WalletRpcClient = env.rpc_client
+
+    outputs = await create_tx_outputs(wallet, wallet_environments.tx_config, [(1234321, None)])
+    tx = (
+        await client.create_signed_transactions(
+            CreateSignedTransaction(additions=outputs, fee=uint64(0)),
+            tx_config=wallet_environments.tx_config,
+        )
+    ).signed_tx
+    assert tx.spend_bundle is not None
+
+    initial_balance = await get_confirmed_balance(client, 1)
+
+    fee = uint64(100)
+    unconfirmed_before = await wallet.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(1)
+    await client.push_tx(PushTX(spend_bundle=tx.spend_bundle, fee=fee))
+
+    unconfirmed_after = await wallet.wallet_state_manager.tx_store.get_unconfirmed_for_wallet(1)
+    assert len(unconfirmed_after) > len(unconfirmed_before)
+
+    fee_tx = next(t for t in unconfirmed_after if t not in unconfirmed_before)
+    assert fee_tx.spend_bundle is not None
+
+    await farm_transaction(full_node_api, wallet_node, fee_tx.spend_bundle)
+
+    fee_tx_confirmed = (await client.get_transaction(GetTransaction(transaction_id=fee_tx.name))).transaction
+    assert fee_tx_confirmed.confirmed
+
+    final_balance = await get_confirmed_balance(client, 1)
+    assert final_balance == initial_balance - tx.amount - fee
+
+
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [
+        {
+            "num_environments": 1,
+            "blocks_needed": [1],
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
+@pytest.mark.anyio
 async def test_get_balance(wallet_environments: WalletTestFramework) -> None:
     env = wallet_environments.environments[0]
     wallet: Wallet = env.xch_wallet

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -476,7 +476,7 @@ async def test_push_tx_with_fee_persists_transactions(wallet_environments: Walle
     assert fee_tx_confirmed.confirmed
 
     final_balance = await get_confirmed_balance(client, 1)
-    assert final_balance == initial_balance - tx.amount - fee
+    assert final_balance == initial_balance - fee
 
 
 @pytest.mark.parametrize(

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -183,6 +183,7 @@ class GetHeightInfoResponse(Streamable):
 @dataclass(kw_only=True, frozen=True)
 class PushTX(Streamable):
     spend_bundle: WalletSpendBundle
+    fee: uint64 = uint64(0)
 
     # We allow for flexibility in transaction parsing here so we need to override
     @classmethod

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -981,10 +981,10 @@ class WalletRpcApi:
             assert self.service.logged_in_fingerprint is not None
 
             bundle_coins = [cs.coin for cs in request.spend_bundle.coin_spends]
-            if not bundle_coins:
+            if len(bundle_coins) == 0:
                 raise ValueError("Spend bundle must contain at least one coin spend.")
             async with self.service.wallet_state_manager.new_action_scope(
-                DEFAULT_TX_CONFIG,
+                self.service.wallet_state_manager.tx_config,
                 push=False,
             ) as action_scope:
                 async with action_scope.use() as interface:

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -991,15 +991,11 @@ class WalletRpcApi:
                 await self.service.wallet_state_manager.main_wallet.create_tandem_xch_tx(
                     request.fee,
                     action_scope,
-                    extra_conditions=(
-                        AssertConcurrentSpend(bundle_coins[0].name()),
-                    ),
+                    extra_conditions=(AssertConcurrentSpend(bundle_coins[0].name()),),
                 )
 
             signed_fee_bundles = [
-                tx.spend_bundle
-                for tx in action_scope.side_effects.transactions
-                if tx.spend_bundle is not None
+                tx.spend_bundle for tx in action_scope.side_effects.transactions if tx.spend_bundle is not None
             ]
             combined_bundle = WalletSpendBundle.aggregate([request.spend_bundle, *signed_fee_bundles])
             await self.service.push_tx(combined_bundle)

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -974,7 +974,38 @@ class WalletRpcApi:
         nodes = self.service.server.get_connections(NodeType.FULL_NODE)
         if len(nodes) == 0:
             raise ValueError("Wallet is not currently connected to any full node peers")
-        await self.service.push_tx(request.spend_bundle)
+
+        if request.fee > 0:
+            if await self.service.wallet_state_manager.synced() is False:
+                raise ValueError("Wallet needs to be fully synced before making transactions.")
+            assert self.service.logged_in_fingerprint is not None
+
+            bundle_coins = [cs.coin for cs in request.spend_bundle.coin_spends]
+            async with self.service.wallet_state_manager.new_action_scope(
+                DEFAULT_TX_CONFIG,
+                push=False,
+            ) as action_scope:
+                async with action_scope.use() as interface:
+                    interface.side_effects.selected_coins.extend(bundle_coins)
+
+                await self.service.wallet_state_manager.main_wallet.create_tandem_xch_tx(
+                    request.fee,
+                    action_scope,
+                    extra_conditions=(
+                        AssertConcurrentSpend(bundle_coins[0].name()),
+                    ),
+                )
+
+            signed_fee_bundles = [
+                tx.spend_bundle
+                for tx in action_scope.side_effects.transactions
+                if tx.spend_bundle is not None
+            ]
+            combined_bundle = WalletSpendBundle.aggregate([request.spend_bundle, *signed_fee_bundles])
+            await self.service.push_tx(combined_bundle)
+        else:
+            await self.service.push_tx(request.spend_bundle)
+
         return Empty()
 
     @tx_endpoint(push=True)

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -1000,7 +1000,21 @@ class WalletRpcApi:
                 tx.spend_bundle for tx in action_scope.side_effects.transactions if tx.spend_bundle is not None
             ]
             combined_bundle = WalletSpendBundle.aggregate([request.spend_bundle, *signed_fee_bundles])
-            await self.service.push_tx(combined_bundle)
+
+            fee_txs = [
+                dataclasses.replace(
+                    tx,
+                    spend_bundle=combined_bundle if i == 0 else None,
+                    name=combined_bundle.name() if i == 0 else tx.name,
+                )
+                for i, tx in enumerate(action_scope.side_effects.transactions)
+            ]
+            await self.service.wallet_state_manager.add_pending_transactions(
+                fee_txs,
+                push=True,
+                sign=False,
+                merge_spends=False,
+            )
         else:
             await self.service.push_tx(request.spend_bundle)
 

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -1013,8 +1013,12 @@ class WalletRpcApi:
                 fee_txs,
                 push=True,
                 sign=False,
-                merge_spends=False,
+                merge_spends=True,
             )
+            if action_scope.side_effects.get_unused_derivation_record_result is not None:
+                await action_scope.side_effects.get_unused_derivation_record_result.to_standard().commit(
+                    self.service.wallet_state_manager
+                )
         else:
             await self.service.push_tx(request.spend_bundle)
 

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -981,6 +981,8 @@ class WalletRpcApi:
             assert self.service.logged_in_fingerprint is not None
 
             bundle_coins = [cs.coin for cs in request.spend_bundle.coin_spends]
+            if not bundle_coins:
+                raise ValueError("Spend bundle must contain at least one coin spend.")
             async with self.service.wallet_state_manager.new_action_scope(
                 DEFAULT_TX_CONFIG,
                 push=False,


### PR DESCRIPTION
### Purpose:

Adds an optional fee parameter to push_tx() in the wallet RPC API which if set appends a coinspend before pushing it to mempool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `wallet_rpc_api.push_tx` behavior to optionally create, persist, and push an additional fee-paying spend, which affects transaction construction and pending-transaction storage. Risk is moderate because it touches mempool submission flow and coin selection/aggregation logic, but is gated behind a new optional `fee` parameter and covered by a new test.
> 
> **Overview**
> Adds an optional `fee` field to the wallet RPC `PushTX` request, enabling callers to push an externally-built `spend_bundle` while having the wallet *append a fee-paying tandem spend*.
> 
> When `fee > 0`, `push_tx` now requires the wallet to be fully synced, derives coins from the provided bundle, creates a tandem XCH fee transaction with concurrency assertions, aggregates the fee spend(s) with the original bundle, and records/pushes the resulting pending transaction(s) with `merge_spends=True`.
> 
> Adds a new RPC test ensuring `push_tx` with a fee creates and persists a new unconfirmed transaction, confirms it on-farm, and debits the confirmed balance by the fee amount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80f1754f8e23a0dbd3b88e5dd5e37a2ab17c8c7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->