### PR TITLE
don't run non-simple generators when an untrusted peer asks us

### DIFF
--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -2316,10 +2316,12 @@ async def test_fill_rate_block_validation(
         # Check for the peak change after farming the block
         assert peak.prev_hash == current_peak.header_hash
         # Check our coin(s)
+        _, dummy_node_id = await add_dummy_connection(full_node_api.server, self_hostname, 12313)
+        dummy_peer = full_node_api.server.all_connections[dummy_node_id]
         for i in range(expected_block_items):
             coin_name, puzzle, _ = sbs_info[i]
             rps_res = await full_node_api.request_puzzle_solution(
-                wallet_protocol.RequestPuzzleSolution(coin_name, peak.height)
+                wallet_protocol.RequestPuzzleSolution(coin_name, peak.height), dummy_peer
             )
             assert rps_res is not None
             rps_res_parsed = wallet_protocol.RespondPuzzleSolution.from_bytes(rps_res.data)

--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -6,11 +6,12 @@ import functools
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from aiosqlite import Error as AIOSqliteError
 from chia_rs import (
+    SIMPLE_GENERATOR,
     BlockRecord,
     CoinState,
     ConsensusConstants,
@@ -200,11 +201,116 @@ async def test_request_block_headers_transactions_filter(
     assert block_headers_res.header_blocks == block_headers
     assert block_headers_res.header_blocks[0].transactions_filter == expected_transactions_filter
     # Go even further and compare this to the outcome of request_block_header
-    msg = await full_node_api.request_block_header(wallet_protocol.RequestBlockHeader(uint32(new_block.height)))
+    _, peer_id = await add_dummy_connection(full_node_api.full_node.server, "127.0.0.1", 12312)
+    peer = full_node_api.full_node.server.all_connections[peer_id]
+    msg = await full_node_api.request_block_header(wallet_protocol.RequestBlockHeader(uint32(new_block.height)), peer)
     assert msg is not None
     block_header_res = RespondBlockHeader.from_bytes(msg.data)
     assert block_header_res.header_block == block_header
     assert block_header_res.header_block.transactions_filter == expected_transactions_filter
+
+
+@pytest.mark.limit_consensus_modes(reason="save time")
+@pytest.mark.anyio
+async def test_simple_generator_flag_for_untrusted_peers(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+) -> None:
+    """
+    Verify that request_block_header and request_puzzle_solution set the
+    SIMPLE_GENERATOR flag when the requesting peer is untrusted.
+    """
+    full_node_api, server, bt = one_node_one_block
+    ph = SerializedProgram.to(1).get_tree_hash()
+    for _ in range(2):
+        await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(ph))
+
+    coins = await full_node_api.full_node.coin_store.get_coin_records_by_puzzle_hash(False, ph)
+    [parent_coin] = [c.coin for c in coins if c.coin.amount == 250_000_000_000]
+    sb = SpendBundle(
+        [
+            make_spend(
+                parent_coin, SerializedProgram.to(1), SerializedProgram.to([[ConditionOpcode.CREATE_COIN, ph, 42]])
+            )
+        ],
+        G2Element(),
+    )
+    blocks = await full_node_api.get_all_full_blocks()
+    blocks = bt.get_consecutive_blocks(1, blocks, guarantee_transaction_block=True, transaction_data=sb)
+    new_block = blocks[-1]
+    await full_node_api.full_node.add_block(new_block)
+
+    _, peer_id = await add_dummy_connection(server, "127.0.0.1", 12312)
+    peer = server.all_connections[peer_id]
+
+    from typing import Any
+
+    from chia_rs import additions_and_removals
+    from chia_rs import get_puzzle_and_solution_for_coin2 as get_puzzle_and_solution_for_coin
+
+    captured_flags: list[int] = []
+
+    def capturing_additions_and_removals(*args: Any, **kwargs: Any) -> Any:
+        captured_flags.append(args[2])
+        return additions_and_removals(*args, **kwargs)
+
+    def capturing_get_puzzle_and_solution(*args: Any, **kwargs: Any) -> Any:
+        captured_flags.append(args[4])
+        return get_puzzle_and_solution_for_coin(*args, **kwargs)
+
+    # -- request_block_header with untrusted peer --
+    with (
+        patch.object(full_node_api, "is_trusted", return_value=False),
+        patch("chia.full_node.full_node_api.additions_and_removals", capturing_additions_and_removals),
+    ):
+        msg = await full_node_api.request_block_header(
+            wallet_protocol.RequestBlockHeader(uint32(new_block.height)), peer
+        )
+    assert msg is not None
+    assert msg.type == ProtocolMessageTypes.respond_block_header.value
+    assert len(captured_flags) == 1
+    assert captured_flags[0] & SIMPLE_GENERATOR != 0
+
+    # -- request_block_header with trusted peer --
+    captured_flags.clear()
+    with (
+        patch.object(full_node_api, "is_trusted", return_value=True),
+        patch("chia.full_node.full_node_api.additions_and_removals", capturing_additions_and_removals),
+    ):
+        msg = await full_node_api.request_block_header(
+            wallet_protocol.RequestBlockHeader(uint32(new_block.height)), peer
+        )
+    assert msg is not None
+    assert msg.type == ProtocolMessageTypes.respond_block_header.value
+    assert len(captured_flags) == 1
+    assert captured_flags[0] & SIMPLE_GENERATOR == 0
+
+    # -- request_puzzle_solution with untrusted peer --
+    captured_flags.clear()
+    with (
+        patch.object(full_node_api, "is_trusted", return_value=False),
+        patch("chia.full_node.full_node_api.get_puzzle_and_solution_for_coin", capturing_get_puzzle_and_solution),
+    ):
+        msg = await full_node_api.request_puzzle_solution(
+            wallet_protocol.RequestPuzzleSolution(parent_coin.name(), new_block.height), peer
+        )
+    assert msg is not None
+    assert msg.type == ProtocolMessageTypes.respond_puzzle_solution.value
+    assert len(captured_flags) == 1
+    assert captured_flags[0] & SIMPLE_GENERATOR != 0
+
+    # -- request_puzzle_solution with trusted peer --
+    captured_flags.clear()
+    with (
+        patch.object(full_node_api, "is_trusted", return_value=True),
+        patch("chia.full_node.full_node_api.get_puzzle_and_solution_for_coin", capturing_get_puzzle_and_solution),
+    ):
+        msg = await full_node_api.request_puzzle_solution(
+            wallet_protocol.RequestPuzzleSolution(parent_coin.name(), new_block.height), peer
+        )
+    assert msg is not None
+    assert msg.type == ProtocolMessageTypes.respond_puzzle_solution.value
+    assert len(captured_flags) == 1
+    assert captured_flags[0] & SIMPLE_GENERATOR == 0
 
 
 # @pytest.mark.parametrize(
@@ -1524,10 +1630,14 @@ async def test_retry_store(
     request_puzzle_solution_failure_tested = False
 
     def flaky_request_puzzle_solution(
-        func: Callable[[FullNodeAPI, wallet_protocol.RequestPuzzleSolution], Awaitable[Message | None]],
-    ) -> Callable[[FullNodeAPI, wallet_protocol.RequestPuzzleSolution], Awaitable[Message | None]]:
+        func: Callable[
+            [FullNodeAPI, wallet_protocol.RequestPuzzleSolution, WSChiaConnection], Awaitable[Message | None]
+        ],
+    ) -> Callable[[FullNodeAPI, wallet_protocol.RequestPuzzleSolution, WSChiaConnection], Awaitable[Message | None]]:
         @functools.wraps(func)
-        async def new_func(self: FullNodeAPI, request: wallet_protocol.RequestPuzzleSolution) -> Message | None:
+        async def new_func(
+            self: FullNodeAPI, request: wallet_protocol.RequestPuzzleSolution, peer: WSChiaConnection
+        ) -> Message | None:
             nonlocal request_puzzle_solution_failure_tested
             if not request_puzzle_solution_failure_tested:
                 request_puzzle_solution_failure_tested = True
@@ -1535,7 +1645,7 @@ async def test_retry_store(
                 reject = wallet_protocol.RejectPuzzleSolution(bytes32.zeros, uint32(0))
                 return make_msg(ProtocolMessageTypes.reject_puzzle_solution, reject)
             else:
-                return await func(self, request)
+                return await func(self, request, peer)
 
         return new_func
 

--- a/chia/apis/full_node_stub.py
+++ b/chia/apis/full_node_stub.py
@@ -272,8 +272,10 @@ class FullNodeApiStub(ApiProtocol, Protocol):
         ...
 
     # WALLET PROTOCOL
-    @metadata.request()
-    async def request_block_header(self, request: wallet_protocol.RequestBlockHeader) -> Message | None:
+    @metadata.request(peer_required=True)
+    async def request_block_header(
+        self, request: wallet_protocol.RequestBlockHeader, peer: WSChiaConnection
+    ) -> Message | None:
         """Handle block header request from wallet."""
         ...
 
@@ -294,8 +296,10 @@ class FullNodeApiStub(ApiProtocol, Protocol):
         """Handle transaction send from wallet."""
         ...
 
-    @metadata.request()
-    async def request_puzzle_solution(self, request: wallet_protocol.RequestPuzzleSolution) -> Message | None:
+    @metadata.request(peer_required=True)
+    async def request_puzzle_solution(
+        self, request: wallet_protocol.RequestPuzzleSolution, peer: WSChiaConnection
+    ) -> Message | None:
         """Handle puzzle solution request from wallet."""
         ...
 

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, ClassVar, cast
 
 import anyio
 from chia_rs import (
+    SIMPLE_GENERATOR,
     AugSchemeMPL,
     BlockRecord,
     CoinRecord,
@@ -1283,8 +1284,10 @@ class FullNodeAPI:
         else:
             return msg
 
-    @metadata.request()
-    async def request_block_header(self, request: wallet_protocol.RequestBlockHeader) -> Message | None:
+    @metadata.request(peer_required=True)
+    async def request_block_header(
+        self, request: wallet_protocol.RequestBlockHeader, peer: WSChiaConnection
+    ) -> Message | None:
         header_hash = self.full_node.blockchain.height_to_hash(request.height)
         if header_hash is None:
             msg = make_msg(ProtocolMessageTypes.reject_header_request, RejectHeaderRequest(request.height))
@@ -1305,14 +1308,22 @@ class FullNodeAPI:
             # transactions_generator, so the block_generator should always be set
             assert block_generator is not None, "failed to get block_generator for tx-block"
             flags = await get_flags(constants=self.full_node.constants, blocks=self.full_node.blockchain, block=block)
-            additions, removals = await asyncio.get_running_loop().run_in_executor(
-                self.executor,
-                additions_and_removals,
-                bytes(block.transactions_generator),
-                block_generator.generator_refs,
-                flags,
-                self.full_node.constants,
-            )
+            # malicious generators may exist on-chain. An untrusted peer
+            # could make us waste compute by requesting such blocks.
+            # SIMPLE_GENERATOR restricts the generator to safe operations.
+            if not self.is_trusted(peer):
+                flags |= SIMPLE_GENERATOR
+            try:
+                additions, removals = await asyncio.get_running_loop().run_in_executor(
+                    self.executor,
+                    additions_and_removals,
+                    bytes(block.transactions_generator),
+                    block_generator.generator_refs,
+                    flags,
+                    self.full_node.constants,
+                )
+            except ValueError:
+                return make_msg(ProtocolMessageTypes.reject_header_request, RejectHeaderRequest(request.height))
             # strip the hint from additions, and compute the puzzle hash for
             # removals
             removals_and_additions = ([name for name, _ in removals], [name for name, _ in additions])
@@ -1509,8 +1520,10 @@ class FullNodeAPI:
                 response = wallet_protocol.TransactionAck(spend_name, uint8(status.value), error_name)
         return make_msg(ProtocolMessageTypes.transaction_ack, response)
 
-    @metadata.request()
-    async def request_puzzle_solution(self, request: wallet_protocol.RequestPuzzleSolution) -> Message | None:
+    @metadata.request(peer_required=True)
+    async def request_puzzle_solution(
+        self, request: wallet_protocol.RequestPuzzleSolution, peer: WSChiaConnection
+    ) -> Message | None:
         coin_name = request.coin_name
         height = request.height
         coin_record = await self.full_node.coin_store.get_coin_record(coin_name)
@@ -1532,6 +1545,12 @@ class FullNodeAPI:
             self.full_node.blockchain.lookup_block_generators, block
         )
         assert block_generator is not None
+        flags = get_flags_for_height_and_constants(height, self.full_node.constants)
+        # malicious generators may exist on-chain. An untrusted peer
+        # could make us waste compute by requesting such blocks.
+        # SIMPLE_GENERATOR restricts the generator to safe operations.
+        if not self.is_trusted(peer):
+            flags |= SIMPLE_GENERATOR
         try:
             puzzle, solution = await asyncio.get_running_loop().run_in_executor(
                 self.executor,
@@ -1540,7 +1559,7 @@ class FullNodeAPI:
                 block_generator.generator_refs,
                 self.full_node.constants.MAX_BLOCK_COST_CLVM,
                 coin_record.coin,
-                get_flags_for_height_and_constants(height, self.full_node.constants),
+                flags,
             )
         except ValueError:
             return reject_msg


### PR DESCRIPTION

### Purpose:

This is meant as a protection against malicious peers.

An untrusted wallet connection can ask us for `request_puzzle_solution` and `request_block_header`, and we (the node) runs the block generator to produce the responses.

A generator is a program that returns the spends. In the 3.0 hard fork we require the generator to just be a list, i.e. not a program. A generator program can be malicious in various ways.

There are legitimate coins created by block generators that are not simple, so this change does reject some coins from being requested by untrusted nodes.

### Current Behavior:

Any wallet peer asking for puzzle and solutions cause the node to execute the generator.

### New Behavior:

When an *untrusted* wallet peer asks for puzzle and solutions, the node will reject the request unless the generator is "simple" (i.e. not a program).

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet-facing full node RPC behavior to execute block generators under the `SIMPLE_GENERATOR` flag for untrusted peers and reject on unsafe generators, which may cause some previously-served header/puzzle-solution requests to fail for untrusted connections.
> 
> **Overview**
> Hardens `FullNodeAPI` wallet endpoints so an *untrusted* peer requesting `request_block_header` or `request_puzzle_solution` cannot force execution of potentially-malicious on-chain generators: the node now ORs `SIMPLE_GENERATOR` into CLVM execution flags for untrusted peers and rejects the request on generator evaluation `ValueError`.
> 
> Updates the wallet protocol stubs and tests to require a `peer` for these requests (`peer_required=True`), adjusts call sites accordingly, and adds a targeted test asserting the `SIMPLE_GENERATOR` flag is set only for untrusted peers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 147e6ffd3c70af3124b319a00a7f249049e3c2e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->