### PR TITLE
CHIA-4202 Improve handling additions/removals requests in WalletNode's validate_received_state_from_peer

### DIFF
--- a/chia/_tests/wallet/sync/test_wallet_sync.py
+++ b/chia/_tests/wallet/sync/test_wallet_sync.py
@@ -12,6 +12,7 @@ import pytest
 from aiosqlite import Error as AIOSqliteError
 from chia_rs import (
     BlockRecord,
+    Coin,
     CoinState,
     ConsensusConstants,
     FullBlock,
@@ -27,6 +28,7 @@ from colorlog import getLogger
 from chia._tests.conftest import ConsensusMode
 from chia._tests.connection_utils import (
     add_dummy_connection,
+    add_dummy_connection_wsc,
     connect_and_get_peer,
     disconnect_all,
     disconnect_all_and_reconnect,
@@ -40,10 +42,11 @@ from chia.consensus.augmented_chain import AugmentedBlockchain
 from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
+from chia.consensus.generator_tools import get_block_header
 from chia.full_node.full_node_api import MAX_COIN_HASHES_PER_REQUEST, FullNodeAPI
 from chia.full_node.weight_proof import WeightProofHandler
 from chia.protocols import full_node_protocol, wallet_protocol
-from chia.protocols.outbound_message import Message, make_msg
+from chia.protocols.outbound_message import Message, NodeType, make_msg
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.protocols.shared_protocol import Capability
 from chia.protocols.wallet_protocol import (
@@ -72,9 +75,11 @@ from chia.util.hash import std_hash
 from chia.wallet.conditions import CreateCoin
 from chia.wallet.nft_wallet.nft_wallet import NFTWallet
 from chia.wallet.util.compute_memos import compute_memos
+from chia.wallet.util.peer_request_cache import PeerRequestCache
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_sync_utils import PeerRequestException
 from chia.wallet.util.wallet_types import WalletIdentifier
+from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_state_manager import WalletStateManager
 from chia.wallet.wallet_weight_proof_handler import get_wp_fork_point
 
@@ -1851,3 +1856,103 @@ async def test_long_reorg_nodes_and_wallet(
     p1 = full_node_2.full_node.blockchain.get_peak()
     assert p1 is not None
     assert p1.header_hash == last_reorg_blk.header_hash
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+async def test_validate_received_state_from_peer_no_additions(
+    simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """
+    Covers the case where we fail to obtain additions in
+    `validate_received_state_from_peer` to make sure we don't disconnect/ban
+    the peer.
+    """
+    [full_node_api], [(wallet_node, _)], bt = simulator_and_wallet
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32.random()))
+    peak = full_node_api.full_node.blockchain.get_peak()
+    assert peak is not None
+    blocks = await full_node_api.get_all_full_blocks()
+    blocks = bt.get_consecutive_blocks(1, blocks, guarantee_transaction_block=True)
+    new_block_header = get_block_header(blocks[-1])
+    created_height = uint32(peak.height + 1)
+    assert new_block_header.height == created_height
+    peer_request_cache = PeerRequestCache()
+    peer_request_cache.add_to_blocks(new_block_header)
+    ph = bytes32.random()
+    coin_state = CoinState(Coin(bytes32.random(), ph, uint64(1)), None, created_height)
+    wsc, _ = await add_dummy_connection_wsc(full_node_api.full_node.server, self_hostname, 42, NodeType.WALLET)
+    caplog.clear()
+    caplog.set_level(logging.INFO)
+    result = await wallet_node.validate_received_state_from_peer(
+        coin_state=coin_state, peer=wsc, peer_request_cache=peer_request_cache, fork_height=None
+    )
+    assert result is False
+    assert (
+        f"Failed to obtain additions for height {created_height} "
+        f"header hash {new_block_header.header_hash} puzzle hash {ph}" in caplog.text
+    )
+    assert not wsc.closed
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+@pytest.mark.parametrize("remote_spent", [True, False])
+async def test_validate_received_state_from_peer_no_removals(
+    simulator_and_wallet: OldSimulatorsAndWallets,
+    self_hostname: str,
+    caplog: pytest.LogCaptureFixture,
+    remote_spent: bool,
+) -> None:
+    """
+    Covers the case where we fail to obtain removals in
+    `validate_received_state_from_peer` to make sure we don't disconnect/ban
+    the peer.
+    """
+    [full_node_api], [(wallet_node, wallet_server)], _ = simulator_and_wallet
+    server = full_node_api.full_node.server
+    await wallet_server.start_client(PeerInfo(self_hostname, server.get_port()), None)
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32.random()))
+    await full_node_api.wait_for_wallet_synced(wallet_node=wallet_node, timeout=10)
+    peak = full_node_api.full_node.blockchain.get_peak()
+    assert peak is not None
+    created_height = peak.height
+    spent_height = created_height
+    coin = Coin(bytes32.random(), bytes32.random(), uint64(1))
+    peer_request_cache = PeerRequestCache()
+    if remote_spent:
+        coin_state = CoinState(coin, spent_height, created_height)
+    else:
+        await wallet_node.wallet_state_manager.coin_store.add_coin_record(
+            WalletCoinRecord(
+                coin=coin,
+                confirmed_block_height=created_height,
+                spent_block_height=spent_height,
+                spent=True,
+                coinbase=False,
+                wallet_type=wallet_node.wallet_state_manager.main_wallet.type(),
+                wallet_id=int(wallet_node.wallet_state_manager.main_wallet.id()),
+            )
+        )
+        coin_state = CoinState(coin, None, created_height)
+    wsc, _ = await add_dummy_connection_wsc(server, self_hostname, 42, NodeType.WALLET)
+    caplog.clear()
+    caplog.set_level(logging.INFO)
+    request_removals_calls: list[uint32] = []
+
+    async def request_removals(self: FullNodeAPI, request: RequestRemovals) -> Message | None:
+        request_removals_calls.append(request.height)
+        reject = RejectRemovalsRequest(request.height, request.header_hash)
+        return make_msg(ProtocolMessageTypes.reject_removals_request, reject)
+
+    with patch_request_handler(api=server.api, handler=request_removals):
+        result = await wallet_node.validate_received_state_from_peer(
+            coin_state=coin_state, peer=wsc, peer_request_cache=peer_request_cache, fork_height=None
+        )
+    assert result is False
+    assert request_removals_calls == [spent_height]
+    assert (
+        f"Failed to obtain removals for height {spent_height} "
+        f"header hash {peak.header_hash} coin name {coin.name()}" in caplog.text
+    )
+    assert not wsc.closed

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -195,14 +195,23 @@ def validate_removals(
 
 async def request_and_validate_removals(
     peer: WSChiaConnection, height: uint32, header_hash: bytes32, coin_name: bytes32, removals_root: bytes32
-) -> bool:
+) -> bool | None:
+    """
+    Returns None on failure to obtain removals, otherwise it returns True or
+    False depending on the outcome of validation.
+    """
     removals_request = RequestRemovals(height, header_hash, [coin_name])
 
     removals_res: RespondRemovals | RejectRemovalsRequest | None = await peer.call_api(
         FullNodeAPI.request_removals, removals_request
     )
     if removals_res is None or isinstance(removals_res, RejectRemovalsRequest):
-        return False
+        log.info(
+            f"Failed to obtain removals for height {height} header hash {header_hash} "
+            f"coin name {coin_name} from peer {peer.peer_node_id} / {peer.peer_info.host} "
+            f"version {peer.version} response: {removals_res}"
+        )
+        return None
     return validate_removals(removals_res.coins, removals_res.proofs, removals_root)
 
 
@@ -213,7 +222,7 @@ async def request_and_validate_additions(
     header_hash: bytes32,
     puzzle_hash: bytes32,
     additions_root: bytes32,
-) -> bool:
+) -> bool | None:
     if peer_request_cache.in_additions_in_block(header_hash, puzzle_hash):
         return True
     additions_request = RequestAdditions(height, header_hash, [puzzle_hash])
@@ -221,7 +230,12 @@ async def request_and_validate_additions(
         FullNodeAPI.request_additions, additions_request
     )
     if additions_res is None or isinstance(additions_res, RejectAdditionsRequest):
-        return False
+        log.info(
+            f"Failed to obtain additions for height {height} header hash {header_hash} "
+            f"puzzle hash {puzzle_hash} from peer {peer.peer_node_id} / {peer.peer_info.host} "
+            f"version {peer.version} response: {additions_res}"
+        )
+        return None
     result: bool = validate_additions(
         additions_res.coins,
         additions_res.proofs,

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1459,6 +1459,8 @@ class WalletNode:
             state_block.foliage_transaction_block.additions_root,
         )
 
+        if validate_additions_result is None:
+            return False
         if validate_additions_result is False:
             self.log.warning("Validate false 1")
             await peer.close(9999)
@@ -1487,13 +1489,15 @@ class WalletNode:
                 assert spent_state_block.foliage_transaction_block is not None
                 peer_request_cache.add_to_blocks(spent_state_block)
 
-                validate_removals_result: bool = await request_and_validate_removals(
+                validate_removals_result = await request_and_validate_removals(
                     peer,
                     current.spent_block_height,
                     spent_state_block.header_hash,
                     coin_state.coin.name(),
                     spent_state_block.foliage_transaction_block.removals_root,
                 )
+                if validate_removals_result is None:
+                    return False
                 if validate_removals_result is False:
                     self.log.warning("Validate false 2")
                     await peer.close(9999)
@@ -1524,6 +1528,8 @@ class WalletNode:
                 coin_state.coin.name(),
                 spent_state_block.foliage_transaction_block.removals_root,
             )
+            if validate_removals_result is None:
+                return False
             if validate_removals_result is False:
                 self.log.warning("Validate false 3")
                 await peer.close(9999)


### PR DESCRIPTION
Differentiate between not obtaining additions/removals and obtaining invalid ones in `WalletNode`'s `validate_received_state_from_peer` to avoid disconnecting/banning peers unless proof validation fails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes untrusted sync validation behavior in `WalletNode.validate_received_state_from_peer`, which can affect peer management and wallet sync correctness if the new `None`/`False` handling is wrong.
> 
> **Overview**
> Improves `WalletNode.validate_received_state_from_peer` handling so peers are **only disconnected** when additions/removals *validate as invalid*, not when the wallet simply **can’t obtain** additions/removals data.
> 
> `request_and_validate_additions`/`request_and_validate_removals` now return `None` on request failure (with more detailed info-level logging), and `wallet_node.py` treats this as a soft failure without closing the connection.
> 
> Adds targeted sync tests covering rejection/absence of additions/removals responses to ensure the wallet logs the failure and keeps the peer connected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604662ae3956e8792c83fe8621ecfa2445c7498f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->