### PR TITLE
CHIA-4211 Annotate timelord_api.py

### DIFF
--- a/chia/timelord/timelord_api.py
+++ b/chia/timelord/timelord_api.py
@@ -29,7 +29,7 @@ class TimelordAPI:
     timelord: Timelord
     metadata: ClassVar[ApiMetadata] = ApiMetadata()
 
-    def __init__(self, timelord) -> None:
+    def __init__(self, timelord: Timelord) -> None:
         self.log = logging.getLogger(__name__)
         self.timelord = timelord
 
@@ -102,7 +102,7 @@ class TimelordAPI:
 
             self.timelord.state_changed("skipping_peak", {"height": new_peak.reward_chain_block.height})
 
-    def check_orphaned_unfinished_block(self, new_peak: NewPeakTimelord):
+    def check_orphaned_unfinished_block(self, new_peak: NewPeakTimelord) -> bool:
         new_peak_unf_rh = new_peak.reward_chain_block.get_unfinished().get_hash()
         for unf_block in self.timelord.unfinished_blocks:
             if unf_block.reward_chain_block.total_iters <= new_peak.reward_chain_block.total_iters:
@@ -123,7 +123,9 @@ class TimelordAPI:
         return False
 
     @metadata.request()
-    async def new_unfinished_block_timelord(self, new_unfinished_block: timelord_protocol.NewUnfinishedBlockTimelord):
+    async def new_unfinished_block_timelord(
+        self, new_unfinished_block: timelord_protocol.NewUnfinishedBlockTimelord
+    ) -> None:
         if self.timelord.last_state is None:
             return None
         async with self.timelord.lock:
@@ -157,7 +159,7 @@ class TimelordAPI:
                     log.debug(f"Non-overflow unfinished block, total {self.timelord.total_unfinished}")
 
     @metadata.request()
-    async def request_compact_proof_of_time(self, vdf_info: timelord_protocol.RequestCompactProofOfTime):
+    async def request_compact_proof_of_time(self, vdf_info: timelord_protocol.RequestCompactProofOfTime) -> None:
         async with self.timelord.lock:
             if not self.timelord.bluebox_mode:
                 return None

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -12,7 +12,6 @@ chia.simulator.full_node_simulator
 chia.simulator.keyring
 chia.simulator.wallet_tools
 chia.ssl.create_ssl
-chia.timelord.timelord_api
 chia.types.blockchain_format.program
 chia.wallet.did_wallet.did_wallet
 chia.wallet.puzzles.load_clvm


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk type-only changes: adds/clarifies type hints and return annotations without altering runtime logic, and removes `chia.timelord.timelord_api` from mypy exclusions (may surface new static type errors).
> 
> **Overview**
> **Improves typing for the timelord API surface.** `TimelordAPI` now has explicit type annotations for its constructor and key RPC handlers (including `-> None` and `check_orphaned_unfinished_block() -> bool`), without changing behavior.
> 
> **Re-enables static checking** for `chia.timelord.timelord_api` by removing it from `mypy-exclusions.txt`, making mypy enforce types for this module going forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36503421fb20ed524907d6df6c404f58d7259da3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->