### PR TITLE
Add get_full_node_peer_count as a function to wallet RPC

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -50,6 +50,7 @@ from chia.cmds.coins import CombineCMD, SplitCMD
 from chia.cmds.param_types import CliAmount
 from chia.full_node.full_node_rpc_client import FullNodeRpcClient
 from chia.pools.pool_wallet_info import NewPoolWalletInitialTargetState
+from chia.protocols.outbound_message import NodeType
 from chia.rpc.rpc_client import ResponseFailureError
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.types.blockchain_format.coin import Coin, coin_as_list
@@ -134,6 +135,7 @@ from chia.wallet.wallet_request_types import (
     GetCoinRecordsByNames,
     GetFarmedAmount,
     GetFarmedAmountResponse,
+    GetFullNodePeerCountResponse,
     GetHeightInfoResponse,
     GetNextAddress,
     GetNotifications,
@@ -2527,6 +2529,28 @@ async def test_get_height_info_response_variants(
     assert response.is_transaction_block == expected_is_tx
     assert response.prev_transaction_block_height == expected_prev
     mock_blockchain.height_to_block_record.assert_called_once_with(sync_height)
+
+
+@pytest.mark.parametrize(
+    "wallet_environments",
+    [{"num_environments": 1, "blocks_needed": [0]}],
+    indirect=True,
+)
+@pytest.mark.limit_consensus_modes(reason="irrelevant")
+@pytest.mark.anyio
+async def test_get_full_node_peer_count(wallet_environments: WalletTestFramework) -> None:
+    """Verifies get_full_node_peer_count reflects live wallet -> full node connections."""
+    env = wallet_environments.environments[0]
+    client = env.rpc_client
+
+    response = await client.get_full_node_peer_count()
+    assert isinstance(response, GetFullNodePeerCountResponse)
+    assert response.peer_count == 1
+
+    await env.node.server.close_all_connections()
+    await time_out_assert(5, lambda: len(env.node.server.get_connections(NodeType.FULL_NODE)), 0)
+
+    assert (await client.get_full_node_peer_count()).peer_count == 0
 
 
 @pytest.mark.parametrize(

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -178,6 +178,7 @@ from chia.wallet.wallet_request_types import (
 from chia.wallet.wallet_rpc_api import WalletRpcApi
 from chia.wallet.wallet_rpc_client import WalletRpcClient
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
+from chia.wallet.wallet_state_manager import SyncStatus
 
 log = logging.getLogger(__name__)
 
@@ -2039,6 +2040,16 @@ async def test_get_coin_records_by_names(wallet_environments: WalletTestFramewor
     # 8. Test the failure case
     with pytest.raises(ValueError, match="not found"):
         await client.get_coin_records_by_names(GetCoinRecordsByNames(names=coin_ids, include_spent_coins=False))
+
+    # 9. Sync-status guard: when not fully synced, requests are rejected unless
+    # allow_unsynced=True. The simulator's get_sync_status short-circuits to
+    # SYNCED so we patch the state manager directly to drive the unsynced path.
+    wsm = wallet_node.wallet_state_manager
+    with patch.object(wsm, "get_sync_status", AsyncMock(return_value=SyncStatus.SLIGHTLY_BEHIND)):
+        with pytest.raises(ValueError, match="fully synced"):
+            await client.get_coin_records_by_names(GetCoinRecordsByNames(names=coin_ids))
+        rpc_result = await client.get_coin_records_by_names(GetCoinRecordsByNames(names=coin_ids, allow_unsynced=True))
+        assert {record.coin for record in rpc_result.coin_records} == coins
 
 
 @pytest.mark.parametrize(

--- a/chia/_tests/wallet/test_wallet_state_manager.py
+++ b/chia/_tests/wallet/test_wallet_state_manager.py
@@ -694,17 +694,26 @@ async def test_rpc_disconnected_errors(wallet_environments: WalletTestFramework)
             wallet_environments.tx_config,
         )
 
-    # select_coins DISCONNECTED check (line 1646)
+    # select_coins DISCONNECTED check
     with pytest.raises(ValueError, match="not connected"):
         await rpc_client.select_coins(SelectCoins(wallet_id=uint32(1), amount=uint64(1)))
 
-    # get_spendable_coins DISCONNECTED check (line 1660)
+    # get_spendable_coins DISCONNECTED check
     with pytest.raises(ValueError, match="not connected"):
         await rpc_client.get_spendable_coins(GetSpendableCoins(wallet_id=uint32(1)))
 
-    # get_coin_records_by_names DISCONNECTED check (line 1708)
+    # get_coin_records_by_names DISCONNECTED check
     with pytest.raises(ValueError, match="not connected"):
         await rpc_client.get_coin_records_by_names(GetCoinRecordsByNames(names=[bytes32.zeros]))
+
+    # Check the no-peers early exit.
+    original_network = wsm.config["selected_network"]
+    wsm.config["selected_network"] = "simulator0"
+    try:
+        with pytest.raises(ValueError, match="No full node peers connected"):
+            await rpc_client.get_coin_records_by_names(GetCoinRecordsByNames(names=[bytes32.zeros]))
+    finally:
+        wsm.config["selected_network"] = original_network
 
 
 @pytest.mark.parametrize(

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -178,6 +178,7 @@ class GetSyncStatusResponse(Streamable):
 class GetFullNodePeerCountResponse(Streamable):
     peer_count: uint64
 
+
 @streamable
 @dataclass(kw_only=True, frozen=True)
 class GetHeightInfo(Streamable):

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -175,6 +175,11 @@ class GetSyncStatusResponse(Streamable):
 
 @streamable
 @dataclass(kw_only=True, frozen=True)
+class GetFullNodePeerCountResponse(Streamable):
+    peer_count: uint64
+
+@streamable
+@dataclass(kw_only=True, frozen=True)
 class GetHeightInfo(Streamable):
     use_peak_height: bool = False
 

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -190,6 +190,7 @@ from chia.wallet.wallet_request_types import (
     GetCurrentDerivationIndexResponse,
     GetFarmedAmount,
     GetFarmedAmountResponse,
+    GetFullNodePeerCountResponse,
     GetHeightInfo,
     GetHeightInfoResponse,
     GetLoggedInFingerprintResponse,
@@ -975,6 +976,10 @@ class WalletRpcApi:
         return GetSyncStatusResponse(synced=synced, syncing=syncing)
 
     @marshal
+    async def get_full_node_peer_count(self, request: Empty) -> GetFullNodePeerCountResponse:
+        return GetFullNodePeerCountResponse(peer_count=len(self.service.wallet_state_manager.wallet_node.get_full_node_peers_in_order()))
+
+    @marshal
     async def get_height_info(self, request: GetHeightInfo) -> GetHeightInfoResponse:
         """
         Returns height info for the current wallet.
@@ -1712,6 +1717,9 @@ class WalletRpcApi:
             raise ValueError("Wallet is not connected to any synced peers.")
         if sync_status != SyncStatus.SYNCED and not request.allow_unsynced:
             raise ValueError("Wallet needs to be fully synced before finding coin information")
+
+        if self.service.wallet_state_manager.wallet_node.get_full_node_peers().is_empty():
+            raise ValueError("No full node peers connected. Please connect to a full node.")
 
         kwargs: dict[str, Any] = {
             "coin_id_filter": HashFilter.include(request.names),

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -1720,7 +1720,7 @@ class WalletRpcApi:
 
         # We use the full node when generating coin records from WalletCoinRecords.
         # If we don't have any full node peers connected we can error out early.
-        if self.get_full_node_peer_count() == 0:
+        if not self.service.wallet_state_manager.wallet_node.get_full_node_peers_in_order():
             raise ValueError("No full node peers connected. Please connect to a full node.")
 
         kwargs: dict[str, Any] = {

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -589,6 +589,7 @@ class WalletRpcApi:
             # Wallet node
             "/set_wallet_resync_on_startup": self.set_wallet_resync_on_startup,
             "/get_sync_status": self.get_sync_status,
+            "/get_full_node_peer_count": self.get_full_node_peer_count,
             "/get_height_info": self.get_height_info,
             "/push_tx": self.push_tx,
             "/push_transactions": self.push_transactions,

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -977,7 +977,7 @@ class WalletRpcApi:
 
     @marshal
     async def get_full_node_peer_count(self, request: Empty) -> GetFullNodePeerCountResponse:
-        return GetFullNodePeerCountResponse(peer_count=len(self.service.wallet_state_manager.wallet_node.get_full_node_peers_in_order()))
+        return GetFullNodePeerCountResponse(peer_count=uint64(len(self.service.wallet_state_manager.wallet_node.get_full_node_peers_in_order())))
 
     @marshal
     async def get_height_info(self, request: GetHeightInfo) -> GetHeightInfoResponse:
@@ -1718,7 +1718,9 @@ class WalletRpcApi:
         if sync_status != SyncStatus.SYNCED and not request.allow_unsynced:
             raise ValueError("Wallet needs to be fully synced before finding coin information")
 
-        if self.service.wallet_state_manager.wallet_node.get_full_node_peers().is_empty():
+        # We use the full node when generating coin records from WalletCoinRecords.
+        # If we don't have any full node peers connected we can error out early.
+        if self.get_full_node_peer_count() == 0:
             raise ValueError("No full node peers connected. Please connect to a full node.")
 
         kwargs: dict[str, Any] = {

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -978,7 +978,9 @@ class WalletRpcApi:
 
     @marshal
     async def get_full_node_peer_count(self, request: Empty) -> GetFullNodePeerCountResponse:
-        return GetFullNodePeerCountResponse(peer_count=uint64(len(self.service.wallet_state_manager.wallet_node.get_full_node_peers_in_order())))
+        return GetFullNodePeerCountResponse(
+            peer_count=uint64(len(self.service.wallet_state_manager.wallet_node.get_full_node_peers_in_order()))
+        )
 
     @marshal
     async def get_height_info(self, request: GetHeightInfo) -> GetHeightInfoResponse:

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -106,6 +106,7 @@ from chia.wallet.wallet_request_types import (
     GetCurrentDerivationIndexResponse,
     GetFarmedAmount,
     GetFarmedAmountResponse,
+    GetFullNodePeerCountResponse,
     GetHeightInfo,
     GetHeightInfoResponse,
     GetLoggedInFingerprintResponse,
@@ -276,6 +277,9 @@ class WalletRpcClient(RpcClient):
 
     async def get_height_info(self, request: GetHeightInfo = GetHeightInfo()) -> GetHeightInfoResponse:
         return GetHeightInfoResponse.from_json_dict(await self.fetch("get_height_info", request.to_json_dict()))
+
+    async def get_full_node_peer_count(self) -> GetFullNodePeerCountResponse:
+        return GetFullNodePeerCountResponse.from_json_dict(await self.fetch("get_full_node_peer_count", {}))
 
     async def push_tx(self, request: PushTX) -> None:
         await self.fetch("push_tx", request.to_json_dict())


### PR DESCRIPTION


### Purpose:

When connected to a wallet node, some calls you might make depend upon the wallet node having a full node peer.
This PR allows users to ask the wallet node if they have full node peers ahead of time instead of waiting to see if their call fails.

### Testing Notes:

A corresponding test has been added to `test_wallet_rpc.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only RPC plus stricter validation on an existing endpoint; behavior is covered by new tests with no auth or funds-handling changes.
> 
> **Overview**
> Adds **`get_full_node_peer_count`** wallet RPC so clients can see how many full-node peers are connected before calling APIs that need chain data. The handler returns the length of **`get_full_node_peers_in_order()`**, with matching **`GetFullNodePeerCountResponse`** / client wiring.
> 
> **`get_coin_records_by_names`** now fails early with a clear error when no full-node peers are available (in addition to existing disconnected / not-synced checks).
> 
> Tests cover peer count after dropping connections, unsynced vs **`allow_unsynced`** behavior for coin-by-name lookup, and the no-peers path in wallet state manager tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 299c52175fb33cbc8a82caa5abb1ac22606c36be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->