### PR TITLE
fix error handling in chia plots check

### DIFF
--- a/chia/plotting/check_plots.py
+++ b/chia/plotting/check_plots.py
@@ -252,7 +252,15 @@ def check_plots(
                                 f"\tQuality doesn't match with proof. Filepath: {plot_path} "
                                 "This can occasionally happen with a compressed plot."
                             )
-                    except AssertionError as e:
+                    except RuntimeError as e:
+                        if str(e) == "GRResult_NoProof received":
+                            log.info(f"Proof dropped due to line point compression. Filepath: {plot_path}")
+                            continue
+                        else:
+                            log.error(f"{type(e)}: {e} error in getting full proof for plot {plot_path}")
+                            caught_exception = True
+                            continue
+                    except Exception as e:
                         log.error(
                             f"{type(e)}: {e} error in proving/verifying for plot {plot_path}. Filepath: {plot_path}"
                         )


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized to `check_plots.py` error handling; main behavior change is skipping and logging a known “no proof” condition instead of treating it as a generic failure.
> 
> **Overview**
> `check_plots` now treats the `RuntimeError` message `"GRResult_NoProof received"` as an expected outcome during full-proof generation/verification (e.g., due to line point compression), logging and skipping that proof instead of failing the plot check.
> 
> Other `RuntimeError`s in the full-proof path are now logged explicitly and flagged as caught exceptions, while unexpected errors continue to mark the plot as problematic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8db248709e6c1aace691d990028696542caa059c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->