### PR TITLE
fix flaky tests (at least when run locally)

### DIFF
--- a/chia/_tests/cmds/cmd_test_utils.py
+++ b/chia/_tests/cmds/cmd_test_utils.py
@@ -45,6 +45,8 @@ from chia.wallet.wallet_request_types import (
     GetTransactionResponse,
     GetWallets,
     GetWalletsResponse,
+    LogIn,
+    LogInResponse,
     NFTCalculateRoyalties,
     NFTCalculateRoyaltiesResponse,
     NFTGetInfo,
@@ -96,12 +98,21 @@ class TestRpcClient:
 class TestFarmerRpcClient(TestRpcClient):
     client_type: type[FarmerRpcClient] = field(init=False, default=FarmerRpcClient)
 
+    async def get_pool_login_link(self, launcher_id: bytes32) -> str | None:
+        self.add_to_log("get_pool_login_link", (launcher_id,))
+        return None
+
 
 @dataclass
 class TestWalletRpcClient(TestRpcClient):
     client_type: type[WalletRpcClient] = field(init=False, default=WalletRpcClient)
     fingerprint: int = field(init=False, default=0)
     wallet_index: int = field(init=False, default=0)
+
+    async def log_in(self, request: LogIn) -> LogInResponse:
+        self.fingerprint = int(request.fingerprint)
+        self.add_to_log("log_in", (request,))
+        return LogInResponse(fingerprint=request.fingerprint)
 
     async def get_sync_status(self) -> GetSyncStatusResponse:
         self.add_to_log("get_sync_status", ())


### PR DESCRIPTION
This fixes local failures with the tests:

```
[gw6] darwin -- Python 3.13.11 /Users/arvid/Documents/dev/2/chia-blockchain/.venv/bin/python
chia/_tests/pools/test_pool_cmdline.py:960: in test_plotnft_cli_get_login_link
    await GetLoginLinkCMD(
chia/cmds/plotnft.py:65: in run
    await get_login_link(self.launcher_id, root_path=self.context.root_path)
chia/cmds/plotnft_funcs.py:281: in get_login_link
    login_link: str | None = await farmer_client.get_pool_login_link(launcher_id)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: 'TestFarmerRpcClient' object has no attribute 'get_pool_login_link'
```

```
[gw6] darwin -- Python 3.13.11 /Users/arvid/Documents/dev/2/chia-blockchain/.venv/bin/python
chia/_tests/cmds/test_cmd_framework.py:418: in test_wallet_rpc_helper
    async with expected_command.rpc_info.wallet_rpc(consume_errors=False) as client_info:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/homebrew/Cellar/python@3.13/3.13.11/Frameworks/Python.framework/Versions/3.13/lib/python3.13/contextlib.py:214: in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
chia/cmds/cmd_helpers.py:56: in wallet_rpc
    async with get_wallet_client(root_path, self.wallet_rpc_port, self.fingerprint, **kwargs) as (
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/homebrew/Cellar/python@3.13/3.13.11/Frameworks/Python.framework/Versions/3.13/lib/python3.13/contextlib.py:214: in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
chia/cmds/cmds_util.py:262: in get_wallet_client
    new_fp = await get_wallet(root_path, wallet_client, fingerprint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
chia/cmds/cmds_util.py:239: in get_wallet
    await wallet_client.log_in(LogIn(fingerprint=uint32(selected_fingerprint)))
          ^^^^^^^^^^^^^^^^^^^^
E   AttributeError: 'TestWalletRpcClient' object has no attribute 'log_in'
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to test-only RPC client stubs and primarily prevent `AttributeError`s in CLI tests; main risk is subtly diverging from real RPC behavior if signatures/return values change again.
> 
> **Overview**
> Fixes locally flaky CLI tests by extending the test RPC stubs in `chia/_tests/cmds/cmd_test_utils.py`.
> 
> `TestFarmerRpcClient` now implements `get_pool_login_link()` and `TestWalletRpcClient` now implements `log_in()` (including tracking the selected fingerprint and logging calls), aligning the test doubles with the RPC methods invoked by the CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 042b80e044fc87daf4ec2ab2309f80222d35ad70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->