### PR TITLE
[CHIA-4181] Prevent unnecessary farming delays of height-asserted spends at exact match height

### DIFF
--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -353,6 +353,54 @@ class TestPendingTxCache:
         assert c.get(item_high.name) is None
 
 
+    def test_drain_boundary_at_exact_height(self) -> None:
+        """
+        Test that drain(H) releases items with assert_height == H.
+
+        When the mempool peak advances to height H, items with
+        assert_height == H should be released because check_time_locks
+        accepts ASSERT_HEIGHT_ABSOLUTE(H) when peak.height >= H.
+
+        Currently drain() uses strict '<', so drain(H) does NOT release
+        items with assert_height == H. This test documents the expected
+        behavior: drain(H) SHOULD release items with assert_height <= H
+        (i.e., use '<=' not '<').
+        """
+        c = PendingTxCache(20000, 1000)
+
+        item_at_100 = make_item(1, assert_height=uint32(100))
+        item_at_101 = make_item(2, assert_height=uint32(101))
+        item_at_102 = make_item(3, assert_height=uint32(102))
+        c.add(item_at_100)
+        c.add(item_at_101)
+        c.add(item_at_102)
+
+        # drain(101) should release items with assert_height <= 101
+        # That means item_at_100 (assert_height=100) AND item_at_101
+        # (assert_height=101) should both be released, because when
+        # peak.height == 101, check_time_locks accepts
+        # ASSERT_HEIGHT_ABSOLUTE(101) (since 101 >= 101).
+        tx = c.drain(uint32(101))
+        assert item_at_100.spend_bundle_name in tx, (
+            "item with assert_height=100 should be released by drain(101)"
+        )
+        assert item_at_101.spend_bundle_name in tx, (
+            "item with assert_height=101 should be released by drain(101) "
+            "because check_time_locks accepts ASSERT_HEIGHT_ABSOLUTE(101) "
+            "when peak.height=101"
+        )
+        assert item_at_102.spend_bundle_name not in tx, (
+            "item with assert_height=102 should NOT be released by drain(101)"
+        )
+
+        # item_at_102 should still be in the cache
+        assert c.get(item_at_102.name) is not None
+
+        # drain(102) should release the remaining item
+        tx = c.drain(uint32(102))
+        assert item_at_102.spend_bundle_name in tx
+
+
 class TestMempool:
     @pytest.mark.anyio
     async def test_basic_mempool(

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -290,23 +290,31 @@ class TestPendingTxCache:
         for i in items:
             c.add(i)
 
+        # drain(101) uses <=, so it releases items with assert_height <= 101:
+        # items[0] (assert_height=100) and items[1] (assert_height=101)
         tx = c.drain(uint32(101))
-        assert tx == {items[0].spend_bundle_name: items[0]}
+        assert tx == {
+            items[0].spend_bundle_name: items[0],
+            items[1].spend_bundle_name: items[1],
+        }
 
+        # drain(105) releases items with assert_height <= 105:
+        # items[2] (102), items[3] (103), items[4] (104), items[5] (105)
         tx = c.drain(uint32(105))
         assert tx == {
-            items[1].spend_bundle_name: items[1],
             items[2].spend_bundle_name: items[2],
             items[3].spend_bundle_name: items[3],
             items[4].spend_bundle_name: items[4],
+            items[5].spend_bundle_name: items[5],
         }
 
         tx = c.drain(uint32(105))
         assert tx == {}
 
+        # drain(110) releases items with assert_height <= 110:
+        # items[6] (106), items[7] (107), items[8] (108), items[9] (109)
         tx = c.drain(uint32(110))
         assert tx == {
-            items[5].spend_bundle_name: items[5],
             items[6].spend_bundle_name: items[6],
             items[7].spend_bundle_name: items[7],
             items[8].spend_bundle_name: items[8],
@@ -351,54 +359,6 @@ class TestPendingTxCache:
         assert c.get(item_low.name) is not None
         assert c.get(item_mid.name) is not None
         assert c.get(item_high.name) is None
-
-
-    def test_drain_boundary_at_exact_height(self) -> None:
-        """
-        Test that drain(H) releases items with assert_height == H.
-
-        When the mempool peak advances to height H, items with
-        assert_height == H should be released because check_time_locks
-        accepts ASSERT_HEIGHT_ABSOLUTE(H) when peak.height >= H.
-
-        Currently drain() uses strict '<', so drain(H) does NOT release
-        items with assert_height == H. This test documents the expected
-        behavior: drain(H) SHOULD release items with assert_height <= H
-        (i.e., use '<=' not '<').
-        """
-        c = PendingTxCache(20000, 1000)
-
-        item_at_100 = make_item(1, assert_height=uint32(100))
-        item_at_101 = make_item(2, assert_height=uint32(101))
-        item_at_102 = make_item(3, assert_height=uint32(102))
-        c.add(item_at_100)
-        c.add(item_at_101)
-        c.add(item_at_102)
-
-        # drain(101) should release items with assert_height <= 101
-        # That means item_at_100 (assert_height=100) AND item_at_101
-        # (assert_height=101) should both be released, because when
-        # peak.height == 101, check_time_locks accepts
-        # ASSERT_HEIGHT_ABSOLUTE(101) (since 101 >= 101).
-        tx = c.drain(uint32(101))
-        assert item_at_100.spend_bundle_name in tx, (
-            "item with assert_height=100 should be released by drain(101)"
-        )
-        assert item_at_101.spend_bundle_name in tx, (
-            "item with assert_height=101 should be released by drain(101) "
-            "because check_time_locks accepts ASSERT_HEIGHT_ABSOLUTE(101) "
-            "when peak.height=101"
-        )
-        assert item_at_102.spend_bundle_name not in tx, (
-            "item with assert_height=102 should NOT be released by drain(101)"
-        )
-
-        # item_at_102 should still be in the cache
-        assert c.get(item_at_102.name) is not None
-
-        # drain(102) should release the remaining item
-        tx = c.drain(uint32(102))
-        assert item_at_102.spend_bundle_name in tx
 
 
 class TestMempool:

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -3442,6 +3442,11 @@ async def test_new_peak_txs_added(condition_and_error: tuple[ConditionOpcode, Er
     """
     Tests that deferred transactions because of time-lock are retried once the
     time-lock allows them to be reconsidered.
+
+    drain() uses <=, so when new_peak.height == condition_height the item is
+    promoted immediately (check_time_locks accepts ASSERT_HEIGHT_ABSOLUTE(H)
+    when peak.height >= H, and ASSERT_HEIGHT_RELATIVE(R) when
+    peak.height >= coin_confirmed + R).
     """
     coins = TestCoins([TEST_COIN], {})
     async with setup_mempool(coins) as mempool_manager:
@@ -3453,23 +3458,24 @@ async def test_new_peak_txs_added(condition_and_error: tuple[ConditionOpcode, Er
         _, status, error = result
         assert status == MempoolInclusionStatus.PENDING
         assert error == expected_error
-        # Advance the mempool beyond the asserted height to retry the test item
+        # Advance the mempool to exactly the asserted height.
+        # drain() uses <=, so the item is promoted at condition_height (not condition_height + 1).
         if optimized_path:
             spent_coins: list[bytes32] | None = []
             new_peak_info = await mempool_manager.new_peak(
                 create_test_block_record(height=uint32(condition_height)), spent_coins
             )
-            # We're not there yet (needs to be higher, not equal)
-            assert new_peak_info.spend_bundle_ids == []
-            assert mempool_manager.get_mempool_item(sb_name, include_pending=False) is None
+            # The item is retried and promoted at exactly condition_height
+            assert new_peak_info.spend_bundle_ids == [sb_name]
+            assert mempool_manager.get_mempool_item(sb_name, include_pending=False) is not None
         else:
             spent_coins = None
-        new_peak_info = await mempool_manager.new_peak(
-            create_test_block_record(height=uint32(condition_height + 1)), spent_coins
-        )
-        # The item gets retried successfully now
-        assert new_peak_info.spend_bundle_ids == [sb_name]
-        assert mempool_manager.get_mempool_item(sb_name, include_pending=False) is not None
+            new_peak_info = await mempool_manager.new_peak(
+                create_test_block_record(height=uint32(condition_height)), spent_coins
+            )
+            # The item is retried and promoted at exactly condition_height
+            assert new_peak_info.spend_bundle_ids == [sb_name]
+            assert mempool_manager.get_mempool_item(sb_name, include_pending=False) is not None
 
 
 @pytest.mark.anyio

--- a/chia/full_node/pending_tx_cache.py
+++ b/chia/full_node/pending_tx_cache.py
@@ -95,7 +95,7 @@ class PendingTxCache:
             return ret
 
         height_line = self._by_height.items()[0]
-        while height_line[0] < up_to_height:
+        while height_line[0] <= up_to_height:
             ret.update(height_line[1])
             for name, item in height_line[1].items():
                 self._cache_cost -= item.cost


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

The problem: When new_peak.height = H, the peak is set to H, so the mempool now accepts ASSERT_HEIGHT_ABSOLUTE(H) (since peak.height >= H). But drain(H) only releases items with assert_height < H. Items with assert_height == H are not released, even though they would now pass validation.

These items remain stuck in the pending cache until the next peak at height H' > H, when drain(H') finally releases them.

5. There is no legitimate reason for < instead of <=
The drain() contract should be: "release all items that are now valid given the new peak." Since ASSERT_HEIGHT_ABSOLUTE(H) passes when peak.height >= H, and drain() is called after self.peak = new_peak, items with assert_height == new_peak.height should be released.

The only scenario where < would be correct is if drain() were called before self.peak was updated — then the items wouldn't pass re-validation anyway. But the code clearly sets self.peak = new_peak at [line 883](vscode-webview://18q3fmpukiukb7qr6cot39qcioiip0ki06meg26g9mli2euko44a/chia/full_node/mempool_manager.py:883), and drain() happens at [line 1025](vscode-webview://18q3fmpukiukb7qr6cot39qcioiip0ki06meg26g9mli2euko44a/chia/full_node/mempool_manager.py:1025), well after.

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

Future-dated height transactions are handled one block after they should be eligible

### New Behavior:

Future-dated height transactions are handled as soon as they should be eligible

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pending-transaction promotion semantics in the mempool by releasing `assert_height == new_peak.height` items immediately, which can affect transaction admission timing and needs careful validation around edge heights.
> 
> **Overview**
> Fixes an off-by-one in `PendingTxCache.drain()` by changing the release condition from `< up_to_height` to `<= up_to_height`, so height-asserted pending spends are retried as soon as the chain reaches the asserted height.
> 
> Updates mempool tests to reflect the new inclusive behavior, including promotion at *exactly* the asserted height in `test_new_peak_txs_added` and expanded expectations in `test_drain_height`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b36e4d287287299f7aa417f31bc16d55c26f9ab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->