### PR TITLE
diagnostic probe: pytest --timeout and chia log artifact upload

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -268,12 +268,39 @@ jobs:
           mv notchia/ chia/
 
       - name: Publish JUnit results
-        if: inputs.collect-junit
+        if: ${{ always() && inputs.collect-junit }}
         uses: actions/upload-artifact@v7
         with:
           name: junit-data-${{ env.JOB_FILE_NAME }}
           path: junit-data/*
           if-no-files-found: error
+
+      - name: Collect node logs and pytest tmp on failure
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p ci-debug-artifacts
+          if [ -d /tmp/pytest-of-runner ]; then
+            tar -czf ci-debug-artifacts/pytest-tmp.tar.gz \
+              --exclude='*.sqlite' --exclude='*.db' \
+              -C /tmp pytest-of-runner 2>/dev/null || true
+          fi
+          find /tmp -maxdepth 6 -name 'debug.log*' -mtime -1 2>/dev/null \
+            | head -200 \
+            | tar -czf ci-debug-artifacts/node-debug-logs.tar.gz -T - 2>/dev/null || true
+          find /tmp -maxdepth 6 -name '*traceback*' -mtime -1 2>/dev/null \
+            | head -200 \
+            | xargs -I {} cp {} ci-debug-artifacts/ 2>/dev/null || true
+          ls -la ci-debug-artifacts/ || true
+
+      - name: Upload diagnostic artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-debug-${{ env.JOB_FILE_NAME }}
+          path: ci-debug-artifacts/
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Process coverage data
         run: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,8 @@
 [pytest]
 ; logging options
 log_cli = False
-addopts = --verbose --tb=long -n auto -p no:monitor --timeout=180 --timeout-method=thread
+addopts = --verbose --tb=long -n auto -p no:monitor
+faulthandler_timeout = 180
 log_level = WARNING
 console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 ; logging options
 log_cli = False
-addopts = --verbose --tb=short -n auto -p no:monitor
+addopts = --verbose --tb=long -n auto -p no:monitor --timeout=180 --timeout-method=thread
 log_level = WARNING
 console_output_style = count
 log_format = %(asctime)s %(name)s: %(levelname)s %(message)s


### PR DESCRIPTION
## Summary

Diagnostic probe to convert the silent CI hang in `core.full_node` (specifically `test_ban_for_mismatched_tx_cost_fee` and `test_mempool_tx_sync` parametrizations) into actionable stack traces and uploaded chia logs.

- pytest.ini: per-test timeout of 180s with `--timeout-method=thread` so pytest-xdist workers dump every thread traceback at the wedge point
- test-single.yml: new `if: always()` steps that tar up `/tmp/pytest-of-runner/`, chia `debug.log` files, and any traceback dumps for upload as a `ci-debug-...` artifact

## Test plan

- Trigger via `workflow_dispatch` with `only=chia/_tests/core/full_node/test_full_node.py` to run only the suspect test file.
- Expect 4 jobs (one per OS/arch matrix entry, default Python 3.12) to fail with a per-test timeout that produces full thread tracebacks.
- Download the `ci-debug-...` artifacts and analyze chia node debug.log to identify whether the wedge is in test body, fixture teardown, or somewhere else.

## Not for merge

This PR is a diagnostic probe. Once the wedge location is identified, this branch will be closed and a targeted fix opened separately. The artifact-upload steps may be retained as a permanent CI improvement in a separate PR.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only changes, but they can increase log/artifact volume and affect CI runtime by forcing timeouts and collecting more data on every job.
> 
> **Overview**
> Improves CI diagnostics for hung/flaky test runs by enabling more verbose pytest tracebacks (`--tb=long`) and configuring a 180s `faulthandler_timeout` in `pytest.ini`.
> 
> Updates `test-single.yml` to always publish JUnit results and to always collect/upload debugging artifacts (tarred `/tmp/pytest-of-runner`, recent `debug.log*`, and traceback dumps) as a short-retention `ci-debug-*` artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7dd998d124a46b0eeb5a0b91f5a4ddde7416a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->