### PR TITLE
CHIA-4171 Improve logging for unfinished blocks that overflow in the first sub-slot of a new epoch

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -73,7 +73,7 @@ from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.peer_info import PeerInfo
 from chia.util.batches import to_batches
 from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER
-from chia.util.errors import Err, ValidationError
+from chia.util.errors import ConsensusError, Err
 from chia.util.hash import std_hash
 from chia.util.limited_semaphore import LimitedSemaphoreFullError
 from chia.util.task_referencer import create_referenced_task
@@ -1206,7 +1206,7 @@ class FullNodeAPI:
         try:
             await self.full_node.add_unfinished_block(new_candidate, None, True)
         except Exception as e:
-            if isinstance(e, ValidationError) and e.code == Err.NO_OVERFLOWS_IN_FIRST_SUB_SLOT_NEW_EPOCH:
+            if isinstance(e, ConsensusError) and e.code == Err.NO_OVERFLOWS_IN_FIRST_SUB_SLOT_NEW_EPOCH:
                 self.full_node.log.info(
                     f"Failed to farm block {e}. Consensus rules prevent this block from being farmed. Not retrying"
                 )


### PR DESCRIPTION
We first introduced this in PR #20016 but now we're checking for the correct exception type.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes error handling during block farming to special-case a consensus rejection and avoid retrying, which could affect how certain failed unfinished blocks are logged and retried.
> 
> **Overview**
> Updates `FullNodeAPI.signed_values()` farming error handling to recognize `Err.NO_OVERFLOWS_IN_FIRST_SUB_SLOT_NEW_EPOCH` as a `ConsensusError` (instead of `ValidationError`) and log a clear *non-retriable* message when this consensus rule prevents farming.
> 
> Also adjusts imports accordingly, removing `ValidationError` usage in this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79bf5a1ee4d989411742e3ee8fdfb17f1964ceb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->