### PR TITLE
CHIA-4176 Avoid recomputing tx peak when creating a block generator in declare_proof_of_space

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -933,10 +933,6 @@ class FullNodeAPI:
                     return None
 
                 if peak is not None:
-                    # Finds the last transaction block before this one
-                    curr_l_tb: BlockRecord = peak
-                    while not curr_l_tb.is_transaction_block:
-                        curr_l_tb = self.full_node.blockchain.block_record(curr_l_tb.prev_hash)
                     try:
                         block_version = self.full_node.config.get("block_creation", 1)
                         block_timeout = self.full_node.config.get("block_creation_timeout", 2.0)
@@ -948,7 +944,8 @@ class FullNodeAPI:
                             self.log.warning(f"Unknown 'block_creation' config: {block_version}")
                             create_block = self.full_node.mempool_manager.create_block_generator
 
-                        new_block_gen = create_block(curr_l_tb.header_hash, block_timeout)
+                        assert tx_peak is not None
+                        new_block_gen = create_block(tx_peak.header_hash, block_timeout)
 
                         if (
                             new_block_gen is not None and peak.height < self.full_node.constants.HARD_FORK_HEIGHT


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches block-farming/block-generator selection logic; although the change is small, using the wrong tip could affect which transactions are included in newly farmed blocks.
> 
> **Overview**
> `declare_proof_of_space` now reuses the already-fetched `tx_peak` (from `blockchain.get_tx_peak()`) when calling `create_block_generator*`, instead of walking back from `peak` to find the last transaction block.
> 
> This removes redundant chain traversal and adds an `assert tx_peak is not None` before using `tx_peak.header_hash` as the generator tip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f61ef7843dde2503cc2264cbb5d2c0e0d8fabc21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->