### PR TITLE
[CHIA-4189] make it clear that bytes100 always is 100 bytes long

### DIFF
--- a/chia/types/blockchain_format/vdf.py
+++ b/chia/types/blockchain_format/vdf.py
@@ -61,6 +61,9 @@ def validate_vdf(
         return False
     if proof.witness_type + 1 > constants.MAX_VDF_WITNESS_SIZE:
         return False
+    if len(input_el.data) != 100:
+        log.error(f"Invalid ClassgroupElement size: {len(input_el.data)} (expected 100)")
+        return False
     try:
         disc: int = get_discriminant(info.challenge, constants.DISCRIMINANT_SIZE_BITS)
         # TODO: parallelize somehow, this might included multiple mini proofs (n weso)


### PR DESCRIPTION
### Purpose:

`chiavdf` takes a pointer to x's, and expect there to be 100 bytes. It's a bit smelly as this assumption is not eforced anywhere and relies on documentation.

### Current Behavior:

the `bytes100` constructor and `from_bytes()` ensures the proof data is exactly 100 bytes.
`chiavdf` relies on the pointer we pass pointing to 100 bytes.

### New Behavior:

Same as today but with one more run-time check to ensure there are not shenanigans, and to make it explicit that his is expected to hold 100 bytes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive check on consensus VDF validation; valid blocks should already use 100-byte inputs, so behavior should be unchanged except for rejecting malformed inputs earlier.
> 
> **Overview**
> Adds a **defensive runtime guard** in `validate_vdf` so VDF verification only proceeds when the class-group input is exactly **100 bytes**, matching what `chiavdf` expects from `bytes100` / `input_el.data`.
> 
> If `len(input_el.data) != 100`, validation now **logs an error** and returns **False** before calling `verify_vdf`, instead of relying on implicit sizing from constructors alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3491105e004bf1e86bbec6a05318ce18e8b5cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->