### PR TITLE
bisect: skip ONLY test_add_transaction_seen_before_validation

### DIFF
--- a/chia/_tests/core/full_node/config.py
+++ b/chia/_tests/core/full_node/config.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-job_timeout = 110
+job_timeout = 45
 checkout_blocks_and_plots = True

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1256,6 +1256,7 @@ async def test_respond_transaction_fail(
     assert incoming_queue.qsize() == 0
 
 
+@pytest.mark.skip(reason="bisect: temporarily disabled to isolate CI hang")
 @pytest.mark.anyio
 @pytest.mark.limit_consensus_modes(
     allowed=[ConsensusMode.HARD_FORK_2_0, ConsensusMode.HARD_FORK_3_0],


### PR DESCRIPTION
Final confirmation — keep all 13 other new tests, skip only test_add_transaction_seen_before_validation. If green: this single test is THE wedge. 45 min job_timeout. Do not merge.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only test configuration and a single test are modified, with no production code impact; risk is limited to temporarily reducing coverage for the `in_flight`/`seen` transaction validation race.
> 
> **Overview**
> Temporarily skips `test_add_transaction_seen_before_validation` in `test_full_node.py` to isolate a CI hang during bisecting.
> 
> Reduces the full-node test suite `job_timeout` from 110 to 45 minutes in `chia/_tests/core/full_node/config.py` to shorten CI runtime while investigating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e98183d0e4bd60bb3feba824751fb2ee03aa075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->