### PR TITLE
CHIA-4212 Annotate timelord_launcher.py

### DIFF
--- a/chia/timelord/timelord_launcher.py
+++ b/chia/timelord/timelord_launcher.py
@@ -132,7 +132,9 @@ async def spawn_process(
             await proc.communicate()
 
 
-async def spawn_all_processes(config: dict, net_config: dict, process_mgr: VDFClientProcessMgr):
+async def spawn_all_processes(
+    config: dict[str, Any], net_config: dict[str, Any], process_mgr: VDFClientProcessMgr
+) -> None:
     await asyncio.sleep(5)
     hostname = net_config["self_hostname"] if "host" not in config else config["host"]
     port = config["port"]
@@ -172,7 +174,7 @@ async def async_main(config: dict[str, Any], net_config: dict[str, Any]) -> None
             log.info("Launcher fully closed.")
 
 
-def main():
+def main() -> int:
     if os.name == "nt":
         log.info("Timelord launcher not supported on Windows.")
         return 1
@@ -184,6 +186,7 @@ def main():
     initialize_logging("TLauncher", config["logging"], root_path)
 
     asyncio.run(async_main(config=config, net_config=net_config))
+    return 0
 
 
 if __name__ == "__main__":

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -13,7 +13,6 @@ chia.simulator.keyring
 chia.simulator.wallet_tools
 chia.ssl.create_ssl
 chia.timelord.timelord_api
-chia.timelord.timelord_launcher
 chia.types.blockchain_format.program
 chia.wallet.did_wallet.did_wallet
 chia.wallet.puzzles.load_clvm


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to type annotations and function return types, with no behavioral changes expected aside from clearer exit code semantics.
> 
> **Overview**
> Adds explicit type annotations to `chia/timelord/timelord_launcher.py` (typed `dict` parameters, `-> None` on async helpers, and `main() -> int` returning `0` on success).
> 
> Removes `chia.timelord.timelord_launcher` from `mypy-exclusions.txt`, enabling mypy to check this module going forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5d4ac0d594d13cc8829e29d937346446192a319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->