### PR TITLE
CHIA-4243 Annotate wallet_user_store.py

### DIFF
--- a/chia/_tests/wallet/test_wallet_user_store.py
+++ b/chia/_tests/wallet/test_wallet_user_store.py
@@ -14,7 +14,9 @@ async def test_store() -> None:
         await store.init_wallet()
         wallet = None
         for i in range(1, 5):
-            assert (await store.get_last_wallet()).id == i
+            last_wallet = await store.get_last_wallet()
+            assert last_wallet is not None
+            assert last_wallet.id == i
             wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
             assert wallet.id == i + 1
         assert wallet is not None
@@ -23,10 +25,14 @@ async def test_store() -> None:
         for i in range(2, 6):
             await store.delete_wallet(i)
 
-        assert (await store.get_last_wallet()).id == 1
+        last_wallet = await store.get_last_wallet()
+        assert last_wallet is not None
+        assert last_wallet.id == 1
         wallet = await store.create_wallet("CAT_WALLET", WalletType.CAT, "abc")
         # Due to autoincrement, we don't reuse IDs
-        assert (await store.get_last_wallet()).id == 6
+        last_wallet = await store.get_last_wallet()
+        assert last_wallet is not None
+        assert last_wallet.id == 6
         assert wallet.id == 6
 
         assert (await store.get_wallet_by_id(7)) is None

--- a/chia/wallet/wallet_user_store.py
+++ b/chia/wallet/wallet_user_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from chia_rs.sized_ints import uint32
+from typing_extensions import Self
 
 from chia.util.db_wrapper import DBWrapper2, execute_fetchone
 from chia.wallet.util.wallet_types import WalletType
@@ -16,7 +17,7 @@ class WalletUserStore:
     db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper2):
+    async def create(cls, db_wrapper: DBWrapper2) -> Self:
         self = cls()
 
         self.db_wrapper = db_wrapper
@@ -38,7 +39,7 @@ class WalletUserStore:
         await self.init_wallet()
         return self
 
-    async def init_wallet(self):
+    async def init_wallet(self) -> None:
         all_wallets = await self.get_all_wallet_info_entries()
         if len(all_wallets) == 0:
             await self.create_wallet("Chia Wallet", WalletType.STANDARD_WALLET, "")
@@ -62,11 +63,11 @@ class WalletUserStore:
 
         return wallet
 
-    async def delete_wallet(self, id: int):
+    async def delete_wallet(self, id: int) -> None:
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             await (await conn.execute("DELETE FROM users_wallets where id=?", (id,))).close()
 
-    async def update_wallet(self, wallet_info: WalletInfo):
+    async def update_wallet(self, wallet_info: WalletInfo) -> None:
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             cursor = await conn.execute(
                 "INSERT or REPLACE INTO users_wallets VALUES(?, ?, ?, ?)",

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -22,7 +22,6 @@ chia.wallet.wallet_interested_store
 chia.wallet.wallet_node_api
 chia.wallet.wallet_puzzle_store
 chia.wallet.wallet_transaction_store
-chia.wallet.wallet_user_store
 chia._tests.clvm.test_puzzles
 chia._tests.clvm.test_singletons
 chia._tests.clvm.test_spend_sim


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Typing and test assertion changes only; no wallet persistence or runtime logic changes.
> 
> **Overview**
> Adds mypy type annotations to **`wallet_user_store.py`** so the module can be type-checked: `create` returns **`Self`**, and **`init_wallet`**, **`delete_wallet`**, and **`update_wallet`** are annotated as **`-> None`**.
> 
> Removes **`chia.wallet.wallet_user_store`** from **`mypy-exclusions.txt`**, enabling strict mypy on that file.
> 
> Updates **`test_wallet_user_store`** to assert **`get_last_wallet()`** is not **`None`** before reading **`.id`**, matching the **`WalletInfo | None`** return type without changing test behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f538514ea03586da7b2f207a22beaae8b64774c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->