### PR TITLE
CHIA-4196 Update more tests after PendingTxCache's drain fix

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3505,9 +3505,9 @@ async def test_pending_tx_cache_retry_on_new_peak(
         # Make sure it ends up in the pending cache, not the mempool
         assert full_node_api.full_node.mempool_manager.get_mempool_item(sb_name, include_pending=False) is None
         assert full_node_api.full_node.mempool_manager.get_mempool_item(sb_name, include_pending=True) is not None
-        # Advance peak to meet the asserted height condition
+        # Advance peak to exactly the asserted height condition
         with caplog.at_level(logging.DEBUG):
-            blocks = bt.get_consecutive_blocks(2, block_list_input=blocks, guarantee_transaction_block=True)
+            blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, guarantee_transaction_block=True)
             for block in blocks:
                 await full_node_api.full_node.add_block(block)
         # This should trigger peak post processing with the added transaction

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -3450,7 +3450,7 @@ async def test_new_peak_txs_added(condition_and_error: tuple[ConditionOpcode, Er
     Tests that deferred transactions because of time-lock are retried once the
     time-lock allows them to be reconsidered.
 
-    drain() uses <=, so when new_peak.height == condition_height the item is
+    PendingTxCache's drain() uses <=, so when new_peak.height == condition_height the item is
     promoted immediately (check_time_locks accepts ASSERT_HEIGHT_ABSOLUTE(H)
     when peak.height >= H, and ASSERT_HEIGHT_RELATIVE(R) when
     peak.height >= coin_confirmed + R).
@@ -3465,24 +3465,18 @@ async def test_new_peak_txs_added(condition_and_error: tuple[ConditionOpcode, Er
         _, status, error = result
         assert status == MempoolInclusionStatus.PENDING
         assert error == expected_error
-        # Advance the mempool to exactly the asserted height.
-        # drain() uses <=, so the item is promoted at condition_height (not condition_height + 1).
+        # Advance the mempool to exactly the asserted height condition and
+        # retry the test item.
         if optimized_path:
             spent_coins: list[bytes32] | None = []
-            new_peak_info = await mempool_manager.new_peak(
-                create_test_block_record(height=uint32(condition_height)), spent_coins
-            )
-            # The item is retried and promoted at exactly condition_height
-            assert new_peak_info.spend_bundle_ids == [sb_name]
-            assert mempool_manager.get_mempool_item(sb_name, include_pending=False) is not None
         else:
             spent_coins = None
-            new_peak_info = await mempool_manager.new_peak(
-                create_test_block_record(height=uint32(condition_height)), spent_coins
-            )
-            # The item is retried and promoted at exactly condition_height
-            assert new_peak_info.spend_bundle_ids == [sb_name]
-            assert mempool_manager.get_mempool_item(sb_name, include_pending=False) is not None
+        new_peak_info = await mempool_manager.new_peak(
+            create_test_block_record(height=uint32(condition_height)), spent_coins
+        )
+        # The item gets retried successfully now
+        assert new_peak_info.spend_bundle_ids == [sb_name]
+        assert mempool_manager.get_mempool_item(sb_name, include_pending=False) is not None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
This is an addendum to PR #20786.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are test-only and adjust expectations around when pending transactions are retried/promoted at a new peak height.
> 
> **Overview**
> Updates time-lock/pending-transaction tests to match the fixed `PendingTxCache.drain()` behavior that promotes items when `new_peak.height == condition_height`.
> 
> Specifically, the full-node integration test now advances the chain by *one* block (to reach the asserted height exactly), and the mempool-manager unit test deduplicates the optimized/non-optimized `new_peak()` paths while asserting the pending item is retried and moved into the mempool at that height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5166af6d09287ebef58d528495f2992f6b9a1d3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->