### PR TITLE
[CHIA-4208] fix(test): wait for wallet sync after puzzle-hash derivation in test_self_revoke

### DIFF
--- a/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
+++ b/chia/_tests/wallet/vc_wallet/test_vc_wallet.py
@@ -729,6 +729,10 @@ async def test_self_revoke(wallet_environments: WalletTestFramework) -> None:
 
     async with wallet_0.wallet_state_manager.new_action_scope(DEFAULT_TX_CONFIG, push=True) as action_scope:
         ph = await action_scope.get_puzzle_hash(wallet_0.wallet_state_manager)
+    # When reuse_puzhash=False, get_puzzle_hash derives a new key and commit() enqueues
+    # puzzle-hash subscriptions on the new_peak_queue.  Wait for the queue to drain so
+    # the wallet reports SYNCED before the RPC call that follows.
+    await wallet_environments.full_node.wait_for_wallet_synced(wallet_node_0)
     vc_record = (
         await client_0.vc_mint(
             VCMint(


### PR DESCRIPTION
### Purpose:

Fix a flaky race condition in `test_self_revoke` that causes intermittent
failures on Windows CI with
`"Wallet needs to be fully synced before making transactions."`

### Current Behavior:

When `reuse_puzhash=False`, the action scope at line 730 derives a new key
and `commit()` enqueues puzzle-hash subscriptions on the `new_peak_queue`.
The immediately following `vc_mint` RPC call checks `get_sync_status()`,
which calls `synced()`, which checks `has_pending_data_process_items()`.
If the subscription queue hasn't drained yet, the wallet reports
`SLIGHTLY_BEHIND` and the RPC raises.

The race is timing-dependent: on Windows with 4 cores under load, the queue
processing sometimes doesn't complete before the RPC fires.

### New Behavior:

A `wait_for_wallet_synced` call is added between the derivation action scope
and the `vc_mint` RPC, matching the existing pattern already used after DID
creation on line 727.

Invariants unchanged:
- No production code modified; test-only change
- The wait call is the same one already used elsewhere in the test
- All 4 parametrized variants still pass (trusted/untrusted × reuse/no-reuse)

### Testing Notes:

- All 4 `test_self_revoke` variants pass locally
- Full validation pipeline passed: ruff, ruff format, mypy, 158 benchmarks,
  diff-cover 100%, all 18 pre-commit hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that adds an extra sync wait to avoid a timing race before an RPC call; no production logic is modified.
> 
> **Overview**
> Fixes a flaky race in `test_self_revoke` by waiting for the wallet to report `SYNCED` after `get_puzzle_hash()` derives a new puzzle hash and before calling `vc_mint`.
> 
> This aligns the test flow with existing sync waits and prevents intermittent failures where the RPC rejects transactions while the wallet is still processing queued puzzle-hash subscriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 225d384b0c032915412c73d14a86b2c65d950e30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->