### PR TITLE
fix monkeypatching in tests to not leak into other tests

### DIFF
--- a/chia/_tests/cmds/cmd_test_utils.py
+++ b/chia/_tests/cmds/cmd_test_utils.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 from chia_rs import BlockRecord, Coin, G1Element, G2Element
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64
@@ -45,8 +46,6 @@ from chia.wallet.wallet_request_types import (
     GetTransactionResponse,
     GetWallets,
     GetWalletsResponse,
-    LogIn,
-    LogInResponse,
     NFTCalculateRoyalties,
     NFTCalculateRoyaltiesResponse,
     NFTGetInfo,
@@ -98,21 +97,12 @@ class TestRpcClient:
 class TestFarmerRpcClient(TestRpcClient):
     client_type: type[FarmerRpcClient] = field(init=False, default=FarmerRpcClient)
 
-    async def get_pool_login_link(self, launcher_id: bytes32) -> str | None:
-        self.add_to_log("get_pool_login_link", (launcher_id,))
-        return None
-
 
 @dataclass
 class TestWalletRpcClient(TestRpcClient):
     client_type: type[WalletRpcClient] = field(init=False, default=WalletRpcClient)
     fingerprint: int = field(init=False, default=0)
     wallet_index: int = field(init=False, default=0)
-
-    async def log_in(self, request: LogIn) -> LogInResponse:
-        self.fingerprint = int(request.fingerprint)
-        self.add_to_log("log_in", (request,))
-        return LogInResponse(fingerprint=request.fingerprint)
 
     async def get_sync_status(self) -> GetSyncStatusResponse:
         self.add_to_log("get_sync_status", ())
@@ -359,12 +349,13 @@ class TestRpcClients:
             raise ValueError(f"Invalid client type requested: {client_type.__name__}")
 
 
-def create_service_and_wallet_client_generators(test_rpc_clients: TestRpcClients, default_root: Path) -> None:
+def create_service_and_wallet_client_generators(
+    test_rpc_clients: TestRpcClients, default_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """
-    Create and monkey patch custom generators designed for testing.
-    These are monkey patched into the chia.cmds.cmds_util module.
-    Each generator below replaces the original function with a new one that returns a custom client, given by the class.
-    The clients given can be changed by changing the variables in the class above, after running this function.
+    Monkey-patch custom RPC client generators for testing into the chia.cmds
+    modules.  All patches are applied via *monkeypatch* so they are undone
+    automatically when the caller's ``MonkeyPatch`` context exits.
     """
 
     @asynccontextmanager
@@ -380,9 +371,7 @@ def create_service_and_wallet_client_generators(test_rpc_clients: TestRpcClients
 
         node_type = node_config_section_names.get(client_type)
         if node_type is None:
-            # Click already checks this, so this should never happen
             raise ValueError(f"Invalid client type requested: {client_type.__name__}")
-        # load variables from config file
         config = load_config(
             root_path,
             "config.yaml",
@@ -410,14 +399,11 @@ def create_service_and_wallet_client_generators(test_rpc_clients: TestRpcClients
     def cli_confirm(input_message: str, abort_message: str = "Did not confirm. Aborting.") -> None:
         return None
 
-    # Monkey patches the functions into the module, the classes returned by these functions can be changed in the class.
-    # For more information, read the docstring of this function.
-    chia.cmds.cmds_util.get_any_service_client = test_get_any_service_client
-    chia.cmds.cmds_util.get_wallet_client = test_get_wallet_client  # type: ignore[assignment]
-    chia.cmds.wallet_funcs.get_wallet_client = test_get_wallet_client  # type: ignore[assignment,attr-defined]
-    # Monkey patches the confirm function to not ask for confirmation
-    chia.cmds.cmds_util.cli_confirm = cli_confirm
-    chia.cmds.wallet_funcs.cli_confirm = cli_confirm  # type: ignore[attr-defined]
+    monkeypatch.setattr(chia.cmds.cmds_util, "get_any_service_client", test_get_any_service_client)
+    monkeypatch.setattr(chia.cmds.cmds_util, "get_wallet_client", test_get_wallet_client)
+    monkeypatch.setattr(chia.cmds.wallet_funcs, "get_wallet_client", test_get_wallet_client)
+    monkeypatch.setattr(chia.cmds.cmds_util, "cli_confirm", cli_confirm)
+    monkeypatch.setattr(chia.cmds.wallet_funcs, "cli_confirm", cli_confirm)
 
 
 def run_cli_command(capsys: object, chia_root: Path, command_list: list[str]) -> str:

--- a/chia/_tests/cmds/conftest.py
+++ b/chia/_tests/cmds/conftest.py
@@ -19,5 +19,6 @@ def get_test_cli_clients() -> Iterator[tuple[TestRpcClients, Path]]:
         create_default_chia_config(root_path)
         # ^ this is basically the generate config fixture.
         global_test_rpc_clients = TestRpcClients()
-        create_service_and_wallet_client_generators(global_test_rpc_clients, root_path)
-        yield global_test_rpc_clients, root_path
+        with pytest.MonkeyPatch.context() as mp:
+            create_service_and_wallet_client_generators(global_test_rpc_clients, root_path, mp)
+            yield global_test_rpc_clients, root_path


### PR DESCRIPTION
### Purpose:

It was not failing on CI because we run smaller groups of tests, but when running all tests in a single command, there would be failures.

This PR also revertes a recent patch to mitigate this issue.

### Current Behavior:

when running command line/CLI tests, we would not restore the monkeypatches. This caused later tests running in the same process to fail.

### New Behavior:

`create_service_and_wallet_client_generators` takes a `pytest.MonkeyPatch` parameter and uses `monkeypatch.setattr()` for all 5 patches. The conftest wraps
  it in `pytest.MonkeyPatch.context()`, which handles save/restore automatically.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that adjust how monkeypatching is applied and automatically reverted; main potential issue is missing a patch or incorrect scoping causing CLI tests to fail.
> 
> **Overview**
> Fixes CLI command tests leaking monkeypatched RPC helpers into later tests by changing `create_service_and_wallet_client_generators` to accept a `pytest.MonkeyPatch` and applying patches via `monkeypatch.setattr()`.
> 
> Updates the `get_test_cli_clients` fixture to wrap setup in `pytest.MonkeyPatch.context()`, ensuring all patched functions (RPC client generators and `cli_confirm`) are automatically restored after the fixture exits, and removes now-unneeded test RPC methods (`log_in`, `get_pool_login_link`) tied to those patches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08788c422db9a8b3a10ca39f57f5f98c881eb7d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->