### PR TITLE
Replace test_add_transaction_seen_before_validation with simpler version

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1257,68 +1257,53 @@ async def test_respond_transaction_fail(
 
 
 @pytest.mark.anyio
-@pytest.mark.limit_consensus_modes(
-    allowed=[ConsensusMode.HARD_FORK_2_0, ConsensusMode.HARD_FORK_3_0],
-    reason="We can no longer (reliably) farm blocks from before the hard fork",
-)
 async def test_add_transaction_seen_before_validation(
-    wallet_nodes: tuple[
-        FullNodeSimulator, FullNodeSimulator, ChiaServer, ChiaServer, WalletTool, WalletTool, BlockTools
-    ],
-    self_hostname: str,
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
 ) -> None:
     """Regression test for SEC-111: tx must be marked in-flight before the
-    expensive pre_validate_spendbundle call so concurrent workers don't
-    redundantly validate the same transaction."""
-    full_node_1, _full_node_2, server_1, server_2, wallet_a, wallet_receiver, bt = wallet_nodes
-    cb_ph = wallet_a.get_new_puzzlehash()
+    pre_validate_spendbundle call so concurrent workers don't redundantly
+    validate the same transaction.
+    """
+    full_node_1, _server_1, _bt = one_node_one_block
+    fn = full_node_1.full_node
 
-    peer = await connect_and_get_peer(server_1, server_2, self_hostname)
-
-    blocks = bt.get_consecutive_blocks(
-        3,
-        guarantee_transaction_block=True,
-        farmer_reward_puzzle_hash=cb_ph,
-    )
-    for block in blocks:
-        await full_node_1.full_node.add_block(block, peer)
-
-    receiver_puzzlehash = wallet_receiver.get_new_puzzlehash()
-    coin = find_reward_coin(blocks[-1], cb_ph)
-    spend_bundle = wallet_a.generate_signed_transaction(uint64(100), receiver_puzzlehash, coin)
-    assert spend_bundle is not None
+    spend_bundle = make_spend_bundle(1)
     spend_name = spend_bundle.name()
 
-    validation_started = asyncio.Event()
-    original_pre_validate = full_node_1.full_node.mempool_manager.pre_validate_spendbundle
+    inside_validate = asyncio.Event()
+    release_validate = asyncio.Event()
 
-    async def slow_pre_validate(
-        sb: SpendBundle, sb_id: bytes32 | None = None, bls_cache: Any = None
-    ) -> SpendBundleConditions:
-        validation_started.set()
-        await asyncio.sleep(0.1)
-        return await original_pre_validate(sb, sb_id, bls_cache)
+    async def gated_pre_validate(*_args: Any, **_kwargs: Any) -> SpendBundleConditions:
+        inside_validate.set()
+        await release_validate.wait()
+        # Short-circuit add_transaction; we only care that the in-flight guard
+        # was populated before this await.
+        raise ValueError("test abort")
 
-    full_node_1.full_node.mempool_manager.pre_validate_spendbundle = slow_pre_validate  # type: ignore[assignment]
-    try:
-        task1 = create_referenced_task(full_node_1.full_node.add_transaction(spend_bundle, spend_name, peer, test=True))
-        await validation_started.wait()
-        # Task 1 is now inside pre_validate_spendbundle. If the in-flight guard
-        # was populated before the await, this second call is rejected
-        # immediately without churning seen-cache.
-        assert full_node_1.full_node.mempool_manager.in_flight(spend_name)
-        assert not full_node_1.full_node.mempool_manager.seen(spend_name)
-        status2, err2 = await full_node_1.full_node.add_transaction(spend_bundle, spend_name, peer, test=True)
-        status1, err1 = await task1
-    finally:
-        full_node_1.full_node.mempool_manager.pre_validate_spendbundle = original_pre_validate  # type: ignore[method-assign]
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr(fn.mempool_manager, "pre_validate_spendbundle", gated_pre_validate)
 
-    assert status1 == MempoolInclusionStatus.SUCCESS
-    assert err1 is None
-    assert status2 == MempoolInclusionStatus.FAILED
-    assert err2 == Err.ALREADY_INCLUDING_TRANSACTION
-    assert not full_node_1.full_node.mempool_manager.in_flight(spend_name)
-    assert full_node_1.full_node.mempool_manager.seen(spend_name)
+        task = create_referenced_task(fn.add_transaction(spend_bundle, spend_name, test=True))
+        await asyncio.wait_for(inside_validate.wait(), timeout=5)
+
+        # While task is paused inside gated_pre_validate, the guard must be set
+        # and the seen-cache must be untouched.
+        assert fn.mempool_manager.in_flight(spend_name)
+        assert not fn.mempool_manager.seen(spend_name)
+
+        # A concurrent caller for the same tx hits the guard and bails.
+        status2, err2 = await fn.add_transaction(spend_bundle, spend_name, test=True)
+        assert status2 == MempoolInclusionStatus.FAILED
+        assert err2 == Err.ALREADY_INCLUDING_TRANSACTION
+
+        # Let task resume; ValueError exits add_transaction at the soft-failure path.
+        release_validate.set()
+        status1, err1 = await asyncio.wait_for(task, timeout=5)
+
+    assert status1 == MempoolInclusionStatus.FAILED
+    assert err1 == Err.INVALID_SPEND_BUNDLE
+    assert not fn.mempool_manager.in_flight(spend_name)
+    assert not fn.mempool_manager.seen(spend_name)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Replaces `test_add_transaction_seen_before_validation`, which bisection identified as the sole cause of the CI hang on the `2.7.1-checkpoint` branch. The replacement preserves SEC-111 regression coverage with a much smaller surface area.

### Why the old test wedged CI
- Heavy `wallet_nodes` fixture (two simulator nodes + real peer connection)
- Backgrounded `add_transaction` task interacting with sync/wallet machinery
- Orphaned async work during fixture teardown under pytest-xdist on CI runners
- Did not reproduce locally; only manifested in CI's xdist worker environment

### What the new test does
- Uses lightweight `one_node_one_block` fixture (single node, no peer connection)
- Uses `pytest.MonkeyPatch.context()` instead of manual attribute swap
- Two `asyncio.Event`s deterministically gate the validate path
- `asyncio.wait_for` on both the gate and the final task — fails fast instead of hanging
- `gated_pre_validate` raises `ValueError` to short-circuit the rest of `add_transaction`; we only need to verify the in-flight guard was set before the await

### Coverage preserved
- Asserts `in_flight(spend_name)` is set while a validate is paused mid-flight
- Asserts `seen(spend_name)` is NOT set during that window
- Asserts a concurrent caller for the same tx returns `FAILED` / `ALREADY_INCLUDING_TRANSACTION`
- Asserts the soft-failure path clears `in_flight` and does not pollute `seen`

## Test plan
- [x] Passes locally across all 5 consensus modes (5/5 in 5.96s)
- [ ] CI green on `2.7.1-checkpoint` (full_node test job no longer hangs)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only rewrites a unit test, but it changes concurrency gating/monkeypatching and could miss regressions if the new assertions don’t match real behavior.
> 
> **Overview**
> Replaces `test_add_transaction_seen_before_validation` with a smaller, deterministic regression test for SEC-111 using the `one_node_one_block` fixture instead of the heavier `wallet_nodes` + peer connection setup.
> 
> The new test monkeypatches `mempool_manager.pre_validate_spendbundle` to pause mid-validation via `asyncio.Event`s, verifies `in_flight()` is set and `seen()` is untouched during the await window, checks a concurrent `add_transaction` call fails with `Err.ALREADY_INCLUDING_TRANSACTION`, and ensures the soft-failure path clears `in_flight` without populating `seen`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ad3299ddaf61f0a52610ad47d5cfe6a6f8fedfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->