### PR TITLE
bisect: keep ONLY test_add_transaction_seen_before_validation

### DIFF
--- a/chia/_tests/core/full_node/config.py
+++ b/chia/_tests/core/full_node/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 110
+job_timeout = 45
 checkout_blocks_and_plots = True

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1321,6 +1321,7 @@ async def test_add_transaction_seen_before_validation(
     assert full_node_1.full_node.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_sync_mode_does_not_mark_in_flight_or_seen(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -1343,6 +1344,7 @@ async def test_add_transaction_sync_mode_does_not_mark_in_flight_or_seen(
     assert not fn.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_no_peak_does_not_mark_in_flight_or_seen(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -1366,6 +1368,7 @@ async def test_add_transaction_no_peak_does_not_mark_in_flight_or_seen(
     assert not fn.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_remove_seen_on_value_error(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -1395,6 +1398,7 @@ async def test_add_transaction_remove_seen_on_value_error(
     assert not fn.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_adds_seen_on_validation_error(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -1422,6 +1426,7 @@ async def test_add_transaction_adds_seen_on_validation_error(
     assert fn.mempool_manager.seen(spend_name)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_add_transaction_remove_seen_on_unexpected_exception(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
@@ -2233,6 +2238,7 @@ async def test_new_signage_point_caching(
     )
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_respond_signage_point_bans_invalid_vdf(
     wallet_nodes: tuple[
@@ -2335,6 +2341,7 @@ async def test_slot_catch_up_genesis(
     await time_out_assert(20, caught_up_slots)
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
 async def test_sp_catchup_semaphore_rejects_when_full(
@@ -2361,6 +2368,7 @@ async def test_sp_catchup_semaphore_rejects_when_full(
         sem._available_count = original_count
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
 async def test_sp_catchup_invalid_response(
@@ -2386,6 +2394,7 @@ async def test_sp_catchup_invalid_response(
     assert result is None
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
 async def test_sp_catchup_diverged_from_peer(
@@ -2419,6 +2428,7 @@ async def test_sp_catchup_diverged_from_peer(
     assert result is None
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
 async def test_sp_catchup_loop_exhausted(
@@ -3005,6 +3015,7 @@ async def test_wallet_sync_task_failure(
     assert not full_node.wallet_sync_task.done()
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_sync_from_fork_point_logs_fetch_stage_exception(
     one_node: SimulatorsAndWalletsServices,
@@ -3037,6 +3048,7 @@ async def test_sync_from_fork_point_logs_fetch_stage_exception(
     assert peer.closed
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_sync_from_fork_point_logs_validate_stage_exception(
     one_node: SimulatorsAndWalletsServices,
@@ -3078,6 +3090,7 @@ async def test_sync_from_fork_point_logs_validate_stage_exception(
     assert peer.closed
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 async def test_wallet_sync_task_failure_before_receiving_update_logs_error(
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
Round 3b — single-test probe. This is the only one of the 6 tx-add tests using wallet_nodes (heavy) + real peer + create_referenced_task. If hangs: this single test is the trigger. 45 min job_timeout. Do not merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the test harness by skipping several full-node integration tests and reducing the test job timeout, which may hide regressions but does not impact production code paths.
> 
> **Overview**
> This PR is a **bisect-focused test-only change** to help isolate a CI hang.
> 
> It reduces `chia/_tests/core/full_node`’s `job_timeout` from `110` to `45` and marks a set of full-node integration tests in `test_full_node.py` with `@pytest.mark.skip` (reason: temporary bisect/CI hang isolation), leaving the transaction in-flight/seen regression test (`test_add_transaction_seen_before_validation`) as the primary remaining signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8294a099513486a44093b9be93db09e463f8538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->