### PR TITLE
ci(workflows): Restrict workflow steps to main repository

### DIFF
--- a/.github/workflows/dependency-cursor-review.yml
+++ b/.github/workflows/dependency-cursor-review.yml
@@ -766,6 +766,7 @@ jobs:
           fi
 
       - name: Run Cursor analysis
+        if: github.repository == 'Chia-Network/chia-blockchain'
         timeout-minutes: 10
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}

--- a/.github/workflows/dependency-cursor-review.yml
+++ b/.github/workflows/dependency-cursor-review.yml
@@ -766,7 +766,7 @@ jobs:
           fi
 
       - name: Run Cursor analysis
-        if: github.repository == 'Chia-Network/chia-blockchain'
+        if: github.repository_owner == 'Chia-Network'
         timeout-minutes: 10
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}

--- a/.github/workflows/update-mozilla-ca-cert.yaml
+++ b/.github/workflows/update-mozilla-ca-cert.yaml
@@ -26,6 +26,7 @@ jobs:
           curl --silent --show-error --location https://curl.se/ca/cacert.pem -o chia/ssl/cacert.pem
 
       - name: Set up commit signing
+        if: github.repository == 'Chia-Network/chia-blockchain'
         uses: Chia-Network/actions/commit-sign/gpg@main
         with:
           gpg_private_key: ${{ secrets.CHIA_AUTOMATION_PRIVATE_GPG_KEY }}

--- a/.github/workflows/update-mozilla-ca-cert.yaml
+++ b/.github/workflows/update-mozilla-ca-cert.yaml
@@ -26,7 +26,7 @@ jobs:
           curl --silent --show-error --location https://curl.se/ca/cacert.pem -o chia/ssl/cacert.pem
 
       - name: Set up commit signing
-        if: github.repository == 'Chia-Network/chia-blockchain'
+        if: github.repository_owner == 'Chia-Network'
         uses: Chia-Network/actions/commit-sign/gpg@main
         with:
           gpg_private_key: ${{ secrets.CHIA_AUTOMATION_PRIVATE_GPG_KEY }}


### PR DESCRIPTION
This pull request makes small but important improvements to the GitHub Actions workflows by ensuring that certain steps only run in the main `Chia-Network/chia-blockchain` repository. This prevents these steps from executing in forks or other repositories, which can help avoid unnecessary failures or security issues.

Workflow condition updates:

* In `.github/workflows/dependency-cursor-review.yml`, added a condition to the "Run Cursor analysis" step so it only runs in the main repository.
* In `.github/workflows/update-mozilla-ca-cert.yaml`, added a condition to the "Set up commit signing" step so it only runs in the main repository.

These changes were made with https://github.com/wallentx/fork-friendly-actions, which you can soon add to your CI to stay fork-friendly as a PR check.