### PR TITLE
CHIA-4199 Avoid redundant close handling on already closed peers in WalletNode's new_peak_wallet

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1134,6 +1134,8 @@ class WalletNode:
         request = RequestBlockHeader(new_peak.height)
         response: RespondBlockHeader | None = await peer.call_api(FullNodeAPI.request_block_header, request)
         if response is None:
+            if peer.closed:
+                return
             self.log.warning(f"Peer {peer.get_peer_info()} did not respond in time.")
             await peer.close(120)
             return


### PR DESCRIPTION
This manifested as `Peer None did not respond in time.` noise in the logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small guard around timeout handling that only changes behavior when the peer is already closed, reducing log noise and redundant close calls.
> 
> **Overview**
> Reduces noisy `did not respond in time` warnings in `WalletNode.new_peak_wallet` by **bailing out early** when the block-header request times out but the peer connection is already closed.
> 
> This avoids triggering redundant `peer.close(120)` handling on already-disconnected peers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd4c7e32e3bc695c8775e7a4dda15f41550e9c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->