### PR TITLE
[CHIA-4209] Handle stale peers during connection garbage collection

### DIFF
--- a/chia/_tests/core/server/test_server.py
+++ b/chia/_tests/core/server/test_server.py
@@ -309,13 +309,75 @@ async def test_get_peer_info(bt: BlockTools) -> None:
 
 class FakeConnection:
     connection_type: NodeType = NodeType.FULL_NODE
-    peer_node_id: bytes32 = bytes32(b"\x00" * 32)
 
-    def __init__(self, peer_info: PeerInfo) -> None:
+    def __init__(self, peer_info: PeerInfo, peer_node_id: bytes32 = bytes32(b"\x00" * 32), closed: bool = True) -> None:
         self.peer_info = peer_info
+        self.peer_node_id = peer_node_id
+        self.closed = closed
 
     def cancel_tasks(self) -> None:
         pass
+
+
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
+@pytest.mark.anyio
+async def test_garbage_collect_connections_tolerates_stale_closed_connections(
+    bt: BlockTools, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    test_config = bt.config["full_node"]
+    private_ca_crt, private_ca_key = private_ssl_ca_paths(bt.root_path, bt.config)
+    chia_ca_crt, chia_ca_key = chia_ssl_ca_paths(bt.root_path, bt.config)
+    my_test_server = ChiaServer.create(
+        port=None,
+        node=None,
+        api=FullNodeAPI(None),  # type: ignore[arg-type]
+        local_type=NodeType.FULL_NODE,
+        ping_interval=0,
+        network_id="Fake",
+        root_path=bt.root_path,
+        capabilities=[],
+        outbound_rate_limit_percent=100,
+        inbound_rate_limit_percent=100,
+        config=test_config,
+        private_ca_crt_key=(private_ca_crt, private_ca_key),
+        chia_ca_crt_key=(chia_ca_crt, chia_ca_key),
+        stub_metadata_for_type={},
+        name="Hello",
+    )
+    missing_connection = FakeConnection(PeerInfo("10.1.1.1", 8444), bytes32(b"\x01" * 32))
+    stale_connection = FakeConnection(PeerInfo("10.1.1.2", 8444), bytes32(b"\x02" * 32))
+    replacement_connection = FakeConnection(stale_connection.peer_info, stale_connection.peer_node_id, closed=False)
+    remaining_connection = FakeConnection(PeerInfo("10.1.1.3", 8444), bytes32(b"\x03" * 32))
+    missing_wsc = cast(WSChiaConnection, missing_connection)
+    stale_wsc = cast(WSChiaConnection, stale_connection)
+    replacement_wsc = cast(WSChiaConnection, replacement_connection)
+    remaining_wsc = cast(WSChiaConnection, remaining_connection)
+    my_test_server.all_connections[missing_connection.peer_node_id] = missing_wsc
+    my_test_server.all_connections[stale_connection.peer_node_id] = stale_wsc
+    my_test_server.all_connections[remaining_connection.peer_node_id] = remaining_wsc
+    sleep_count = 0
+
+    async def sleep_one_iteration(_delay: float) -> None:
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count > 1:
+            raise asyncio.CancelledError
+
+    def change_stale_connections(_message: str) -> None:
+        if missing_connection.peer_node_id in my_test_server.all_connections:
+            my_test_server.all_connections.pop(missing_connection.peer_node_id)
+        elif my_test_server.all_connections.get(stale_connection.peer_node_id) is stale_wsc:
+            my_test_server.all_connections[stale_connection.peer_node_id] = replacement_wsc
+
+    monkeypatch.setattr(asyncio, "sleep", sleep_one_iteration)
+    monkeypatch.setattr(my_test_server.log, "debug", change_stale_connections)
+
+    with pytest.raises(asyncio.CancelledError):
+        await my_test_server.garbage_collect_connections_task()
+
+    assert missing_connection.peer_node_id not in my_test_server.all_connections
+    assert my_test_server.all_connections[stale_connection.peer_node_id] is replacement_wsc
+    assert remaining_connection.peer_node_id not in my_test_server.all_connections
 
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")

--- a/chia/server/server.py
+++ b/chia/server/server.py
@@ -264,7 +264,9 @@ class ChiaServer:
             for connection in to_remove:
                 self.log.debug(f"Garbage collecting connection {connection.peer_info.host} due to inactivity")
                 if connection.closed:
-                    self.all_connections.pop(connection.peer_node_id)
+                    present_connection = self.all_connections.get(connection.peer_node_id)
+                    if present_connection is connection:
+                        self.all_connections.pop(connection.peer_node_id)
                 else:
                     await connection.close()
 


### PR DESCRIPTION
### Purpose:

Connection close callbacks can remove or replace a peer while connection garbage collection is processing a stale snapshot. This makes closed-connection cleanup tolerant of that race without removing a newer connection under the same peer ID.

### Current Behavior:

Garbage collection assumes a closed connection selected from its snapshot is still the current `all_connections` entry when it is processed.

### New Behavior:

Garbage collection removes a closed connection only when the current `all_connections` entry is the same connection object selected for cleanup. Already-removed closed connections are treated as already cleaned up, and replacement connections under the same peer ID are preserved.

Invariants unchanged:

- Rounding/precision: not applicable.
- `None` vs falsy/zero: no caller-visible value semantics changed.
- Caller contract semantics: live idle connections are still closed through `connection.close()`.
- Error vs silent-ignore behavior: stale closed entries are ignored as cleanup-complete; non-stale closed entries are removed as before.

### Testing Notes:

Added regression coverage for stale closed connections that are already missing or have been replaced before GC processes them.

Validation run:

- `./tools/py -m ruff check chia/server/server.py chia/_tests/core/server/test_server.py`
- `./tools/py -m ruff format --check chia/server/server.py chia/_tests/core/server/test_server.py`
- `./tools/py -m mypy chia/server/server.py chia/_tests/core/server/test_server.py --config-file mypy.ini`
- `unset CI && ./tools/pytest chia/_tests/core/server/test_server.py::test_garbage_collect_connections_tolerates_stale_closed_connections -v --override-ini="addopts=--verbose --tb=short" --cov=chia --cov-config=.coveragerc --cov-report=`
- `unset CI && ./tools/pytest -m benchmark -n 0 --capture no --ignore=chia/_tests/tools/test_legacy_keyring.py chia/_tests/`
- `$HOME/Projects/dotfiles/bin/chia-diff-cover --compare-branch origin/main` (100%)
- `pre-commit run --all-files`
- Fresh-context pre-push review; initial warning fixed, re-review found no issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection lifecycle logic: garbage collection now conditionally removes entries from `all_connections`, so regressions could lead to leaked or prematurely retained connections under load.
> 
> **Overview**
> Fixes a race in `ChiaServer.garbage_collect_connections_task()` by only removing a *closed* connection from `all_connections` when the current mapping for that `peer_node_id` is the same connection object (avoiding deleting a newer replacement or failing when it was already removed).
> 
> Adds a regression test (`test_garbage_collect_connections_tolerates_stale_closed_connections`) that simulates connections being removed/replaced mid-GC and asserts missing entries are tolerated and replacement connections are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b91aee71a632ff4cb3a970ce01621ac5e6942bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->