### PR TITLE
CHIA-4206 Speedup test_ban_for_mismatched_tx_cost_fee

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3523,6 +3523,7 @@ async def test_pending_tx_cache_retry_on_new_peak(
 
 
 @pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
 @pytest.mark.parametrize("mismatch_cost", [True, False])
 @pytest.mark.parametrize("mismatch_fee", [True, False])
 @pytest.mark.parametrize("tx_already_seen", [True, False])
@@ -3604,8 +3605,8 @@ async def test_ban_for_mismatched_tx_cost_fee(
     async def send_from_node_3() -> None:
         await ws_con_3.send_message(msg)
 
-    for node in [full_node_1.full_node, full_node_2.full_node, full_node_3.full_node]:
-        await time_out_assert(5, node.synced)
+    for node_api in [full_node_1, full_node_2, full_node_3]:
+        await time_out_assert(5, lambda: node_height_at_least(node_api, blocks[-1].height))
     await asyncio.gather(send_from_node_2(), send_from_node_3())
     if mismatch_on_reannounce and (mismatch_cost or mismatch_fee):
         # Send a second NewTransaction that doesn't match the first
@@ -3624,7 +3625,9 @@ async def test_ban_for_mismatched_tx_cost_fee(
         # hasn't seen the transaction before, it will issue a transaction
         # request. We need to wait until it receives the transaction and add it
         # to its mempool.
-        await time_out_assert(30, lambda: full_node_1.full_node.mempool_manager.seen(mempool_item.name))
+        await time_out_assert(
+            30, lambda: full_node_1.full_node.mempool_manager.get_spendbundle(mempool_item.name) is not None
+        )
     # Make sure the first full node has banned the second as the item it has
     # already seen has a different validation cost and/or fee than the one from
     # the NewTransaction message.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts test gating and synchronization assertions, with no production code changes.
> 
> **Overview**
> Speeds up `test_ban_for_mismatched_tx_cost_fee` by restricting it to `ConsensusMode.HARD_FORK_2_0` and replacing slow `synced()` waits with a height-based readiness check via `node_height_at_least`.
> 
> Also updates the test’s “tx received” wait condition to check for an actual spend bundle presence (`get_spendbundle(...)`) instead of relying on the mempool “seen” cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea9f88efce6e661f6fe538fafab6b639373d5f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->