### PR TITLE
chore: improve chia-blockchain maintenance path

### DIFF
--- a/chia/_tests/util/rpc.py
+++ b/chia/_tests/util/rpc.py
@@ -6,6 +6,8 @@ from chia.rpc.rpc_server import RpcApiProtocol
 
 async def validate_get_routes(client: RpcClient, api: RpcApiProtocol) -> None:
     routes_client = (await client.fetch("get_routes", {}))["routes"]
+    assert isinstance(routes_client, list)
+    assert all(isinstance(route, str) for route in routes_client)
     assert len(routes_client) > 0
     routes_api = list(api.get_routes().keys())
     # TODO: avoid duplication of RpcServer.get_routes()


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in chia/_tests/ether.py, chia/_tests/util/rpc.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertions in a shared helper; no production RPC or node behavior changes.
> 
> **Overview**
> Tightens the shared RPC test helper `validate_get_routes` so `get_routes` responses are checked as a **list of strings** before the existing non-empty and route-equality assertions run.
> 
> This catches malformed or unexpectedly typed `routes` payloads from the RPC client earlier in farmer, harvester, and full-node route tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a61fbdcb62f3f0710a73860c2b54d0af205588b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->