### PR TITLE
suppress new mypy warnings

### DIFF
--- a/chia/_tests/connection_utils.py
+++ b/chia/_tests/connection_utils.py
@@ -84,7 +84,7 @@ async def add_dummy_connection_wsc(
     generate_ca_signed_cert(ca_crt_path.read_bytes(), ca_key_path.read_bytes(), dummy_crt_path, dummy_key_path)
     ssl_context = ssl_context_for_client(ca_crt_path, ca_key_path, dummy_crt_path, dummy_key_path)
     pem_cert = x509.load_pem_x509_certificate(dummy_crt_path.read_bytes(), default_backend())
-    der_cert = x509.load_der_x509_certificate(pem_cert.public_bytes(serialization.Encoding.DER), default_backend())
+    der_cert = x509.load_der_x509_certificate(pem_cert.public_bytes(serialization.Encoding.DER), default_backend())  # type: ignore[arg-type]
     peer_id = bytes32(der_cert.fingerprint(hashes.SHA256()))
     url = f"wss://{self_hostname}:{server._port}/ws"
     ws = await session.ws_connect(url, autoclose=True, autoping=True, ssl=ssl_context)

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -102,7 +102,7 @@ def ssl_context_for_client(
 
 def calculate_node_id(cert_path: Path) -> bytes32:
     pem_cert = x509.load_pem_x509_certificate(cert_path.read_bytes(), default_backend())
-    der_cert_bytes = pem_cert.public_bytes(encoding=serialization.Encoding.DER)
+    der_cert_bytes = pem_cert.public_bytes(encoding=serialization.Encoding.DER)  # type: ignore[arg-type]
     der_cert = x509.load_der_x509_certificate(der_cert_bytes, default_backend())
     return bytes32(der_cert.fingerprint(hashes.SHA256()))
 

--- a/chia/ssl/create_ssl.py
+++ b/chia/ssl/create_ssl.py
@@ -91,13 +91,13 @@ def generate_ca_signed_cert(ca_crt: bytes, ca_key: bytes, cert_out: Path, key_ou
             x509.SubjectAlternativeName([x509.DNSName("chia.net")]),
             critical=False,
         )
-        .sign(root_key, hashes.SHA256(), default_backend())  # type: ignore[arg-type]
+        .sign(root_key, hashes.SHA256(), default_backend())
     )
 
-    cert_pem = cert.public_bytes(encoding=serialization.Encoding.PEM)
+    cert_pem = cert.public_bytes(encoding=serialization.Encoding.PEM)  # type: ignore[arg-type]
     key_pem = cert_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
+        encoding=serialization.Encoding.PEM,  # type: ignore[arg-type]
+        format=serialization.PrivateFormat.PKCS8,  # type: ignore[arg-type]
         encryption_algorithm=serialization.NoEncryption(),
     )
 
@@ -125,10 +125,10 @@ def make_ca_cert(cert_path: Path, key_path: Path):
         .sign(root_key, hashes.SHA256(), default_backend())
     )
 
-    cert_pem = root_cert.public_bytes(encoding=serialization.Encoding.PEM)
+    cert_pem = root_cert.public_bytes(encoding=serialization.Encoding.PEM)  # type: ignore[arg-type]
     key_pem = root_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
+        encoding=serialization.Encoding.PEM,  # type: ignore[arg-type]
+        format=serialization.PrivateFormat.PKCS8,  # type: ignore[arg-type]
         encryption_algorithm=serialization.NoEncryption(),
     )
 


### PR DESCRIPTION
The root cause is a mypy 1.20 bug: when cryptography's Encoding and PrivateFormat enums are re-exported through a module with from __future__ import annotations, mypy resolves the enum members as str instead

  of their proper enum type.

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds/removes type-checking suppressions around `cryptography` serialization calls; runtime behavior is unchanged aside from comments, with minimal operational risk.
> 
> **Overview**
> Suppresses new mypy `arg-type` warnings in SSL/certificate code by adding targeted `# type: ignore[arg-type]` annotations to `cryptography` calls (e.g., `public_bytes()`/`private_bytes()`) used for peer/node ID derivation and test dummy cert creation.
> 
> Also removes a now-unneeded `type: ignore` on certificate `.sign(...)` while keeping the underlying SSL generation and node ID logic unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0631629685b3318c7c29c9366f74f02928f2ba4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->