### PR TITLE
CHIA-4238 Avoid recomputing peak header block in WalletNode's wallet_short_sync_backtrack

### DIFF
--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -629,8 +629,8 @@ async def test_wallet_short_sync_backtrack_cap_exceeded_returns_none(node_height
     peer = make_backtrack_test_peer()
     rollback_calls = patch_rollback(node)
     header = make_header(node_height + 1, _test_hash_for_height(node_height), _test_hash_for_height(node_height + 1))
-
-    result = await node.wallet_short_sync_backtrack(header, peer)
+    peak_hb = await node.wallet_state_manager.blockchain.get_peak_block()
+    result = await node.wallet_short_sync_backtrack(peak_hb, header, peer)
     assert result is None
     assert rollback_calls == []
     assert cast(Any, node.wallet_state_manager.blockchain.add_block).await_count == 0
@@ -642,7 +642,8 @@ async def test_wallet_short_sync_backtrack_stops_at_threshold() -> None:
     node = make_backtrack_test_node(height=500, has_peak=True)
     peer = make_backtrack_test_peer()
     header = make_header(501, _test_hash_for_height(500), _test_hash_for_height(501))
-    await node.wallet_short_sync_backtrack(header, peer)
+    peak_hb = await node.wallet_state_manager.blockchain.get_peak_block()
+    await node.wallet_short_sync_backtrack(peak_hb, header, peer)
     assert peer.call_api.await_count == node.LONG_SYNC_THRESHOLD
     peer.close.assert_not_awaited()
 
@@ -658,8 +659,8 @@ async def test_wallet_short_sync_backtrack_initial_sync_no_cap() -> None:
 
     peer = make_backtrack_test_peer()
     header = make_header(401, _test_hash_for_height(400), _test_hash_for_height(401))
-
-    result = await node.wallet_short_sync_backtrack(header, peer)
+    peak_hb = await node.wallet_state_manager.blockchain.get_peak_block()
+    result = await node.wallet_short_sync_backtrack(peak_hb, header, peer)
     assert result == 0
     assert rollback_calls == []
     assert peer.call_api.await_count == 401
@@ -676,8 +677,8 @@ async def test_wallet_short_sync_backtrack_short_chain_no_cap() -> None:
 
     peer = make_backtrack_test_peer()
     header = make_header(401, _test_hash_for_height(400), _test_hash_for_height(401))
-
-    result = await node.wallet_short_sync_backtrack(header, peer)
+    peak_hb = await node.wallet_state_manager.blockchain.get_peak_block()
+    result = await node.wallet_short_sync_backtrack(peak_hb, header, peer)
     assert result == 0
     assert peer.call_api.await_count == 401
     assert peer.call_api.await_count > node.LONG_SYNC_THRESHOLD
@@ -701,8 +702,8 @@ async def test_wallet_short_sync_backtrack_rollback_when_peak_exists_and_reaches
 
     peer = make_backtrack_test_peer()
     header = make_header(101, _test_hash_for_height(100), _test_hash_for_height(101))
-
-    result = await node.wallet_short_sync_backtrack(header, peer)
+    peak_hb = await node.wallet_state_manager.blockchain.get_peak_block()
+    result = await node.wallet_short_sync_backtrack(peak_hb, header, peer)
     assert result == 0
     assert rollback_calls == [0], "Should roll back to genesis when peak exists but no known blocks found"
 
@@ -714,9 +715,9 @@ async def test_wallet_short_sync_backtrack_shutdown_before_backtrack() -> None:
     node._shut_down = True
     setattr(node, "perform_atomic_rollback", AsyncMock())
     header = make_header(51, _test_hash_for_height(50), _test_hash_for_height(51))
-
+    peak_hb = await node.wallet_state_manager.blockchain.get_peak_block()
     with pytest.raises(RuntimeError, match="Shutdown requested during wallet backtrack sync"):
-        await node.wallet_short_sync_backtrack(header, peer)
+        await node.wallet_short_sync_backtrack(peak_hb, header, peer)
     assert cast(Any, node.perform_atomic_rollback).await_count == 0
     assert cast(Any, node.wallet_state_manager.blockchain.add_block).await_count == 0
 
@@ -753,8 +754,8 @@ async def test_wallet_short_sync_backtrack_rejects_discontinuous_chain() -> None
     peer.peer_info = MagicMock()
     peer.peer_info.host = "attacker.example"
     header = make_header(3, bad_prev, bytes32(b"\x13" * 32))
-
-    result = await node.wallet_short_sync_backtrack(header, peer)
+    peak_hb = await node.wallet_state_manager.blockchain.get_peak_block()
+    result = await node.wallet_short_sync_backtrack(peak_hb, header, peer)
     assert result is None
     assert rollback_calls == []
     assert cast(Any, node.wallet_state_manager.blockchain.add_block).await_count == 0
@@ -792,8 +793,8 @@ async def test_wallet_short_sync_backtrack_happy_path_connected_chain() -> None:
     peer.peer_info = MagicMock()
     peer.peer_info.host = "good.example"
     header = make_header(3, h2_hash, bytes32(b"\x23" * 32))
-
-    result = await node.wallet_short_sync_backtrack(header, peer)
+    peak_hb = await node.wallet_state_manager.blockchain.get_peak_block()
+    result = await node.wallet_short_sync_backtrack(peak_hb, header, peer)
     assert result == 1
     assert rollback_calls == [1]
     assert cast(Any, node.wallet_state_manager.blockchain.add_block).await_count == 2
@@ -830,8 +831,8 @@ async def test_wallet_short_sync_backtrack_genesis_unanchored_skips_rollback() -
     peer.peer_info = MagicMock()
     peer.peer_info.host = "genesis.example"
     header = make_header(2, h1_hash, bytes32(b"\x34" * 32))
-
-    result = await node.wallet_short_sync_backtrack(header, peer)
+    peak_hb = await node.wallet_state_manager.blockchain.get_peak_block()
+    result = await node.wallet_short_sync_backtrack(peak_hb, header, peer)
     assert result == 0
     assert rollback_calls == []
     assert cast(Any, node.wallet_state_manager.blockchain.add_block).await_count == 3
@@ -856,7 +857,8 @@ async def test_sync_from_untrusted_close_to_peak_returns_false_on_backtrack_cap(
 
     result = await node.sync_from_untrusted_close_to_peak(new_peak_hb, peer)
     assert result is False
-    cast(Any, node.wallet_short_sync_backtrack).assert_awaited_once_with(new_peak_hb, peer)
+    peak_hb = cast(Any, node.wallet_state_manager.blockchain.get_peak_block).return_value
+    cast(Any, node.wallet_short_sync_backtrack).assert_awaited_once_with(peak_hb, new_peak_hb, peer)
 
 
 @pytest.mark.anyio

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1329,7 +1329,7 @@ class WalletNode:
         async with self.wallet_state_manager.lock:
             peak_hb = await self.wallet_state_manager.blockchain.get_peak_block()
             if peak_hb is None or new_peak_hb.weight > peak_hb.weight:
-                backtrack_fork_height: int | None = await self.wallet_short_sync_backtrack(new_peak_hb, peer)
+                backtrack_fork_height: int | None = await self.wallet_short_sync_backtrack(peak_hb, new_peak_hb, peer)
                 if backtrack_fork_height is None:
                     return False
             else:
@@ -1379,9 +1379,9 @@ class WalletNode:
             self.log.info(f"Finished processing new peak of {new_peak_hb.height}")
             return True
 
-    async def wallet_short_sync_backtrack(self, header_block: HeaderBlock, peer: WSChiaConnection) -> int | None:
-        peak: HeaderBlock | None = await self.wallet_state_manager.blockchain.get_peak_block()
-
+    async def wallet_short_sync_backtrack(
+        self, peak_hb: HeaderBlock | None, header_block: HeaderBlock, peer: WSChiaConnection
+    ) -> int | None:
         top = header_block
         blocks = [top]
         # Fetch blocks backwards until we hit the one that we have,
@@ -1395,7 +1395,7 @@ class WalletNode:
             if self._shut_down:
                 raise RuntimeError("Shutdown requested during wallet backtrack sync")
             if (
-                peak is not None
+                peak_hb is not None
                 and len(blocks) > self.LONG_SYNC_THRESHOLD
                 and header_block.height >= self.constants.WEIGHT_PROOF_RECENT_BLOCKS
             ):
@@ -1426,7 +1426,7 @@ class WalletNode:
 
         if top.height == 0:
             fork_height = 0
-            should_skip_rollback = peak is None
+            should_skip_rollback = peak_hb is None
 
         # Roll back coins and transactions
         peak_height = await self.wallet_state_manager.blockchain.get_finished_sync_up_to()
@@ -1436,8 +1436,6 @@ class WalletNode:
             await self.perform_atomic_rollback(fork_height)
             await self.update_ui()
 
-        if peak is not None:
-            assert header_block.weight >= peak.weight
         for block in blocks:
             # Set blockchain to the latest peak
             res, err = await self.wallet_state_manager.blockchain.add_block(block)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small API refactor on wallet short backtrack sync with matching test updates; behavior should match prior logic aside from removing an in-method weight assert already enforced by callers.
> 
> **Overview**
> **`wallet_short_sync_backtrack`** now takes the wallet’s current peak header (`peak_hb`, or `None`) as its first argument instead of calling `get_peak_block()` inside the method. **`sync_from_untrusted_close_to_peak`** already loads `peak_hb` under lock and passes it through, so the peak is not fetched twice on the close-to-peak untrusted sync path.
> 
> Backtrack logic still uses `peak_hb` for the long-sync cap, genesis rollback skip, and related branches. The post-backtrack **`assert header_block.weight >= peak.weight`** was removed from backtrack (weight checks remain in the caller where applicable).
> 
> Wallet node backtrack tests and the **`sync_from_untrusted_close_to_peak`** mock assertion were updated to pass **`(peak_hb, new_peak_hb, peer)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 772a6df4c788ee0e463cd41c6cc5c1823ded544d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->