### PR TITLE
Stop checking permissions on bundled Mozilla CA bundle

### DIFF
--- a/chia/_tests/util/test_ssl_check.py
+++ b/chia/_tests/util/test_ssl_check.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from chia.ssl.create_ssl import create_all_ssl
+from chia.ssl.create_ssl import create_all_ssl, get_mozilla_ca_crt
 from chia.ssl.ssl_check import check_ssl
 
 
@@ -29,3 +29,28 @@ def test_check_ssl_stream_with_bad_permissions(
             assert captured.err == ""
         else:
             assert "WARNING: UNPROTECTED SSL FILE!" in captured.err
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SSL permission checks are not enforced on Windows")
+def test_check_ssl_ignores_bundled_mozilla_ca_permissions(
+    capsys: pytest.CaptureFixture[str],
+    root_path_populated_with_config: Path,
+) -> None:
+    mozilla_ca = Path(get_mozilla_ca_crt())
+    original_mode = mozilla_ca.stat().st_mode & 0o777
+
+    with capsys.disabled():
+        create_all_ssl(root_path=root_path_populated_with_config)
+        mozilla_ca.chmod(mode=0o664)
+
+    try:
+        check_ssl(root_path=root_path_populated_with_config)
+
+        with capsys.disabled():
+            captured = capsys.readouterr()
+
+            assert captured.out == ""
+            assert "cacert.pem" not in captured.err
+            assert "WARNING: UNPROTECTED SSL FILE!" not in captured.err
+    finally:
+        mozilla_ca.chmod(mode=original_mode)

--- a/chia/ssl/ssl_check.py
+++ b/chia/ssl/ssl_check.py
@@ -64,8 +64,6 @@ warned_ssl_files: set[Path] = set()
 
 def get_all_ssl_file_paths(root_path: Path) -> tuple[list[Path], list[Path]]:
     """Lookup config values and append to a list of files whose permissions we need to check"""
-    from chia.ssl.create_ssl import get_mozilla_ca_crt
-
     all_certs: list[Path] = []
     all_keys: list[Path] = []
 
@@ -80,9 +78,6 @@ def get_all_ssl_file_paths(root_path: Path) -> tuple[list[Path], list[Path]]:
                     print(
                         f"Failed to lookup config value for {path}: {e}"
                     )  # lgtm [py/clear-text-logging-sensitive-data]
-
-        # Check the Mozilla Root CAs as well
-        all_certs.append(Path(get_mozilla_ca_crt()))
     except (FileNotFoundError, ValueError):
         pass
 


### PR DESCRIPTION
## Summary
- Stop including git-tracked `chia/ssl/cacert.pem` in the SSL permission checks run on every `chia` CLI invocation
- Add a test confirming group-writable (`0664`) permissions on the bundled CA bundle do not trigger warnings

## Problem
After `git checkout` of a release tag, `cacert.pem` is often rewritten with `0664` permissions on Linux systems using umask `002`. Chia then prints a recurring `UNPROTECTED SSL FILE` warning even though:
- `install.sh` does not adjust SSL file modes
- the bundled Mozilla CA file is public, non-sensitive data
- private keys and user config certs under `~/.chia` remain checked as before

## Test plan
- [ ] `tools/pytest chia/_tests/util/test_ssl_check.py -v`
- [ ] Confirm `chmod 664 chia/ssl/cacert.pem && chia version` no longer prints the SSL warning on Linux


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes a permission warning for a non-sensitive, git-tracked CA bundle while leaving private key/cert permission checks unchanged.
> 
> **Overview**
> Stops including the bundled Mozilla CA bundle (`chia/ssl/cacert.pem`, returned by `get_mozilla_ca_crt()`) in `ssl_check.get_all_ssl_file_paths()`, so CLI SSL permission warnings no longer trigger based on that file’s mode.
> 
> Adds a non-Windows test that temporarily sets the CA bundle to `0664` and asserts `check_ssl()` emits no `UNPROTECTED SSL FILE` warning and doesn’t mention `cacert.pem`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b577a753bc1052f35228055601d16c1855f182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->