### PR TITLE
bisect: skip test_wallet_sync_task_failure tests

### DIFF
--- a/chia/_tests/core/full_node/config.py
+++ b/chia/_tests/core/full_node/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 110
+job_timeout = 45
 checkout_blocks_and_plots = True

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2977,6 +2977,7 @@ async def test_node_start_with_existing_blocks(db_version: int) -> None:
                     assert block_record.height == expected_height, f"wrong height on cycle {cycle + 1}"
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_wallet_sync_task_failure(
     one_node: SimulatorsAndWalletsServices, caplog: pytest.LogCaptureFixture
@@ -3078,6 +3079,7 @@ async def test_sync_from_fork_point_logs_validate_stage_exception(
     assert peer.closed
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_wallet_sync_task_failure_before_receiving_update_logs_error(
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
Bisection probe — skip both new wallet_sync_task_failure tests. macos-arm wedged immediately as test_wallet_sync_task_failure_before_receiving_update_logs_error started, so this is high-suspicion. 45 min job_timeout. Do not merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes test configuration/selection; the main impact is reduced CI coverage for wallet sync failure handling.
> 
> **Overview**
> Lowers `chia/_tests/core/full_node` `job_timeout` from 110 to 45 minutes.
> 
> Marks `test_wallet_sync_task_failure` and `test_wallet_sync_task_failure_before_receiving_update_logs_error` as skipped with a temporary bisect/CI-hang isolation reason, reducing coverage of wallet sync task failure scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de6d3452aef701db80264ead0948144dedf5adaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->