### PR TITLE
CHIA-4207 Improve state block handling in WalletNode's validate_received_state_from_peer

### DIFF
--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import enum
 import logging
 import sys
 import time
@@ -15,18 +16,22 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64, uint128
 
 from chia._tests.conftest import ConsensusMode
+from chia._tests.connection_utils import add_dummy_connection_wsc
 from chia._tests.environments.wallet import WalletTestFramework
 from chia._tests.util.misc import CoinGenerator, patch_request_handler
 from chia._tests.util.setup_nodes import OldSimulatorsAndWallets
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.blockchain import AddBlockResult
+from chia.consensus.generator_tools import get_block_header
+from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols import wallet_protocol
-from chia.protocols.outbound_message import Message, make_msg
+from chia.protocols.outbound_message import Message, NodeType, make_msg
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
 from chia.server.api_protocol import Self
 from chia.server.ws_connection import WSChiaConnection
 from chia.simulator.add_blocks_in_batches import add_blocks_in_batches
 from chia.simulator.block_tools import test_constants
+from chia.simulator.simulator_protocol import FarmNewBlockProtocol
 from chia.types.blockchain_format.coin import Coin
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.peer_info import PeerInfo
@@ -34,9 +39,10 @@ from chia.util.config import load_config
 from chia.util.errors import Err
 from chia.util.hash import std_hash
 from chia.util.keychain import Keychain, KeyData, generate_mnemonic
+from chia.wallet.util.peer_request_cache import PeerRequestCache
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_sync_utils import PeerRequestException
-from chia.wallet.wallet_node import Balance, WalletNode
+from chia.wallet.wallet_node import Balance, WalletNode, request_and_validate_header_block
 
 
 @pytest.mark.anyio
@@ -1532,3 +1538,129 @@ async def test_start_with_multiple_keys(
 
     await restart_with_fingerprint(fingerprint_2)
     assert wallet_node.wallet_state_manager.private_key == initial_sk
+
+
+class HeaderBlockCase(enum.Enum):
+    NoneResponse = 0
+    WrongCount = 1
+    WrongHeight = 2
+    NonTx = 3
+    ValidResponse = 4
+
+
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+@pytest.mark.parametrize(
+    "header_block_case, expected_success, expected_closed",
+    [
+        (HeaderBlockCase.NoneResponse, False, False),
+        (HeaderBlockCase.WrongCount, False, False),
+        (HeaderBlockCase.WrongHeight, False, True),
+        (HeaderBlockCase.NonTx, False, False),
+        (HeaderBlockCase.ValidResponse, True, False),
+    ],
+)
+@pytest.mark.anyio
+async def test_request_and_validate_header_block(
+    simulator_and_wallet: OldSimulatorsAndWallets,
+    self_hostname: str,
+    header_block_case: HeaderBlockCase,
+    expected_success: bool,
+    expected_closed: bool,
+) -> None:
+    """
+    Covers the header block validation cases (`None` response, wrong count,
+    wrong height, non transaction header block and finally a valid response)
+    for request_and_validate_header_block.
+    """
+    [full_node_api], [(wallet_node, _)], _ = simulator_and_wallet
+    server = full_node_api.full_node.server
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32.random()))
+    peak = full_node_api.full_node.blockchain.get_peak()
+    assert peak is not None
+    correct_full_block = await full_node_api.full_node.block_store.get_full_block(peak.header_hash)
+    assert correct_full_block is not None
+    assert correct_full_block.foliage_transaction_block is not None
+    correct_block_header = get_block_header(correct_full_block)
+    all_blocks = await full_node_api.get_all_full_blocks()
+    wrong_full_block = next(b for b in all_blocks if b.height != correct_full_block.height)
+    wrong_height_block_header = get_block_header(wrong_full_block)
+    no_tx_block_header = correct_block_header.replace(foliage_transaction_block=None)
+    wsc, _ = await add_dummy_connection_wsc(server, self_hostname, 42, NodeType.WALLET, wait_for_peer_added=False)
+    requested_height = correct_block_header.height
+    calls: list[tuple[uint32, uint32]] = []
+
+    async def request_block_headers(self: FullNodeAPI, request: wallet_protocol.RequestBlockHeaders) -> Message | None:
+        calls.append((request.start_height, request.end_height))
+        if header_block_case == HeaderBlockCase.NoneResponse:
+            reject = wallet_protocol.RejectBlockHeaders(request.start_height, request.end_height)
+            return make_msg(ProtocolMessageTypes.reject_block_headers, reject)
+        headers = []
+        if header_block_case == HeaderBlockCase.WrongCount:
+            headers = [correct_block_header, wrong_height_block_header]
+        elif header_block_case == HeaderBlockCase.WrongHeight:
+            headers = [wrong_height_block_header]
+        elif header_block_case == HeaderBlockCase.NonTx:
+            headers = [no_tx_block_header]
+        elif header_block_case == HeaderBlockCase.ValidResponse:
+            headers = [correct_block_header]
+        else:
+            assert False  # pragma: no cover
+        response = wallet_protocol.RespondBlockHeaders(request.start_height, request.end_height, headers)
+        return make_msg(ProtocolMessageTypes.respond_block_headers, response)
+
+    with patch_request_handler(api=server.api, handler=request_block_headers):
+        result = await request_and_validate_header_block(wsc, requested_height, wallet_node.log)
+
+    assert calls == [(requested_height, requested_height)]
+    if expected_success:
+        assert result == correct_block_header
+    else:
+        assert result is None
+    if expected_closed:
+        assert wsc.closed
+    else:
+        assert not wsc.closed
+
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.HARD_FORK_2_0], reason="irrelevant")
+@pytest.mark.parametrize("created_cached_non_tx", [False, True])
+@pytest.mark.parametrize("spent_cached_non_tx", [False, True])
+async def test_validate_received_state_from_peer_cached_non_tx(
+    simulator_and_wallet: OldSimulatorsAndWallets,
+    self_hostname: str,
+    created_cached_non_tx: bool,
+    spent_cached_non_tx: bool,
+) -> None:
+    """
+    Covers the scenarios where `validate_received_state_from_peer` is called
+    with the peer request cache returning non transaction header blocks for the
+    created and/or spent heights, to make sure the validation fails and the
+    peer's connection stays intact.
+    """
+    [full_node_api], [(wallet_node, _)], _ = simulator_and_wallet
+    server = full_node_api.full_node.server
+    await full_node_api.farm_new_transaction_block(FarmNewBlockProtocol(bytes32.random()))
+    blocks = await full_node_api.get_all_full_blocks()
+    tx_blocks = [b for b in blocks if b.is_transaction_block()]
+    assert len(tx_blocks) == 2
+    created_tx_header = get_block_header(tx_blocks[-2])
+    spent_tx_header = get_block_header(tx_blocks[-1])
+    # Create non tx variants
+    created_non_tx_block_header = created_tx_header.replace(foliage_transaction_block=None)
+    spent_non_tx_block_header = spent_tx_header.replace(foliage_transaction_block=None)
+    peer_request_cache = PeerRequestCache()
+    coin = Coin(bytes32.random(), bytes32.random(), uint64(1))
+    coin_state = CoinState(coin, spent_non_tx_block_header.height, created_tx_header.height)
+    if created_cached_non_tx:
+        peer_request_cache._blocks.put(created_non_tx_block_header.height, created_non_tx_block_header)
+        coin_state = CoinState(coin, None, created_non_tx_block_header.height)
+    if spent_cached_non_tx:
+        peer_request_cache.add_to_blocks(created_tx_header)
+        peer_request_cache._blocks.put(spent_non_tx_block_header.height, spent_non_tx_block_header)
+    wsc, _ = await add_dummy_connection_wsc(server, self_hostname, 42, NodeType.WALLET, wait_for_peer_added=False)
+    result = await wallet_node.validate_received_state_from_peer(
+        coin_state=coin_state, peer=wsc, peer_request_cache=peer_request_cache, fork_height=None
+    )
+    assert result is False
+    assert not wsc.closed

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -102,6 +102,31 @@ class Balance(Streamable):
     pending_coin_removal_count: uint32 = uint32(0)
 
 
+async def request_and_validate_header_block(
+    peer: WSChiaConnection, height: uint32, log: logging.Logger
+) -> HeaderBlock | None:
+    header_blocks = await request_header_blocks(peer, height, height)
+    if header_blocks is None or len(header_blocks) != 1:
+        return None
+    header_block = header_blocks[0]
+    if header_block.height != height:
+        log.info(
+            f"Peer {peer.peer_node_id} / {peer.peer_info.host} version "
+            f"{peer.version} returned a header block with the wrong "
+            f"height {header_block.height} vs {height}"
+        )
+        await peer.close(9999)
+        return None
+    if header_block.foliage_transaction_block is None:
+        log.info(
+            f"Peer {peer.peer_node_id} / {peer.peer_info.host} version "
+            f"{peer.version} returned a non transaction header block "
+            f"for height {header_block.height}"
+        )
+        return None
+    return header_block
+
+
 @dataclasses.dataclass
 class WalletNode:
     if TYPE_CHECKING:
@@ -1508,15 +1533,13 @@ class WalletNode:
         # request header block for created height
         state_block: HeaderBlock | None = peer_request_cache.get_block(confirmed_height)
         if state_block is None or reorg_mode:
-            state_blocks = await request_header_blocks(peer, confirmed_height, confirmed_height)
-            if state_blocks is None:
+            state_block = await request_and_validate_header_block(peer, confirmed_height, self.log)
+            if state_block is None:
                 return False
-            state_block = state_blocks[0]
-            assert state_block is not None
             peer_request_cache.add_to_blocks(state_block)
-
+        if state_block.foliage_transaction_block is None:
+            return False
         # get proof of inclusion
-        assert state_block.foliage_transaction_block is not None
         validate_additions_result = await request_and_validate_additions(
             peer,
             peer_request_cache,
@@ -1545,17 +1568,11 @@ class WalletNode:
             if spent_height is None and current.spent_block_height != 0:
                 # Peer is telling us that coin that was previously known to be spent is not spent anymore
                 # Check old state
-
-                spent_state_blocks: list[HeaderBlock] | None = await request_header_blocks(
-                    peer, current.spent_block_height, current.spent_block_height
-                )
-                if spent_state_blocks is None:
+                spent_state_block = await request_and_validate_header_block(peer, current.spent_block_height, self.log)
+                if spent_state_block is None:
                     return False
-                spent_state_block = spent_state_blocks[0]
-                assert spent_state_block.height == current.spent_block_height
-                assert spent_state_block.foliage_transaction_block is not None
                 peer_request_cache.add_to_blocks(spent_state_block)
-
+                assert spent_state_block.foliage_transaction_block is not None
                 validate_removals_result = await request_and_validate_removals(
                     peer,
                     current.spent_block_height,
@@ -1577,17 +1594,14 @@ class WalletNode:
             # request header block for created height
             cached_spent_state_block = peer_request_cache.get_block(spent_height)
             if cached_spent_state_block is None:
-                spent_state_blocks = await request_header_blocks(peer, spent_height, spent_height)
-                if spent_state_blocks is None:
+                spent_state_block = await request_and_validate_header_block(peer, spent_height, self.log)
+                if spent_state_block is None:
                     return False
-                spent_state_block = spent_state_blocks[0]
-                assert spent_state_block.height == spent_height
-                assert spent_state_block.foliage_transaction_block is not None
                 peer_request_cache.add_to_blocks(spent_state_block)
             else:
                 spent_state_block = cached_spent_state_block
-            assert spent_state_block is not None
-            assert spent_state_block.foliage_transaction_block is not None
+            if spent_state_block.foliage_transaction_block is None:
+                return False
             validate_removals_result = await request_and_validate_removals(
                 peer,
                 spent_state_block.height,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes untrusted sync validation and peer disconnect behavior for wrong header heights; incorrect logic could reject valid states or accept bad ones, but scope is limited to wallet peer validation.
> 
> **Overview**
> Introduces **`request_and_validate_header_block`** so the wallet requests a single header at a height and rejects bad peer data: missing/wrong count, **wrong height** (closes the peer), or **non-transaction** blocks.
> 
> **`validate_received_state_from_peer`** now uses that helper for created/spent heights instead of raw `request_header_blocks`, and explicitly fails when cached blocks lack **`foliage_transaction_block`** without disconnecting.
> 
> New tests cover the helper’s response variants and cached non-tx header paths through **`validate_received_state_from_peer`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc0414d0999fb741f58d623274e27a9a61289eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->