### PR TITLE
Remove unused wallet outbound rate-limit config key

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -587,7 +587,6 @@ wallet:
 
   # wallet overrides for limits
   inbound_rate_limit_percent: 100
-  outbound_rate_limit_percent: 60
 
   # timeout for weight proof request
   weight_proof_timeout: *weight_proof_timeout


### PR DESCRIPTION
### Purpose:

Remove a wallet config key that is not actually configurable at runtime.

### Current Behavior:

`wallet.outbound_rate_limit_percent` is present in default `config.yaml`, but wallet service startup unconditionally forces outbound rate limit percent to `60`, so editing this key has no effect.

### New Behavior:

The default wallet config no longer includes `wallet.outbound_rate_limit_percent`.

Invariants unchanged:
- Wallet outbound rate limiting behavior remains fixed at `60` (no runtime behavior change)
- Existing inbound wallet rate-limit override remains unchanged
- Error handling and peer connection logic are unchanged

### Testing Notes:

- Ran focused mypy check:
  - `./tools/py -m mypy chia/server/start_service.py --config-file mypy.ini.template`
- Ran targeted config test suite:
  - `unset CI && ./tools/pytest chia/_tests/core/util/test_config.py -v --override-ini=\"addopts=--verbose --tb=short\"`
- Ran generic pre-push adversarial diff review (fresh-context subagent): no issues found
- Benchmarks skipped per request for this simple config-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this is a config-template-only change and does not alter runtime wallet or networking behavior.
> 
> **Overview**
> Removes `wallet.outbound_rate_limit_percent` from `chia/util/initial-config.yaml` to avoid advertising a wallet setting that has no effect.
> 
> Keeps the existing `wallet.inbound_rate_limit_percent` override intact; no code-path or networking behavior changes are introduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cb96bf874d78bced07a62dff662a685a0d3b319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->