### PR TITLE
bisect: skip test_ban_for_mismatched_tx_cost_fee

### DIFF
--- a/chia/_tests/core/full_node/config.py
+++ b/chia/_tests/core/full_node/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 110
+job_timeout = 45
 checkout_blocks_and_plots = True

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -4014,6 +4014,7 @@ async def test_pending_tx_cache_retry_on_new_peak(
         assert full_node_api.full_node.mempool_manager.get_mempool_item(sb_name, include_pending=False) is not None
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 @pytest.mark.parametrize("mismatch_cost", [True, False])
 @pytest.mark.parametrize("mismatch_fee", [True, False])


### PR DESCRIPTION
Bisection probe — skip test_ban_for_mismatched_tx_cost_fee (new in checkpoint, ~64 parametrizations clustered at the wedge time). 45 min job_timeout for fast feedback. If green, this test (or its peer.close ban codepath) is the smoking gun. Do not merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that reduce CI runtime and skip a heavily parametrized test; main risk is reduced coverage for transaction ban behavior while the skip is in place.
> 
> **Overview**
> Reduces full-node test suite `job_timeout` from `110` to `45` minutes for faster CI feedback.
> 
> Temporarily disables the heavily parametrized `test_ban_for_mismatched_tx_cost_fee` via `@pytest.mark.skip` to help isolate a CI hang, at the cost of coverage for the mismatched cost/fee ban path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb6e1ac1eb79443853407aaba98bb8bc144a4eb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->