### PR TITLE
Fix chia peer errors for invalid or missing services

### DIFF
--- a/chia/_tests/cmds/cmd_test_utils.py
+++ b/chia/_tests/cmds/cmd_test_utils.py
@@ -12,6 +12,7 @@ from chia_rs import BlockRecord, Coin, G1Element, G2Element
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint16, uint32, uint64
 
+import chia.cmds.peer_funcs
 import chia.cmds.wallet_funcs
 from chia._tests.cmds.testing_classes import create_test_block_record
 from chia._tests.cmds.wallet.test_consts import STD_TX, STD_UTX, get_bytes32
@@ -400,6 +401,7 @@ def create_service_and_wallet_client_generators(
         return None
 
     monkeypatch.setattr(chia.cmds.cmds_util, "get_any_service_client", test_get_any_service_client)
+    monkeypatch.setattr(chia.cmds.peer_funcs, "get_any_service_client", test_get_any_service_client)
     monkeypatch.setattr(chia.cmds.cmds_util, "get_wallet_client", test_get_wallet_client)
     monkeypatch.setattr(chia.cmds.wallet_funcs, "get_wallet_client", test_get_wallet_client)
     monkeypatch.setattr(chia.cmds.cmds_util, "cli_confirm", cli_confirm)

--- a/chia/_tests/cmds/test_cmds_util.py
+++ b/chia/_tests/cmds/test_cmds_util.py
@@ -95,3 +95,30 @@ async def test_failure_output_no_consumption(
     assert exception_info.value.response == expected_response
 
     assert capsys.readouterr() == ("", "")
+
+
+@pytest.mark.anyio
+async def test_get_any_service_client_rejects_unknown_client_without_port(
+    root_path_populated_with_config: Path,
+) -> None:
+    with pytest.raises(ValueError, match="Invalid client type requested: RpcClient"):
+        await get_any_service_client(RpcClient, root_path_populated_with_config).__aenter__()
+
+
+@pytest.mark.anyio
+async def test_get_any_service_client_consumes_unexpected_errors(
+    root_path_populated_with_config: Path,
+    recording_web_server: RecordingWebServer,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async with get_any_service_client(
+        client_type=RpcClient,
+        rpc_port=recording_web_server.web_server.listen_port,
+        root_path=root_path_populated_with_config,
+        use_ssl=False,
+    ) as (_, _):
+        raise RuntimeError("unexpected failure")
+
+    out, _err = capsys.readouterr()
+    assert "Exception from 'RpcClient'" in out
+    assert "unexpected failure" in out

--- a/chia/_tests/cmds/test_peer.py
+++ b/chia/_tests/cmds/test_peer.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import re
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from chia.cmds import peer_funcs
+from chia.cmds.chia import cli
+from chia.cmds.cmd_classes import ChiaCliContext
+from chia.cmds.cmds_util import get_any_service_client
+from chia.solver.solver_rpc_client import SolverRpcClient
+from chia.util.config import load_config
+
+
+@pytest.mark.parametrize("service_name", ["base", "Bob", "Sue"])
+def test_peer_rejects_unknown_service(service_name: str, root_path_populated_with_config: Path) -> None:
+    runner = CliRunner()
+    context = ChiaCliContext(root_path=root_path_populated_with_config)
+
+    result = runner.invoke(
+        cli,
+        ["--root-path", str(root_path_populated_with_config), "peer", service_name, "-c"],
+        obj=context.to_click(),
+    )
+
+    assert result.exit_code == 2
+    assert f"'{service_name}' is not one of" in result.output
+
+
+@pytest.mark.anyio
+async def test_get_any_service_client_missing_config_section(
+    root_path_populated_with_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = load_config(root_path_populated_with_config, "config.yaml")
+    del config["solver"]
+
+    with monkeypatch.context() as m:
+        m.setattr("chia.cmds.cmds_util.load_config", lambda *_args, **_kwargs: config)
+
+        with pytest.raises(click.UsageError, match=re.escape("Service 'solver' is not configured in config.yaml")):
+            async with get_any_service_client(SolverRpcClient, root_path_populated_with_config):
+                pass
+
+
+@pytest.mark.anyio
+async def test_peer_show_connections_missing_config_section(
+    root_path_populated_with_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = load_config(root_path_populated_with_config, "config.yaml")
+    del config["solver"]
+
+    class FakeRpcClient:
+        pass
+
+    @asynccontextmanager
+    async def fake_get_any_service_client(
+        client_type: type,
+        root_path: Path,
+        rpc_port: int | None = None,
+        consume_errors: bool = True,
+        use_ssl: bool = True,
+    ) -> AsyncIterator[tuple[FakeRpcClient, dict[str, Any]]]:
+        del client_type, root_path, consume_errors, use_ssl
+        yield FakeRpcClient(), config
+
+    with monkeypatch.context() as m:
+        m.setattr(peer_funcs, "get_any_service_client", fake_get_any_service_client)
+
+        with pytest.raises(click.UsageError, match=re.escape("Service 'solver' is not configured in config.yaml")):
+            await peer_funcs.peer_async(
+                "solver",
+                8667,
+                root_path_populated_with_config,
+                show_connections=True,
+                add_connection="",
+                remove_connection="",
+            )

--- a/chia/_tests/cmds/test_peer.py
+++ b/chia/_tests/cmds/test_peer.py
@@ -3,19 +3,46 @@ from __future__ import annotations
 import re
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import click
 import pytest
+from chia_rs.sized_bytes import bytes32
 from click.testing import CliRunner
 
+from chia._tests.cmds.cmd_test_utils import TestFullNodeRpcClient, TestRpcClients, logType, run_cli_command_and_assert
+from chia._tests.cmds.wallet.test_consts import get_bytes32
 from chia.cmds import peer_funcs
 from chia.cmds.chia import cli
 from chia.cmds.cmd_classes import ChiaCliContext
 from chia.cmds.cmds_util import get_any_service_client
+from chia.protocols.outbound_message import NodeType
 from chia.solver.solver_rpc_client import SolverRpcClient
 from chia.util.config import load_config
+
+
+@dataclass
+class PeerFullNodeRpcClient(TestFullNodeRpcClient):
+    async def get_connections(self, node_type: NodeType | None = None) -> list[dict[str, str | int | float | bytes32]]:
+        self.add_to_log("get_connections", (node_type,))
+        return [
+            {
+                "bytes_read": 10000,
+                "bytes_written": 100,
+                "creation_time": 169140000.0,
+                "last_message_time": 169141001.0,
+                "local_port": 19411,
+                "node_id": get_bytes32(1),
+                "peer_host": "127.0.0.1",
+                "peer_port": 47482,
+                "peer_server_port": 47482,
+                "type": NodeType.FULL_NODE.value,
+                "peak_height": 42,
+                "peak_hash": "0x" + get_bytes32(2).hex(),
+            }
+        ]
 
 
 @pytest.mark.parametrize("service_name", ["base", "Bob", "Sue"])
@@ -33,6 +60,23 @@ def test_peer_rejects_unknown_service(service_name: str, root_path_populated_wit
     assert f"'{service_name}' is not one of" in result.output
 
 
+def test_peer_show_connections(capsys: object, get_test_cli_clients: tuple[TestRpcClients, Path]) -> None:
+    test_rpc_clients, root_dir = get_test_cli_clients
+    test_rpc_clients.full_node_rpc_client = PeerFullNodeRpcClient()
+    run_cli_command_and_assert(
+        capsys,
+        root_dir,
+        ["peer", "full_node", "-c"],
+        [
+            "Connections:",
+            "FULL_NODE 127.0.0.1",
+            "47482/47482",
+        ],
+    )
+    expected_calls: logType = {"get_connections": [(None,)]}
+    test_rpc_clients.full_node_rpc_client.check_log(expected_calls)
+
+
 @pytest.mark.anyio
 async def test_get_any_service_client_missing_config_section(
     root_path_populated_with_config: Path,
@@ -45,8 +89,7 @@ async def test_get_any_service_client_missing_config_section(
         m.setattr("chia.cmds.cmds_util.load_config", lambda *_args, **_kwargs: config)
 
         with pytest.raises(click.UsageError, match=re.escape("Service 'solver' is not configured in config.yaml")):
-            async with get_any_service_client(SolverRpcClient, root_path_populated_with_config):
-                pass
+            await get_any_service_client(SolverRpcClient, root_path_populated_with_config).__aenter__()
 
 
 @pytest.mark.anyio

--- a/chia/cmds/cmds_util.py
+++ b/chia/cmds/cmds_util.py
@@ -36,7 +36,6 @@ from chia.wallet.wallet_request_types import LogIn
 from chia.wallet.wallet_rpc_client import WalletRpcClient
 
 NODE_TYPES: dict[str, type[RpcClient]] = {
-    "base": RpcClient,
     "farmer": FarmerRpcClient,
     "wallet": WalletRpcClient,
     "full_node": FullNodeRpcClient,
@@ -47,7 +46,6 @@ NODE_TYPES: dict[str, type[RpcClient]] = {
 }
 
 node_config_section_names: dict[type[RpcClient], str] = {
-    RpcClient: "base",
     FarmerRpcClient: "farmer",
     WalletRpcClient: "wallet",
     FullNodeRpcClient: "full_node",
@@ -58,6 +56,14 @@ node_config_section_names: dict[type[RpcClient], str] = {
 }
 
 _T_RpcClient = TypeVar("_T_RpcClient", bound=RpcClient)
+
+
+def raise_if_config_section_missing(config: dict[str, Any], config_section: str) -> None:
+    if config_section not in config:
+        configured = sorted({section for section in node_config_section_names.values() if section in config})
+        raise click.UsageError(
+            f"Service '{config_section}' is not configured in config.yaml. Valid options: {', '.join(configured)}"
+        )
 
 
 def transaction_submitted_msg(tx: TransactionRecord) -> str:
@@ -109,14 +115,16 @@ async def get_any_service_client(
     """
 
     node_type = node_config_section_names.get(client_type)
-    if node_type is None:
-        # Click already checks this, so this should never happen
-        raise ValueError(f"Invalid client type requested: {client_type.__name__}")
     # load variables from config file
     config = load_config(root_path, "config.yaml", fill_missing_services=issubclass(client_type, DataLayerRpcClient))
     self_hostname = config["self_hostname"]
     if rpc_port is None:
+        if node_type is None:
+            raise ValueError(f"Invalid client type requested: {client_type.__name__}")
+        raise_if_config_section_missing(config, node_type)
         rpc_port = config[node_type]["rpc_port"]
+
+    connection_type_name = node_type if node_type is not None else client_type.__name__
 
     async with contextlib.AsyncExitStack() as exit_stack:
         # select node client type based on string
@@ -131,7 +139,7 @@ async def get_any_service_client(
 
         try:
             # check if we can connect to node
-            await validate_client_connection(node_client, node_type, rpc_port, consume_errors)
+            await validate_client_connection(node_client, connection_type_name, rpc_port, consume_errors)
             yield node_client, config
         except ResponseFailureError as e:
             if not consume_errors:
@@ -151,7 +159,7 @@ async def get_any_service_client(
         except Exception as e:  # this is only here to make the errors more user-friendly.
             if not consume_errors:
                 raise
-            print(f"Exception from '{node_type}' {e}:\n{traceback.format_exc()}")
+            print(f"Exception from '{connection_type_name}' {e}:\n{traceback.format_exc()}")
 
 
 async def get_wallet(root_path: Path, wallet_client: WalletRpcClient, fingerprint: int | None) -> int:

--- a/chia/cmds/peer.py
+++ b/chia/cmds/peer.py
@@ -11,10 +11,7 @@ from chia.cmds.peer_funcs import peer_async
 @click.option(
     "-p",
     "--rpc-port",
-    help=(
-        "Set the port where the farmer, wallet, full node or harvester "
-        "is hosting the RPC interface. See the rpc_port in config.yaml"
-    ),
+    help=("Set the port where the service is hosting the RPC interface. See the rpc_port in config.yaml"),
     type=int,
     default=None,
 )
@@ -25,7 +22,7 @@ from chia.cmds.peer_funcs import peer_async
 @click.option(
     "-r", "--remove-connection", help="Remove a Node by the first 8 characters of NodeID", type=str, default=""
 )
-@click.argument("node_type", type=click.Choice(list(NODE_TYPES.keys())), nargs=1, required=True)
+@click.argument("node_type", type=click.Choice(sorted(NODE_TYPES.keys())), nargs=1, required=True)
 @click.pass_context
 def peer_cmd(
     ctx: click.Context,

--- a/chia/cmds/peer_funcs.py
+++ b/chia/cmds/peer_funcs.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from chia.cmds.cmds_util import NODE_TYPES, get_any_service_client
+from chia.cmds.cmds_util import (
+    NODE_TYPES,
+    get_any_service_client,
+    node_config_section_names,
+    raise_if_config_section_missing,
+)
 from chia.rpc.rpc_client import RpcClient
 from chia.util.network import parse_host_port
 
@@ -114,11 +119,13 @@ async def peer_async(
     remove_connection: str,
 ) -> None:
     client_type = NODE_TYPES[node_type]
+    config_section = node_config_section_names[client_type]
     async with get_any_service_client(client_type, root_path, rpc_port) as (rpc_client, config):
         # Check or edit node connections
         if show_connections:
-            trusted_peers: dict[str, Any] = config[node_type].get("trusted_peers", {})
-            trusted_cidrs: list[str] = config[node_type].get("trusted_cidrs", [])
+            raise_if_config_section_missing(config, config_section)
+            trusted_peers: dict[str, Any] = config[config_section].get("trusted_peers", {})
+            trusted_cidrs: list[str] = config[config_section].get("trusted_cidrs", [])
             await print_connections(rpc_client, trusted_peers, trusted_cidrs)
             # if called together with state, leave a blank line
         if add_connection:


### PR DESCRIPTION
## Summary

Fixes [#20963](https://github.com/Chia-Network/chia-blockchain/issues/20963), where `chia peer` with invalid or outdated service names (e.g. `base`) raised an unhandled `KeyError` instead of a clear CLI error. Removes the legacy `base` mapping, validates missing config sections with `click.UsageError`, and uses `node_config_section_names` when reading peer config so names like `simulator` resolve correctly.

## Test plan

- [x] `tools/pytest chia/_tests/cmds/test_peer.py chia/_tests/cmds/test_cmds_util.py`
- [x] `chia peer base` shows Click choice error (no traceback)
- [x] `chia peer full_node -c` lists connections when full node is running

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only validation and config lookup changes with no auth, consensus, or network protocol impact; covered by new unit tests.
> 
> **Overview**
> **`chia peer`** and shared RPC client setup now fail with clear Click errors instead of tracebacks when users pick invalid services or omit config sections.
> 
> The legacy **`base`** service is removed from peer/CLI service maps. Unknown service names (e.g. `base`) are rejected by Click’s sorted choice list. Missing **`config.yaml`** sections raise **`click.UsageError`** with a list of configured services via new **`raise_if_config_section_missing`**. **`get_any_service_client`** only treats unmapped client types as invalid when no **`--rpc-port`** is given; with an explicit port, generic clients can connect and errors label the client class name. **`peer_async`** reads **`trusted_peers` / `trusted_cidrs`** from the correct config section (e.g. **`simulator`** → **`full_node`**) using **`node_config_section_names`**, not the CLI argument string.
> 
> Tests cover invalid peer services, connection listing, missing config for solver, and **`get_any_service_client`** edge cases; CLI test helpers also patch **`peer_funcs.get_any_service_client`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c921ea573fa7f4aea25c73c56a008fc17880cdff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->