### PR TITLE
bisect: skip test_long_reorg_nodes

### DIFF
--- a/chia/_tests/core/full_node/config.py
+++ b/chia/_tests/core/full_node/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 110
+job_timeout = 45
 checkout_blocks_and_plots = True

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3258,6 +3258,7 @@ async def test_long_reorg(
     await validate_coin_set(node.full_node._coin_store, blocks)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 @pytest.mark.parametrize("light_blocks", [True, False])
 @pytest.mark.parametrize("chain_length", [0, 100])


### PR DESCRIPTION
Bisection probe — skip test_long_reorg_nodes (heavy three_nodes fixture user, ran around wedge time). 45 min job_timeout. Do not merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that skips a heavy integration test and shortens a test job timeout; low risk to production code but may reduce CI coverage for long reorg scenarios.
> 
> **Overview**
> Temporarily disables `test_long_reorg_nodes` via `@pytest.mark.skip` to help isolate a CI hang during bisection.
> 
> Reduces the full-node test suite `job_timeout` from `110` to `45` minutes in `chia/_tests/core/full_node/config.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c83d108259ed72e5e2251523246078992bbb8fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->