### PR TITLE
[CHIA-4225] support treating old consensus constant names as the new ones

### DIFF
--- a/chia/_tests/util/test_replace_str_to_bytes.py
+++ b/chia/_tests/util/test_replace_str_to_bytes.py
@@ -139,6 +139,27 @@ def test_replace_str_to_bytes_deprecated_field(caplog: pytest.LogCaptureFixture)
     assert caplog.text == ""
 
 
+def test_replace_str_to_bytes_legacy_min_plot_size(caplog: pytest.LogCaptureFixture) -> None:
+    test2 = replace_str_to_bytes(test_constants, MIN_PLOT_SIZE=uint8(18))
+    assert test2 == test_constants.replace(MIN_PLOT_SIZE_V1=uint8(18))
+    assert test2.MIN_PLOT_SIZE_V1 == 18
+    assert caplog.text == ""
+
+
+def test_replace_str_to_bytes_legacy_max_plot_size(caplog: pytest.LogCaptureFixture) -> None:
+    test2 = replace_str_to_bytes(test_constants, MAX_PLOT_SIZE=uint8(40))
+    assert test2 == test_constants.replace(MAX_PLOT_SIZE_V1=uint8(40))
+    assert test2.MAX_PLOT_SIZE_V1 == 40
+    assert caplog.text == ""
+
+
+def test_replace_str_to_bytes_legacy_does_not_override_new(caplog: pytest.LogCaptureFixture) -> None:
+    test2 = replace_str_to_bytes(test_constants, MIN_PLOT_SIZE=uint8(18), MIN_PLOT_SIZE_V1=uint8(20))
+    assert test2 == test_constants.replace(MIN_PLOT_SIZE_V1=uint8(20))
+    assert test2.MIN_PLOT_SIZE_V1 == 20
+    assert caplog.text == ""
+
+
 def test_replace_str_to_bytes_invalid_value() -> None:
     # invalid value
     if sys.version_info >= (3, 14):

--- a/chia/_tests/util/test_testnet_overrides.py
+++ b/chia/_tests/util/test_testnet_overrides.py
@@ -15,7 +15,7 @@ def test_min_plot_size() -> None:
     overrides: dict[str, Any] = {"MIN_PLOT_SIZE": 18}
     update_testnet_overrides("testnet11", overrides)
     assert overrides == {
-        "MIN_PLOT_SIZE_V1": 18,
+        "MIN_PLOT_SIZE": 18,
         "PLOT_SIZE_V2": 28,
         "SOFT_FORK8_HEIGHT": 3755000,
         "SOFT_FORK9_HEIGHT": 3924000,
@@ -26,7 +26,7 @@ def test_max_plot_size() -> None:
     overrides: dict[str, Any] = {"MAX_PLOT_SIZE": 32}
     update_testnet_overrides("testnet11", overrides)
     assert overrides == {
-        "MAX_PLOT_SIZE_V1": 32,
+        "MAX_PLOT_SIZE": 32,
         "PLOT_SIZE_V2": 28,
         "SOFT_FORK8_HEIGHT": 3755000,
         "SOFT_FORK9_HEIGHT": 3924000,

--- a/chia/consensus/constants.py
+++ b/chia/consensus/constants.py
@@ -11,10 +11,19 @@ from chia.util.hash import std_hash
 log = logging.getLogger(__name__)
 
 
+LEGACY_RENAMES = {"MIN_PLOT_SIZE": "MIN_PLOT_SIZE_V1", "MAX_PLOT_SIZE": "MAX_PLOT_SIZE_V1"}
+
+
 def replace_str_to_bytes(constants: ConsensusConstants, **changes: Any) -> ConsensusConstants:
     """
     Overrides str (hex) values with bytes.
     """
+
+    for old_name, new_name in LEGACY_RENAMES.items():
+        if old_name in changes and new_name not in changes:
+            changes[new_name] = changes.pop(old_name)
+        elif old_name in changes:
+            del changes[old_name]
 
     filtered_changes = {}
     for k, v in changes.items():

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -102,13 +102,6 @@ DEFAULT_CONSTANTS = ConsensusConstants(
 
 
 def update_testnet_overrides(network_id: str, overrides: dict[str, Any]) -> None:
-    # These constants changed names to support v2 plots
-    if "MIN_PLOT_SIZE_V1" not in overrides and "MIN_PLOT_SIZE" in overrides:
-        overrides["MIN_PLOT_SIZE_V1"] = overrides["MIN_PLOT_SIZE"]
-        overrides.pop("MIN_PLOT_SIZE")
-    if "MAX_PLOT_SIZE_V1" not in overrides and "MAX_PLOT_SIZE" in overrides:
-        overrides["MAX_PLOT_SIZE_V1"] = overrides["MAX_PLOT_SIZE"]
-        overrides.pop("MAX_PLOT_SIZE")
     if network_id in {"testnet11", "testneta"}:
         if "PLOT_SIZE_V2" not in overrides:
             overrides["PLOT_SIZE_V2"] = 28


### PR DESCRIPTION
It's not clear to me exactly how you would see the error:

```
invalid key in network configuration (config.yaml) "MIN_PLOT_SIZE". Ignoring
```

the farmer, harvester and node already call `update_testnet_overrides()` before `replace_str_to_bytes()`, which is supposed to update these keys.

This patch moves the renaming into `replace_str_to_bytes()`, which is a bit more robust.

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

If you don't call `update_testnet_overrides()` before `replace_str_to_bytes()`, it may fail if you have old key names in your override settings.

### New Behavior:

`replace_str_to_bytes()`, supports the old key names directly.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->
