### PR TITLE
bisect: keep test_add_transaction no_peak+remove_value_error pair

### DIFF
--- a/chia/_tests/core/full_node/config.py
+++ b/chia/_tests/core/full_node/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 110
+job_timeout = 45
 checkout_blocks_and_plots = True

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1261,6 +1261,7 @@ async def test_respond_transaction_fail(
     allowed=[ConsensusMode.HARD_FORK_2_0, ConsensusMode.HARD_FORK_3_0],
     reason="We can no longer (reliably) farm blocks from before the hard fork",
 )
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 async def test_add_transaction_seen_before_validation(
     wallet_nodes: tuple[
         FullNodeSimulator, FullNodeSimulator, ChiaServer, ChiaServer, WalletTool, WalletTool, BlockTools
@@ -1321,6 +1322,7 @@ async def test_add_transaction_seen_before_validation(
     assert full_node_1.full_node.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_sync_mode_does_not_mark_in_flight_or_seen(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -1395,6 +1397,7 @@ async def test_add_transaction_remove_seen_on_value_error(
     assert not fn.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_adds_seen_on_validation_error(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -1422,6 +1425,7 @@ async def test_add_transaction_adds_seen_on_validation_error(
     assert fn.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_remove_seen_on_unexpected_exception(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -2233,6 +2237,7 @@ async def test_new_signage_point_caching(
     )
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_respond_signage_point_bans_invalid_vdf(
     wallet_nodes: tuple[
@@ -2335,6 +2340,7 @@ async def test_slot_catch_up_genesis(
     await time_out_assert(20, caught_up_slots)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
 async def test_sp_catchup_semaphore_rejects_when_full(
@@ -2361,6 +2367,7 @@ async def test_sp_catchup_semaphore_rejects_when_full(
         sem._available_count = original_count
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
 async def test_sp_catchup_invalid_response(
@@ -2386,6 +2393,7 @@ async def test_sp_catchup_invalid_response(
     assert result is None
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
 async def test_sp_catchup_diverged_from_peer(
@@ -2419,6 +2427,7 @@ async def test_sp_catchup_diverged_from_peer(
     assert result is None
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
 async def test_sp_catchup_loop_exhausted(
@@ -3005,6 +3014,7 @@ async def test_wallet_sync_task_failure(
     assert not full_node.wallet_sync_task.done()
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_sync_from_fork_point_logs_fetch_stage_exception(
     one_node: SimulatorsAndWalletsServices,
@@ -3037,6 +3047,7 @@ async def test_sync_from_fork_point_logs_fetch_stage_exception(
     assert peer.closed
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_sync_from_fork_point_logs_validate_stage_exception(
     one_node: SimulatorsAndWalletsServices,
@@ -3078,6 +3089,7 @@ async def test_sync_from_fork_point_logs_validate_stage_exception(
     assert peer.closed
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_wallet_sync_task_failure_before_receiving_update_logs_error(
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
Round 3 inverse-bisect — keep only test_add_transaction_no_peak_does_not_mark_in_flight_or_seen + test_add_transaction_remove_seen_on_value_error. If hangs: bug is in this pair. 45 min job_timeout. Do not merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that reduce CI runtime and temporarily disable multiple full-node tests, which lowers coverage but doesn’t affect production code paths.
> 
> **Overview**
> Reduces the full-node test suite `job_timeout` from `110` to `45` minutes to speed up CI during a hang investigation.
> 
> Temporarily marks a set of potentially related tests in `chia/_tests/core/full_node/test_full_node.py` as skipped (with a `bisect`-specific reason) to isolate the CI hang, leaving only the targeted `add_transaction` regression tests active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b94467ea77c124aa23c8aa3b1d580c6ac43da3ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->