### PR TITLE
Ignore ruff warning for float comparison

### DIFF
--- a/chia/util/priority_thread_pool_executor.py
+++ b/chia/util/priority_thread_pool_executor.py
@@ -207,7 +207,7 @@ class PriorityThreadPoolExecutor:
         max_wait = 0.0
         with q.mutex:
             for item in q.queue:
-                if item._sentinel or item.enqueue_time == 0.0:
+                if item._sentinel or item.enqueue_time == 0.0:  # noqa: RUF069
                     continue
                 assert item.future is not None
                 if not item.future.running() and not item.future.done():


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only suppresses a linter warning on an internal instrumentation check and does not change runtime behavior.
> 
> **Overview**
> Adds an inline `# noqa: RUF069` to the `enqueue_time == 0.0` guard in `PriorityThreadPoolExecutor._oldest_pending_wait()` to silence Ruff’s float-comparison warning for this sentinel/disabled-instrumentation case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cccb8744ef8ae4d8fed6e1bbac911f8e4c80fe03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->