### PR TITLE
CHIA-4175 Remove no longer needed tx peak computation in declare_proof_of_space

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1057,7 +1057,6 @@ class FullNodeAPI:
                     if sub_slot.challenge_chain.new_sub_slot_iters is not None:
                         sub_slot_iters = sub_slot.challenge_chain.new_sub_slot_iters
 
-            tx_peak = self.full_node.blockchain.get_tx_peak()
             required_iters: uint64 = calculate_iterations_quality(
                 self.full_node.constants,
                 quality_string,


### PR DESCRIPTION
It was added in PR #19616 but became no longer needed in PR #20216

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line cleanup removing a redundant variable assignment; no functional logic paths are changed.
> 
> **Overview**
> Removes an unused `tx_peak` recomputation in `FullNodeAPI.declare_proof_of_space`, relying on the existing difficulty/sub-slot iteration calculations without fetching the transaction peak again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cccbbbb8f83d1f1c681505fa511d3a032f170a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->