### PR TITLE
Use SQLITE_MAX_VARIABLE_NUMBER for chunking limit

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -45,7 +45,7 @@ from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.weight_proof import WeightProof
 from chia.util.batches import to_batches
 from chia.util.config import lock_and_load_config, process_config_start_method, save_config
-from chia.util.db_wrapper import manage_connection
+from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER, manage_connection
 from chia.util.errors import Err, KeychainIsEmpty, KeychainIsLocked, KeychainKeyNotFound, KeychainProxyConnectionFailure
 from chia.util.hash import std_hash
 from chia.util.keychain import Keychain
@@ -988,7 +988,7 @@ class WalletNode:
 
         # Keep chunk size below 1000 just in case, windows has sqlite limits of 999 per query
         # Untrusted has a smaller batch size since validation has to happen which takes a while
-        chunk_size: int = 900 if trusted else 10
+        chunk_size: int = SQLITE_MAX_VARIABLE_NUMBER if trusted else 10
 
         reorged_coin_states = []
         updated_coin_states = []


### PR DESCRIPTION
Wallet code was using the old 900 limit for chunking with trusted node - this change uses the SQLITE_MAX_VARIABLE_NUMBER var which sets the limit much highter in newer sqlite versions

Note, the untrusted limit remains unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant swap for trusted-path batching only; untrusted behavior unchanged and the limit still respects SQLite version caps.
> 
> **Overview**
> For **trusted** full-node coin state ingestion, batching now uses `SQLITE_MAX_VARIABLE_NUMBER` from `chia.util.db_wrapper` instead of a fixed **900** bound. That constant is **900** on SQLite &lt; 3.32 and **32700** on newer builds, so trusted sync can issue larger per-query batches where the runtime allows it.
> 
> **Untrusted** peers still use chunk size **10** (unchanged), since validation cost dominates there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d996abbd88dd3f25ff24a484e7dbbb17001211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->