### PR TITLE
checkpoint: into main from release/2.7.1  @ 560a4ab7a96b619bafd4efd5aa2f2e5c8cffea67

### DIFF
--- a/chia/_tests/core/full_node/stores/test_full_node_store.py
+++ b/chia/_tests/core/full_node/stores/test_full_node_store.py
@@ -40,7 +40,6 @@ from chia.full_node.full_node_store import (
     FUTURE_SP_CACHE_MAX_KEYS,
     MAX_UNFINISHED_BLOCKS_PER_REWARD_HASH,
     FullNodeStore,
-    SignagePointAddResult,
     UnfinishedBlockEntry,
     find_best_block,
 )
@@ -569,8 +568,7 @@ async def test_basic_store(
             [],
             peak.sub_slot_iters,
         )
-        sp_result = store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
-        assert sp_result == SignagePointAddResult.ADDED
+        assert store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
 
     blocks = blocks_reorg
     while True:
@@ -678,8 +676,7 @@ async def test_basic_store(
             [],
             peak.sub_slot_iters,
         )
-        sp_result = store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
-        assert sp_result == SignagePointAddResult.ADDED
+        assert store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
 
     # Test adding future signage point, a few slots forward (good)
     saved_sp_hash = None
@@ -701,8 +698,7 @@ async def test_basic_store(
             saved_sp_hash = sp.cc_vdf.output.get_hash()
             saved_index = uint8(i)
             saved_challenge = sp.cc_vdf.challenge
-            sp_result = store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
-            assert sp_result == SignagePointAddResult.ADDED
+            assert store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
 
     # Test adding future signage point (bad)
     for i in range(
@@ -720,8 +716,7 @@ async def test_basic_store(
             finished_sub_slots[: len(finished_sub_slots)],
             peak.sub_slot_iters,
         )
-        sp_result = store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
-        assert sp_result == SignagePointAddResult.NOT_ADDED
+        assert not store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
 
     # Test adding past signage point
     sp = SignagePoint(
@@ -730,17 +725,12 @@ async def test_basic_store(
         blocks[1].reward_chain_block.reward_chain_sp_vdf,
         blocks[1].reward_chain_sp_proof,
     )
-    assert (
-        store.new_signage_point(
-            blocks[1].reward_chain_block.signage_point_index,
-            blockchain,
-            peak,
-            uint64(
-                blockchain.block_record(blocks[1].header_hash).sp_sub_slot_total_iters(custom_block_tools.constants)
-            ),
-            sp,
-        )
-        == SignagePointAddResult.NOT_ADDED
+    assert not store.new_signage_point(
+        blocks[1].reward_chain_block.signage_point_index,
+        blockchain,
+        peak,
+        uint64(blockchain.block_record(blocks[1].header_hash).sp_sub_slot_total_iters(custom_block_tools.constants)),
+        sp,
     )
 
     # Get signage point by index
@@ -781,8 +771,7 @@ async def test_basic_store(
             [],
             peak.sub_slot_iters,
         )
-        sp_result = store.new_signage_point(uint8(i), blockchain, None, peak.sub_slot_iters, sp)
-        assert sp_result == SignagePointAddResult.ADDED
+        assert store.new_signage_point(uint8(i), blockchain, None, peak.sub_slot_iters, sp)
 
     blocks_3 = custom_block_tools.get_consecutive_blocks(
         1,
@@ -817,8 +806,7 @@ async def test_basic_store(
                 finished_sub_slots[:slot_offset],
                 peak.sub_slot_iters,
             )
-            sp_result = store.new_signage_point(uint8(i), blockchain, None, peak.sub_slot_iters, sp)
-            assert sp_result == SignagePointAddResult.ADDED
+            assert store.new_signage_point(uint8(i), blockchain, None, peak.sub_slot_iters, sp)
 
     # Test adding signage points after genesis
     blocks_4 = custom_block_tools.get_consecutive_blocks(
@@ -869,8 +857,7 @@ async def test_basic_store(
             finished_sub_slots,
             peak.sub_slot_iters,
         )
-        sp_result = store.new_signage_point(uint8(i), empty_blockchain, sb, peak.sub_slot_iters, sp)
-        assert sp_result == SignagePointAddResult.ADDED
+        assert store.new_signage_point(uint8(i), empty_blockchain, sb, peak.sub_slot_iters, sp)
 
     # Test future EOS cache
     store.initialize_genesis_sub_slot()
@@ -1085,8 +1072,7 @@ async def test_basic_store(
                     peak.sub_slot_iters,
                 )
                 all_sps[i] = sp
-                sp_result = store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
-                assert sp_result == SignagePointAddResult.ADDED
+                assert store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
 
             # Adding a new peak clears all SPs after that peak
             await _validate_and_add_block_no_error(blockchain, blocks[-2], fork_info=fork_info)
@@ -1129,8 +1115,7 @@ async def test_basic_store(
                     peak.sub_slot_iters,
                 )
                 all_sps[i] = sp
-                sp_result = store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
-                assert sp_result == SignagePointAddResult.ADDED
+                assert store.new_signage_point(uint8(i), blockchain, peak, peak.sub_slot_iters, sp)
 
             assert_sp_none(i2, False)
             assert_sp_none(i2 + 1, False)
@@ -1541,109 +1526,3 @@ async def test_new_finished_sub_slot_eos_per_key_drop() -> None:
     )
     assert result is None
     assert store.future_eos_cache.total_entries == FUTURE_EOS_CACHE_MAX_ENTRIES_PER_KEY
-
-
-@pytest.mark.limit_consensus_modes(reason="save time")
-@pytest.mark.anyio
-async def test_new_signage_point_invalid_vdf(
-    empty_blockchain: Blockchain,
-    custom_block_tools: BlockTools,
-) -> None:
-    blockchain = empty_blockchain
-    blocks = custom_block_tools.get_consecutive_blocks(2, skip_slots=2)
-
-    store = FullNodeStore(empty_blockchain.constants)
-    store.initialize_genesis_sub_slot()
-
-    fork_info = ForkInfo(-1, -1, blockchain.constants.GENESIS_CHALLENGE)
-    for block in blocks:
-        await _validate_and_add_block_no_error(blockchain, block, fork_info=fork_info)
-        sb = blockchain.block_record(block.header_hash)
-        result = await blockchain.get_sp_and_ip_sub_slots(block.header_hash)
-        assert result is not None
-        sp_sub_slot, ip_sub_slot = result
-        next_sub_slot_iters, next_difficulty = get_next_sub_slot_iters_and_difficulty(
-            blockchain.constants, False, sb, blockchain
-        )
-        store.new_peak(sb, block, sp_sub_slot, ip_sub_slot, None, blockchain, next_sub_slot_iters, next_difficulty)
-
-    peak = blockchain.get_peak()
-    assert peak is not None
-    ss_start_iters = peak.ip_sub_slot_total_iters(custom_block_tools.constants)
-
-    sp = get_signage_point(
-        custom_block_tools.constants,
-        blockchain,
-        peak,
-        ss_start_iters,
-        uint8(1),
-        [],
-        peak.sub_slot_iters,
-    )
-    assert sp.cc_vdf is not None
-    assert sp.cc_proof is not None
-    assert sp.rc_vdf is not None
-    assert sp.rc_proof is not None
-
-    # Valid SP should be accepted
-    assert store.new_signage_point(uint8(1), blockchain, peak, peak.sub_slot_iters, sp) == SignagePointAddResult.ADDED
-
-    # Use index 2 so it isn't a duplicate of the one already added at index 1
-    sp2 = get_signage_point(
-        custom_block_tools.constants,
-        blockchain,
-        peak,
-        ss_start_iters,
-        uint8(2),
-        [],
-        peak.sub_slot_iters,
-    )
-    assert sp2.cc_proof is not None
-    assert sp2.rc_proof is not None
-    corrupted_cc_proof_2 = sp2.cc_proof.replace(witness=b"\xff" * len(sp2.cc_proof.witness))
-    corrupted_sp2 = SignagePoint(sp2.cc_vdf, corrupted_cc_proof_2, sp2.rc_vdf, sp2.rc_proof)
-
-    sp_result = store.new_signage_point(uint8(2), blockchain, peak, peak.sub_slot_iters, corrupted_sp2)
-    assert sp_result == SignagePointAddResult.INVALID_VDF
-
-    # Verify the invalid SP was NOT added to future_sp_cache
-    all_cached = [sp for key in store.future_sp_cache.keys() for _, sp in store.future_sp_cache[key]]
-    assert not any(sp.cc_vdf == corrupted_sp2.cc_vdf for sp in all_cached), "invalid VDF SP should not be cached"
-
-    # Corrupt the RC proof instead, keep CC proof valid
-    corrupted_rc_proof = sp2.rc_proof.replace(witness=b"\xff" * len(sp2.rc_proof.witness))
-    sp_result = store.new_signage_point(
-        uint8(2),
-        blockchain,
-        peak,
-        peak.sub_slot_iters,
-        SignagePoint(sp2.cc_vdf, sp2.cc_proof, sp2.rc_vdf, corrupted_rc_proof),
-    )
-    assert sp_result == SignagePointAddResult.INVALID_VDF
-
-    # Corrupt a normalized-to-identity CC proof to exercise the other INVALID_VDF branch
-    sp3 = get_signage_point(
-        custom_block_tools.constants,
-        blockchain,
-        peak,
-        ss_start_iters,
-        uint8(3),
-        [],
-        peak.sub_slot_iters,
-        normalized_to_identity_cc_sp=True,
-    )
-    assert sp3.cc_proof is not None
-    assert sp3.cc_proof.normalized_to_identity
-    corrupted_nti_proof = sp3.cc_proof.replace(witness=b"\xff" * len(sp3.cc_proof.witness))
-    corrupted_sp4 = SignagePoint(sp3.cc_vdf, corrupted_nti_proof, sp3.rc_vdf, sp3.rc_proof)
-
-    sp_result = store.new_signage_point(uint8(3), blockchain, peak, peak.sub_slot_iters, corrupted_sp4)
-    assert sp_result == SignagePointAddResult.INVALID_VDF
-
-    # Structural mismatch: correct challenge hash but wrong iteration count
-    assert sp2.cc_vdf is not None
-    wrong_iters_vdf = sp2.cc_vdf.replace(number_of_iterations=uint64(sp2.cc_vdf.number_of_iterations + 1))
-    wrong_sp = SignagePoint(wrong_iters_vdf, sp2.cc_proof, sp2.rc_vdf, sp2.rc_proof)
-
-    sp_result = store.new_signage_point(uint8(2), blockchain, peak, peak.sub_slot_iters, wrong_sp)
-    assert sp_result == SignagePointAddResult.NOT_ADDED

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -13,7 +13,6 @@ from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any
 
 import pytest
-from aiohttp import WSCloseCode
 from chia_rs import (
     AugSchemeMPL,
     Coin,
@@ -70,7 +69,6 @@ from chia.protocols.farmer_protocol import DeclareProofOfSpace
 from chia.protocols.full_node_protocol import NewTransaction, RespondTransaction
 from chia.protocols.outbound_message import Message, NodeType, make_msg
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
-from chia.protocols.protocol_timing import CONSENSUS_ERROR_BAN_SECONDS
 from chia.protocols.shared_protocol import Capability, default_capabilities
 from chia.protocols.wallet_protocol import RespondHeaderBlocks, SendTransaction, TransactionAck
 from chia.server.address_manager import AddressManager
@@ -2216,73 +2214,6 @@ async def test_new_signage_point_caching(
         )
         is not None
     )
-
-
-@pytest.mark.anyio
-async def test_respond_signage_point_bans_invalid_vdf(
-    wallet_nodes: tuple[
-        FullNodeSimulator, FullNodeSimulator, ChiaServer, ChiaServer, WalletTool, WalletTool, BlockTools
-    ],
-    empty_blockchain: Blockchain,
-    self_hostname: str,
-) -> None:
-    full_node_1, _full_node_2, server_1, server_2, _wallet_a, _wallet_receiver, bt = wallet_nodes
-    blocks = await full_node_1.get_all_full_blocks()
-
-    peer = await connect_and_get_peer(server_1, server_2, self_hostname)
-    peer.peer_info = PeerInfo("192.168.1.100", peer.peer_info.port)
-    blocks = bt.get_consecutive_blocks(3, block_list_input=blocks, skip_slots=2)
-    await full_node_1.full_node.add_block(blocks[-3])
-    await full_node_1.full_node.add_block(blocks[-2])
-    await full_node_1.full_node.add_block(blocks[-1])
-
-    blockchain = full_node_1.full_node.blockchain
-
-    second_blockchain = empty_blockchain
-    for block in blocks:
-        await _validate_and_add_block(second_blockchain, block)
-
-    peak_2 = second_blockchain.get_peak()
-    assert peak_2 is not None
-    sp: SignagePoint = get_signage_point(
-        bt.constants,
-        blockchain,
-        peak_2,
-        peak_2.ip_sub_slot_total_iters(bt.constants),
-        uint8(4),
-        [],
-        peak_2.sub_slot_iters,
-    )
-    assert sp.cc_vdf is not None
-    assert sp.cc_proof is not None
-    assert sp.rc_vdf is not None
-    assert sp.rc_proof is not None
-
-    corrupted_cc_proof = sp.cc_proof.replace(witness=b"\xff" * len(sp.cc_proof.witness))
-    corrupted_request = fnp.RespondSignagePoint(uint8(4), sp.cc_vdf, corrupted_cc_proof, sp.rc_vdf, sp.rc_proof)
-
-    original_close = peer.close
-    close_calls: list[tuple[int, bool]] = []
-
-    async def tracking_close(
-        ban_time: int = 0,
-        ws_close_code: WSCloseCode = WSCloseCode.OK,
-        error: Err | None = None,
-    ) -> None:
-        lock_held = full_node_1.full_node.timelord_lock.locked()
-        close_calls.append((ban_time, lock_held))
-        await original_close(ban_time, ws_close_code, error)
-
-    peer.close = tracking_close  # type: ignore[method-assign]
-
-    await full_node_1.respond_signage_point(corrupted_request, peer)
-
-    assert len(close_calls) == 1, f"expected exactly one close call, got {len(close_calls)}"
-    ban_time, lock_was_held = close_calls[0]
-    assert ban_time == CONSENSUS_ERROR_BAN_SECONDS, (
-        f"expected CONSENSUS_ERROR_BAN_SECONDS ({CONSENSUS_ERROR_BAN_SECONDS}), got {ban_time}"
-    )
-    assert not lock_was_held, "peer.close() must be called after timelord_lock is released"
 
 
 @pytest.mark.anyio

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -43,7 +43,6 @@ from chia.consensus.signage_point import SignagePoint
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
 from chia.full_node.full_block_utils import get_height_and_tx_status_from_block, header_block_from_block
-from chia.full_node.full_node_store import SignagePointAddResult
 from chia.full_node.hard_fork_utils import get_flags
 from chia.full_node.tx_processing_queue import PeerWithTx, TransactionQueueEntry, TransactionQueueFull
 from chia.protocols import farmer_protocol, full_node_protocol, introducer_protocol, timelord_protocol, wallet_protocol
@@ -76,7 +75,6 @@ from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER
 from chia.util.errors import ConsensusError, Err
 from chia.util.hash import std_hash
 from chia.util.limited_semaphore import LimitedSemaphore, LimitedSemaphoreFullError
-from chia.util.network import is_in_network, is_localhost
 from chia.util.task_referencer import create_referenced_task
 
 if TYPE_CHECKING:
@@ -793,6 +791,8 @@ class FullNodeAPI:
         if self.full_node.sync_store.get_sync_mode():
             return None
         async with self.full_node.timelord_lock:
+            # Already have signage point
+
             if self.full_node.full_node_store.have_newer_signage_point(
                 request.challenge_chain_vdf.challenge,
                 request.index_from_challenge,
@@ -819,7 +819,7 @@ class FullNodeAPI:
                 next_sub_slot_iters = sub_slot_iters
                 ip_sub_slot = None
 
-            result = self.full_node.full_node_store.new_signage_point(
+            added = self.full_node.full_node_store.new_signage_point(
                 request.index_from_challenge,
                 self.full_node.blockchain,
                 self.full_node.blockchain.get_peak(),
@@ -832,34 +832,16 @@ class FullNodeAPI:
                 ),
             )
 
-            if result == SignagePointAddResult.ADDED:
+            if added:
                 await self.full_node.signage_point_post_processing(request, peer, ip_sub_slot)
-                return None
-            if result != SignagePointAddResult.INVALID_VDF:
+            else:
                 self.log.debug(
                     f"Signage point {request.index_from_challenge} not added, CC challenge: "
                     f"{request.challenge_chain_vdf.challenge.hex()}, "
                     f"RC challenge: {request.reward_chain_vdf.challenge.hex()}"
                 )
-                return None
 
-        # INVALID_VDF: ban peer after releasing timelord_lock
-        server = self.full_node.server
-        peer_host = peer.peer_info.host
-
-        if is_localhost(peer_host):
-            self.log.debug(f"Not banning localhost peer for invalid signage point VDF proof: {peer_host}")
-        elif server is not None and is_in_network(peer_host, server.exempt_peer_networks):
-            self.log.debug(f"Not banning exempt network peer for invalid signage point VDF proof: {peer_host}")
-        else:
-            self.log.warning(
-                f"Banning {peer.get_peer_logging()} for invalid signage point VDF proof. "
-                f"SP index: {request.index_from_challenge}, "
-                f"CC challenge: {request.challenge_chain_vdf.challenge.hex()}"
-            )
-            await peer.close(CONSENSUS_ERROR_BAN_SECONDS)
-
-        return None
+            return None
 
     @metadata.request(peer_required=True)
     async def respond_end_of_sub_slot(

--- a/chia/full_node/full_node_store.py
+++ b/chia/full_node/full_node_store.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
-import enum
 import logging
 import time
 
@@ -40,12 +39,6 @@ FUTURE_EOS_CACHE_MAX_ENTRIES_PER_KEY = 4
 
 FUTURE_IP_CACHE_MAX_KEYS = 128
 FUTURE_IP_CACHE_MAX_ENTRIES_PER_KEY = 8
-
-
-class SignagePointAddResult(enum.Enum):
-    ADDED = "added"
-    NOT_ADDED = "not_added"
-    INVALID_VDF = "invalid_vdf"
 
 
 @streamable
@@ -701,14 +694,9 @@ class FullNodeStore:
         next_sub_slot_iters: uint64,
         signage_point: SignagePoint,
         skip_vdf_validation: bool = False,
-    ) -> SignagePointAddResult:
+    ) -> bool:
         """
-        Returns:
-            ADDED: SP was stored successfully.
-            NOT_ADDED: SP was rejected for structural reasons (wrong sub-slot, future SP,
-                info mismatch). May be cached for later retry via add_to_future_sp.
-            INVALID_VDF: Challenge hash and VDF info matched expectations but the
-                cryptographic proof failed verification. Caller should ban the peer.
+        Returns true if sp successfully added
         """
         assert len(self.finished_sub_slots) >= 1
 
@@ -717,8 +705,9 @@ class FullNodeStore:
         else:
             sub_slot_iters = peak.sub_slot_iters
 
+        # If we don't have this slot, return False
         if index == 0 or index >= self.constants.NUM_SPS_SUB_SLOT:
-            return SignagePointAddResult.NOT_ADDED
+            return False
         assert (
             signage_point.cc_vdf is not None
             and signage_point.cc_proof is not None
@@ -791,35 +780,34 @@ class FullNodeStore:
                     )
                 if not signage_point.cc_vdf == cc_vdf_info_expected.replace(number_of_iterations=delta_iters):
                     self.add_to_future_sp(signage_point, index)
-                    return SignagePointAddResult.NOT_ADDED
+                    return False
                 if check_from_start_of_ss:
                     start_ele = ClassgroupElement.get_default_element()
                 else:
                     assert curr is not None
                     start_ele = curr.challenge_vdf_output
                 if not skip_vdf_validation:
-                    # A Wesolowski VDF proof cannot be accidentally invalid when the challenge
-                    # and iteration count match — forging one requires the sequential computation.
-                    # Proof failure here is definitively malicious.
                     if not signage_point.cc_proof.normalized_to_identity and not validate_vdf(
                         signage_point.cc_proof,
                         self.constants,
                         start_ele,
                         cc_vdf_info_expected,
                     ):
-                        return SignagePointAddResult.INVALID_VDF
+                        self.add_to_future_sp(signage_point, index)
+                        return False
                     if signage_point.cc_proof.normalized_to_identity and not validate_vdf(
                         signage_point.cc_proof,
                         self.constants,
                         ClassgroupElement.get_default_element(),
                         signage_point.cc_vdf,
                     ):
-                        return SignagePointAddResult.INVALID_VDF
+                        self.add_to_future_sp(signage_point, index)
+                        return False
 
                 if rc_vdf_info_expected.challenge != signage_point.rc_vdf.challenge:
                     # This signage point is probably outdated
                     self.add_to_future_sp(signage_point, index)
-                    return SignagePointAddResult.NOT_ADDED
+                    return False
 
                 if not skip_vdf_validation:
                     if not validate_vdf(
@@ -829,13 +817,14 @@ class FullNodeStore:
                         signage_point.rc_vdf,
                         rc_vdf_info_expected,
                     ):
-                        return SignagePointAddResult.INVALID_VDF
+                        self.add_to_future_sp(signage_point, index)
+                        return False
 
                 sp_arr[index] = signage_point
                 self.recent_signage_points.put(signage_point.cc_vdf.output.get_hash(), (signage_point, time.time()))
-                return SignagePointAddResult.ADDED
+                return True
         self.add_to_future_sp(signage_point, index)
-        return SignagePointAddResult.NOT_ADDED
+        return False
 
     def get_signage_point(self, cc_signage_point: bytes32) -> SignagePoint | None:
         assert len(self.finished_sub_slots) >= 1
@@ -1009,7 +998,7 @@ class FullNodeStore:
         ).copy()
         for index, sp in future_sps:
             assert sp.cc_vdf is not None
-            if self.new_signage_point(index, blocks, peak, peak.sub_slot_iters, sp) == SignagePointAddResult.ADDED:
+            if self.new_signage_point(index, blocks, peak, peak.sub_slot_iters, sp):
                 new_sps.append((index, sp))
 
         for ip in self.future_ip_cache.get(peak.reward_infusion_new_challenge, []):


### PR DESCRIPTION
Source hash: 560a4ab7a96b619bafd4efd5aa2f2e5c8cffea67
Remaining commits: 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect consensus networking behavior around `respond_signage_point`, removing the explicit invalid-VDF ban path and altering how invalid proofs are handled/cached. This could impact peer misbehavior handling and signage point propagation, but the change is localized to signage-point add flow and associated tests.
> 
> **Overview**
> Simplifies signage-point handling by changing `FullNodeStore.new_signage_point()` to return a boolean instead of `SignagePointAddResult`, and removes the `SignagePointAddResult` enum entirely.
> 
> Updates `FullNodeAPI.respond_signage_point()` to treat non-added signage points uniformly (debug log only) and **removes the special-case path that banned peers for `INVALID_VDF` proofs**; invalid VDF proofs are now treated as a non-add and are added to the future SP cache like other rejected cases.
> 
> Adjusts tests to assert on boolean results and removes coverage that specifically expected `INVALID_VDF` results and peer banning for invalid signage-point VDF proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a003daed2e6ad54648684a31ba96c98d8699548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->