### PR TITLE
change of by one to cleanup_race_cache

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1294,7 +1294,7 @@ class WalletNode:
                 await self.add_states_from_peer(list(race_cache), peer)
 
             # Clear old entries that are no longer relevant
-            cache.cleanup_race_cache(min_height=backtrack_fork_height)
+            cache.cleanup_race_cache(min_height=backtrack_fork_height + 1)
 
             self.wallet_state_manager.state_changed("new_block")
             self.log.info(f"Finished processing new peak of {new_peak_hb.height}")


### PR DESCRIPTION
DO NOT MERGE

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches untrusted wallet short-sync cache eviction logic; an off-by-one here can affect whether coin states are re-applied or dropped around reorg boundaries.
> 
> **Overview**
> Fixes an off-by-one in untrusted close-to-peak syncing by changing `cleanup_race_cache()` to retain entries starting at `backtrack_fork_height + 1` after applying per-height race-cache updates, instead of including the fork height itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b168467ee04ea3860922a15f4ea8035aa36c96e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->