### PR TITLE
Wallet: skip parent fetch in determine_coin_type for locally-known DL coins

### DIFF
--- a/chia/_tests/wallet/test_wallet_state_manager.py
+++ b/chia/_tests/wallet/test_wallet_state_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from unittest.mock import AsyncMock
 
 import pytest
 from chia_rs import CoinState, G2Element
@@ -16,7 +17,6 @@ from chia._tests.util.time_out_assert import time_out_assert
 from chia.data_layer.data_layer_wallet import DataLayerWallet
 from chia.data_layer.singleton_record import SingletonRecord
 from chia.protocols.outbound_message import NodeType
-from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.coin_spend import make_spend
@@ -252,22 +252,12 @@ async def test_add_coin_states_skips_parent_fetch_for_tracked_dl_singleton(
         )
     )
 
-    parent_fetch_calls: list[tuple[bytes32, ...]] = []
+    get_coin_state_mock = AsyncMock(return_value=[])
+    get_timestamp_mock = AsyncMock(return_value=uint64(0))
 
-    async def _record_get_coin_state(
-        self_arg: WalletNode,
-        coin_names: list[bytes32],
-        peer: WSChiaConnection,
-        fork_height: uint32 | None = None,
-    ) -> list[CoinState]:
-        parent_fetch_calls.append(tuple(coin_names))
-        return []
-
-    async def _stub_timestamp(self_arg: WalletNode, height: uint32) -> uint64:
-        return uint64(0)
-
-    monkeypatch.setattr(WalletNode, "get_coin_state", _record_get_coin_state)
-    monkeypatch.setattr(WalletNode, "get_timestamp_for_height", _stub_timestamp)
+    monkeypatch.setattr(WalletNode, "get_coin_state", get_coin_state_mock)
+    monkeypatch.setattr(WalletNode, "get_timestamp_for_height", get_timestamp_mock)
+    assert await wallet_node.get_timestamp_for_height(uint32(0)) == uint64(0)
 
     coin_state = CoinState(singleton_coin, None, uint32(10))
     # Drive through ``add_coin_states``, the same entry point
@@ -275,9 +265,11 @@ async def test_add_coin_states_skips_parent_fetch_for_tracked_dl_singleton(
     assert await wsm.add_coin_states([coin_state], peer, None)
 
     coin_record = await wsm.coin_store.get_coin_record(singleton_coin.name())
-    assert coin_record is not None, f"tracked DL singleton was not added; parent fetches: {parent_fetch_calls}"
+    assert coin_record is not None, (
+        f"tracked DL singleton was not added; parent fetches: {get_coin_state_mock.await_args_list}"
+    )
     assert coin_record.wallet_id == dl_wallet.id()
-    assert parent_fetch_calls == [], (
+    assert get_coin_state_mock.await_count == 0, (
         "determine_coin_type performed a parent get_coin_state for a locally classified DL "
         "singleton instead of short-circuiting through _data_layer_identifier_for_coin"
     )

--- a/chia/_tests/wallet/test_wallet_state_manager.py
+++ b/chia/_tests/wallet/test_wallet_state_manager.py
@@ -13,17 +13,23 @@ from chia._tests.conftest import ConsensusMode
 from chia._tests.environments.wallet import WalletStateTransition, WalletTestFramework
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
 from chia._tests.util.time_out_assert import time_out_assert
+from chia.data_layer.data_layer_wallet import DataLayerWallet
+from chia.data_layer.singleton_record import SingletonRecord
 from chia.protocols.outbound_message import NodeType
+from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.types.coin_spend import make_spend
 from chia.types.peer_info import PeerInfo
+from chia.wallet.db_wallet.db_wallet_puzzles import MIRROR_PUZZLE_HASH
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.derive_keys import master_sk_to_wallet_sk, master_sk_to_wallet_sk_unhardened
+from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.remote_wallet.remote_wallet import RemoteWallet
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.transaction_type import TransactionType
 from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.wallet_node import WalletNode
 from chia.wallet.wallet_request_types import (
     CreateNewWallet,
     CreateNewWalletType,
@@ -117,6 +123,163 @@ async def test_determine_coin_type(simulator_and_wallet: OldSimulatorsAndWallets
     peer = wallet_node.server.get_connections(NodeType.FULL_NODE)[0]
     assert (None, None) == await wallet_state_manager.determine_coin_type(
         peer, CoinState(Coin(bytes32(b"1" * 32), bytes32(b"1" * 32), uint64(0)), uint32(0), uint32(0)), None
+    )
+
+
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
+@pytest.mark.anyio
+async def test_data_layer_identifier_for_coin_returns_none_without_dl_wallet(
+    simulator_and_wallet: OldSimulatorsAndWallets,
+) -> None:
+    """No DL wallet → helper returns None and ``determine_coin_type`` must fetch the parent."""
+    _, [(wallet_node, _)], _ = simulator_and_wallet
+    wsm: WalletStateManager = wallet_node.wallet_state_manager
+    mirror_coin = Coin(bytes32(b"m" * 32), MIRROR_PUZZLE_HASH, uint64(1))
+    assert await wsm._data_layer_identifier_for_coin(mirror_coin) is None
+
+
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
+@pytest.mark.anyio
+async def test_data_layer_identifier_for_coin_mirror_puzzle_hash(
+    simulator_and_wallet: OldSimulatorsAndWallets,
+) -> None:
+    """Mirror coins are classified by their fixed puzzle hash without any DB read on dl_store."""
+    _, [(wallet_node, _)], _ = simulator_and_wallet
+    wsm: WalletStateManager = wallet_node.wallet_state_manager
+    dl_wallet = await DataLayerWallet.create_new_dl_wallet(wsm)
+    mirror_coin = Coin(bytes32(b"m" * 32), MIRROR_PUZZLE_HASH, uint64(1))
+    identifier = await wsm._data_layer_identifier_for_coin(mirror_coin)
+    assert identifier is not None
+    assert identifier.id == dl_wallet.id()
+    assert identifier.type == dl_wallet.type()
+
+
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
+@pytest.mark.anyio
+async def test_data_layer_identifier_for_coin_tracked_singleton(
+    simulator_and_wallet: OldSimulatorsAndWallets,
+) -> None:
+    """Singletons whose coin_id is in dl_store classify as DL without inspecting puzzle_hash."""
+    _, [(wallet_node, _)], _ = simulator_and_wallet
+    wsm: WalletStateManager = wallet_node.wallet_state_manager
+    dl_wallet = await DataLayerWallet.create_new_dl_wallet(wsm)
+
+    # Use a non-mirror, non-derivation outer puzzle_hash so this test
+    # exclusively exercises the dl_store coin_id branch.
+    singleton_coin = Coin(bytes32(b"s" * 32), bytes32(b"o" * 32), uint64(1))
+    singleton_record = SingletonRecord(
+        coin_id=singleton_coin.name(),
+        launcher_id=bytes32(b"L" * 32),
+        root=bytes32(b"r" * 32),
+        inner_puzzle_hash=bytes32(b"x" * 32),
+        confirmed=True,
+        confirmed_at_height=uint32(0),
+        lineage_proof=LineageProof(
+            parent_name=bytes32(b"p" * 32),
+            inner_puzzle_hash=bytes32(b"x" * 32),
+            amount=uint64(1),
+        ),
+        generation=uint32(0),
+        timestamp=uint64(0),
+    )
+    await wsm.dl_store.add_singleton_record(singleton_record)
+
+    identifier = await wsm._data_layer_identifier_for_coin(singleton_coin)
+    assert identifier is not None
+    assert identifier.id == dl_wallet.id()
+    assert identifier.type == dl_wallet.type()
+
+
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
+@pytest.mark.anyio
+async def test_data_layer_identifier_for_coin_no_match_with_dl_wallet(
+    simulator_and_wallet: OldSimulatorsAndWallets,
+) -> None:
+    """A DL wallet exists but the coin is neither a mirror nor in dl_store → None."""
+    _, [(wallet_node, _)], _ = simulator_and_wallet
+    wsm: WalletStateManager = wallet_node.wallet_state_manager
+    await DataLayerWallet.create_new_dl_wallet(wsm)
+    unrelated_coin = Coin(bytes32(b"u" * 32), bytes32(b"v" * 32), uint64(1))
+    assert await wsm._data_layer_identifier_for_coin(unrelated_coin) is None
+
+
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0])
+@pytest.mark.anyio
+async def test_add_coin_states_skips_parent_fetch_for_tracked_dl_singleton(
+    simulator_and_wallet: OldSimulatorsAndWallets, self_hostname: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Through the production call chain, a tracked DL singleton is classified without a parent fetch.
+
+    Pins the actual optimization the diff delivers: ``_add_coin_states``
+    reaches ``determine_coin_type`` only when neither ``puzzle_store`` nor
+    ``interested_store`` matched the puzzle_hash (the short-circuit at
+    ``wallet_state_manager.py:1773-1804``). A DL singleton's outer
+    puzzle_hash rotates per spend and is in neither store, so before this
+    PR ``determine_coin_type`` paid a parent ``get_coin_state`` plus a
+    ``request_puzzle_solution`` per coin. With ``dl_store`` populated by
+    a prior generation, ``_data_layer_identifier_for_coin`` now classifies
+    the coin without that round-trip.
+
+    A non-mirror puzzle_hash is intentional: ``DataLayerWallet.coin_added``
+    only does its own parent fetch on the mirror branch, so a tracked
+    singleton makes the parent-fetch-elimination assertion strict.
+    """
+    full_nodes, wallets, _ = simulator_and_wallet
+    full_node_api = full_nodes[0]
+    full_node_server = full_node_api.full_node.server
+    wallet_node, wallet_server = wallets[0]
+    await wallet_server.start_client(PeerInfo(self_hostname, full_node_server.get_port()), None)
+    wsm: WalletStateManager = wallet_node.wallet_state_manager
+    peer = wallet_node.server.get_connections(NodeType.FULL_NODE)[0]
+    dl_wallet = await DataLayerWallet.create_new_dl_wallet(wsm)
+
+    singleton_coin = Coin(bytes32(b"P" * 32), bytes32(b"o" * 32), uint64(1))
+    await wsm.dl_store.add_singleton_record(
+        SingletonRecord(
+            coin_id=singleton_coin.name(),
+            launcher_id=bytes32(b"L" * 32),
+            root=bytes32(b"r" * 32),
+            inner_puzzle_hash=bytes32(b"x" * 32),
+            confirmed=True,
+            confirmed_at_height=uint32(0),
+            lineage_proof=LineageProof(
+                parent_name=bytes32(b"q" * 32),
+                inner_puzzle_hash=bytes32(b"x" * 32),
+                amount=uint64(1),
+            ),
+            generation=uint32(0),
+            timestamp=uint64(0),
+        )
+    )
+
+    parent_fetch_calls: list[tuple[bytes32, ...]] = []
+
+    async def _record_get_coin_state(
+        self_arg: WalletNode,
+        coin_names: list[bytes32],
+        peer: WSChiaConnection,
+        fork_height: uint32 | None = None,
+    ) -> list[CoinState]:
+        parent_fetch_calls.append(tuple(coin_names))
+        return []
+
+    async def _stub_timestamp(self_arg: WalletNode, height: uint32) -> uint64:
+        return uint64(0)
+
+    monkeypatch.setattr(WalletNode, "get_coin_state", _record_get_coin_state)
+    monkeypatch.setattr(WalletNode, "get_timestamp_for_height", _stub_timestamp)
+
+    coin_state = CoinState(singleton_coin, None, uint32(10))
+    # Drive through ``add_coin_states``, the same entry point
+    # ``add_states_from_peer`` uses in trusted mode at ``wallet_node.py:999``.
+    assert await wsm.add_coin_states([coin_state], peer, None)
+
+    coin_record = await wsm.coin_store.get_coin_record(singleton_coin.name())
+    assert coin_record is not None, f"tracked DL singleton was not added; parent fetches: {parent_fetch_calls}"
+    assert coin_record.wallet_id == dl_wallet.id()
+    assert parent_fetch_calls == [], (
+        "determine_coin_type performed a parent get_coin_state for a locally classified DL "
+        "singleton instead of short-circuiting through _data_layer_identifier_for_coin"
     )
 
 

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -860,6 +860,37 @@ class WalletStateManager:
         trade_removals: dict[bytes32, WalletCoinRecord] = await self.trade_manager.get_locked_coins()
         return {**removals, **{coin_id: cr.coin for coin_id, cr in trade_removals.items() if cr.wallet_id == wallet_id}}
 
+    async def _data_layer_identifier_for_coin(self, coin: Coin) -> WalletIdentifier | None:
+        """
+        Returns the ``DataLayer`` ``WalletIdentifier`` for ``coin`` when local
+        DL metadata already classifies it — without fetching the coin's parent
+        or its puzzle solution.
+
+        Two cases are handled:
+
+        * ``coin.puzzle_hash == MIRROR_PUZZLE_HASH``: every DL mirror coin
+          shares this fixed puzzle hash, so a hash compare is sufficient.
+        * ``dl_wallet.get_singleton_record(coin.name())`` returns non-None:
+          a ``SingletonRecord`` was previously written to ``dl_store`` (e.g.
+          by ``DataLayerWallet._track_new_launcher_id``) for this coin id.
+
+        ``determine_coin_type`` calls this helper before the parent-fetch +
+        CLVM-uncurry round-trip so the bulk-subscription case (e.g. CADT
+        replaying tens of thousands of DL singleton coin states for a tracked
+        launcher) doesn't pay a ``request_puzzle_solution`` plus a parent
+        ``get_coin_state`` per coin.
+
+        Returns ``None`` when this wallet has no ``DataLayerWallet`` or when
+        neither DL match condition holds.
+        """
+        try:
+            dl_wallet = await self.get_dl_wallet()
+        except ValueError:
+            return None
+        if coin.puzzle_hash == MIRROR_PUZZLE_HASH or await dl_wallet.get_singleton_record(coin.name()) is not None:
+            return WalletIdentifier.create(dl_wallet)
+        return None
+
     async def determine_coin_type(
         self, peer: WSChiaConnection, coin_state: CoinState, fork_height: uint32 | None
     ) -> tuple[WalletIdentifier | None, Streamable | None]:
@@ -868,6 +899,21 @@ class WalletStateManager:
             or self.is_farmer_reward(uint32(coin_state.created_height), coin_state.coin)
         ):
             return None, None
+
+        # If local DL metadata already classifies this coin, skip the
+        # parent-fetch + CLVM-uncurry round-trip. ``coin_data`` is None on
+        # this path: ``DataLayerWallet.coin_added`` does not consume
+        # ``coin_data``, so DL classification works the same as before
+        # (where the post-call DL override in ``_add_coin_states`` produced
+        # the same identifier with ``coin_data == None``).
+        dl_identifier = await self._data_layer_identifier_for_coin(coin_state.coin)
+        if dl_identifier is not None:
+            self.log.debug(
+                "Classified coin via DL metadata; skipping parent fetch: coin=%s wallet=%s",
+                coin_state.coin.name(),
+                dl_identifier,
+            )
+            return dl_identifier, None
 
         response: list[CoinState] = await self.wallet_node.get_coin_state(
             [coin_state.coin.parent_coin_info], peer=peer, fork_height=fork_height
@@ -1743,17 +1789,11 @@ class WalletStateManager:
                         # rather than relying on add_coin_record() replacement semantics.
                         wallet_identifier = WalletIdentifier(uint32(local_record.wallet_id), local_record.wallet_type)
                     elif coin_state.created_height is not None:
+                        # ``determine_coin_type`` short-circuits to the DL
+                        # wallet via ``_data_layer_identifier_for_coin`` for
+                        # mirror coins and tracked singletons before any
+                        # parent fetch.
                         wallet_identifier, coin_data = await self.determine_coin_type(peer, coin_state, fork_height)
-                        try:
-                            dl_wallet = await self.get_dl_wallet()
-                        except ValueError:
-                            pass
-                        else:
-                            if (
-                                await dl_wallet.get_singleton_record(coin_name) is not None
-                                or coin_state.coin.puzzle_hash == MIRROR_PUZZLE_HASH
-                            ):
-                                wallet_identifier = WalletIdentifier.create(dl_wallet)
 
                     # If this coin was previously only stored as an "interest-only" record (REMOTE),
                     # but we now recognize it as belonging to a real wallet, treat it as a new coin so wallet-specific


### PR DESCRIPTION
### Purpose:

Speed up wallet sync of DataLayer singletons (the CADT-style bulk-subscription case) by classifying tracked DL coins from local metadata before paying the parent `get_coin_state` + `request_puzzle_solution` round-trip in `WalletStateManager.determine_coin_type`.

### Current Behavior:

For DataLayer mirror coins and previously-tracked singletons, `WalletStateManager._add_coin_states` falls through to `determine_coin_type`, which fetches the parent coin state and the puzzle solution and runs CLVM uncurry. None of the CAT/NFT/DID/Clawback/VC patterns match for these coins; the function returns and a subsequent block in `_add_coin_states` re-queries `dl_store` (or compares against `MIRROR_PUZZLE_HASH`) and re-classifies the coin to the DL wallet. The two RPCs and the CLVM uncurry are wasted work for every DL-classified coin, and the worst case (a heavily-used DL launcher being replayed against a freshly-tracking wallet) is ten of thousands of singleton coin states each paying that tax.

### New Behavior:

A new `WalletStateManager._data_layer_identifier_for_coin` helper performs the same predicate (`puzzle_hash == MIRROR_PUZZLE_HASH or dl_store.get_singleton_record(coin.name()) is not None`) using only local data. `determine_coin_type` calls it after the existing pool / farmer reward early-return and returns the DL `WalletIdentifier` immediately when it matches, skipping the parent fetch and the CLVM uncurry. The post-call DL override block in `_add_coin_states` is removed because the helper covers the same predicate strictly earlier in the per-coin pipeline.

Invariants unchanged:

- Set of coins classified as DL is identical (same predicate, evaluated in the same transaction).
- `coin_data` for DL-classified coins is `None` on this path, matching what the old post-call override produced.
- Pool / farmer reward early-return runs before the new short-circuit.
- Coins not classified by local DL metadata still take the full parent-fetch path through `determine_coin_type`.
- The `request_puzzle_solution` and parent `get_coin_state` round-trip are still performed for all other classifications (CAT, NFT, DID, Clawback, VC, notifications).

### Testing Notes:

New unit tests in `chia/_tests/wallet/test_wallet_state_manager.py` pin each branch of the helper:

- `test_data_layer_identifier_for_coin_returns_none_without_dl_wallet`
- `test_data_layer_identifier_for_coin_mirror_puzzle_hash`
- `test_data_layer_identifier_for_coin_tracked_singleton`
- `test_data_layer_identifier_for_coin_no_match_with_dl_wallet`

New integration test `test_add_coin_states_skips_parent_fetch_for_tracked_dl_singleton` drives a tracked DL singleton through the production entry point (`WalletStateManager.add_coin_states`, the same one used by `add_states_from_peer` in trusted mode at `wallet_node.py:999`) with `WalletNode.get_coin_state` monkeypatched as a recorder. It asserts that `parent_fetch_calls == []` and that the coin is owned by the DL wallet.

Mutation-verified locally: temporarily disabling the short-circuit makes the integration test fail with `parent_fetch_calls != []`, then re-enabling it restores the pass.

Local validation pipeline (skipping benchmarks, will run in CI):

- Phase 1 (ruff check / ruff format --check / mypy on changed files): clean.
- Phase 2 (targeted tests): `chia/_tests/wallet/test_wallet_state_manager.py` (39 selected), `chia/_tests/wallet/db_wallet/test_dl_wallet.py` (mirror, lifecycle, reorg, ownership-rollback), `chia/_tests/wallet/test_wallet_node.py` (41 selected), `chia/_tests/wallet/sync/test_wallet_sync.py` (sync, long_sync, reorgs, dusted wallet) — 120+ tests passing.
- Phase 5 (`pre-commit run --all-files`): clean.