### PR TITLE
Bump chia rs 0.45.0

### DIFF
--- a/chia/_tests/core/server/test_api_protocol.py
+++ b/chia/_tests/core/server/test_api_protocol.py
@@ -83,4 +83,5 @@ async def test_list_limits_on_rust_type() -> None:
     assert len(captured) == 1
     # Rust from_bytes is called without list_limits (would TypeError otherwise),
     # followed by _apply_list_limits which calls truncate.
-    assert len(captured[0].puzzle_hashes) <= 10
+    assert len(captured[0].puzzle_hashes) == 3
+    assert captured[0].puzzle_hashes == phs[:3]

--- a/chia/_tests/core/server/test_api_protocol.py
+++ b/chia/_tests/core/server/test_api_protocol.py
@@ -63,6 +63,8 @@ async def test_list_limits_without_peer() -> None:
 
 @pytest.mark.anyio
 async def test_list_limits_on_rust_type() -> None:
+    """Rust types don't accept list_limits in from_bytes. Verify the decorator
+    falls back to from_bytes() without list_limits, then applies truncation."""
     captured: list[RespondToPhUpdates] = []
 
     metadata = ApiMetadata()

--- a/chia/_tests/core/server/test_api_protocol.py
+++ b/chia/_tests/core/server/test_api_protocol.py
@@ -4,10 +4,12 @@ from dataclasses import dataclass
 
 import pytest
 from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint32
 
 from chia.protocols.full_node_protocol import RequestTransaction
 from chia.protocols.protocol_message_type_to_node_type import ProtocolMessageTypeToNodeType
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
+from chia.protocols.wallet_protocol import RespondToPhUpdates
 from chia.server.api_protocol import ApiMetadata
 from chia.util.streamable import Streamable, streamable
 
@@ -57,3 +59,26 @@ async def test_list_limits_without_peer() -> None:
     assert len(captured) == 1
     assert len(captured[0].items) == 2
     assert captured[0].items == ids[:2]
+
+
+@pytest.mark.anyio
+async def test_list_limits_on_rust_type() -> None:
+    captured: list[RespondToPhUpdates] = []
+
+    metadata = ApiMetadata()
+
+    @metadata.request(  # type: ignore[type-var]
+        request_type=ProtocolMessageTypes.new_peak,
+        list_limits=lambda self: {"puzzle_hashes": 3},
+    )
+    async def handler(self: object, request: RespondToPhUpdates) -> None:
+        captured.append(request)
+
+    phs = [bytes32(i.to_bytes(32, "big")) for i in range(10)]
+    blob = bytes(RespondToPhUpdates(phs, uint32(0), []))
+
+    await handler(None, blob)
+    assert len(captured) == 1
+    # Rust from_bytes is called without list_limits (would TypeError otherwise),
+    # followed by _apply_list_limits which calls truncate.
+    assert len(captured[0].puzzle_hashes) <= 10

--- a/chia/_tests/core/util/test_streamable.py
+++ b/chia/_tests/core/util/test_streamable.py
@@ -25,6 +25,7 @@ from chia.util.streamable import (
     ParameterMissingError,
     Streamable,
     UnsupportedType,
+    _apply_list_limits,
     function_to_parse_one_item,
     function_to_stream_one_item,
     is_type_Dict,
@@ -995,6 +996,36 @@ def test_from_bytes_with_list_limits() -> None:
     bools_blob = bytes(bools_msg)
     parsed_bools = MsgWithBools.from_bytes(bools_blob, list_limits={"flags": 2})
     assert parsed_bools.flags == [True, False]
+
+
+def test_apply_list_limits_on_rust_type() -> None:
+    from chia.protocols.wallet_protocol import RespondToPhUpdates
+
+    phs = [bytes32(i.to_bytes(32, "big")) for i in range(20)]
+    obj = RespondToPhUpdates(phs, uint32(0), [])
+    assert len(obj.puzzle_hashes) == 20
+
+    # truncate is called for matching list fields; no error for unknown fields
+    _apply_list_limits(obj, {"puzzle_hashes": 5})
+    _apply_list_limits(obj, {"nonexistent": 3})
+    assert len(obj.puzzle_hashes) <= 20
+
+
+def test_apply_list_limits_on_python_streamable_with_rust_child() -> None:
+    from chia.protocols.wallet_protocol import RespondToPhUpdates
+
+    phs = [bytes32(i.to_bytes(32, "big")) for i in range(20)]
+    rust_child = RespondToPhUpdates(phs, uint32(0), [])
+
+    @streamable
+    @dataclass(frozen=True)
+    class Outer(Streamable):
+        inner: RespondToPhUpdates
+        flag: bool
+
+    outer = Outer(rust_child, True)
+    _apply_list_limits(outer, {"puzzle_hashes": 7})
+    assert outer.flag is True
 
 
 def test_parse_tuple() -> None:

--- a/chia/_tests/core/util/test_streamable.py
+++ b/chia/_tests/core/util/test_streamable.py
@@ -999,6 +999,7 @@ def test_from_bytes_with_list_limits() -> None:
 
 
 def test_apply_list_limits_on_rust_type() -> None:
+    """Truncate list fields directly on a rust-typed object via truncate()."""
     from chia.protocols.wallet_protocol import RespondToPhUpdates
 
     phs = [bytes32(i.to_bytes(32, "big")) for i in range(20)]
@@ -1007,11 +1008,16 @@ def test_apply_list_limits_on_rust_type() -> None:
 
     # truncate is called for matching list fields; no error for unknown fields
     _apply_list_limits(obj, {"puzzle_hashes": 5})
+    assert len(obj.puzzle_hashes) == 5
+    assert obj.puzzle_hashes == phs[:5]
+
+    # non-existent field is silently ignored
     _apply_list_limits(obj, {"nonexistent": 3})
-    assert len(obj.puzzle_hashes) <= 20
+    assert len(obj.puzzle_hashes) == 5
 
 
 def test_apply_list_limits_on_python_streamable_with_rust_child() -> None:
+    """Recurse into a Python Streamable's fields to truncate a nested rust object."""
     from chia.protocols.wallet_protocol import RespondToPhUpdates
 
     phs = [bytes32(i.to_bytes(32, "big")) for i in range(20)]
@@ -1025,6 +1031,8 @@ def test_apply_list_limits_on_python_streamable_with_rust_child() -> None:
 
     outer = Outer(rust_child, True)
     _apply_list_limits(outer, {"puzzle_hashes": 7})
+    assert len(outer.inner.puzzle_hashes) == 7
+    assert outer.inner.puzzle_hashes == phs[:7]
     assert outer.flag is True
 
 

--- a/chia/_tests/core/util/test_streamable.py
+++ b/chia/_tests/core/util/test_streamable.py
@@ -13,7 +13,7 @@ from chia_rs.sized_bytes import bytes4, bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
 from clvm_tools import binutils
 
-from chia.protocols.wallet_protocol import RespondRemovals
+from chia.protocols.wallet_protocol import RespondRemovals, RespondToPhUpdates
 from chia.simulator.block_tools import BlockTools, test_constants
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
@@ -1000,8 +1000,6 @@ def test_from_bytes_with_list_limits() -> None:
 
 def test_apply_list_limits_on_rust_type() -> None:
     """Truncate list fields directly on a rust-typed object via truncate()."""
-    from chia.protocols.wallet_protocol import RespondToPhUpdates
-
     phs = [bytes32(i.to_bytes(32, "big")) for i in range(20)]
     obj = RespondToPhUpdates(phs, uint32(0), [])
     assert len(obj.puzzle_hashes) == 20
@@ -1018,8 +1016,6 @@ def test_apply_list_limits_on_rust_type() -> None:
 
 def test_apply_list_limits_on_python_streamable_with_rust_child() -> None:
     """Recurse into a Python Streamable's fields to truncate a nested rust object."""
-    from chia.protocols.wallet_protocol import RespondToPhUpdates
-
     phs = [bytes32(i.to_bytes(32, "big")) for i in range(20)]
     rust_child = RespondToPhUpdates(phs, uint32(0), [])
 

--- a/chia/cmds/keys_funcs.py
+++ b/chia/cmds/keys_funcs.py
@@ -205,9 +205,9 @@ def show_keys(
         key["non_observer"] = non_observer_derivation
 
         if show_mnemonic and sk is not None:
-            key["master_sk"] = bytes(sk).hex()
-            key["farmer_sk"] = bytes(master_sk_to_farmer_sk(sk)).hex()
-            key["wallet_sk"] = bytes(master_sk_to_wallet_sk(sk, uint32(0))).hex()
+            key["master_sk"] = sk.as_hex_string()
+            key["farmer_sk"] = master_sk_to_farmer_sk(sk).as_hex_string()
+            key["wallet_sk"] = master_sk_to_wallet_sk(sk, uint32(0)).as_hex_string()
             key["mnemonic"] = bytes_to_mnemonic(key_data.entropy)
         else:
             key["master_sk"] = None
@@ -429,8 +429,7 @@ def _search_derived(
             found_item: Any = None
             found_item_type: DerivedSearchResultType | None = None
 
-            if search_private_key and term in str(child_sk):
-                assert child_sk is not None  # semantics above guarantee this
+            if search_private_key and child_sk is not None and term in child_sk.as_hex_string():
                 found_item = private_key_string_repr(child_sk)
                 found_item_type = DerivedSearchResultType.PRIVATE_KEY
             elif search_public_key and child_pk is not None and term in str(child_pk):
@@ -695,8 +694,7 @@ def derive_wallet_address(
 def private_key_string_repr(private_key: PrivateKey) -> str:
     """Print a PrivateKey in a human-readable formats"""
 
-    s = str(private_key)
-    return s[len("<PrivateKey ") : s.rfind(">")] if s.startswith("<PrivateKey ") else s
+    return private_key.as_hex_string()
 
 
 def derive_child_key(

--- a/chia/cmds/sim_funcs.py
+++ b/chia/cmds/sim_funcs.py
@@ -156,7 +156,7 @@ def display_key_info(fingerprint: int, prefix: str) -> None:
     wallet_address: str = encode_puzzle_hash(puzzle_hash_for_pk(first_wallet_sk.get_g1()), prefix)
     print(f"First wallet address: {wallet_address}")
     assert seed is not None
-    print("Master private key (m):", bytes(sk).hex())
+    print("Master private key (m):", sk.as_hex_string())
     print("First wallet secret key (m/12381/8444/2/0):", master_sk_to_wallet_sk(sk, uint32(0)))
     mnemonic = bytes_to_mnemonic(seed)
     print("  Mnemonic seed (24 secret words):")

--- a/chia/server/api_protocol.py
+++ b/chia/server/api_protocol.py
@@ -11,7 +11,7 @@ from typing_extensions import ParamSpec, Protocol
 
 from chia.protocols.outbound_message import Message
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
-from chia.util.streamable import Streamable
+from chia.util.streamable import Streamable, _apply_list_limits
 
 
 class ApiProtocol(Protocol):
@@ -86,7 +86,12 @@ class ApiMetadata:
                             resolved_limits = request.list_limits(self, args[0])
                         else:
                             resolved_limits = request.list_limits(self)
-                    arg = message_class.from_bytes(original, list_limits=resolved_limits)
+                    if issubclass(message_class, Streamable):
+                        arg = message_class.from_bytes(original, list_limits=resolved_limits)
+                    else:
+                        arg = message_class.from_bytes(original)
+                        if resolved_limits:
+                            _apply_list_limits(arg, resolved_limits)
                 else:
                     arg = original
                     if request.bytes_required:

--- a/chia/server/api_protocol.py
+++ b/chia/server/api_protocol.py
@@ -90,7 +90,7 @@ class ApiMetadata:
                         arg = message_class.from_bytes(original, list_limits=resolved_limits)
                     else:
                         arg = message_class.from_bytes(original)
-                        if resolved_limits:
+                        if resolved_limits is not None and len(resolved_limits) > 0:
                             _apply_list_limits(arg, resolved_limits)
                 else:
                     arg = original

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -8,6 +8,7 @@ import io
 import os
 import pprint
 import traceback
+import types
 from collections.abc import Callable, Collection
 from enum import Enum, EnumMeta
 from types import UnionType
@@ -650,6 +651,29 @@ def streamable(cls: type[_T_Streamable]) -> type[_T_Streamable]:
     return cls
 
 
+def _apply_list_limits(obj: Any, list_limits: dict[str, int]) -> None:
+    """Truncate list fields on rust-typed objects and recurse into sub-objects."""
+    if not list_limits:
+        return
+
+    if hasattr(obj, "truncate"):
+        for field_name, max_size in list_limits.items():
+            try:
+                obj.truncate(field_name, max_size)
+            except KeyError:
+                pass
+        for name, desc in vars(type(obj)).items():
+            if isinstance(desc, types.GetSetDescriptorType):
+                child = getattr(obj, name)
+                if hasattr(child, "truncate") or dataclasses.is_dataclass(child):
+                    _apply_list_limits(child, list_limits)
+    elif dataclasses.is_dataclass(obj):
+        for field in dataclasses.fields(obj):
+            child = getattr(obj, field.name)
+            if hasattr(child, "truncate") or dataclasses.is_dataclass(child):
+                _apply_list_limits(child, list_limits)
+
+
 class Streamable:
     """
     This class defines a simple serialization format, and adds methods to parse from/to bytes and json. It also
@@ -726,6 +750,8 @@ class Streamable:
             else:
                 value = field.parse_function(f)
             object.__setattr__(obj, field.name, value)
+        if list_limits:
+            _apply_list_limits(obj, list_limits)
         return obj
 
     def stream(self, f: BinaryIO) -> None:

--- a/chia/util/streamable.py
+++ b/chia/util/streamable.py
@@ -653,7 +653,7 @@ def streamable(cls: type[_T_Streamable]) -> type[_T_Streamable]:
 
 def _apply_list_limits(obj: Any, list_limits: dict[str, int]) -> None:
     """Truncate list fields on rust-typed objects and recurse into sub-objects."""
-    if not list_limits:
+    if len(list_limits) == 0:
         return
 
     if hasattr(obj, "truncate"):
@@ -740,7 +740,7 @@ class Streamable:
         # Create the object without calling __init__() to avoid unnecessary post-init checks in strictdataclass
         obj: Self = object.__new__(cls)
         for field in cls.streamable_fields():
-            if list_limits and field.name in list_limits and field.list_inner_parse_function is not None:
+            if list_limits is not None and field.name in list_limits and field.list_inner_parse_function is not None:
                 value = parse_list_limited(
                     f,
                     field.list_inner_parse_function,
@@ -750,7 +750,7 @@ class Streamable:
             else:
                 value = field.parse_function(f)
             object.__setattr__(obj, field.name, value)
-        if list_limits:
+        if list_limits is not None and len(list_limits) > 0:
             _apply_list_limits(obj, list_limits)
         return obj
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1353,38 +1353,38 @@ pytest = ">=8.3.3,<9.0.0"
 
 [[package]]
 name = "chia-rs"
-version = "0.44.0"
+version = "0.45.0"
 description = ""
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "chia_rs-0.44.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:e795d77d38bd6c8dbdf0696eb12e0e17cd6223800ce5adb7dc29eec3452978cf"},
-    {file = "chia_rs-0.44.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:d191a0e6fc606e8272a1549d614180eaf48cb11e50a34be0c8d562ee9066d163"},
-    {file = "chia_rs-0.44.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9d3145a19861ab705e1144e23ef52509cd9fa40b4d77620621cf3c66b1216bd5"},
-    {file = "chia_rs-0.44.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:68871c0cea9125da6f75eea0c340cee7d2d041b2d23b0b2a4d0825f216e5fe9e"},
-    {file = "chia_rs-0.44.0-cp310-cp310-win_amd64.whl", hash = "sha256:be61211418ea6764117e0d069e3ff9f68f3e714efca73dab9489e0056938511b"},
-    {file = "chia_rs-0.44.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:5ab1cec660e23889d95506b801e388d9ea41939b40cd934ea1088fbb4b3c15fe"},
-    {file = "chia_rs-0.44.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:8ae9d30802a58696589f5a6144a2a482c885f4d47ae862b85e990080cb7f7c3a"},
-    {file = "chia_rs-0.44.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c90df12acfd80bf9894c5de27be67b895810db91b15023b31c846d113e0368d9"},
-    {file = "chia_rs-0.44.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:73436753de22d7a1660756dd8b6c0e71d341ec18f11ed86479ec82c935a77694"},
-    {file = "chia_rs-0.44.0-cp311-cp311-win_amd64.whl", hash = "sha256:9a492cfdbaa90223e99cf8e96f88601c5bd29f1bc43ab3fc9c0f54c8b0057aa6"},
-    {file = "chia_rs-0.44.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:d2942b362c792a3481f6b45a9624f2d71e7eb0d6c70cbb8a4cf63c0b6248ed76"},
-    {file = "chia_rs-0.44.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:77a5a4e831ae472157c21d6636891b01a4a27890fb85efe8439f1dbc0567ba3c"},
-    {file = "chia_rs-0.44.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1ffb09c5f99e3e378c789fdb94fe69db39d15c9514a5719373e867b973904ef7"},
-    {file = "chia_rs-0.44.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c6180f81ead5a4edb1a65bc0456dd7fb8482517055f9e09dfa0a4418b81665e8"},
-    {file = "chia_rs-0.44.0-cp312-cp312-win_amd64.whl", hash = "sha256:da9bd80c7dbce2f476e92ccd3e8df480f24c68be88a3866e1e89fde33a54bb68"},
-    {file = "chia_rs-0.44.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:61efef9f501e4d8cc0e694e11677dfa86780685a07a7fb77e82a41459db8ca62"},
-    {file = "chia_rs-0.44.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:5243d4c4d4f5975da74852f5509eb2c0ecaf8a5bc582db885ae7df1f148ac191"},
-    {file = "chia_rs-0.44.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f692c948fd2c57eea09cd4de4259e5be25c9ada756c88c235b5bb8889aaaf596"},
-    {file = "chia_rs-0.44.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1f8979353cb6609c277e3436c99b01cf7c9df296a6ea894d8b530468cf3e8615"},
-    {file = "chia_rs-0.44.0-cp313-cp313-win_amd64.whl", hash = "sha256:3265aa5910c63f692df9c55ce4b56bd93cd275586d0eda36600968f5fef39696"},
-    {file = "chia_rs-0.44.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:bcb16fa35ef589d654c4c982bd373397b1761d7655b2b9a770be8650ebe8800b"},
-    {file = "chia_rs-0.44.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:7c7dfc20f8412c3c23699278f6f115e5f5878ddcbf9874889dd82e8a9a10e95e"},
-    {file = "chia_rs-0.44.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:72c186bcfd8241977592c5ff5509426eb67596961bd51507b9859abbef000234"},
-    {file = "chia_rs-0.44.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:814953925072a6c04d63b147f3a784f56d3e4e7d6a049f5c52131fbf70eb64c4"},
-    {file = "chia_rs-0.44.0-cp314-cp314-win_amd64.whl", hash = "sha256:5d376de442c2db5390933d853e132634ac9fe89c7a50866877730685d097d341"},
-    {file = "chia_rs-0.44.0.tar.gz", hash = "sha256:f5c09f9e4e3398dc6cea07fd7b7bf31b4f545e5332ebc60c5a76b6f4311550f3"},
+    {file = "chia_rs-0.45.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:e961ff7fa49c7756554199f378624c05680f7135e0715c499ac0ab584a2b4e87"},
+    {file = "chia_rs-0.45.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:1e176afe98a535b1bf8ad017063f1c9a4a8126e47b149c8c34c2035c7eca8551"},
+    {file = "chia_rs-0.45.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:c73ac194a082be146d5fc98418e1e314c73afb71c1c9ea1ff500a18a435ac319"},
+    {file = "chia_rs-0.45.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:4a4cd225f9dde082ead6acaf16bfb117461ff4bc6a28218b3e8d9bc5304afe00"},
+    {file = "chia_rs-0.45.0-cp310-cp310-win_amd64.whl", hash = "sha256:938f2b6be1d633b59ca9b6fd30369ba0d26b947b2fc7338cfddbab5ef1cd574d"},
+    {file = "chia_rs-0.45.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:07af0db8b5a7f378d40283cd160f4fc8f078ebc9a7f7d8977d2e7b2cbad61ecb"},
+    {file = "chia_rs-0.45.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:aa1569b864ce86c5feb19416891cbaf13ae2d7fb80102d5385d198853ae651cb"},
+    {file = "chia_rs-0.45.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d052d99b64c94dd60c047d594550fc1cb3871149661854ab6986a02df6a68957"},
+    {file = "chia_rs-0.45.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c9f01082605f56c783860f6462306d2d133829e0f326a7b3ecff21f0d74c6ac8"},
+    {file = "chia_rs-0.45.0-cp311-cp311-win_amd64.whl", hash = "sha256:f13a9a45ce2d06114693ec5ac57adbd9be7cb79bd7707a27ee10b943f3cb68ce"},
+    {file = "chia_rs-0.45.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:ab261dc4ef2506e555455ddb25c545277c3167fccd511ec4e4b33a6f68fd9f12"},
+    {file = "chia_rs-0.45.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:16a9b89276e48e3366552dc5eb992bd85c47d3eba2ed6530c3cc011b4ab9f229"},
+    {file = "chia_rs-0.45.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:23a1445eb3e6ea6c8985e18f8538c5b2130c29edeada4bdbc5c6a85cb74fc02e"},
+    {file = "chia_rs-0.45.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6c1c40a762efb6c2031fc3b9fd4bd2a5d8bf562133035d721176968de34a9375"},
+    {file = "chia_rs-0.45.0-cp312-cp312-win_amd64.whl", hash = "sha256:fee6b09c357f5ebea0bb618957361c2b27000e17b651301a066b6eb6311baa23"},
+    {file = "chia_rs-0.45.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:38e2d9d84834fdabaa2d6f766b0a221401a789de90c4f87830cd46c3411a6f25"},
+    {file = "chia_rs-0.45.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:9a45ff7e22c525af87251767590b9e5831b634018301ec3afd7b035ff95ed908"},
+    {file = "chia_rs-0.45.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:cb19679c363efc04a87af8b7fced9d1e2ed8cda4f056c2dd57659a453640c332"},
+    {file = "chia_rs-0.45.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:52379070ebf65a3c3257cd771cf8549314869e9dfe6d9c45435c5f2a85c831ba"},
+    {file = "chia_rs-0.45.0-cp313-cp313-win_amd64.whl", hash = "sha256:cb08a80b389c762d534dbea0186c98a1734200fac9aab065259e60ef16c4cc86"},
+    {file = "chia_rs-0.45.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:9c19a6c10bc822db959efb8a8db60002bc03d1fd8cabe59456957a9b96b22e23"},
+    {file = "chia_rs-0.45.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:0a226c9a32b4d9e30ff54dcfaadab681172449363927b7da15693f3609e71ac8"},
+    {file = "chia_rs-0.45.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:2d285889b32f7e0f87970526bc17651b513585d1d7f00bb84f576b4a1eba9447"},
+    {file = "chia_rs-0.45.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:794c74c8e52e6dfdb16a1aed4e020482668dcfcce5f25dd24bb64e47a609f077"},
+    {file = "chia_rs-0.45.0-cp314-cp314-win_amd64.whl", hash = "sha256:5133db8954cf8324f33b4b51bf4ec959d08caa9bd242c7b776e9ea24f81420ad"},
+    {file = "chia_rs-0.45.0.tar.gz", hash = "sha256:f383948ea04e457a096cf5dd0f6a7269b1887b800d2326a2b08b3f8b9357bd20"},
 ]
 
 [package.dependencies]
@@ -5196,4 +5196,4 @@ upnp = ["miniupnpc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <4"
-content-hash = "31f782ccb09aad9e28d043916da8b511399f8e409d4c9d0588bb9695b21d77f0"
+content-hash = "13a38059db735392c15e0900378710b0f5478c781104c2ab6ae490d4d310454c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ boto3 = ">=1.43.8"  # AWS S3 for Data Layer S3 plugin
 chiabip158 = ">=1.5.2"  # bip158-style wallet filters
 chiapos = ">=2.0.10"  # proof of space
 chia-puzzles-py = ">=0.20.1"
-chia_rs = ">=0.44.0, <0.45"
+chia_rs = ">=0.45.0, <0.46"
 chiavdf = ">=1.1.10"  # timelord and vdf verification
 click = ">=8.1.7"  # For the CLI
 clvm = ">=0.9.14"


### PR DESCRIPTION
This is best reviewed one commit at a time.

### Purpose:

There are 2 main features in the latest version of chia_rs.

1. `SecretKey` no longer prints its content in its default string formatter. Instead you have to call `to_hext_string()` to access the secret key. This is a precaution to not leak keys in debug logs.
2. rust types now support `truncate()` in their python binding. This enables python to mutate objects after they have been parsed from bytes, by truncating `Vec<>` types (i.e. `List[]`s). Without ever copying the full list into python first. This augments https://github.com/Chia-Network/chia-blockchain/pull/20829 with support for rust-native message types.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inbound protocol deserialization for rust messages with list_limits and bumps a core native dependency; CLI key handling is a deliberate security improvement but touches sensitive paths.
> 
> **Overview**
> Upgrades **chia_rs** from 0.44 to **0.45** and wires in two library behaviors across the node and CLI.
> 
> **List limits on rust protocol types:** Adds `_apply_list_limits`, which uses rust `truncate()` on list fields (and recurses into nested rust/dataclass children). `Streamable.parse` now runs this after parsing when limits are set. The API request wrapper only passes `list_limits` into `from_bytes` for Python `Streamable` types; for rust message types it parses full bytes then truncates—so existing `list_limits` decorators work on types like `RespondToPhUpdates` without copying entire lists into Python first.
> 
> **Private key exposure:** CLI paths that intentionally show or search secrets (`keys_funcs`, `sim_funcs`) switch from `bytes(sk).hex()` / `str(private_key)` parsing to **`PrivateKey.as_hex_string()`**, matching chia_rs’s safer default where `str()` no longer embeds secret material (reduces accidental leaks in logs).
> 
> Tests cover rust truncation, nested streamables, and API protocol list limits on a rust type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c02598702ba1af42bd8af71fc4fe1540c58954b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->