### PR TITLE
CHIA-4170 CHIA-4168 Improve proof of space unfinished block handling

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3295,11 +3295,9 @@ def unfinished_from_full_block(block: FullBlock) -> UnfinishedBlock:
     return unfinished_block_expected
 
 
-async def declare_pos_unfinished_block(
-    full_node_api: FullNodeAPI,
-    dummy_peer: WSChiaConnection,
-    block: FullBlock,
-) -> UnfinishedBlock:
+async def declare_pos_unfinished_block_pos_request(
+    full_node_api: FullNodeAPI, dummy_peer: WSChiaConnection, block: FullBlock
+) -> tuple[UnfinishedBlock, DeclareProofOfSpace]:
     blockchain = full_node_api.full_node.blockchain
     full_node_store = full_node_api.full_node.full_node_store
     overflow = is_overflow_block(blockchain.constants, block.reward_chain_block.signage_point_index)
@@ -3393,7 +3391,13 @@ async def declare_pos_unfinished_block(
         foliage_transaction_block=block.foliage_transaction_block,
         foliage=block.foliage,
     )
+    return unfinised_block, pospace
 
+
+async def declare_pos_unfinished_block(
+    full_node_api: FullNodeAPI, dummy_peer: WSChiaConnection, block: FullBlock
+) -> UnfinishedBlock:
+    unfinised_block, _ = await declare_pos_unfinished_block_pos_request(full_node_api, dummy_peer, block)
     return unfinised_block
 
 
@@ -3989,3 +3993,161 @@ async def test_request_puzzle_state_responds_normally(
 
     assert response is not None
     assert response.type == ProtocolMessageTypes.respond_puzzle_state.value
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_add_unfinished_block_farmed_behind_current_head(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools], caplog: pytest.LogCaptureFixture
+) -> None:
+    """
+    Covers the scenario where we call `add_unfinished_block` on a farmed
+    unfinished block that would be infused before the current finished head, so
+    it's already too late, to make sure it gets properly dropped.
+    """
+    full_node_api, _, bt = one_node_one_block
+    blocks = bt.get_consecutive_blocks(3, guarantee_transaction_block=True)
+    await add_blocks_in_batches(blocks, full_node_api.full_node)
+    # Build a valid unfinished block candidate extending the chain
+    blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, guarantee_transaction_block=True)
+    unfinished_block = unfinished_from_full_block(blocks[-1])
+    peak = full_node_api.full_node.blockchain.get_peak()
+    assert peak is not None
+    assert peak.total_iters > 0
+    # Create an unfinished block that would be infused before the current
+    # finished head.
+    lower_total_iters = uint128(peak.total_iters - 1)
+    reward_chain_block = unfinished_block.reward_chain_block.replace(total_iters=lower_total_iters)
+    late_unfinished_block = unfinished_block.replace(reward_chain_block=reward_chain_block)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        await full_node_api.full_node.add_unfinished_block(late_unfinished_block, None, farmed_block=True)
+    assert "Dropping farmed unfinished block as it would be infused before the current head" in caplog.text
+    # Make sure we didn't add this unfinished block
+    assert full_node_api.full_node.full_node_store.get_unfinished_block(late_unfinished_block.partial_hash) is None
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_declare_proof_of_space_late_unfinished_block(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Covers the scenario where an unfinished block is already too late as it
+    would be infused before the current finished head, to make sure it gets dropped.
+    """
+    full_node_api, server, bt = one_node_one_block
+    _, dummy_node_id = await add_dummy_connection_wsc(server, self_hostname, 1337)
+    dummy_peer = server.all_connections[dummy_node_id]
+    wallet = WalletTool(test_constants)
+    coinbase_puzzlehash = wallet.get_new_puzzlehash()
+    blocks = bt.get_consecutive_blocks(
+        num_blocks=3, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
+    )
+    await add_blocks_in_batches(blocks, full_node_api.full_node)
+    blocks = bt.get_consecutive_blocks(
+        block_list_input=blocks,
+        num_blocks=1,
+        farmer_reward_puzzle_hash=coinbase_puzzlehash,
+        guarantee_transaction_block=True,
+    )
+    candidate_block = blocks[-1]
+    # Run one normal declare proof of space call first so this SP/challenge is
+    # known to the node and grab the `DeclareProofOfSpace` request.
+    _, declare_pos_request = await declare_pos_unfinished_block_pos_request(full_node_api, dummy_peer, candidate_block)
+    peak = full_node_api.full_node.blockchain.get_peak()
+    assert peak is not None
+    # Now make the same unfinished block candidate look behind the current
+    # finished head.
+    monkeypatch.setattr(
+        full_node_api.full_node.blockchain, "get_peak", lambda: peak.replace(total_iters=uint128(123456789))
+    )
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        await full_node_api.declare_proof_of_space(declare_pos_request, dummy_peer)
+    assert "Dropping farmed unfinished block candidate as it's behind the current head" in caplog.text
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_declare_proof_of_space_empty_block_no_new_tx_window_yet(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Covers the scenario where the unfinished block signage point is at or
+    before the end of the window where the last transaction block prevents a
+    new transaction block from being created, to make sure we properly create
+    an empty block.
+    """
+    full_node_api, server, bt = one_node_one_block
+    _, dummy_node_id = await add_dummy_connection_wsc(server, self_hostname, 1337)
+    dummy_peer = server.all_connections[dummy_node_id]
+    wallet = WalletTool(test_constants)
+    coinbase_puzzlehash = wallet.get_new_puzzlehash()
+    blocks = bt.get_consecutive_blocks(
+        num_blocks=3, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
+    )
+    await add_blocks_in_batches(blocks, full_node_api.full_node)
+    sb = await add_tx_to_mempool(
+        full_node_api, dummy_peer, wallet, blocks[-1], coinbase_puzzlehash, bytes32.random(), uint64(42)
+    )
+    assert sb is not None
+    blocks = bt.get_consecutive_blocks(
+        block_list_input=blocks,
+        num_blocks=1,
+        farmer_reward_puzzle_hash=coinbase_puzzlehash,
+        guarantee_transaction_block=True,
+        transaction_data=sb,
+    )
+    candidate_block = blocks[-1]
+    tx_peak = full_node_api.full_node.blockchain.get_tx_peak()
+    assert tx_peak is not None
+    # Force candidate's signage point position to be before the latest
+    # transaction block's infusion position.
+    monkeypatch.setattr(
+        full_node_api.full_node.blockchain, "get_tx_peak", lambda: tx_peak.replace(total_iters=uint128(123456789))
+    )
+    unfinished_block = await declare_pos_unfinished_block(full_node_api, dummy_peer, candidate_block)
+    # Make sure we created an empty block
+    assert unfinished_block.transactions_generator is None
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_declare_proof_of_space_unfinished_block_includes_block_generator(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools], self_hostname: str
+) -> None:
+    """
+    Covers the scenario where the unfinished block includes a block generator
+    created from the mempool.
+    """
+    full_node_api, server, bt = one_node_one_block
+    _, dummy_node_id = await add_dummy_connection_wsc(server, self_hostname, 1337)
+    dummy_peer = server.all_connections[dummy_node_id]
+    wallet = WalletTool(test_constants)
+    coinbase_puzzlehash = wallet.get_new_puzzlehash()
+    blocks = bt.get_consecutive_blocks(
+        num_blocks=3, farmer_reward_puzzle_hash=coinbase_puzzlehash, guarantee_transaction_block=True
+    )
+    await add_blocks_in_batches(blocks, full_node_api.full_node)
+    sb = await add_tx_to_mempool(
+        full_node_api, dummy_peer, wallet, blocks[-1], coinbase_puzzlehash, bytes32.random(), uint64(42)
+    )
+    assert sb is not None
+    blocks = bt.get_consecutive_blocks(
+        block_list_input=blocks,
+        num_blocks=1,
+        farmer_reward_puzzle_hash=coinbase_puzzlehash,
+        guarantee_transaction_block=True,
+        transaction_data=sb,
+    )
+    candidate_block = blocks[-1]
+    unfinished_block = await declare_pos_unfinished_block(full_node_api, dummy_peer, candidate_block)
+    assert unfinished_block.transactions_generator is not None
+    assert unfinished_block.transactions_info is not None
+    assert unfinished_block.transactions_info.cost > 0

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -286,10 +286,9 @@ def create_foliage(
 def create_unfinished_block(
     constants: ConsensusConstants,
     sub_slot_start_total_iters: uint128,
-    sub_slot_iters: uint64,
+    infusion_point_total_iters: uint128,
     signage_point_index: uint8,
     sp_iters: uint64,
-    ip_iters: uint64,
     proof_of_space: ProofOfSpace,
     slot_cc_challenge: bytes32,
     farmer_reward_puzzle_hash: bytes32,
@@ -312,7 +311,7 @@ def create_unfinished_block(
     Args:
         constants: consensus constants being used for this chain
         sub_slot_start_total_iters: the starting sub-slot iters at the signage point sub-slot
-        sub_slot_iters: sub-slot-iters at the infusion point epoch
+        infusion_point_total_iters: total iters at the infusion point
         signage_point_index: signage point index of the block to create
         sp_iters: sp_iters of the block to create
         ip_iters: ip_iters of the block to create
@@ -337,7 +336,6 @@ def create_unfinished_block(
         finished_sub_slots: list[EndOfSubSlotBundle] = []
     else:
         finished_sub_slots = finished_sub_slots_input.copy()
-    overflow: bool = sp_iters > ip_iters
     total_iters_sp: uint128 = uint128(sub_slot_start_total_iters + sp_iters)
     is_genesis: bool = prev_block is None
 
@@ -371,10 +369,8 @@ def create_unfinished_block(
     assert rc_sp_signature is not None
     assert chia_rs.AugSchemeMPL.verify(proof_of_space.plot_public_key, cc_sp_hash, cc_sp_signature)
 
-    total_iters = uint128(sub_slot_start_total_iters + ip_iters + (sub_slot_iters if overflow else 0))
-
     rc_block = RewardChainBlockUnfinished(
-        total_iters,
+        infusion_point_total_iters,
         signage_point_index,
         slot_cc_challenge,
         proof_of_space,
@@ -515,3 +511,13 @@ def unfinished_block_to_full_block(
         new_generator_ref_list,
     )
     return ret
+
+
+def calculate_infusion_point_total_iters(
+    sub_slot_start_total_iters: uint128, sp_iters: uint64, ip_iters: uint64, sub_slot_iters: uint64
+) -> uint128:
+    """
+    Calculates the candidate's infusion point total iterations
+    """
+    overflow = sp_iters > ip_iters
+    return uint128(sub_slot_start_total_iters + ip_iters + (sub_slot_iters if overflow else 0))

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -2370,8 +2370,18 @@ class FullNode:
 
         peak: BlockRecord | None = self.blockchain.get_peak()
         if peak is not None:
-            if block.total_iters < peak.sp_total_iters(self.constants):
-                # This means this unfinished block is pretty far behind, it will not add weight to our chain
+            if block.total_iters < peak.total_iters:
+                # This unfinished block would be infused before the current
+                # finished head so it's already too late.
+                self.log.log(
+                    logging.WARNING if farmed_block else logging.INFO,
+                    f"Dropping{' farmed' if farmed_block else ''} unfinished block as it would be "
+                    "infused before the current head. "
+                    f"Signage point index: {block.reward_chain_block.signage_point_index}, "
+                    f"block total iters: {block.total_iters}, "
+                    f"current head total iters: {peak.total_iters}, "
+                    f"peak height: {peak.height}.",
+                )
                 return None
 
         if block.prev_header_hash == self.constants.GENESIS_CHALLENGE:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -35,7 +35,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64, uint128
 from chiabip158 import PyBIP158
 
-from chia.consensus.block_creation import create_unfinished_block
+from chia.consensus.block_creation import calculate_infusion_point_total_iters, create_unfinished_block
 from chia.consensus.blockchain import BlockchainMutexPriority
 from chia.consensus.generator_tools import get_block_header
 from chia.consensus.get_block_generator import get_block_generator
@@ -1072,7 +1072,36 @@ class FullNodeAPI:
                 request.signage_point_index,
                 required_iters,
             )
-
+            # Candidate position at infusion time in total iterations
+            infusion_point_total_iters = calculate_infusion_point_total_iters(
+                sub_slot_start_total_iters=total_iters_pos_slot,
+                sp_iters=sp_iters,
+                ip_iters=ip_iters,
+                sub_slot_iters=sub_slot_iters,
+            )
+            # If this candidate would be infused before the current finished
+            # head then it's already too late and it should be dropped. This
+            # indicates latency issues.
+            peak = self.full_node.blockchain.get_peak()
+            if peak is not None and infusion_point_total_iters < peak.total_iters:
+                self.log.warning(
+                    "Dropping farmed unfinished block candidate as it's "
+                    "behind the current head (latency issues). "
+                    f"Signage point index: {request.signage_point_index} "
+                    f"unfinished block infusion point total iters: {infusion_point_total_iters} "
+                    f"current head total iters: {peak.total_iters} "
+                    f"peak height: {peak.height}"
+                )
+                return None
+            # Candidate signage point position in total iterations
+            candidate_sp_total_iters = uint128(total_iters_pos_slot + sp_iters)
+            # If this candidate would be infused at or after the current
+            # finished head, and its signage point's position is at or before
+            # the end of the window where the last transaction block prevents a
+            # new transaction block from being created, then we should create
+            # an empty block.
+            if tx_peak is not None and candidate_sp_total_iters <= tx_peak.total_iters:
+                new_block_gen = None
             # The block's timestamp must be greater than the previous transaction block's timestamp
             timestamp = uint64(time.time())
             curr: BlockRecord | None = prev_b
@@ -1087,10 +1116,9 @@ class FullNodeAPI:
             unfinished_block: UnfinishedBlock = create_unfinished_block(
                 self.full_node.constants,
                 total_iters_pos_slot,
-                sub_slot_iters,
+                infusion_point_total_iters,
                 request.signage_point_index,
                 sp_iters,
-                ip_iters,
                 request.proof_of_space,
                 cc_challenge_hash,
                 farmer_ph,
@@ -1143,10 +1171,9 @@ class FullNodeAPI:
                 unfinished_block_backup = create_unfinished_block(
                     self.full_node.constants,
                     total_iters_pos_slot,
-                    sub_slot_iters,
+                    infusion_point_total_iters,
                     request.signage_point_index,
                     sp_iters,
-                    ip_iters,
                     request.proof_of_space,
                     cc_challenge_hash,
                     farmer_ph,

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -47,7 +47,11 @@ from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
 from filelock import FileLock
 from typing_extensions import Self
 
-from chia.consensus.block_creation import create_unfinished_block, unfinished_block_to_full_block
+from chia.consensus.block_creation import (
+    calculate_infusion_point_total_iters,
+    create_unfinished_block,
+    unfinished_block_to_full_block,
+)
 from chia.consensus.block_record import BlockRecordProtocol
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.condition_costs import ConditionCost
@@ -1542,13 +1546,18 @@ class BlockTools:
                     if len(finished_sub_slots) < skip_slots:
                         continue
 
+                    infusion_point_total_iters = calculate_infusion_point_total_iters(
+                        sub_slot_start_total_iters=sub_slot_total_iters,
+                        sp_iters=sp_iters,
+                        ip_iters=ip_iters,
+                        sub_slot_iters=constants.SUB_SLOT_ITERS_STARTING,
+                    )
                     unfinished_block = create_unfinished_block(
                         constants,
                         sub_slot_total_iters,
-                        constants.SUB_SLOT_ITERS_STARTING,
+                        infusion_point_total_iters,
                         uint8(signage_point_index),
                         sp_iters,
-                        ip_iters,
                         proof_of_space,
                         cc_challenge,
                         constants.GENESIS_PRE_FARM_FARMER_PUZZLE_HASH,
@@ -2108,14 +2117,19 @@ def get_full_block_and_block_record(
         timestamp = last_timestamp + time_per_block
     sp_iters = calculate_sp_iters(constants, sub_slot_iters, signage_point_index)
     ip_iters = calculate_ip_iters(constants, sub_slot_iters, signage_point_index, required_iters)
+    infusion_point_total_iters = calculate_infusion_point_total_iters(
+        sub_slot_start_total_iters=sub_slot_start_total_iters,
+        sp_iters=sp_iters,
+        ip_iters=ip_iters,
+        sub_slot_iters=sub_slot_iters,
+    )
 
     unfinished_block = create_unfinished_block(
         constants,
         sub_slot_start_total_iters,
-        sub_slot_iters,
+        infusion_point_total_iters,
         signage_point_index,
         sp_iters,
-        ip_iters,
         proof_of_space,
         slot_cc_challenge,
         farmer_reward_puzzle_hash,


### PR DESCRIPTION
Improve the unfinished block decision based on the hard deadlines it's subject to (infusion window and transaction block window) which gives us 3 cases:

1. If the unfinished block infusion would happen behind current peak then that indicates latency issue and we're already late. As a result, there is no point in creating an unfinished block.  
2. If the unfinished block is not late for infusion but its signage point is still before or at the end of the "no new transaction block yet after the current one" window, then we can only send an empty block.  
3. Finally if the unfinished block is not late by infusion and its signage point is after the current transaction block's window, then we can send a transaction block candidate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-critical unfinished block creation/validation paths (`declare_proof_of_space`, `create_unfinished_block`, `add_unfinished_block`) and changes iteration-based gating, which could affect farming behavior if miscomputed, but is bounded by new targeted tests.
> 
> **Overview**
> Improves unfinished-block handling by basing decisions on *hard iteration deadlines*: the candidate’s infusion-point `total_iters` and the transaction-block “no-new-tx” window.
> 
> `create_unfinished_block` now takes a precomputed `infusion_point_total_iters` (with shared helper `calculate_infusion_point_total_iters`) and callers compute this consistently. The full node drops farmed unfinished blocks/candidates that would be infused before the current peak (new warning/info logs), and `declare_proof_of_space` forces empty candidates when the signage point is still within the post-tx-block window.
> 
> Adds focused tests covering late farmed unfinished blocks being dropped, late PoS declares being ignored, and correct empty-vs-tx-generator candidate creation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 416d9b3aaf638d1365411cd5419ec9028a0aa513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->