### PR TITLE
PR for CHIA-4002 thanks roopd3v

### DIFF
--- a/chia/wallet/util/peer_request_cache.py
+++ b/chia/wallet/util/peer_request_cache.py
@@ -52,6 +52,10 @@ class PeerRequestCache:
     def in_states_validated(self, coin_state_hash: bytes32) -> bool:
         return self._states_validated.get(coin_state_hash) is not None
 
+    def coin_state_validation_recorded(self, coin_state_hash: bytes32) -> bool:
+        """True if we recorded validation for this coin state (including reorg markers stored as None)."""
+        return coin_state_hash in self._states_validated.cache
+
     def add_to_states_validated(self, coin_state: CoinState) -> None:
         cs_height: uint32 | None = None
         if coin_state.spent_height is not None:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1284,7 +1284,7 @@ class WalletNode:
                 return False
 
             # Include exact fork height to avoid dropping boundary race-cache entries.
-            for potential_height in range(backtrack_fork_height, new_peak_hb.height + 1):
+            for potential_height in range(fork_height, new_peak_hb.height + 1):
                 try:
                     race_cache = cache.get_race_cache(potential_height)
                 except KeyError:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1283,8 +1283,8 @@ class WalletNode:
                 # Don't process blocks at the same weight
                 return False
 
-            # For every block, we need to apply the cache from race_cache
-            for potential_height in range(backtrack_fork_height + 1, new_peak_hb.height + 1):
+            # Include exact fork height to avoid dropping boundary race-cache entries.
+            for potential_height in range(backtrack_fork_height, new_peak_hb.height + 1):
                 try:
                     race_cache = cache.get_race_cache(potential_height)
                 except KeyError:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1283,15 +1283,28 @@ class WalletNode:
                 # Don't process blocks at the same weight
                 return False
 
-            # Include exact fork height to avoid dropping boundary race-cache entries.
-            for potential_height in range(fork_height, new_peak_hb.height + 1):
+            # For every block, we need to apply the cache from race_cache. Include the exact fork height
+            # (CHIA-4002) so boundary entries are not dropped; skip states already validated so we do not
+            # apply the same coin state twice (which can re-run config-dependent handlers like notifications).
+            #
+            # Note: clear_after_height() can remove _states_validated markers for heights above a fork while
+            # leaving rows in _race_cache. After a successful apply, remove those coin states from the race
+            # cache so they cannot be replayed once validation markers are gone.
+            for potential_height in range(backtrack_fork_height, new_peak_hb.height + 1):
                 try:
                     race_cache = cache.get_race_cache(potential_height)
                 except KeyError:
                     continue
 
-                self.log.info(f"Apply race cache - height: {potential_height}, coin_states: {race_cache}")
-                await self.add_states_from_peer(list(race_cache), peer)
+                to_apply = [cs for cs in race_cache if not cache.coin_state_validation_recorded(cs.get_hash())]
+                if len(to_apply) == 0:
+                    continue
+
+                self.log.info(f"Apply race cache - height: {potential_height}, coin_states: {to_apply}")
+                applied_ok = await self.add_states_from_peer(to_apply, peer)
+                if applied_ok:
+                    for cs in to_apply:
+                        race_cache.discard(cs)
 
             # Clear old entries that are no longer relevant
             cache.cleanup_race_cache(min_height=backtrack_fork_height)


### PR DESCRIPTION
DO NOT MERGE 

### Purpose:

Off by one for wallet race cache

### Current Behavior:

Does not include fork point

### New Behavior:

Includes fork point

### Testing Notes:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches untrusted wallet sync/reorg edge cases and changes when cached coin states are (re)applied, which could affect transaction/notification handling if the new filtering is incorrect.
> 
> **Overview**
> Fixes an off-by-one in untrusted wallet short-sync race-cache application by including the exact fork height when replaying cached `CoinState` updates.
> 
> Adds `PeerRequestCache.coin_state_validation_recorded()` and uses it to skip already-recorded validations (including reorg markers), and prunes successfully-applied entries from `_race_cache` to prevent coin states from being replayed after `clear_after_height()` drops validation markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe0cbc5e312152769ff57dcf7f184c831301c281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->