### PR TITLE
[CHIA-4210] Fix flaky test_transaction_ack_duplicate_without_resend_ignored

### DIFF
--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -866,64 +866,67 @@ async def test_transaction_ack_duplicate_without_resend_ignored(
     wallet_environments: WalletTestFramework, caplog: pytest.LogCaptureFixture
 ) -> None:
     env = wallet_environments.environments[0]
-    full_node_api = wallet_environments.full_node
     wallet_node = env.node
     wallet = env.xch_wallet
 
-    logged_spends = []
+    # Disable the pending-tx callback so add_pending_transactions doesn't
+    # schedule a background _resend_queue task that could repopulate
+    # _tx_messages_in_progress between the duplicate acks below. This test
+    # is about the dedup gate in transaction_ack, not the resend path.
+    wallet_node.wallet_state_manager.pending_tx_callback = None
 
-    async def send_transaction(
-        self: Self, request: wallet_protocol.SendTransaction, peer: WSChiaConnection, *, test: bool = False
-    ) -> Message | None:
-        logged_spends.append(request.transaction.name())
-        return None
+    async with wallet.wallet_state_manager.new_action_scope(
+        wallet.wallet_state_manager.tx_config, push=True
+    ) as action_scope:
+        await wallet.generate_signed_transaction([uint64(0)], [bytes32.zeros], action_scope)
+    [tx] = action_scope.side_effects.transactions
 
-    assert full_node_api.full_node._server is not None
-    with patch_request_handler(api=full_node_api.full_node._server.get_connections()[0].api, handler=send_transaction):
-        async with wallet.wallet_state_manager.new_action_scope(
-            wallet.wallet_state_manager.tx_config, push=True
-        ) as action_scope:
-            await wallet.generate_signed_transaction([uint64(0)], [bytes32.zeros], action_scope)
-        [tx] = action_scope.side_effects.transactions
+    # Mark the SendTransaction as in-flight directly, the way
+    # _send_transaction_message would. Bypassing _resend_queue removes a
+    # source of asynchronous interleaving and makes the dedup behavior the
+    # only thing under test.
+    conn = env.peer_server.get_connections()[0]
+    sb = tx.spend_bundle
+    assert sb is not None
+    send_msg = make_msg(ProtocolMessageTypes.send_transaction, wallet_protocol.SendTransaction(sb))
+    msg_name = std_hash(send_msg.data)
+    wallet_node._tx_messages_in_progress.setdefault(conn.peer_node_id, []).append(msg_name)
 
-        await wallet_node._resend_queue()
-        await time_out_assert(5, lambda: len(logged_spends), 1)
+    msg = make_msg(
+        ProtocolMessageTypes.transaction_ack,
+        wallet_protocol.TransactionAck(tx.name, uint8(MempoolInclusionStatus.FAILED), Err.GENERATOR_RUNTIME_ERROR.name),
+    )
 
-        msg = make_msg(
-            ProtocolMessageTypes.transaction_ack,
-            wallet_protocol.TransactionAck(
-                tx.name, uint8(MempoolInclusionStatus.FAILED), Err.GENERATOR_RUNTIME_ERROR.name
-            ),
-        )
-        conn = env.peer_server.get_connections()[0]
-        await conn.incoming_queue.put(msg)
+    def check_wallet_cache_empty() -> bool:
+        return wallet_node._tx_messages_in_progress == {}
 
-        def check_wallet_cache_empty() -> bool:
-            return wallet_node._tx_messages_in_progress == {}
+    def incoming_queue_empty() -> bool:
+        return conn.incoming_queue.qsize() == 0
 
-        def incoming_queue_empty() -> bool:
-            return conn.incoming_queue.qsize() == 0
+    # First ack matches the seeded entry: the handler should clear it and
+    # update the transaction record.
+    await conn.incoming_queue.put(msg)
+    await time_out_assert(5, check_wallet_cache_empty, True)
 
-        await time_out_assert(5, check_wallet_cache_empty, True)
-        first_tx_record = await wallet_node.wallet_state_manager.get_transaction(tx.name)
-        assert first_tx_record is not None
-        first_sent = first_tx_record.sent
-        first_sent_to = first_tx_record.sent_to.copy()
-        first_confirmed = first_tx_record.confirmed
+    first_tx_record = await wallet_node.wallet_state_manager.get_transaction(tx.name)
+    assert first_tx_record is not None
+    first_sent = first_tx_record.sent
+    first_sent_to = first_tx_record.sent_to.copy()
+    first_confirmed = first_tx_record.confirmed
 
-        # Duplicate acks without another send should all be ignored.
-        with caplog.at_level(logging.DEBUG, logger="chia.wallet.wallet_node"):
-            for _ in range(10):
-                await conn.incoming_queue.put(msg)
-                await time_out_assert(5, incoming_queue_empty, True)
-                await time_out_assert(5, check_wallet_cache_empty, True)
+    # Duplicate acks without another send should all be ignored.
+    with caplog.at_level(logging.DEBUG, logger="chia.wallet.wallet_node"):
+        for _ in range(10):
+            await conn.incoming_queue.put(msg)
+            await time_out_assert(5, incoming_queue_empty, True)
+            await time_out_assert(5, check_wallet_cache_empty, True)
 
-        second_tx_record = await wallet_node.wallet_state_manager.get_transaction(tx.name)
-        assert second_tx_record is not None
-        assert second_tx_record.sent == first_sent
-        assert second_tx_record.sent_to == first_sent_to
-        assert second_tx_record.confirmed == first_confirmed
-        assert sum("Ignoring unsolicited transaction ack" in record.getMessage() for record in caplog.records) >= 10
+    second_tx_record = await wallet_node.wallet_state_manager.get_transaction(tx.name)
+    assert second_tx_record is not None
+    assert second_tx_record.sent == first_sent
+    assert second_tx_record.sent_to == first_sent_to
+    assert second_tx_record.confirmed == first_confirmed
+    assert sum("Ignoring unsolicited transaction ack" in record.getMessage() for record in caplog.records) >= 10
 
 
 @pytest.mark.limit_consensus_modes(reason="consensus rules irrelevant")

--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -915,6 +915,7 @@ async def test_transaction_ack_duplicate_without_resend_ignored(
     first_confirmed = first_tx_record.confirmed
 
     # Duplicate acks without another send should all be ignored.
+    caplog.clear()
     with caplog.at_level(logging.DEBUG, logger="chia.wallet.wallet_node"):
         for _ in range(10):
             await conn.incoming_queue.put(msg)
@@ -926,7 +927,7 @@ async def test_transaction_ack_duplicate_without_resend_ignored(
     assert second_tx_record.sent == first_sent
     assert second_tx_record.sent_to == first_sent_to
     assert second_tx_record.confirmed == first_confirmed
-    assert sum("Ignoring unsolicited transaction ack" in record.getMessage() for record in caplog.records) >= 10
+    assert caplog.text.count("Ignoring unsolicited transaction ack") == 10
 
 
 @pytest.mark.limit_consensus_modes(reason="consensus rules irrelevant")


### PR DESCRIPTION
### Purpose:

Fix intermittent flake in `test_transaction_ack_duplicate_without_resend_ignored` (`chia/_tests/wallet/test_wallet_node.py`). Observed on the macOS-Intel CI shard, where the assertion `second_tx_record.sent == first_sent` failed with `1 == 0` despite no actual change to the dedup logic in `WalletNodeAPI.transaction_ack`.

### Current Behavior:

The test calls `_resend_queue()` so the wallet's `_send_transaction_message` populates `_tx_messages_in_progress` with the transaction's hash, then injects 11 fake `transaction_ack` messages (1 first, then 10 duplicates) to verify the dedup gate in `WalletNodeAPI.transaction_ack`.

However, `add_pending_transactions` (called inside the action scope) also fires `tx_pending_changed()` -> `pending_tx_callback`, which schedules a background `_resend_queue` task via `create_referenced_task`. On slow runners that scheduled task can run between iterations of the duplicate-ack loop and re-add the txid to `_tx_messages_in_progress`. The next "duplicate" ack then matches the freshly re-added entry and calls `remove_from_queue` -> `increment_sent`, breaking the test's assumption that no duplicate gets processed.

### New Behavior:

- Set `wallet_node.wallet_state_manager.pending_tx_callback = None` at the start of the test body so no background `_resend_queue` is scheduled by the action scope. This is the only path that schedules `_resend_queue`, so this is sufficient.
- Seed `_tx_messages_in_progress` directly with `std_hash(SendTransaction(sb).bytes())` (which equals `tx.name`), exactly mirroring what `_send_transaction_message` would have stored. This pattern matches the sister test `test_retry_fee_failed_skips_disconnected_and_in_flight` already in the same file.
- Drop the now-unused `patch_request_handler` and `logged_spends` accumulator.

Invariants unchanged:

- The test still validates the dedup gate in `WalletNodeAPI.transaction_ack`: the first ack matches the seeded entry and is processed; the next 10 acks find an empty cache and are ignored.
- `assert second_tx_record.sent_to == first_sent_to` after the duplicate loop remains a hard regression guard. If dedup were broken, each of the 10 duplicates would call `increment_sent` and `sent_to` would grow by 10 entries.
- `assert second_tx_record.sent == first_sent` and `assert second_tx_record.confirmed == first_confirmed` are preserved.
- The `>= 10` "Ignoring unsolicited transaction ack" log-count assertion is preserved.
- Coverage of the resend-then-ack integration path (which this test no longer exercises) is still provided by `test_transaction_send_cache` and `test_retry_fee_failed_skips_disconnected_and_in_flight`.

### Testing Notes:

- `./tools/py -m ruff check chia/_tests/wallet/test_wallet_node.py` - clean
- `./tools/py -m ruff format --check chia/_tests/wallet/test_wallet_node.py` - clean
- `./tools/py -m mypy chia/_tests/wallet/test_wallet_node.py --config-file mypy.ini` - clean
- `unset CI && ./tools/pytest chia/_tests/wallet/test_wallet_node.py::test_transaction_ack_duplicate_without_resend_ignored -v` - all 4 parametrized variants pass
- Same test repeated 5 times sequentially - all 5 runs pass (~10s each, no failures)
- Sister tests `test_retry_fee_failed_skips_disconnected_and_in_flight` and `test_transaction_send_cache` - still pass
- `chia-diff-cover --compare-branch origin/main` - 100% (33/33 changed lines)
- `pre-commit run --all-files` - all 18 hooks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in wallet_node tests; no production wallet or protocol behavior modified.
> 
> **Overview**
> **`test_transaction_ack_duplicate_without_resend_ignored`** is reworked so it only exercises `WalletNodeAPI.transaction_ack` dedup, not the resend pipeline.
> 
> The test **disables** `wallet_state_manager.pending_tx_callback` so creating a pending tx no longer schedules background **`_resend_queue`**, which could refill **`_tx_messages_in_progress`** between duplicate acks and cause flakes (e.g. `sent` changing from 0 to 1).
> 
> Instead of **`patch_request_handler`** + **`_resend_queue()`**, it **seeds** **`_tx_messages_in_progress`** with the same hash **`_send_transaction_message`** would use (same approach as **`test_retry_fee_failed_skips_disconnected_and_in_flight`**). The first ack still clears the in-flight entry; ten more acks must leave **`sent`**, **`sent_to`**, and **`confirmed`** unchanged and log **"Ignoring unsolicited transaction ack"** exactly ten times (**`caplog.clear()`** + **`caplog.text.count(...)`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 718cf9672885ad8d3f1a5ace84bf7683ecb27743. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->