### PR TITLE
CHIA-4205 Simplify TransactionQueueEntry

### DIFF
--- a/chia/_tests/core/full_node/test_tx_processing_queue.py
+++ b/chia/_tests/core/full_node/test_tx_processing_queue.py
@@ -187,12 +187,8 @@ def test_tx_queue_entry_order_compare() -> None:
     # Let's create two items with the same transaction ID but different data
     sb = SpendBundle([], G2Element())
     sb_name = sb.name()
-    item1 = TransactionQueueEntry(
-        transaction=sb, transaction_bytes=bytes(sb), spend_name=sb_name, peer=None, test=False, peers_with_tx={}
-    )
-    item2 = TransactionQueueEntry(
-        transaction=sb, transaction_bytes=None, spend_name=sb_name, peer=None, test=True, peers_with_tx={}
-    )
+    item1 = TransactionQueueEntry(transaction=sb, spend_name=sb_name, peer=None, test=False, peers_with_tx={})
+    item2 = TransactionQueueEntry(transaction=sb, spend_name=sb_name, peer=None, test=True, peers_with_tx={})
     # They should be ordered and compared (considered equal) by `spend_name`
     # regardless of other fields.
     assert (item1 < item2) is False

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -119,7 +119,6 @@ async def tx_request_and_timeout(full_node: FullNode, transaction_id: bytes32, t
                 continue
             entry = TransactionQueueEntry(
                 transaction=response.transaction,
-                transaction_bytes=bytes(response.transaction),
                 spend_name=response.transaction.name(),
                 peer=random_peer,
                 test=False,
@@ -346,7 +345,7 @@ class FullNodeAPI:
         # TODO: Use fee in priority calculation, to prioritize high fee TXs
         try:
             self.full_node.transaction_queue.put(
-                TransactionQueueEntry(tx.transaction, tx_bytes, spend_name, peer, test, peers_with_tx),
+                TransactionQueueEntry(tx.transaction, spend_name, peer, test, peers_with_tx),
                 peer.peer_node_id,
             )
         except TransactionQueueFull:
@@ -1512,7 +1511,7 @@ class FullNodeAPI:
             response = wallet_protocol.TransactionAck(spend_name, uint8(MempoolInclusionStatus.SUCCESS), None)
             return make_msg(ProtocolMessageTypes.transaction_ack, response)
         high_priority = self.is_trusted(peer)
-        queue_entry = TransactionQueueEntry(request.transaction, None, spend_name, None, test)
+        queue_entry = TransactionQueueEntry(request.transaction, spend_name, None, test)
         try:
             self.full_node.transaction_queue.put(queue_entry, peer_id=peer.peer_node_id, high_priority=high_priority)
         except TransactionQueueFull:

--- a/chia/full_node/tx_processing_queue.py
+++ b/chia/full_node/tx_processing_queue.py
@@ -60,7 +60,6 @@ class TransactionQueueEntry:
     """
 
     transaction: SpendBundle = field(compare=False)
-    transaction_bytes: bytes | None = field(compare=False)
     spend_name: bytes32
     peer: WSChiaConnection | None = field(compare=False)
     test: bool = field(compare=False)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a small internal data-structure simplification with straightforward call-site updates, and no remaining references to the removed field were found.
> 
> **Overview**
> **Simplifies `TransactionQueueEntry`** by removing the `transaction_bytes` field, leaving the queue to track only the `SpendBundle`, `spend_name`, peer/test flags, and `peers_with_tx` metadata.
> 
> Updates full node transaction ingestion paths (`tx_request_and_timeout`, `respond_transaction`, and `send_transaction`) and the associated unit test to construct `TransactionQueueEntry` with the new, smaller signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634d541569f6b628d1eb1fb0651248513309ba59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->