### PR TITLE
Improve gui build script for local development

### DIFF
--- a/install-gui.sh
+++ b/install-gui.sh
@@ -83,6 +83,8 @@ echo ""
 # Pipelines directly, so skip unless you are completing a source/developer install.
 # Ubuntu special cases above.
 if [ ! "$CI" ]; then
+  echo "Undoing any package-lock.json changes before submodule update"
+  git checkout package-lock.json
   echo "Running git submodule update --init --recursive."
   echo ""
   git submodule update --init --recursive


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

no.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line guard in the local install path only; no CI, auth, or runtime logic changes.
> 
> **Overview**
> For **local** (non-CI) GUI installs, `install-gui.sh` now **resets the repo root `package-lock.json`** with `git checkout` immediately before `git submodule update`, with a short log line explaining why.
> 
> This avoids carrying accidental lockfile edits from local `npm` work into the submodule update and subsequent `npm ci` in `chia-blockchain-gui`, aligning with the same “restore lockfile before build” idea used elsewhere (e.g. clean-runner). **CI behavior is unchanged** (`$CI` still skips this block).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b87d1483dca59555e8d17c31117174b53595b941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->