### PR TITLE
CHIA-4198 Improve handling nonced timed out requests in WSChiaConnection's _send_message

### DIFF
--- a/chia/_tests/core/server/test_server.py
+++ b/chia/_tests/core/server/test_server.py
@@ -486,3 +486,42 @@ async def test_inbound_handler_none_msg(
     assert read_calls == 1
     assert wsc.incoming_queue.qsize() == 0
     await wsc.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_send_message_timed_out_nonced_request(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Covers the scenario where a nonced request gets timed out while it's in the
+    outgoing queue to make sure it gets dropped.
+    """
+    _, server, _ = one_node_one_block
+    wsc, _ = await add_dummy_connection_wsc(server, self_hostname, 1337)
+    event = asyncio.Event()
+    original_send_message = wsc._send_message
+    request_id: uint16 | None = None
+
+    async def test_send_message(message: Message) -> None:
+        nonlocal request_id
+        request_id = message.id
+        await event.wait()
+        await original_send_message(message)
+
+    monkeypatch.setattr(wsc, "_send_message", test_send_message)
+    msg_type = ProtocolMessageTypes.request_block
+    msg = make_msg(msg_type, b"")
+    response = await wsc.send_request(message_no_id=msg, timeout=0)
+    assert response is None
+    assert request_id in wsc.timed_out_requests
+    caplog.clear()
+    caplog.set_level(logging.INFO)
+    event.set()
+    await time_out_assert(
+        5, lambda: f"Dropping timed out request ID {request_id} with msg type {msg_type.name}" in caplog.text
+    )
+    assert request_id not in wsc.timed_out_requests

--- a/chia/server/ws_connection.py
+++ b/chia/server/ws_connection.py
@@ -687,6 +687,19 @@ class WSChiaConnection:
         encoded: bytes = bytes(message)
         size = len(encoded)
         assert len(encoded) < (2 ** (LENGTH_BYTES * 8))
+        message_type = ProtocolMessageTypes(message.type)
+        # If a request timed out while being queued, there is no point in
+        # sending it while tracking it as a timed out request and having the
+        # receiver respond to it only to drop that response.
+        if message.id in self.timed_out_requests:
+            self.log.info(
+                f"Dropping timed out request ID {message.id} "
+                f"with msg type {message_type.name} "
+                f"to peer {self.peer_node_id} / {self.peer_info.host} "
+                f"version {self.version}"
+            )
+            self.timed_out_requests.discard(message.id)
+            return None
         limiter_msg = self.outbound_rate_limiter.process_msg_and_check(
             message, self.local_capabilities, self.peer_capabilities
         )
@@ -694,7 +707,6 @@ class WSChiaConnection:
             if not is_localhost(self.peer_info.host) and not is_in_network(
                 self.peer_info.host, self.exempt_peer_networks
             ):
-                message_type = ProtocolMessageTypes(message.type)
                 last_time = self.log_rate_limit_last_time[message_type]
                 now = time.monotonic()
                 if now - last_time >= 30:


### PR DESCRIPTION
If a nonced request timed out before being sent, there is no point in sending it while tracking it as a timed out request and having the receiver respond to it only to drop that response.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core websocket send-path logic; while the change is small and well-covered by a targeted test, it could affect request/response behavior under timing/race conditions.
> 
> **Overview**
> Prevents `WSChiaConnection` from sending nonced requests that have already timed out while waiting in the outbound queue, avoiding unnecessary network traffic and late responses that will be ignored.
> 
> `_send_message()` now checks `timed_out_requests` and logs/drops the message (and clears the nonce) before rate-limiter processing/sending, and a new test (`test_send_message_timed_out_nonced_request`) exercises this queue-timeout scenario and asserts the drop + cleanup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f5ea15789d14dee43068e7715eca72786e404f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->