### PR TITLE
Isolate per-subscription failures in the DataLayer management loop

### DIFF
--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -17,7 +17,9 @@ from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
 from typing import Any, cast
+from unittest.mock import MagicMock
 
+import aiohttp
 import anyio
 import chia_rs.datalayer
 import pytest
@@ -41,7 +43,7 @@ from chia.cmds.data_funcs import (
     wallet_log_in_cmd,
 )
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
-from chia.data_layer.data_layer import DataLayer
+from chia.data_layer.data_layer import TRACK_FAILURE_LOG_INTERVAL, DataLayer
 from chia.data_layer.data_layer_errors import KeyNotFoundError, OfferIntegrityError
 from chia.data_layer.data_layer_rpc_api import DataLayerRpcApi
 from chia.data_layer.data_layer_rpc_client import DataLayerRpcClient
@@ -52,6 +54,7 @@ from chia.data_layer.data_layer_util import (
     ProofLayer,
     Status,
     StoreProofs,
+    Subscription,
     get_delta_filename_path,
     get_full_tree_filename_path,
     key_hash,
@@ -60,6 +63,7 @@ from chia.data_layer.data_layer_util import (
 from chia.data_layer.data_layer_wallet import DataLayerWallet, verify_offer
 from chia.data_layer.data_store import DataStore
 from chia.data_layer.start_data_layer import create_data_layer_service
+from chia.rpc.rpc_client import ResponseFailureError
 from chia.simulator.block_tools import BlockTools
 from chia.simulator.full_node_simulator import FullNodeSimulator
 from chia.simulator.simulator_protocol import FarmNewBlockProtocol
@@ -3930,3 +3934,281 @@ async def test_local_store_exception(
             await asyncio.sleep(manage_data_interval)
 
             assert f"Can't subscribe to local store {fake_store.hex()}:" in caplog.text
+
+
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
+@pytest.mark.anyio
+async def test_invalid_subscription_does_not_deadlock_management_loop(
+    self_hostname: str,
+    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    tmp_path: Path,
+    monkeypatch: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Regression test: a single subscription whose `dl_track_new` always raises must not block
+    # tracking of other subscriptions, fetching/validation of healthy stores, or draining of the
+    # unsubscribe queue. Previously, one bad subscription present at startup permanently deadlocked
+    # the entire DataLayer management loop.
+    _wallet_rpc_api, _full_node_api, wallet_rpc_port, _ph, bt = await init_wallet_and_node(
+        self_hostname, one_wallet_and_one_simulator_services
+    )
+    manage_data_interval = 1
+    bad_store = bytes32([1] * 32)
+    healthy_store = bytes32([2] * 32)
+
+    # Pre-seed the persisted subscriptions DB *before* the service starts, so the very first
+    # management cycle reads them. This reproduces the incident faithfully: a bad subscription
+    # persisted in the DB that survives restart. `DataStore.subscribe` is DB-level and does not
+    # call `dl_track_new`, unlike `DataLayer.subscribe`.
+    async with DataStore.managed(
+        database=tmp_path.joinpath("db.sqlite"),
+        merkle_blobs_path=tmp_path.joinpath("merkle-blobs"),
+        key_value_blobs_path=tmp_path.joinpath("key-value-blobs"),
+    ) as data_store:
+        await data_store.subscribe(Subscription(bad_store, []))
+        await data_store.subscribe(Subscription(healthy_store, []))
+
+    tracked: list[bytes32] = []
+    fetched: set[bytes32] = set()
+
+    async def mock_dl_track_new(self: Any, request: Any) -> None:
+        tracked.append(request.launcher_id)
+        if request.launcher_id == bad_store:
+            # Mirrors the real failure: the wallet can't find the launcher coin on chain and the
+            # data_layer side sees it as a ResponseFailureError.
+            raise ResponseFailureError({"success": False, "error": f"Launcher ID {bad_store} is not a valid coin"})
+
+    async def mock_dl_stop_tracking(self: Any, request: Any) -> None:
+        return None
+
+    async def mock_update_subscriptions_from_wallet(self: Any, store_id: bytes32) -> None:
+        return None
+
+    async def spy_fetch_and_validate(self: Any, store_id: bytes32) -> None:
+        # Invocation alone proves the management loop reached the per-store work pool; the heavy
+        # fetch path is deliberately skipped for these synthetic stores.
+        fetched.add(store_id)
+
+    def healthy_fetched() -> bool:
+        return healthy_store in fetched
+
+    def bad_store_retried() -> bool:
+        return tracked.count(bad_store) >= 2
+
+    with monkeypatch.context() as m, caplog.at_level(logging.INFO):
+        m.setattr("chia.wallet.wallet_rpc_client.WalletRpcClient.dl_track_new", mock_dl_track_new)
+        m.setattr("chia.wallet.wallet_rpc_client.WalletRpcClient.dl_stop_tracking", mock_dl_stop_tracking)
+        m.setattr(
+            "chia.data_layer.data_layer.DataLayer.update_subscriptions_from_wallet",
+            mock_update_subscriptions_from_wallet,
+        )
+        m.setattr("chia.data_layer.data_layer.DataLayer.fetch_and_validate", spy_fetch_and_validate)
+
+        async with init_data_layer(
+            wallet_rpc_port=wallet_rpc_port,
+            bt=bt,
+            db_path=tmp_path,
+            manage_data_interval=manage_data_interval,
+            maximum_full_file_count=100,
+        ) as data_layer:
+            # (ii) Fetch liveness: the healthy store is fetched/validated even though the bad
+            # subscription's tracking call raises every cycle. Pre-fix this never happens because
+            # the management loop deadlocks before ever reaching the work pool.
+            await time_out_assert(30, healthy_fetched, True)
+
+            # (i) Tracking isolation: the healthy store is still tracked despite the bad one raising
+            # in the same batch.
+            assert healthy_store in tracked
+            assert bad_store in tracked
+
+            # (iii) Unsubscribe liveness: a queued unsubscribe is actually processed while the bad
+            # subscription keeps failing. Pre-fix the unsubscribe queue never drains.
+            await data_layer.unsubscribe(healthy_store, retain_data=False)
+
+            async def healthy_unsubscribed() -> bool:
+                subscriptions = await data_layer.get_subscriptions()
+                return all(subscription.store_id != healthy_store for subscription in subscriptions)
+
+            await time_out_assert(30, healthy_unsubscribed, True)
+
+            # (iv) Recovery: the bad subscription keeps being retried on later cycles rather than
+            # being silently dropped, so it can recover once its launcher becomes valid again.
+            await time_out_assert(30, bad_store_retried, True)
+
+        # (v) Honest logging: the failure is reported as a per-subscription tracking error naming
+        # the store, not the misleading generic "Cannot connect to the wallet" connectivity message.
+        assert f"Exception while requesting wallet track subscription {bad_store.hex()}" in caplog.text
+        assert "Cannot connect to the wallet. Retrying in 3s." not in caplog.text
+        assert "Cannot connect to the wallet to track subscriptions" not in caplog.text
+
+
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
+@pytest.mark.anyio
+async def test_track_subscriptions_stops_when_wallet_unreachable(
+    self_hostname: str,
+    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    tmp_path: Path,
+    monkeypatch: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # When the wallet itself is unreachable, tracking logs a connectivity warning and stops trying
+    # the remaining subscriptions for this cycle (they are retried next cycle) instead of treating
+    # it as a per-subscription failure.
+    _wallet_rpc_api, _full_node_api, wallet_rpc_port, _ph, bt = await init_wallet_and_node(
+        self_hostname, one_wallet_and_one_simulator_services
+    )
+    store_a = bytes32([3] * 32)
+    store_b = bytes32([4] * 32)
+    tracked: list[bytes32] = []
+
+    async def mock_dl_track_new(self: Any, request: Any) -> None:
+        tracked.append(request.launcher_id)
+        raise aiohttp.client_exceptions.ClientConnectorError(MagicMock(), OSError("wallet unreachable"))
+
+    with monkeypatch.context() as m, caplog.at_level(logging.WARNING):
+        m.setattr("chia.wallet.wallet_rpc_client.WalletRpcClient.dl_track_new", mock_dl_track_new)
+
+        async with init_data_layer(
+            wallet_rpc_port=wallet_rpc_port,
+            bt=bt,
+            db_path=tmp_path,
+            manage_data_interval=1,
+            maximum_full_file_count=100,
+        ) as data_layer:
+            await data_layer.track_subscriptions([Subscription(store_a, []), Subscription(store_b, [])])
+
+    # Only the first subscription was attempted; tracking bailed out for the rest of the batch.
+    assert store_a in tracked
+    assert store_b not in tracked
+    assert "Cannot connect to the wallet to track subscriptions" in caplog.text
+
+
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
+@pytest.mark.anyio
+async def test_failing_unsubscribe_does_not_kill_management_loop(
+    self_hostname: str,
+    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    tmp_path: Path,
+    monkeypatch: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A queued unsubscribe whose processing raises (e.g. the wallet is unreachable when
+    # dl_stop_tracking is called) must not kill the management loop or block management of other
+    # stores; it is retried on later cycles and eventually takes effect once the wallet recovers.
+    _wallet_rpc_api, _full_node_api, wallet_rpc_port, _ph, bt = await init_wallet_and_node(
+        self_hostname, one_wallet_and_one_simulator_services
+    )
+    manage_data_interval = 1
+    keep_store = bytes32([6] * 32)
+    unsub_store = bytes32([7] * 32)
+
+    async with DataStore.managed(
+        database=tmp_path.joinpath("db.sqlite"),
+        merkle_blobs_path=tmp_path.joinpath("merkle-blobs"),
+        key_value_blobs_path=tmp_path.joinpath("key-value-blobs"),
+    ) as data_store:
+        await data_store.subscribe(Subscription(keep_store, []))
+        await data_store.subscribe(Subscription(unsub_store, []))
+
+    fetch_counts: dict[bytes32, int] = {}
+    stop_tracking_should_fail = True
+
+    async def mock_dl_track_new(self: Any, request: Any) -> None:
+        return None
+
+    async def mock_dl_stop_tracking(self: Any, request: Any) -> None:
+        if stop_tracking_should_fail:
+            raise aiohttp.client_exceptions.ClientConnectorError(MagicMock(), OSError("wallet unreachable"))
+
+    async def mock_update_subscriptions_from_wallet(self: Any, store_id: bytes32) -> None:
+        return None
+
+    async def spy_fetch_and_validate(self: Any, store_id: bytes32) -> None:
+        fetch_counts[store_id] = fetch_counts.get(store_id, 0) + 1
+
+    def keep_store_managed_across_cycles() -> bool:
+        return fetch_counts.get(keep_store, 0) >= 3
+
+    with monkeypatch.context() as m, caplog.at_level(logging.INFO):
+        m.setattr("chia.wallet.wallet_rpc_client.WalletRpcClient.dl_track_new", mock_dl_track_new)
+        m.setattr("chia.wallet.wallet_rpc_client.WalletRpcClient.dl_stop_tracking", mock_dl_stop_tracking)
+        m.setattr(
+            "chia.data_layer.data_layer.DataLayer.update_subscriptions_from_wallet",
+            mock_update_subscriptions_from_wallet,
+        )
+        m.setattr("chia.data_layer.data_layer.DataLayer.fetch_and_validate", spy_fetch_and_validate)
+
+        async with init_data_layer(
+            wallet_rpc_port=wallet_rpc_port,
+            bt=bt,
+            db_path=tmp_path,
+            manage_data_interval=manage_data_interval,
+            maximum_full_file_count=100,
+        ) as data_layer:
+            await data_layer.unsubscribe(unsub_store, retain_data=False)
+
+            # The loop survives the failing unsubscribe and keeps managing the healthy store across
+            # multiple cycles. Pre-fix the unguarded process_unsubscribe killed the loop task here.
+            await time_out_assert(60, keep_store_managed_across_cycles, True)
+            assert f"Exception while processing queued unsubscribe for {unsub_store.hex()}" in caplog.text
+
+            # The unsubscribe was retried (not dropped); once the wallet recovers it takes effect.
+            stop_tracking_should_fail = False
+
+            async def unsub_store_gone() -> bool:
+                subscriptions = await data_layer.get_subscriptions()
+                return all(subscription.store_id != unsub_store for subscription in subscriptions)
+
+            await time_out_assert(60, unsub_store_gone, True)
+
+            # Processing an unsubscribe for an already-removed store is a no-op, so a request that
+            # was queued more than once can't raise and wedge the drain loop.
+            await data_layer.process_unsubscribe(unsub_store, retain_data=False)
+
+
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
+@pytest.mark.anyio
+async def test_track_subscriptions_throttles_repeated_failures(
+    self_hostname: str,
+    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    tmp_path: Path,
+    monkeypatch: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A persistently-failing subscription logs on the first failure and then only every
+    # TRACK_FAILURE_LOG_INTERVAL-th consecutive failure; a success in between resets the throttle.
+    _wallet_rpc_api, _full_node_api, wallet_rpc_port, _ph, bt = await init_wallet_and_node(
+        self_hostname, one_wallet_and_one_simulator_services
+    )
+    store = bytes32([8] * 32)
+    should_fail = True
+
+    async def mock_dl_track_new(self: Any, request: Any) -> None:
+        if should_fail:
+            raise RuntimeError("cannot track")
+
+    message = f"Exception while requesting wallet track subscription {store.hex()}"
+
+    with monkeypatch.context() as m, caplog.at_level(logging.WARNING):
+        m.setattr("chia.wallet.wallet_rpc_client.WalletRpcClient.dl_track_new", mock_dl_track_new)
+
+        # A large interval keeps the background management loop from interfering; we drive
+        # track_subscriptions directly so the failure count is deterministic.
+        async with init_data_layer(
+            wallet_rpc_port=wallet_rpc_port,
+            bt=bt,
+            db_path=tmp_path,
+            manage_data_interval=600,
+            maximum_full_file_count=100,
+        ) as data_layer:
+            for _ in range(TRACK_FAILURE_LOG_INTERVAL):
+                await data_layer.track_subscriptions([Subscription(store, [])])
+            # Logged only on the 1st and TRACK_FAILURE_LOG_INTERVAL-th consecutive failures.
+            assert caplog.text.count(message) == 2
+
+            # A success clears the counter, so the next failure logs immediately again.
+            should_fail = False
+            await data_layer.track_subscriptions([Subscription(store, [])])
+            should_fail = True
+            await data_layer.track_subscriptions([Subscription(store, [])])
+            assert caplog.text.count(message) == 3

--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -43,7 +43,7 @@ from chia.cmds.data_funcs import (
     wallet_log_in_cmd,
 )
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
-from chia.data_layer.data_layer import TRACK_FAILURE_LOG_INTERVAL, DataLayer
+from chia.data_layer.data_layer import DataLayer
 from chia.data_layer.data_layer_errors import KeyNotFoundError, OfferIntegrityError
 from chia.data_layer.data_layer_rpc_api import DataLayerRpcApi
 from chia.data_layer.data_layer_rpc_client import DataLayerRpcClient
@@ -4164,51 +4164,3 @@ async def test_failing_unsubscribe_does_not_kill_management_loop(
             # Processing an unsubscribe for an already-removed store is a no-op, so a request that
             # was queued more than once can't raise and wedge the drain loop.
             await data_layer.process_unsubscribe(unsub_store, retain_data=False)
-
-
-@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
-@pytest.mark.anyio
-async def test_track_subscriptions_throttles_repeated_failures(
-    self_hostname: str,
-    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
-    tmp_path: Path,
-    monkeypatch: Any,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    # A persistently-failing subscription logs on the first failure and then only every
-    # TRACK_FAILURE_LOG_INTERVAL-th consecutive failure; a success in between resets the throttle.
-    _wallet_rpc_api, _full_node_api, wallet_rpc_port, _ph, bt = await init_wallet_and_node(
-        self_hostname, one_wallet_and_one_simulator_services
-    )
-    store = bytes32([8] * 32)
-    should_fail = True
-
-    async def mock_dl_track_new(self: Any, request: Any) -> None:
-        if should_fail:
-            raise RuntimeError("cannot track")
-
-    message = f"Exception while requesting wallet track subscription {store.hex()}"
-
-    with monkeypatch.context() as m, caplog.at_level(logging.WARNING):
-        m.setattr("chia.wallet.wallet_rpc_client.WalletRpcClient.dl_track_new", mock_dl_track_new)
-
-        # A large interval keeps the background management loop from interfering; we drive
-        # track_subscriptions directly so the failure count is deterministic.
-        async with init_data_layer(
-            wallet_rpc_port=wallet_rpc_port,
-            bt=bt,
-            db_path=tmp_path,
-            manage_data_interval=600,
-            maximum_full_file_count=100,
-        ) as data_layer:
-            for _ in range(TRACK_FAILURE_LOG_INTERVAL):
-                await data_layer.track_subscriptions([Subscription(store, [])])
-            # Logged only on the 1st and TRACK_FAILURE_LOG_INTERVAL-th consecutive failures.
-            assert caplog.text.count(message) == 2
-
-            # A success clears the counter, so the next failure logs immediately again.
-            should_fail = False
-            await data_layer.track_subscriptions([Subscription(store, [])])
-            should_fail = True
-            await data_layer.track_subscriptions([Subscription(store, [])])
-            assert caplog.text.count(message) == 3

--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -11,13 +11,14 @@ import random
 import sqlite3
 import sys
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import anyio
@@ -79,7 +80,13 @@ from chia.wallet.trading.offer import Offer as TradingOffer
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.wallet_node import WalletNode
-from chia.wallet.wallet_request_types import CheckOfferValidity, DLLatestSingleton
+from chia.wallet.wallet_request_types import (
+    CheckOfferValidity,
+    DLLatestSingleton,
+    DLOwnedSingletonsResponse,
+    DLStopTracking,
+    DLTrackNew,
+)
 from chia.wallet.wallet_rpc_api import WalletRpcApi
 from chia.wallet.wallet_service import WalletService
 
@@ -3936,30 +3943,62 @@ async def test_local_store_exception(
             assert f"Can't subscribe to local store {fake_store.hex()}:" in caplog.text
 
 
+def _mock_wallet_rpc_client(
+    dl_track_new: Callable[[DLTrackNew], Awaitable[None]],
+    dl_stop_tracking: Callable[[DLStopTracking], Awaitable[None]],
+) -> Any:
+    async def await_closed() -> None:
+        return None
+
+    async def dl_owned_singletons() -> DLOwnedSingletonsResponse:
+        return DLOwnedSingletonsResponse(singletons=[], count=uint32(0))
+
+    return SimpleNamespace(
+        await_closed=await_closed,
+        close=lambda: None,
+        dl_owned_singletons=dl_owned_singletons,
+        dl_stop_tracking=dl_stop_tracking,
+        dl_track_new=dl_track_new,
+    )
+
+
+def _patch_wallet_rpc_client_create(monkeypatch: Any, wallet_rpc_client: Any) -> None:
+    async def mock_wallet_rpc_client_create(*args: Any, **kwargs: Any) -> Any:
+        return wallet_rpc_client
+
+    monkeypatch.setattr("chia.data_layer.start_data_layer.WalletRpcClient.create", mock_wallet_rpc_client_create)
+
+
+def _patch_synthetic_management_cycle(
+    monkeypatch: Any,
+    fetch_and_validate: Callable[[DataLayer, bytes32], Awaitable[None]],
+) -> None:
+    async def noop_store_method(self: DataLayer, store_id: bytes32) -> None:
+        return None
+
+    monkeypatch.setattr("chia.data_layer.data_layer.DataLayer.update_subscriptions_from_wallet", noop_store_method)
+    monkeypatch.setattr("chia.data_layer.data_layer.DataLayer.fetch_and_validate", fetch_and_validate)
+    monkeypatch.setattr("chia.data_layer.data_layer.DataLayer.upload_files", noop_store_method)
+    monkeypatch.setattr("chia.data_layer.data_layer.DataLayer.clean_old_full_tree_files", noop_store_method)
+
+
 @pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.anyio
 async def test_invalid_subscription_does_not_deadlock_management_loop(
-    self_hostname: str,
-    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    bt: BlockTools,
     tmp_path: Path,
     monkeypatch: Any,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    # Regression test: a single subscription whose `dl_track_new` always raises must not block
-    # tracking of other subscriptions, fetching/validation of healthy stores, or draining of the
-    # unsubscribe queue. Previously, one bad subscription present at startup permanently deadlocked
-    # the entire DataLayer management loop.
-    _wallet_rpc_api, _full_node_api, wallet_rpc_port, _ph, bt = await init_wallet_and_node(
-        self_hostname, one_wallet_and_one_simulator_services
-    )
+    # A single subscription whose `dl_track_new` always raises must not block tracking of other
+    # subscriptions, fetching/validation of healthy stores, or draining of the unsubscribe queue.
     manage_data_interval = 1
     bad_store = bytes32([1] * 32)
     healthy_store = bytes32([2] * 32)
 
-    # Pre-seed the persisted subscriptions DB *before* the service starts, so the very first
-    # management cycle reads them. This reproduces the incident faithfully: a bad subscription
-    # persisted in the DB that survives restart. `DataStore.subscribe` is DB-level and does not
-    # call `dl_track_new`, unlike `DataLayer.subscribe`.
+    # Pre-seed the persisted subscriptions DB before the service starts so the first management
+    # cycle reads them. `DataStore.subscribe` is DB-level and does not call `dl_track_new`, unlike
+    # `DataLayer.subscribe`.
     async with DataStore.managed(
         database=tmp_path.joinpath("db.sqlite"),
         merkle_blobs_path=tmp_path.joinpath("merkle-blobs"),
@@ -3971,58 +4010,53 @@ async def test_invalid_subscription_does_not_deadlock_management_loop(
     tracked: list[bytes32] = []
     fetched: set[bytes32] = set()
 
-    async def mock_dl_track_new(self: Any, request: Any) -> None:
+    async def mock_dl_track_new(request: DLTrackNew) -> None:
         tracked.append(request.launcher_id)
         if request.launcher_id == bad_store:
             # Mirrors the real failure: the wallet can't find the launcher coin on chain and the
             # data_layer side sees it as a ResponseFailureError.
             raise ResponseFailureError({"success": False, "error": f"Launcher ID {bad_store} is not a valid coin"})
 
-    async def mock_dl_stop_tracking(self: Any, request: Any) -> None:
+    async def mock_dl_stop_tracking(request: DLStopTracking) -> None:
         return None
 
-    async def mock_update_subscriptions_from_wallet(self: Any, store_id: bytes32) -> None:
-        return None
-
-    async def spy_fetch_and_validate(self: Any, store_id: bytes32) -> None:
+    async def spy_fetch_and_validate(self: DataLayer, store_id: bytes32) -> None:
         # Invocation alone proves the management loop reached the per-store work pool; the heavy
         # fetch path is deliberately skipped for these synthetic stores.
         fetched.add(store_id)
 
-    def healthy_fetched() -> bool:
-        return healthy_store in fetched
-
-    def bad_store_retried() -> bool:
-        return tracked.count(bad_store) >= 2
-
     with monkeypatch.context() as m, caplog.at_level(logging.INFO):
-        m.setattr("chia.wallet.wallet_rpc_client.WalletRpcClient.dl_track_new", mock_dl_track_new)
-        m.setattr("chia.wallet.wallet_rpc_client.WalletRpcClient.dl_stop_tracking", mock_dl_stop_tracking)
-        m.setattr(
-            "chia.data_layer.data_layer.DataLayer.update_subscriptions_from_wallet",
-            mock_update_subscriptions_from_wallet,
+        wallet_rpc_client = _mock_wallet_rpc_client(
+            dl_track_new=mock_dl_track_new,
+            dl_stop_tracking=mock_dl_stop_tracking,
         )
-        m.setattr("chia.data_layer.data_layer.DataLayer.fetch_and_validate", spy_fetch_and_validate)
+        _patch_wallet_rpc_client_create(m, wallet_rpc_client)
+        _patch_synthetic_management_cycle(m, spy_fetch_and_validate)
 
         async with init_data_layer(
-            wallet_rpc_port=wallet_rpc_port,
+            wallet_rpc_port=uint16(1),
             bt=bt,
             db_path=tmp_path,
             manage_data_interval=manage_data_interval,
             maximum_full_file_count=100,
         ) as data_layer:
-            # (ii) Fetch liveness: the healthy store is fetched/validated even though the bad
-            # subscription's tracking call raises every cycle. Pre-fix this never happens because
-            # the management loop deadlocks before ever reaching the work pool.
+
+            def healthy_fetched() -> bool:
+                return healthy_store in fetched
+
+            def bad_store_retried() -> bool:
+                return tracked.count(bad_store) >= 2
+
+            # Fetch liveness: the healthy store is fetched/validated even though the bad
+            # subscription's tracking call raises every cycle.
             await time_out_assert(30, healthy_fetched, True)
 
-            # (i) Tracking isolation: the healthy store is still tracked despite the bad one raising
-            # in the same batch.
+            # Tracking isolation: the healthy store is still tracked despite the bad one raising.
             assert healthy_store in tracked
             assert bad_store in tracked
 
-            # (iii) Unsubscribe liveness: a queued unsubscribe is actually processed while the bad
-            # subscription keeps failing. Pre-fix the unsubscribe queue never drains.
+            # Unsubscribe liveness: a queued unsubscribe is processed while the bad subscription
+            # keeps failing.
             await data_layer.unsubscribe(healthy_store, retain_data=False)
 
             async def healthy_unsubscribed() -> bool:
@@ -4031,22 +4065,26 @@ async def test_invalid_subscription_does_not_deadlock_management_loop(
 
             await time_out_assert(30, healthy_unsubscribed, True)
 
-            # (iv) Recovery: the bad subscription keeps being retried on later cycles rather than
-            # being silently dropped, so it can recover once its launcher becomes valid again.
+            # Recovery: the bad subscription keeps being retried on later cycles.
             await time_out_assert(30, bad_store_retried, True)
 
-        # (v) Honest logging: the failure is reported as a per-subscription tracking error naming
+        # Honest logging: the failure is reported as a per-subscription tracking error naming
         # the store, not the misleading generic "Cannot connect to the wallet" connectivity message.
         assert f"Exception while requesting wallet track subscription {bad_store.hex()}" in caplog.text
+        assert any(
+            record.levelno == logging.WARNING
+            and f"Exception while requesting wallet track subscription {bad_store.hex()}" in record.getMessage()
+            for record in caplog.records
+        )
         assert "Cannot connect to the wallet. Retrying in 3s." not in caplog.text
         assert "Cannot connect to the wallet to track subscriptions" not in caplog.text
+        assert all(record.levelno < logging.ERROR for record in caplog.records)
 
 
 @pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.anyio
 async def test_track_subscriptions_stops_when_wallet_unreachable(
-    self_hostname: str,
-    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    bt: BlockTools,
     tmp_path: Path,
     monkeypatch: Any,
     caplog: pytest.LogCaptureFixture,
@@ -4054,22 +4092,23 @@ async def test_track_subscriptions_stops_when_wallet_unreachable(
     # When the wallet itself is unreachable, tracking logs a connectivity warning and stops trying
     # the remaining subscriptions for this cycle (they are retried next cycle) instead of treating
     # it as a per-subscription failure.
-    _wallet_rpc_api, _full_node_api, wallet_rpc_port, _ph, bt = await init_wallet_and_node(
-        self_hostname, one_wallet_and_one_simulator_services
-    )
     store_a = bytes32([3] * 32)
     store_b = bytes32([4] * 32)
     tracked: list[bytes32] = []
 
-    async def mock_dl_track_new(self: Any, request: Any) -> None:
+    async def mock_dl_track_new(request: DLTrackNew) -> None:
         tracked.append(request.launcher_id)
         raise aiohttp.client_exceptions.ClientConnectorError(MagicMock(), OSError("wallet unreachable"))
 
     with monkeypatch.context() as m, caplog.at_level(logging.WARNING):
-        m.setattr("chia.wallet.wallet_rpc_client.WalletRpcClient.dl_track_new", mock_dl_track_new)
+        wallet_rpc_client = _mock_wallet_rpc_client(
+            dl_track_new=mock_dl_track_new,
+            dl_stop_tracking=AsyncMock(),
+        )
+        _patch_wallet_rpc_client_create(m, wallet_rpc_client)
 
         async with init_data_layer(
-            wallet_rpc_port=wallet_rpc_port,
+            wallet_rpc_port=uint16(1),
             bt=bt,
             db_path=tmp_path,
             manage_data_interval=1,
@@ -4081,13 +4120,18 @@ async def test_track_subscriptions_stops_when_wallet_unreachable(
     assert store_a in tracked
     assert store_b not in tracked
     assert "Cannot connect to the wallet to track subscriptions" in caplog.text
+    assert any(
+        record.levelno == logging.WARNING
+        and "Cannot connect to the wallet to track subscriptions" in record.getMessage()
+        for record in caplog.records
+    )
+    assert all(record.levelno < logging.ERROR for record in caplog.records)
 
 
 @pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.anyio
 async def test_failing_unsubscribe_does_not_kill_management_loop(
-    self_hostname: str,
-    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    bt: BlockTools,
     tmp_path: Path,
     monkeypatch: Any,
     caplog: pytest.LogCaptureFixture,
@@ -4095,9 +4139,6 @@ async def test_failing_unsubscribe_does_not_kill_management_loop(
     # A queued unsubscribe whose processing raises (e.g. the wallet is unreachable when
     # dl_stop_tracking is called) must not kill the management loop or block management of other
     # stores; it is retried on later cycles and eventually takes effect once the wallet recovers.
-    _wallet_rpc_api, _full_node_api, wallet_rpc_port, _ph, bt = await init_wallet_and_node(
-        self_hostname, one_wallet_and_one_simulator_services
-    )
     manage_data_interval = 1
     keep_store = bytes32([6] * 32)
     unsub_store = bytes32([7] * 32)
@@ -4113,33 +4154,26 @@ async def test_failing_unsubscribe_does_not_kill_management_loop(
     fetch_counts: dict[bytes32, int] = {}
     stop_tracking_should_fail = True
 
-    async def mock_dl_track_new(self: Any, request: Any) -> None:
+    async def mock_dl_track_new(request: DLTrackNew) -> None:
         return None
 
-    async def mock_dl_stop_tracking(self: Any, request: Any) -> None:
+    async def mock_dl_stop_tracking(request: DLStopTracking) -> None:
         if stop_tracking_should_fail:
             raise aiohttp.client_exceptions.ClientConnectorError(MagicMock(), OSError("wallet unreachable"))
 
-    async def mock_update_subscriptions_from_wallet(self: Any, store_id: bytes32) -> None:
-        return None
-
-    async def spy_fetch_and_validate(self: Any, store_id: bytes32) -> None:
+    async def spy_fetch_and_validate(self: DataLayer, store_id: bytes32) -> None:
         fetch_counts[store_id] = fetch_counts.get(store_id, 0) + 1
 
-    def keep_store_managed_across_cycles() -> bool:
-        return fetch_counts.get(keep_store, 0) >= 3
-
     with monkeypatch.context() as m, caplog.at_level(logging.INFO):
-        m.setattr("chia.wallet.wallet_rpc_client.WalletRpcClient.dl_track_new", mock_dl_track_new)
-        m.setattr("chia.wallet.wallet_rpc_client.WalletRpcClient.dl_stop_tracking", mock_dl_stop_tracking)
-        m.setattr(
-            "chia.data_layer.data_layer.DataLayer.update_subscriptions_from_wallet",
-            mock_update_subscriptions_from_wallet,
+        wallet_rpc_client = _mock_wallet_rpc_client(
+            dl_track_new=mock_dl_track_new,
+            dl_stop_tracking=mock_dl_stop_tracking,
         )
-        m.setattr("chia.data_layer.data_layer.DataLayer.fetch_and_validate", spy_fetch_and_validate)
+        _patch_wallet_rpc_client_create(m, wallet_rpc_client)
+        _patch_synthetic_management_cycle(m, spy_fetch_and_validate)
 
         async with init_data_layer(
-            wallet_rpc_port=wallet_rpc_port,
+            wallet_rpc_port=uint16(1),
             bt=bt,
             db_path=tmp_path,
             manage_data_interval=manage_data_interval,
@@ -4148,9 +4182,14 @@ async def test_failing_unsubscribe_does_not_kill_management_loop(
             await data_layer.unsubscribe(unsub_store, retain_data=False)
 
             # The loop survives the failing unsubscribe and keeps managing the healthy store across
-            # multiple cycles. Pre-fix the unguarded process_unsubscribe killed the loop task here.
-            await time_out_assert(60, keep_store_managed_across_cycles, True)
+            # multiple cycles.
+            await time_out_assert(60, lambda: fetch_counts.get(keep_store, 0) >= 3, True)
             assert f"Exception while processing queued unsubscribe for {unsub_store.hex()}" in caplog.text
+            assert any(
+                record.levelno == logging.WARNING
+                and f"Exception while processing queued unsubscribe for {unsub_store.hex()}" in record.getMessage()
+                for record in caplog.records
+            )
 
             # The unsubscribe was retried (not dropped); once the wallet recovers it takes effect.
             stop_tracking_should_fail = False
@@ -4164,3 +4203,5 @@ async def test_failing_unsubscribe_does_not_kill_management_loop(
             # Processing an unsubscribe for an already-removed store is a no-op, so a request that
             # was queued more than once can't raise and wedge the drain loop.
             await data_layer.process_unsubscribe(unsub_store, retain_data=False)
+
+        assert all(record.levelno < logging.ERROR for record in caplog.records)

--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -16,7 +16,6 @@ from copy import deepcopy
 from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -3863,7 +3862,7 @@ async def test_auto_subscribe_to_local_stores(
     self_hostname: str,
     one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
     tmp_path: Path,
-    monkeypatch: Any,
+    monkeypatch: pytest.MonkeyPatch,
     auto_subscribe_to_local_stores: bool,
 ) -> None:
     _wallet_rpc_api, _full_node_api, wallet_rpc_port, _ph, bt = await init_wallet_and_node(
@@ -3912,7 +3911,7 @@ async def test_local_store_exception(
     self_hostname: str,
     one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
     tmp_path: Path,
-    monkeypatch: Any,
+    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     _wallet_rpc_api, _full_node_api, wallet_rpc_port, _ph, bt = await init_wallet_and_node(
@@ -3943,55 +3942,57 @@ async def test_local_store_exception(
             assert f"Can't subscribe to local store {fake_store.hex()}:" in caplog.text
 
 
-def _mock_wallet_rpc_client(
-    dl_track_new: Callable[[DLTrackNew], Awaitable[None]],
-    dl_stop_tracking: Callable[[DLStopTracking], Awaitable[None]],
-) -> Any:
-    async def await_closed() -> None:
+class TestDataLayerWalletRpcClient:
+    def __init__(
+        self,
+        dl_track_new: Callable[[DLTrackNew], Awaitable[None]] | None = None,
+        dl_stop_tracking: Callable[[DLStopTracking], Awaitable[None]] | None = None,
+    ) -> None:
+        self._dl_track_new = dl_track_new if dl_track_new is not None else self._default_dl_track_new
+        self._dl_stop_tracking = dl_stop_tracking if dl_stop_tracking is not None else self._default_dl_stop_tracking
+
+    async def _default_dl_track_new(self, request: DLTrackNew) -> None:
+        del request
+
+    async def _default_dl_stop_tracking(self, request: DLStopTracking) -> None:
+        del request
+
+    async def await_closed(self) -> None:
         return None
 
-    async def dl_owned_singletons() -> DLOwnedSingletonsResponse:
+    def close(self) -> None:
+        return None
+
+    async def dl_owned_singletons(self) -> DLOwnedSingletonsResponse:
         return DLOwnedSingletonsResponse(singletons=[], count=uint32(0))
 
-    return SimpleNamespace(
-        await_closed=await_closed,
-        close=lambda: None,
-        dl_owned_singletons=dl_owned_singletons,
-        dl_stop_tracking=dl_stop_tracking,
-        dl_track_new=dl_track_new,
-    )
+    async def dl_track_new(self, request: DLTrackNew) -> None:
+        await self._dl_track_new(request)
+
+    async def dl_stop_tracking(self, request: DLStopTracking) -> None:
+        await self._dl_stop_tracking(request)
 
 
-def _patch_wallet_rpc_client_create(monkeypatch: Any, wallet_rpc_client: Any) -> None:
-    async def mock_wallet_rpc_client_create(*args: Any, **kwargs: Any) -> Any:
-        return wallet_rpc_client
-
-    monkeypatch.setattr("chia.data_layer.start_data_layer.WalletRpcClient.create", mock_wallet_rpc_client_create)
-
-
-def _patch_synthetic_management_cycle(
-    monkeypatch: Any,
-    fetch_and_validate: Callable[[DataLayer, bytes32], Awaitable[None]],
-) -> None:
-    async def noop_store_method(self: DataLayer, store_id: bytes32) -> None:
-        return None
-
-    monkeypatch.setattr("chia.data_layer.data_layer.DataLayer.update_subscriptions_from_wallet", noop_store_method)
-    monkeypatch.setattr("chia.data_layer.data_layer.DataLayer.fetch_and_validate", fetch_and_validate)
-    monkeypatch.setattr("chia.data_layer.data_layer.DataLayer.upload_files", noop_store_method)
-    monkeypatch.setattr("chia.data_layer.data_layer.DataLayer.clean_old_full_tree_files", noop_store_method)
+async def _seed_subscriptions(tmp_path: Path, *store_ids: bytes32) -> None:
+    async with DataStore.managed(
+        database=tmp_path.joinpath("db.sqlite"),
+        merkle_blobs_path=tmp_path.joinpath("merkle-blobs"),
+        key_value_blobs_path=tmp_path.joinpath("key-value-blobs"),
+    ) as data_store:
+        for store_id in store_ids:
+            await data_store.subscribe(Subscription(store_id, []))
 
 
 @pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.anyio
-async def test_invalid_subscription_does_not_deadlock_management_loop(
+async def test_invalid_subscription_handling(
     bt: BlockTools,
     tmp_path: Path,
-    monkeypatch: Any,
+    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     # A single subscription whose `dl_track_new` always raises must not block tracking of other
-    # subscriptions, fetching/validation of healthy stores, or draining of the unsubscribe queue.
+    # subscriptions or per-store update work.
     manage_data_interval = 1
     bad_store = bytes32([1] * 32)
     healthy_store = bytes32([2] * 32)
@@ -3999,13 +4000,7 @@ async def test_invalid_subscription_does_not_deadlock_management_loop(
     # Pre-seed the persisted subscriptions DB before the service starts so the first management
     # cycle reads them. `DataStore.subscribe` is DB-level and does not call `dl_track_new`, unlike
     # `DataLayer.subscribe`.
-    async with DataStore.managed(
-        database=tmp_path.joinpath("db.sqlite"),
-        merkle_blobs_path=tmp_path.joinpath("merkle-blobs"),
-        key_value_blobs_path=tmp_path.joinpath("key-value-blobs"),
-    ) as data_store:
-        await data_store.subscribe(Subscription(bad_store, []))
-        await data_store.subscribe(Subscription(healthy_store, []))
+    await _seed_subscriptions(tmp_path, bad_store, healthy_store)
 
     tracked: list[bytes32] = []
     fetched: set[bytes32] = set()
@@ -4017,21 +4012,22 @@ async def test_invalid_subscription_does_not_deadlock_management_loop(
             # data_layer side sees it as a ResponseFailureError.
             raise ResponseFailureError({"success": False, "error": f"Launcher ID {bad_store} is not a valid coin"})
 
-    async def mock_dl_stop_tracking(request: DLStopTracking) -> None:
-        return None
-
-    async def spy_fetch_and_validate(self: DataLayer, store_id: bytes32) -> None:
+    async def spy_update_subscription(self: DataLayer, worker_id: int, job: Any) -> None:
         # Invocation alone proves the management loop reached the per-store work pool; the heavy
-        # fetch path is deliberately skipped for these synthetic stores.
-        fetched.add(store_id)
+        # per-store update path is deliberately skipped for these synthetic stores.
+        del self, worker_id
+        fetched.add(job.input.store_id)
 
     with monkeypatch.context() as m, caplog.at_level(logging.INFO):
-        wallet_rpc_client = _mock_wallet_rpc_client(
-            dl_track_new=mock_dl_track_new,
-            dl_stop_tracking=mock_dl_stop_tracking,
+        m.setattr(
+            "chia.data_layer.start_data_layer.WalletRpcClient.create",
+            AsyncMock(
+                return_value=TestDataLayerWalletRpcClient(
+                    dl_track_new=mock_dl_track_new,
+                )
+            ),
         )
-        _patch_wallet_rpc_client_create(m, wallet_rpc_client)
-        _patch_synthetic_management_cycle(m, spy_fetch_and_validate)
+        m.setattr("chia.data_layer.data_layer.DataLayer.update_subscription", spy_update_subscription)
 
         async with init_data_layer(
             wallet_rpc_port=uint16(1),
@@ -4039,74 +4035,60 @@ async def test_invalid_subscription_does_not_deadlock_management_loop(
             db_path=tmp_path,
             manage_data_interval=manage_data_interval,
             maximum_full_file_count=100,
-        ) as data_layer:
-
-            def healthy_fetched() -> bool:
-                return healthy_store in fetched
-
-            def bad_store_retried() -> bool:
-                return tracked.count(bad_store) >= 2
-
+        ):
             # Fetch liveness: the healthy store is fetched/validated even though the bad
             # subscription's tracking call raises every cycle.
-            await time_out_assert(30, healthy_fetched, True)
+            await time_out_assert(30, lambda: healthy_store in fetched, True)
 
             # Tracking isolation: the healthy store is still tracked despite the bad one raising.
             assert healthy_store in tracked
             assert bad_store in tracked
 
-            # Unsubscribe liveness: a queued unsubscribe is processed while the bad subscription
-            # keeps failing.
-            await data_layer.unsubscribe(healthy_store, retain_data=False)
-
-            async def healthy_unsubscribed() -> bool:
-                subscriptions = await data_layer.get_subscriptions()
-                return all(subscription.store_id != healthy_store for subscription in subscriptions)
-
-            await time_out_assert(30, healthy_unsubscribed, True)
-
             # Recovery: the bad subscription keeps being retried on later cycles.
-            await time_out_assert(30, bad_store_retried, True)
+            await time_out_assert(30, lambda: tracked.count(bad_store) >= 2, True)
 
         # Honest logging: the failure is reported as a per-subscription tracking error naming
         # the store, not the misleading generic "Cannot connect to the wallet" connectivity message.
         assert f"Exception while requesting wallet track subscription {bad_store.hex()}" in caplog.text
-        assert any(
-            record.levelno == logging.WARNING
-            and f"Exception while requesting wallet track subscription {bad_store.hex()}" in record.getMessage()
-            for record in caplog.records
-        )
         assert "Cannot connect to the wallet. Retrying in 3s." not in caplog.text
         assert "Cannot connect to the wallet to track subscriptions" not in caplog.text
-        assert all(record.levelno < logging.ERROR for record in caplog.records)
 
 
 @pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.anyio
-async def test_track_subscriptions_stops_when_wallet_unreachable(
+async def test_invalid_subscription_does_not_block_unsubscribe(
     bt: BlockTools,
     tmp_path: Path,
-    monkeypatch: Any,
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # When the wallet itself is unreachable, tracking logs a connectivity warning and stops trying
-    # the remaining subscriptions for this cycle (they are retried next cycle) instead of treating
-    # it as a per-subscription failure.
-    store_a = bytes32([3] * 32)
-    store_b = bytes32([4] * 32)
+    # Even if one subscription fails tracking each cycle, queued unsubscribes for other stores
+    # must still be processed.
+    bad_store = bytes32([8] * 32)
+    healthy_store = bytes32([9] * 32)
     tracked: list[bytes32] = []
+    stop_tracking_requests: list[bytes32] = []
+
+    await _seed_subscriptions(tmp_path, bad_store, healthy_store)
 
     async def mock_dl_track_new(request: DLTrackNew) -> None:
         tracked.append(request.launcher_id)
-        raise aiohttp.client_exceptions.ClientConnectorError(MagicMock(), OSError("wallet unreachable"))
+        if request.launcher_id == bad_store:
+            raise ResponseFailureError({"success": False, "error": f"Launcher ID {bad_store} is not a valid coin"})
 
-    with monkeypatch.context() as m, caplog.at_level(logging.WARNING):
-        wallet_rpc_client = _mock_wallet_rpc_client(
-            dl_track_new=mock_dl_track_new,
-            dl_stop_tracking=AsyncMock(),
+    async def mock_dl_stop_tracking(request: DLStopTracking) -> None:
+        stop_tracking_requests.append(request.launcher_id)
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            "chia.data_layer.start_data_layer.WalletRpcClient.create",
+            AsyncMock(
+                return_value=TestDataLayerWalletRpcClient(
+                    dl_track_new=mock_dl_track_new,
+                    dl_stop_tracking=mock_dl_stop_tracking,
+                )
+            ),
         )
-        _patch_wallet_rpc_client_create(m, wallet_rpc_client)
-
+        m.setattr("chia.data_layer.data_layer.DataLayer.update_subscription", AsyncMock(return_value=None))
         async with init_data_layer(
             wallet_rpc_port=uint16(1),
             bt=bt,
@@ -4114,26 +4096,48 @@ async def test_track_subscriptions_stops_when_wallet_unreachable(
             manage_data_interval=1,
             maximum_full_file_count=100,
         ) as data_layer:
-            await data_layer.track_subscriptions([Subscription(store_a, []), Subscription(store_b, [])])
+            await time_out_assert(30, lambda: tracked.count(bad_store) >= 1, True)
+            await data_layer.unsubscribe(healthy_store, retain_data=False)
 
-    # Only the first subscription was attempted; tracking bailed out for the rest of the batch.
-    assert store_a in tracked
-    assert store_b not in tracked
-    assert "Cannot connect to the wallet to track subscriptions" in caplog.text
-    assert any(
-        record.levelno == logging.WARNING
-        and "Cannot connect to the wallet to track subscriptions" in record.getMessage()
-        for record in caplog.records
-    )
-    assert all(record.levelno < logging.ERROR for record in caplog.records)
+            async def healthy_unsubscribed() -> bool:
+                subscriptions = await data_layer.get_subscriptions()
+                return all(subscription.store_id != healthy_store for subscription in subscriptions)
+
+            await time_out_assert(30, healthy_unsubscribed, True)
+            await time_out_assert(30, lambda: tracked.count(bad_store) >= 2, True)
+
+    assert healthy_store in stop_tracking_requests
 
 
 @pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
 @pytest.mark.anyio
-async def test_failing_unsubscribe_does_not_kill_management_loop(
+async def test_track_subscriptions_wallet_unreachable(
     bt: BlockTools,
     tmp_path: Path,
-    monkeypatch: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # When the wallet isn't reachable, tracking emits a connectivity warning.
+    with caplog.at_level(logging.WARNING):
+        async with init_data_layer(
+            wallet_rpc_port=uint16(1),
+            bt=bt,
+            db_path=tmp_path,
+            manage_data_interval=1,
+            maximum_full_file_count=100,
+        ) as data_layer:
+            await data_layer.track_subscriptions(
+                [Subscription(bytes32([3] * 32), []), Subscription(bytes32([4] * 32), [])]
+            )
+
+    assert "Cannot connect to the wallet to track subscriptions" in caplog.text
+
+
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
+@pytest.mark.anyio
+async def test_failing_unsubscribe(
+    bt: BlockTools,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     # A queued unsubscribe whose processing raises (e.g. the wallet is unreachable when
@@ -4143,13 +4147,7 @@ async def test_failing_unsubscribe_does_not_kill_management_loop(
     keep_store = bytes32([6] * 32)
     unsub_store = bytes32([7] * 32)
 
-    async with DataStore.managed(
-        database=tmp_path.joinpath("db.sqlite"),
-        merkle_blobs_path=tmp_path.joinpath("merkle-blobs"),
-        key_value_blobs_path=tmp_path.joinpath("key-value-blobs"),
-    ) as data_store:
-        await data_store.subscribe(Subscription(keep_store, []))
-        await data_store.subscribe(Subscription(unsub_store, []))
+    await _seed_subscriptions(tmp_path, keep_store, unsub_store)
 
     fetch_counts: dict[bytes32, int] = {}
     stop_tracking_should_fail = True
@@ -4161,17 +4159,22 @@ async def test_failing_unsubscribe_does_not_kill_management_loop(
         if stop_tracking_should_fail:
             raise aiohttp.client_exceptions.ClientConnectorError(MagicMock(), OSError("wallet unreachable"))
 
-    async def spy_fetch_and_validate(self: DataLayer, store_id: bytes32) -> None:
+    async def spy_update_subscription(self: DataLayer, worker_id: int, job: Any) -> None:
+        del self, worker_id
+        store_id = job.input.store_id
         fetch_counts[store_id] = fetch_counts.get(store_id, 0) + 1
 
     with monkeypatch.context() as m, caplog.at_level(logging.INFO):
-        wallet_rpc_client = _mock_wallet_rpc_client(
-            dl_track_new=mock_dl_track_new,
-            dl_stop_tracking=mock_dl_stop_tracking,
+        m.setattr(
+            "chia.data_layer.start_data_layer.WalletRpcClient.create",
+            AsyncMock(
+                return_value=TestDataLayerWalletRpcClient(
+                    dl_track_new=mock_dl_track_new,
+                    dl_stop_tracking=mock_dl_stop_tracking,
+                )
+            ),
         )
-        _patch_wallet_rpc_client_create(m, wallet_rpc_client)
-        _patch_synthetic_management_cycle(m, spy_fetch_and_validate)
-
+        m.setattr("chia.data_layer.data_layer.DataLayer.update_subscription", spy_update_subscription)
         async with init_data_layer(
             wallet_rpc_port=uint16(1),
             bt=bt,
@@ -4203,5 +4206,3 @@ async def test_failing_unsubscribe_does_not_kill_management_loop(
             # Processing an unsubscribe for an already-removed store is a no-op, so a request that
             # was queued more than once can't raise and wedge the drain loop.
             await data_layer.process_unsubscribe(unsub_store, retain_data=False)
-
-        assert all(record.levelno < logging.ERROR for record in caplog.records)

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -117,11 +117,6 @@ async def get_plugin_info(
         return plugin_remote, {"error": f"{type(e).__name__}: {e}"}
 
 
-# Log a per-subscription wallet-tracking failure on the first occurrence and then only
-# every Nth consecutive failure, so a persistently invalid launcher can't flood the log.
-TRACK_FAILURE_LOG_INTERVAL = 10
-
-
 @final
 @dataclasses.dataclass
 class DataLayer:
@@ -157,7 +152,6 @@ class DataLayer:
     )
     group_files_by_store: bool = False
     max_delta_file_size: int = 250
-    _track_failure_counts: dict[bytes32, int] = dataclasses.field(default_factory=dict)
 
     @property
     def server(self) -> ChiaServer:
@@ -926,7 +920,6 @@ class DataLayer:
         # stop tracking first, then unsubscribe from the data store
         await self.wallet_rpc.dl_stop_tracking(DLStopTracking(launcher_id=store_id))
         await self.data_store.unsubscribe(store_id)
-        self._track_failure_counts.pop(store_id, None)
 
         self.log.info(f"Unsubscribed to {store_id}")
         for file_path in paths:
@@ -1072,16 +1065,9 @@ class DataLayer:
                 return
             except Exception as e:
                 # One subscription failing to track must not abort tracking of the others.
-                count = self._track_failure_counts.get(subscription.store_id, 0) + 1
-                self._track_failure_counts[subscription.store_id] = count
-                if count == 1 or count % TRACK_FAILURE_LOG_INTERVAL == 0:
-                    self.log.warning(
-                        f"Exception while requesting wallet track subscription {subscription.store_id} "
-                        f"(consecutive failures: {count}): {type(e)} {e}"
-                    )
-            else:
-                # Clear the failure counter so a later failure logs immediately.
-                self._track_failure_counts.pop(subscription.store_id, None)
+                self.log.warning(
+                    f"Exception while requesting wallet track subscription {subscription.store_id}: {type(e)} {e}"
+                )
 
     async def update_subscription(
         self,

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast, final
 
 import aiohttp
+import anyio
 from chia_rs.datalayer import ProofOfInclusion, ProofOfInclusionLayer
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
@@ -260,13 +261,15 @@ class DataLayer:
                 if self._wallet_rpc is not None:
                     self.wallet_rpc.close()
 
-                if self.periodically_manage_data_task is not None:
+                with anyio.CancelScope(shield=True):
                     try:
-                        self.periodically_manage_data_task.cancel()
-                    except asyncio.CancelledError:
-                        pass
-                if self._wallet_rpc is not None:
-                    await self.wallet_rpc.await_closed()
+                        if self.periodically_manage_data_task is not None:
+                            self.periodically_manage_data_task.cancel()
+                            with contextlib.suppress(asyncio.CancelledError):
+                                await self.periodically_manage_data_task
+                    finally:
+                        if self._wallet_rpc is not None:
+                            await self.wallet_rpc.await_closed()
 
     def _set_state_changed_callback(self, callback: StateChangedProtocol) -> None:
         self.state_changed_callback = callback

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -117,6 +117,11 @@ async def get_plugin_info(
         return plugin_remote, {"error": f"{type(e).__name__}: {e}"}
 
 
+# Log a per-subscription wallet-tracking failure on the first occurrence and then only
+# every Nth consecutive failure, so a persistently invalid launcher can't flood the log.
+TRACK_FAILURE_LOG_INTERVAL = 10
+
+
 @final
 @dataclasses.dataclass
 class DataLayer:
@@ -152,6 +157,7 @@ class DataLayer:
     )
     group_files_by_store: bool = False
     max_delta_file_size: int = 250
+    _track_failure_counts: dict[bytes32, int] = dataclasses.field(default_factory=dict)
 
     @property
     def server(self) -> ChiaServer:
@@ -889,7 +895,8 @@ class DataLayer:
         # This function already acquired `subscriptions_lock`.
         subscriptions = await self.data_store.get_subscriptions()
         if store_id not in (subscription.store_id for subscription in subscriptions):
-            raise RuntimeError("No subscription found for the given store_id.")
+            # Already unsubscribed (e.g. the request was queued more than once); nothing to do.
+            return
         paths: list[Path] = []
         if await self.data_store.store_id_exists(store_id) and not retain_data:
             generation = await self.data_store.get_tree_generation(store_id)
@@ -919,6 +926,7 @@ class DataLayer:
         # stop tracking first, then unsubscribe from the data store
         await self.wallet_rpc.dl_stop_tracking(DLStopTracking(launcher_id=store_id))
         await self.data_store.unsubscribe(store_id)
+        self._track_failure_counts.pop(store_id, None)
 
         self.log.info(f"Unsubscribed to {store_id}")
         for file_path in paths:
@@ -975,29 +983,13 @@ class DataLayer:
     async def periodically_manage_data(self) -> None:
         manage_data_interval = self.config.get("manage_data_interval", 60)
         while not self._shut_down:
-            async with self.subscription_lock:
-                try:
-                    subscriptions = await self.data_store.get_subscriptions()
-                    for subscription in subscriptions:
-                        await self.wallet_rpc.dl_track_new(DLTrackNew(launcher_id=subscription.store_id))
-                    break
-                except aiohttp.client_exceptions.ClientConnectorError:
-                    pass
-                except Exception as e:
-                    self.log.error(f"Exception while requesting wallet track subscription: {type(e)} {e}")
-
-            self.log.warning("Cannot connect to the wallet. Retrying in 3s.")
-
-            delay_until = time.monotonic() + 3
-            while time.monotonic() < delay_until:
-                if self._shut_down:
-                    break
-                await asyncio.sleep(0.1)
-
-        while not self._shut_down:
             # Add existing subscriptions
             async with self.subscription_lock:
                 subscriptions = await self.data_store.get_subscriptions()
+
+            # Track each subscription individually so one bad subscription can't block the
+            # others or entry into the rest of the management cycle.
+            await self.track_subscriptions(subscriptions)
 
             # pseudo-subscribe to all unsubscribed owned stores
             # Need this to make sure we process updates and generate DAT files
@@ -1055,10 +1047,41 @@ class DataLayer:
 
             # Do unsubscribes after the fetching of data is complete, to avoid races.
             async with self.subscription_lock:
+                still_pending: list[UnsubscribeData] = []
                 for unsubscribe_data in self.unsubscribe_data_queue:
-                    await self.process_unsubscribe(unsubscribe_data.store_id, unsubscribe_data.retain_data)
-                self.unsubscribe_data_queue.clear()
+                    try:
+                        await self.process_unsubscribe(unsubscribe_data.store_id, unsubscribe_data.retain_data)
+                    except Exception as e:
+                        # A single failing unsubscribe (e.g. the wallet is unreachable) must not
+                        # kill the loop or block the others; retry it on the next cycle.
+                        self.log.warning(
+                            f"Exception while processing queued unsubscribe for "
+                            f"{unsubscribe_data.store_id}: {type(e)} {e}"
+                        )
+                        still_pending.append(unsubscribe_data)
+                self.unsubscribe_data_queue[:] = still_pending
             await asyncio.sleep(manage_data_interval)
+
+    async def track_subscriptions(self, subscriptions: list[Subscription]) -> None:
+        for subscription in subscriptions:
+            try:
+                await self.wallet_rpc.dl_track_new(DLTrackNew(launcher_id=subscription.store_id))
+            except aiohttp.client_exceptions.ClientConnectorError as e:
+                # Wallet unreachable: retry the remaining subscriptions on the next cycle.
+                self.log.warning(f"Cannot connect to the wallet to track subscriptions ({e}). Retrying next cycle.")
+                return
+            except Exception as e:
+                # One subscription failing to track must not abort tracking of the others.
+                count = self._track_failure_counts.get(subscription.store_id, 0) + 1
+                self._track_failure_counts[subscription.store_id] = count
+                if count == 1 or count % TRACK_FAILURE_LOG_INTERVAL == 0:
+                    self.log.warning(
+                        f"Exception while requesting wallet track subscription {subscription.store_id} "
+                        f"(consecutive failures: {count}): {type(e)} {e}"
+                    )
+            else:
+                # Clear the failure counter so a later failure logs immediately.
+                self._track_failure_counts.pop(subscription.store_id, None)
 
     async def update_subscription(
         self,


### PR DESCRIPTION
### Purpose:

A single invalid DataLayer subscription could permanently deadlock the entire DataLayer management loop (`periodically_manage_data`), starving **every** store of tracking, fetch/validate, and unsubscribe processing — unrecoverable across restarts without manual DB surgery.

The initial wallet-tracking loop iterated all subscriptions calling `dl_track_new` and only broke into the main management loop if the whole list succeeded. If `dl_track_new` raised for any one subscription (for example a launcher whose coin can't be found on chain, which the wallet raises as `LauncherCoinNotFoundError` and the data-layer side sees as `ResponseFailureError`), the loop aborted before the break, the exception was caught by a generic handler, and the loop retried the whole list forever — logging a misleading "Cannot connect to the wallet. Retrying in 3s." even though the wallet was reachable. The main loop was never entered, so no store was ever fetched/validated and queued unsubscribes never drained (`chia data unsubscribe` returned success but did nothing, for any store). A restart re-read the same bad subscription and re-deadlocked.

Apps such as CADT subscribe to many stores; one invalid entry must not be able to take down DataLayer for all of them.

### Current Behavior:

One subscription whose `dl_track_new` raises a non-connection error wedges the management loop indefinitely: no `fetch_and_validate` runs for any store, the unsubscribe queue never drains, and the failure is mislabeled as a wallet-connectivity problem.

### New Behavior:

Wallet tracking is folded into the main management loop and performed per-subscription with fault isolation:

- A failing `dl_track_new` for one subscription is logged and skipped; other subscriptions are still tracked and the rest of the cycle can run.
- Real wallet-connectivity failures (`ClientConnectorError`) are distinguished from per-subscription tracking failures and retried on the next cycle, with honest log messages. The misleading "Cannot connect to the wallet. Retrying in 3s." message is removed.
- The unsubscribe-queue drain tolerates a failing `process_unsubscribe` (for example, the wallet being unreachable when `dl_stop_tracking` is called): the failure is logged and the item is retried on the next cycle rather than killing the loop or blocking other queued unsubscribes.
- `process_unsubscribe` is idempotent for an already-removed store, so a request queued more than once cannot wedge the drain.
- Shutdown now drains the background management task before waiting for the wallet RPC client to close.

**Invariants unchanged:**
- Healthy-path behavior is unchanged: subscriptions are still tracked through `dl_track_new`, and owned-store pseudo-subscribe / work-pool concurrency / `manage_data_interval` cadence are unchanged.
- The RPC/CLI `subscribe` contract is unchanged. The RPC-facing `unsubscribe` still raises for an unknown store; the idempotent no-op is internal to the queue drainer and not visible to RPC clients.
- No wire-protocol, RPC-schema, DB-schema, consensus/fork-gating, or persisted-state changes.

**Deliberate behavior change:** the previous 3s fast-retry while the wallet was unreachable at startup is replaced by retrying at the normal `manage_data_interval` cadence (default 60s). This is acceptable because the main loop already tolerates a down wallet.

**Out of scope (related):** the separate `migrate_db` gap that can leave a store "synced" with an incomplete `ids` table, and DB-persisted quarantine/auto-prune of persistently-invalid launchers.

### Testing Notes:

Added regression tests in `chia/_tests/core/data_layer/test_data_rpc.py`:

- `test_invalid_subscription_handling` — seeds a bad and healthy subscription into the persisted DB before startup, makes the bad store's `dl_track_new` raise `ResponseFailureError` each cycle, and asserts the healthy store still reaches per-store update work while the bad store keeps being retried.
- `test_invalid_subscription_does_not_block_unsubscribe` — verifies a queued unsubscribe for a healthy store drains while another subscription keeps failing tracking.
- `test_track_subscriptions_wallet_unreachable` — verifies a wallet connectivity failure is logged as connectivity rather than a per-subscription tracking error.
- `test_failing_unsubscribe` — verifies a queued unsubscribe whose `dl_stop_tracking` initially raises is retained and retried, and that an already-removed store is a no-op for the internal drainer.

Validation: targeted DataLayer tests pass; `ruff` / `ruff format --check` / `mypy` clean; local diff coverage gate is 100%; pre-commit hooks clean. Benchmarks reproduce the pre-existing `HARD_FORK_3_0` block-generation failures in `test_node_load`/`test_performance` and are unrelated to this change.