### PR TITLE
ci: shallow checkout in test-single to fix Windows runner tag-lock failures

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -136,7 +136,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: false
 
       - name: Set Env
         uses: Chia-Network/actions/setjobenv@main


### PR DESCRIPTION
## Summary

- Switches `actions/checkout` in `test-single.yml` from a full clone (`fetch-depth: 0`) to a shallow clone (`fetch-depth: 1`, `fetch-tags: false`)
- Fixes Windows CI failures caused by a stale `.git/refs/tags/alpha-1.0.lock` file that prevents `actions/checkout` from refreshing tag refs
- Tests don't need git history or tags, so this is a safe no-op for test behavior

## Test plan

- [x] Verify the only change is in `.github/workflows/test-single.yml`
- [ ] Confirm Windows test jobs in this PR's CI run get past `Checkout code`
- [ ] Confirm Linux/macOS test jobs remain unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limits `actions/checkout` to a shallow clone (no tags) in `test-single.yml`, which is unlikely to affect test execution but could impact any steps that implicitly rely on git history/tags.
> 
> **Overview**
> Updates the `test-single` reusable CI workflow to perform a shallow `actions/checkout` (`fetch-depth: 1`) and skip fetching tags (`fetch-tags: false`) instead of doing a full clone.
> 
> This reduces git ref/tag operations during checkout, aiming to avoid Windows runner failures related to stale tag lock files and speed up the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dc59788dcd74dce9ed0b2093a86f8f263b0845b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->