### PR TITLE
bisect: keep only sync-wallet group

### DIFF
--- a/chia/_tests/core/full_node/config.py
+++ b/chia/_tests/core/full_node/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 110
+job_timeout = 45
 checkout_blocks_and_plots = True

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1261,6 +1261,7 @@ async def test_respond_transaction_fail(
     allowed=[ConsensusMode.HARD_FORK_2_0, ConsensusMode.HARD_FORK_3_0],
     reason="We can no longer (reliably) farm blocks from before the hard fork",
 )
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 async def test_add_transaction_seen_before_validation(
     wallet_nodes: tuple[
         FullNodeSimulator, FullNodeSimulator, ChiaServer, ChiaServer, WalletTool, WalletTool, BlockTools
@@ -1321,6 +1322,7 @@ async def test_add_transaction_seen_before_validation(
     assert full_node_1.full_node.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_sync_mode_does_not_mark_in_flight_or_seen(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -1343,6 +1345,7 @@ async def test_add_transaction_sync_mode_does_not_mark_in_flight_or_seen(
     assert not fn.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_no_peak_does_not_mark_in_flight_or_seen(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -1366,6 +1369,7 @@ async def test_add_transaction_no_peak_does_not_mark_in_flight_or_seen(
     assert not fn.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_remove_seen_on_value_error(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -1395,6 +1399,7 @@ async def test_add_transaction_remove_seen_on_value_error(
     assert not fn.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_adds_seen_on_validation_error(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -1422,6 +1427,7 @@ async def test_add_transaction_adds_seen_on_validation_error(
     assert fn.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_remove_seen_on_unexpected_exception(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -2233,6 +2239,7 @@ async def test_new_signage_point_caching(
     )
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_respond_signage_point_bans_invalid_vdf(
     wallet_nodes: tuple[
@@ -2335,6 +2342,7 @@ async def test_slot_catch_up_genesis(
     await time_out_assert(20, caught_up_slots)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
 async def test_sp_catchup_semaphore_rejects_when_full(
@@ -2361,6 +2369,7 @@ async def test_sp_catchup_semaphore_rejects_when_full(
         sem._available_count = original_count
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
 async def test_sp_catchup_invalid_response(
@@ -2386,6 +2395,7 @@ async def test_sp_catchup_invalid_response(
     assert result is None
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
 async def test_sp_catchup_diverged_from_peer(
@@ -2419,6 +2429,7 @@ async def test_sp_catchup_diverged_from_peer(
     assert result is None
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
 async def test_sp_catchup_loop_exhausted(


### PR DESCRIPTION
Bisection inverse-probe — skip all 14 new checkpoint tests EXCEPT 3 sync/wallet-handler tests (test_sync_from_fork_point_logs_*, test_wallet_sync_task_failure_before_receiving_update_logs_error). If this hangs: sync/wallet path is the culprit. 45 min job_timeout. Do not merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that reduce coverage by skipping multiple `test_full_node.py` cases and tightening the test job timeout; low product risk but may mask regressions and affect CI signal.
> 
> **Overview**
> Reduces the full-node test suite `job_timeout` in `chia/_tests/core/full_node/config.py` from `110` to `45` minutes.
> 
> Temporarily disables several full-node tests in `test_full_node.py` by adding `@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")`, primarily around transaction in-flight/seen handling and signage-point catchup/banning scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d54e02ea94ae32fa9382690d0144d5fb44dcb326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->