### PR TITLE
CHIA-4177 Improve logging unsolicited transactions in FullNodeAPI's respond_transaction

### DIFF
--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -334,7 +334,10 @@ class FullNodeAPI:
         elif peer.expected_mempool_responses > 0:
             peer.expected_mempool_responses -= 1
         else:
-            self.log.warning(f"Received unsolicited transaction from peer {peer.peer_node_id}")
+            self.log.info(
+                f"Received unsolicited transaction {spend_name} from peer "
+                f"{peer.peer_node_id} / {peer.peer_info.host} version {peer.version}"
+            )
             return None
         peers_with_tx = {}
         if spend_name in self.full_node.full_node_store.peers_with_tx:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: behavior is unchanged aside from log level and message content, affecting only observability and potentially log volume.
> 
> **Overview**
> Improves observability when `respond_transaction` receives an unsolicited transaction by switching the log from `warning` to `info` and including the transaction hash plus peer ID, host, and protocol version in the message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e26bbc98a14a4e35af7f5e90ff0b4c7b7d9f0c2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->