### PR TITLE
Update Managed Files

### DIFF
--- a/.github/workflows/check-commit-signing.yml
+++ b/.github/workflows/check-commit-signing.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dependency-cursor-review.yml
+++ b/.github/workflows/dependency-cursor-review.yml
@@ -72,7 +72,7 @@ jobs:
             core.setOutput('head_sha', pr.head?.sha || '');
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.target_pr.outputs.head_sha }}
           persist-credentials: false
@@ -242,7 +242,7 @@ jobs:
         run: mkdir -p ".upstream-dependency"
 
       - name: Checkout upstream repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ steps.dependabot_context.outputs.upstream_repo }}
           path: .upstream-dependency

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v5.0.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Routine CI dependency pin bumps on checkout steps only; no application, auth, or runtime behavior changes in this diff.
> 
> **Overview**
> Bumps **`actions/checkout`** from **v6** to **v7** in three **repo-content-updater** managed GitHub Actions workflows.
> 
> **`check-commit-signing.yml`** updates the main repo checkout step. **`dependency-cursor-review.yml`** updates all three checkout steps (target PR, upstream dependency). **`dependency-review.yml`** updates the PR checkout before dependency review runs.
> 
> No step inputs, job logic, or other actions change—only the checkout action major version pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 240c2aadd0d90ca3027612c819da3c6bf5a5a755. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->