### PR TITLE
Test INTERNED_GENERATOR: manually wire flag post-HF2

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -194,6 +194,13 @@ jobs:
           mkdir "${GITHUB_WORKSPACE}/.chia"
           mv "${GITHUB_WORKSPACE}/test-cache-${{ env.BLOCKS_AND_PLOTS_VERSION }}/"* "${GITHUB_WORKSPACE}/.chia"
 
+      - name: Install Rust toolchain (needed to build chia_rs from git source)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install C compiler (Ubuntu)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y build-essential
+
       - uses: ./.github/actions/install
         with:
           python-version: ${{ matrix.python.install_sh }}

--- a/chia/_tests/blockchain/test_build_chains.py
+++ b/chia/_tests/blockchain/test_build_chains.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import pytest
-from chia_rs import Coin, ConsensusConstants, FullBlock, additions_and_removals, get_flags_for_height_and_constants
+from chia_rs import Coin, ConsensusConstants, FullBlock, additions_and_removals
 from chia_rs.sized_ints import uint64
 
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.simulator.block_tools import BlockTools
 
 # These test targets are used to trigger a build of the test chains.

--- a/chia/_tests/core/full_node/stores/test_coin_store.py
+++ b/chia/_tests/core/full_node/stores/test_coin_store.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import aiosqlite
 import pytest
-from chia_rs import CoinRecord, CoinState, FullBlock, additions_and_removals, get_flags_for_height_and_constants
+from chia_rs import CoinRecord, CoinState, FullBlock, additions_and_removals
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
@@ -19,6 +19,7 @@ from chia.consensus.block_height_map import BlockHeightMap
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.blockchain import AddBlockResult, Blockchain
 from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.hint_store import HintStore

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -31,7 +31,6 @@ from chia_rs import (
     UnfinishedBlock,
     VDFInfo,
     additions_and_removals,
-    get_flags_for_height_and_constants,
 )
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
@@ -55,6 +54,7 @@ from chia.consensus.augmented_chain import AugmentedBlockchain
 from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.blockchain import Blockchain
 from chia.consensus.coin_store_protocol import CoinStoreProtocol
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.consensus.get_block_challenge import get_block_challenge
 from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_block
 from chia.consensus.pot_iterations import is_overflow_block

--- a/chia/_tests/core/full_node/test_hard_fork_utils.py
+++ b/chia/_tests/core/full_node/test_hard_fork_utils.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import pytest
-from chia_rs import BlockRecord, get_flags_for_height_and_constants
+from chia_rs import BlockRecord
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32
 
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.consensus.get_block_challenge import pre_sp_tx_block_height
 from chia.full_node.hard_fork_utils import get_flags
 from chia.simulator.block_tools import BlockTools, load_block_list, test_constants

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -15,7 +15,6 @@ from chia_rs import (
     G2Element,
     SpendBundle,
     SpendBundleConditions,
-    get_flags_for_height_and_constants,
     run_block_generator2,
 )
 from chia_rs import get_puzzle_and_solution_for_coin2 as get_puzzle_and_solution_for_coin
@@ -43,6 +42,7 @@ from chia._tests.util.misc import BenchmarkRunner, invariant_check_mempool
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
 from chia.full_node.fee_estimation import EmptyMempoolInfo, MempoolInfo
 from chia.full_node.full_node_api import FullNodeAPI

--- a/chia/_tests/core/test_cost_calculation.py
+++ b/chia/_tests/core/test_cost_calculation.py
@@ -4,7 +4,7 @@ import logging
 import pathlib
 
 import pytest
-from chia_rs import G1Element, get_flags_for_height_and_constants
+from chia_rs import G1Element
 from chia_rs import get_puzzle_and_solution_for_coin2 as get_puzzle_and_solution_for_coin
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
@@ -15,6 +15,7 @@ from chia._tests.util.get_name_puzzle_conditions import NPCResult, get_name_puzz
 from chia._tests.util.misc import BenchmarkRunner
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.full_node.bundle_tools import simple_solution_generator
 from chia.simulator.block_tools import BlockTools, test_constants
 from chia.types.blockchain_format.coin import Coin

--- a/chia/_tests/util/get_name_puzzle_conditions.py
+++ b/chia/_tests/util/get_name_puzzle_conditions.py
@@ -9,12 +9,12 @@ from chia_rs import (
     ConsensusConstants,
     G2Element,
     SpendBundleConditions,
-    get_flags_for_height_and_constants,
     run_block_generator,
     run_block_generator2,
 )
 from chia_rs.sized_ints import uint16, uint32
 
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.types.generator_types import BlockGenerator
 from chia.util.errors import Err
 from chia.util.streamable import Streamable, streamable

--- a/chia/_tests/util/spend_sim.py
+++ b/chia/_tests/util/spend_sim.py
@@ -17,7 +17,6 @@ from chia_rs import (
     ConsensusConstants,
     G2Element,
     SpendBundle,
-    get_flags_for_height_and_constants,
     run_block_generator2,
 )
 from chia_rs import get_puzzle_and_solution_for_coin2 as get_puzzle_and_solution_for_coin
@@ -28,6 +27,7 @@ from typing_extensions import Self
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.full_node.bundle_tools import simple_solution_generator
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.hint_store import HintStore

--- a/chia/_tests/wallet/conftest.py
+++ b/chia/_tests/wallet/conftest.py
@@ -13,7 +13,6 @@ from chia_rs import (
     ConsensusConstants,
     FullBlock,
     SpendBundleConditions,
-    get_flags_for_height_and_constants,
     run_block_generator,
     run_block_generator2,
 )
@@ -22,6 +21,7 @@ from chia_rs.sized_ints import uint32, uint64, uint128
 from chia._tests.environments.wallet import NewPuzzleHashError, WalletEnvironment, WalletState, WalletTestFramework
 from chia._tests.util.setup_nodes import setup_simulators_and_wallets_service
 from chia._tests.wallet.wallet_block_tools import WalletBlockTools
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.full_node.full_node import FullNode
 from chia.full_node.full_node_rpc_client import FullNodeRpcClient
 from chia.types.peer_info import PeerInfo

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -20,7 +20,6 @@ from chia_rs import (
     SubEpochSummary,
     UnfinishedBlock,
     additions_and_removals,
-    get_flags_for_height_and_constants,
 )
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint16, uint32, uint64, uint128
@@ -31,6 +30,7 @@ from chia.consensus.block_height_map import BlockHeightMap
 from chia.consensus.coin_store_protocol import CoinStoreProtocol
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
 from chia.consensus.find_fork_point import lookup_fork_chain
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.generator_tools import get_block_header
 from chia.consensus.get_block_challenge import pre_sp_tx_block_height

--- a/chia/consensus/flags.py
+++ b/chia/consensus/flags.py
@@ -1,0 +1,20 @@
+"""Consensus flag helpers for testing INTERNED_GENERATOR activation."""
+
+from __future__ import annotations
+
+from chia_rs import ConsensusConstants, get_flags_for_height_and_constants
+
+# ConsensusFlags::INTERNED_GENERATOR = 0x0800_0000
+# Not yet wired in chia_rs get_flags_for_height_and_constants,
+# but the run_block_generator code already supports it.
+INTERNED_GENERATOR: int = 0x0800_0000
+
+
+def get_flags_for_height_and_constants_interned(
+    prev_tx_height: int,
+    constants: ConsensusConstants,
+) -> int:
+    flags = get_flags_for_height_and_constants(prev_tx_height, constants)
+    if prev_tx_height >= constants.HARD_FORK2_HEIGHT:
+        flags |= INTERNED_GENERATOR
+    return flags

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -13,7 +13,6 @@ from chia_rs import (
     FullBlock,
     SpendBundleConditions,
     SubEpochSummary,
-    get_flags_for_height_and_constants,
     run_block_generator,
     run_block_generator2,
 )
@@ -23,6 +22,7 @@ from chia_rs.sized_ints import uint16, uint32, uint64
 from chia.consensus.augmented_chain import AugmentedBlockchain
 from chia.consensus.block_header_validation import validate_finished_header_block
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.generator_tools import get_block_header, tx_removals_and_additions
 from chia.consensus.get_block_challenge import get_block_challenge, pre_sp_tx_block_height

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -30,7 +30,6 @@ from chia_rs import (
     SpendBundleConditions,
     SubEpochSummary,
     UnfinishedBlock,
-    get_flags_for_height_and_constants,
     run_block_generator,
     run_block_generator2,
 )
@@ -47,6 +46,7 @@ from chia.consensus.blockchain_interface import BlockchainInterface
 from chia.consensus.coin_store_protocol import CoinStoreProtocol
 from chia.consensus.condition_tools import pkm_pairs
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.consensus.make_sub_epoch_summary import next_sub_epoch_summary
 from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_block
 from chia.consensus.pot_iterations import calculate_sp_iters

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -27,7 +27,6 @@ from chia_rs import (
     SubEpochSummary,
     UnfinishedBlock,
     additions_and_removals,
-    get_flags_for_height_and_constants,
 )
 from chia_rs import get_puzzle_and_solution_for_coin2 as get_puzzle_and_solution_for_coin
 from chia_rs.sized_bytes import bytes32
@@ -36,6 +35,7 @@ from chiabip158 import PyBIP158
 
 from chia.consensus.block_creation import create_unfinished_block
 from chia.consensus.blockchain import BlockchainMutexPriority
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.consensus.generator_tools import get_block_header
 from chia.consensus.get_block_generator import get_block_generator
 from chia.consensus.pot_iterations import calculate_ip_iters, calculate_iterations_quality, calculate_sp_iters

--- a/chia/full_node/hard_fork_utils.py
+++ b/chia/full_node/hard_fork_utils.py
@@ -3,9 +3,10 @@
 # since a new one might be infused by the time the block is infused
 from __future__ import annotations
 
-from chia_rs import ConsensusConstants, FullBlock, get_flags_for_height_and_constants
+from chia_rs import ConsensusConstants, FullBlock
 
 from chia.consensus.blockchain_interface import BlocksProtocol
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.consensus.pot_iterations import is_overflow_block
 
 

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -17,7 +17,6 @@ from chia_rs import (
     ConsensusConstants,
     G2Element,
     SpendBundle,
-    get_flags_for_height_and_constants,
     run_block_generator2,
     solution_generator_backrefs,
 )
@@ -25,6 +24,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.full_node.eligible_coin_spends import (
     IdenticalSpendDedup,
     SingletonFastForward,

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -18,7 +18,6 @@ from chia_rs import (
     SpendBundle,
     SpendBundleConditions,
     check_time_locks,
-    get_flags_for_height_and_constants,
     supports_fast_forward,
     validate_clvm_and_signature,
 )
@@ -28,6 +27,7 @@ from chiabip158 import PyBIP158
 from typing_extensions import Self
 
 from chia.consensus.block_record import BlockRecordProtocol
+from chia.consensus.flags import get_flags_for_height_and_constants_interned as get_flags_for_height_and_constants
 from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
 from chia.full_node.fee_estimation import FeeBlockInfo, MempoolInfo, MempoolItemInfo
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface

--- a/poetry.lock
+++ b/poetry.lock
@@ -871,43 +871,24 @@ clvm-tools-rs = ">=0.1.45,<0.2.0"
 pytest = ">=8.3.3,<9.0.0"
 
 [[package]]
-name = "chia-rs"
+name = "chia_rs"
 version = "0.42.0"
 description = ""
 optional = false
 python-versions = "*"
 groups = ["main"]
-files = [
-    {file = "chia_rs-0.42.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:c7fc1700eba78a6fa2f9884b0d3ff8d6311ab1bb50f870907a1f60a7a05c793a"},
-    {file = "chia_rs-0.42.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:52948d034993afce118a59172bef237bf862faba885d70bcaca0bd534f870cc9"},
-    {file = "chia_rs-0.42.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:52b7628db5df487d517f5b837a501a5ee25dd76c8d10edfd880b271daaa5cb8f"},
-    {file = "chia_rs-0.42.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:698121e4ee770dd08f7bdb3c58aa28edcd529513d8392d3308104e423e58a944"},
-    {file = "chia_rs-0.42.0-cp310-cp310-win_amd64.whl", hash = "sha256:55c96f7b9c117f5ee2c980ac0ea7ed6641ad72b9071bf8acf78ec72d59acc377"},
-    {file = "chia_rs-0.42.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:fd158c03f12761c7afafd4fde9b9395cc88bbd4f0678cf1e8e21946873ba8dcd"},
-    {file = "chia_rs-0.42.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:b5549379810191cac011ea613fed6ab8be9e3e89e8d652485861049cbec5c807"},
-    {file = "chia_rs-0.42.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:6515435a1fb5638a0f3eaf69df5a61e70babbd2cb51a469c6be800c6ce2d403a"},
-    {file = "chia_rs-0.42.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:e9536e3f252807434aaeaf2ba5984d9f82fcb584ebef8f848b04ecd12c13b0f1"},
-    {file = "chia_rs-0.42.0-cp311-cp311-win_amd64.whl", hash = "sha256:e5ec25c43cdc1ca1c7d77a4fd3b3f865f3edd3f5231c4d7fa3d1b6209c2ac591"},
-    {file = "chia_rs-0.42.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:03ddb1232aeb5c0bc6b4b4472c06e4089140630b39a75053d4189818280683e7"},
-    {file = "chia_rs-0.42.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:229dce5d26c5dd660fa17e9aaec81ebbc080a4919593d4a9b147f929bcaa613d"},
-    {file = "chia_rs-0.42.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:42fe55992ad7ba7eaadbd2a61541a2acfaefe70925df9a6ed3ca65808b35ecea"},
-    {file = "chia_rs-0.42.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d2141d24974265ac47def75d3d9917f7265def851bda6ba1d87f0756881bce9a"},
-    {file = "chia_rs-0.42.0-cp312-cp312-win_amd64.whl", hash = "sha256:31955cfcf1a4f523f0907f936aac5f52e74c5606027db0aab2cbffbdb03d2f86"},
-    {file = "chia_rs-0.42.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:50f3ee3349995bf94e9415243814007c303300afbc178a1c6e892cedf14ba75c"},
-    {file = "chia_rs-0.42.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:5a11ff69b69140d3541a413f19769978152f0d0e6804eb5504595f2cd5dc28a5"},
-    {file = "chia_rs-0.42.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:10f2183ca4d96a2617dce4770718b7b558d8c088a155ba43740280f4f21fb3c4"},
-    {file = "chia_rs-0.42.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:bc9e5383cd384ce824692f54cc1db0aa9c7cd04d3b008d68be6c11a1359d1f9e"},
-    {file = "chia_rs-0.42.0-cp313-cp313-win_amd64.whl", hash = "sha256:2a0cdbc119e67326fca0a81a86f519fe8208ca38e3d12b41f9718e3752acf234"},
-    {file = "chia_rs-0.42.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:186311829e6ba974be34beb749020dbc8ee43a03ec022772a6797c7fccce50d1"},
-    {file = "chia_rs-0.42.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:fc4c42cfff564aad546751894f7e1b78c508b4b9d5868ddc0574443497b597c0"},
-    {file = "chia_rs-0.42.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:9f5393378c9a4316d55fe1676a3dea6d96515e27b443701ccf883daeff2fc108"},
-    {file = "chia_rs-0.42.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:0c5f862a3eac12b9c527ecff36e539c4603d0dab00a8eebf6c86bbb869fcd9ba"},
-    {file = "chia_rs-0.42.0-cp314-cp314-win_amd64.whl", hash = "sha256:fc0cb9790f7e74f6941d36e53501ab3011947d6e7d7e97a4d769efc08cd7772b"},
-    {file = "chia_rs-0.42.0.tar.gz", hash = "sha256:90ce4be20acd5715c190f705377426924400ab825b0a568baf03abc49a80d4c7"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 typing-extensions = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/Chia-Network/chia_rs.git"
+reference = "9774629f"
+resolved_reference = "9774629f95af4cc95d27e6957efdc1a0963698f8"
+subdirectory = "wheel"
 
 [[package]]
 name = "chiabip158"
@@ -4124,4 +4105,4 @@ upnp = ["miniupnpc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <4"
-content-hash = "494723fc688325b4604dc40787ab5b820c61799cecb30ab7e67e97d3dadc0edb"
+content-hash = "b31bc82c188cefbc1c6bf5b06294759d08db3a6a2bac10c4f96169d68c30e852"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ boto3 = ">=1.35.43"  # AWS S3 for Data Layer S3 plugin
 chiabip158 = ">=1.5.2"  # bip158-style wallet filters
 chiapos = ">=2.0.10"  # proof of space
 chia-puzzles-py = ">=0.20.1"
-chia_rs = ">=0.42.0, <0.43"
+chia_rs = {git = "https://github.com/Chia-Network/chia_rs.git", rev = "9774629f", subdirectory = "wheel"}
 chiavdf = ">=1.1.10"  # timelord and vdf verification
 click = ">=8.1.7"  # For the CLI
 clvm = ">=0.9.14"


### PR DESCRIPTION
## Summary

- Points chia_rs at PR #1377 (`pure-storage-model-v2`, commit `9774629f`) which has `INTERNED_GENERATOR` defined but **not** wired in `get_flags_for_height_and_constants`.
- Adds `chia/consensus/flags.py` with a wrapper that ORs in `INTERNED_GENERATOR` (`0x0800_0000`) when `prev_tx_height >= HARD_FORK2_HEIGHT`.
- All 16 call sites now import this wrapper (aliased as `get_flags_for_height_and_constants`), so existing calling code is unchanged.

## Purpose

Identify exactly which tests break when INTERNED_GENERATOR is activated, **without modifying chia_rs itself**. This is the strategy agreed in the 2026-04-16 meeting (Richard, Arvid, Earle, Bill): ship `#1377` with the flag unwired, then test activation separately in chia-blockchain.

## Test plan

- [ ] Let CI run — failures show what needs fixing before HF2 activation
- [ ] Cost assertion tests will likely fail (tree-based cost differs from byte-length)
- [ ] BlockTools may need updating (cost computation for block creation)
- [ ] Mempool tests may need adjustment (interning changes relative spend costs)

Made with [Cursor](https://cursor.com)