### PR TITLE
Add /get_constants RPC to full node

### DIFF
--- a/chia/_tests/core/test_full_node_rpc.py
+++ b/chia/_tests/core/test_full_node_rpc.py
@@ -563,7 +563,7 @@ async def test_signage_points(
 
 
 @pytest.mark.anyio
-async def test_get_network_info(
+async def test_get_network_info_and_constants(
     one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices, self_hostname: str
 ) -> None:
     nodes, _, _bt = one_wallet_and_one_simulator_services
@@ -583,6 +583,7 @@ async def test_get_network_info(
             "genesis_challenge": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "success": True,
         }
+        assert await client.get_constants() == full_node_service_1._node.constants
 
 
 @pytest.mark.anyio

--- a/chia/full_node/full_node_rpc_api.py
+++ b/chia/full_node/full_node_rpc_api.py
@@ -116,6 +116,7 @@ class FullNodeRpcApi:
             "/get_additions_and_removals": self.get_additions_and_removals,
             "/get_aggsig_additional_data": self.get_aggsig_additional_data,
             "/get_recent_signage_point_or_eos": self.get_recent_signage_point_or_eos,
+            "/get_constants": self.get_constants,
             # Coins
             "/get_coin_records_by_puzzle_hash": self.get_coin_records_by_puzzle_hash,
             "/get_coin_records_by_puzzle_hashes": self.get_coin_records_by_puzzle_hashes,
@@ -685,6 +686,9 @@ class FullNodeRpcApi:
             * eligible_plots_filter_multiplier
         )
         return {"space": uint128(network_space_bytes_estimate)}
+
+    async def get_constants(self, request: dict[str, Any]) -> EndpointResult:
+        return {"constants": self.service.constants.to_json_dict()}
 
     async def get_coin_records_by_puzzle_hash(self, request: dict[str, Any]) -> EndpointResult:
         """

--- a/chia/full_node/full_node_rpc_client.py
+++ b/chia/full_node/full_node_rpc_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from chia_rs import BlockRecord, CoinRecord, CoinSpend, EndOfSubSlotBundle, FullBlock, SpendBundle
+from chia_rs import BlockRecord, CoinRecord, CoinSpend, ConsensusConstants, EndOfSubSlotBundle, FullBlock, SpendBundle
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32
 
@@ -78,6 +78,10 @@ class FullNodeRpcClient(RpcClient):
         )
 
         return cast(int, network_space_bytes_estimate["space"])
+
+    async def get_constants(self) -> ConsensusConstants:
+        response = await self.fetch("get_constants", {})
+        return ConsensusConstants.from_json_dict(response["constants"])
 
     async def get_coin_record_by_name(self, coin_id: bytes32) -> CoinRecord:
         response = await self.fetch("get_coin_record_by_name", {"name": coin_id.hex()})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a read-only RPC endpoint that returns consensus constants and a small client/test wiring change, without affecting consensus or transaction processing logic.
> 
> **Overview**
> Adds a new full node RPC endpoint, `get_constants`, that returns the node’s consensus constants as JSON.
> 
> Updates `FullNodeRpcClient` with a typed `get_constants()` helper (using `ConsensusConstants.from_json_dict`) and extends the full node RPC test to assert the returned constants match the node’s configured constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85009da98896b588db5e6c7576c62fbfb3ae5145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->