### PR TITLE
fix running tests with a local keyring

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -286,6 +286,26 @@ def _install_plot_cache() -> None:
     install_plot_cache(DEFAULT_ROOT_PATH.parent / "test-plots")
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _block_production_keyring_access(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
+    from unittest.mock import patch
+
+    fake_keys_root = tmp_path_factory.mktemp("fake_keys_root")
+
+    with (
+        patch("chia.util.keyring_wrapper.DEFAULT_KEYS_ROOT_PATH", fake_keys_root),
+        patch("chia.util.file_keyring.DEFAULT_KEYS_ROOT_PATH", fake_keys_root),
+        patch(
+            "chia.util.keyring_wrapper.prompt_for_passphrase",
+            side_effect=RuntimeError(
+                "Tests must not prompt for a keyring passphrase. "
+                "Use the TempKeyring fixture to avoid accessing the production keyring."
+            ),
+        ),
+    ):
+        yield
+
+
 @pytest.fixture(scope="session", name="bt")
 async def block_tools_fixture(
     get_keychain, blockchain_constants, anyio_backend, testrun_uid: str


### PR DESCRIPTION
### Purpose:

When running some tests locally, if you have chia installed with a keyring, some tests will try to load it and prompt for a password. This stalls, and ultimately fails, those tests.

This fixes it by preventing the production keyring from being loaded by tests.

### Current Behavior:

Some tests load the production keyring.

### New Behavior:

Tests load a mocked keyring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only conftest changes; no production runtime behavior.
> 
> **Overview**
> Adds a **session-scoped autouse** pytest fixture in `conftest.py` so the test suite never reads or writes the real Chia keys directory (`~/.chia_keys`).
> 
> For the whole session it **patches** `DEFAULT_KEYS_ROOT_PATH` in `chia.util.keyring_wrapper` and `chia.util.file_keyring` to a temporary `fake_keys_root`, and replaces `prompt_for_passphrase` with a **hard failure** that tells developers to use `TempKeyring` instead of blocking on a production keyring password.
> 
> This stops local runs from hanging or failing when a production keyring is present, without changing production code paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcc3adc1cf0f241d1bdbaacdea40ef43755791c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->