### PR TITLE
CHIA-3566: plot_sync v2 metadata via capability negotiation

### DIFF
--- a/chia/_tests/plot_sync/test_delta.py
+++ b/chia/_tests/plot_sync/test_delta.py
@@ -8,6 +8,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint64
 
 from chia.plot_sync.delta import Delta, DeltaType, PathListDelta, PlotListDelta
+from chia.plot_sync.plot_record import PlotRecord
 from chia.protocols.harvester_protocol import Plot
 
 log = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ def test_list_delta(delta: DeltaType) -> None:
     if type(delta) is PathListDelta:
         delta.additions.append("0")
     elif type(delta) is PlotListDelta:
-        delta.additions["0"] = dummy_plot("0")
+        delta.additions["0"] = PlotRecord.from_plot(dummy_plot("0"))
     else:
         assert False, "Invalid delta type"
     assert not delta.empty()
@@ -87,7 +88,7 @@ def test_delta_empty() -> None:
     all_deltas: list[DeltaType] = [delta.valid, delta.invalid, delta.keys_missing, delta.duplicates]
     assert delta.empty()
     for d1 in all_deltas:
-        delta.valid.additions["0"] = dummy_plot("0")
+        delta.valid.additions["0"] = PlotRecord.from_plot(dummy_plot("0"))
         delta.invalid.additions.append("0")
         delta.keys_missing.additions.append("0")
         delta.duplicates.additions.append("0")

--- a/chia/_tests/plot_sync/test_plot_record.py
+++ b/chia/_tests/plot_sync/test_plot_record.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+import pytest
+from chia_rs import G1Element, PlotParam
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint8, uint16, uint64
+
+from chia.plot_sync.plot_record import PlotRecord
+from chia.plotting.prover import ProverProtocol
+from chia.plotting.util import PlotInfo
+from chia.protocols.harvester_protocol import Plot, PlotV2
+
+
+@dataclass
+class MockProver:
+    filename: str
+    plot_param: PlotParam
+    plot_id: bytes32
+    compression_level: uint8 | None = uint8(0)
+
+    def get_filename(self) -> str:
+        return self.filename
+
+    def get_param(self) -> PlotParam:
+        return self.plot_param
+
+    def get_id(self) -> bytes32:
+        return self.plot_id
+
+    def get_compression_level(self) -> uint8 | None:
+        return self.compression_level
+
+
+def make_plot_info(plot_param: PlotParam, filename: str = "plot.dat") -> PlotInfo:
+    return PlotInfo(
+        prover=cast(ProverProtocol, MockProver(filename, plot_param, bytes32.zeros, uint8(0))),
+        pool_public_key=None,
+        pool_contract_puzzle_hash=None,
+        plot_public_key=G1Element(),
+        file_size=123,
+        time_modified=456.0,
+    )
+
+
+def test_from_plot_info_v1() -> None:
+    plot_param = PlotParam.make_v1(uint8(32))
+    record = PlotRecord.from_plot_info(make_plot_info(plot_param))
+    assert record.plot_param == plot_param
+    assert record.filename == "plot.dat"
+    assert record.file_size == uint64(123)
+    assert record.time_modified == uint64(456)
+
+
+def test_from_plot_info_v2() -> None:
+    plot_param = PlotParam.make_v2(uint16(3), uint8(2), uint8(5))
+    record = PlotRecord.from_plot_info(make_plot_info(plot_param))
+    assert record.plot_param == plot_param
+    assert record.plot_param.plot_index == 3
+    assert record.plot_param.meta_group == 2
+    assert record.plot_param.strength_v2 == 5
+
+
+def test_from_plot_roundtrip_v1() -> None:
+    plot = Plot(
+        "plot_v1",
+        uint8(32),
+        bytes32.zeros,
+        None,
+        None,
+        G1Element(),
+        uint64(100),
+        uint64(200),
+        uint8(1),
+    )
+    record = PlotRecord.from_plot(plot)
+    roundtrip = record.to_plot()
+    assert roundtrip.filename == plot.filename
+    assert roundtrip.size == plot.size
+    assert roundtrip.plot_id == plot.plot_id
+    assert roundtrip.file_size == plot.file_size
+
+
+def test_from_plot_roundtrip_v2_msb() -> None:
+    plot = Plot(
+        "plot_v2",
+        uint8(0x80 | 5),
+        bytes32.zeros,
+        None,
+        None,
+        G1Element(),
+        uint64(100),
+        uint64(200),
+        uint8(0),
+    )
+    record = PlotRecord.from_plot(plot)
+    assert record.plot_param.strength_v2 == 5
+    roundtrip = record.to_plot()
+    assert roundtrip.size == uint8(0x80 | 5)
+
+
+@pytest.mark.parametrize(
+    ["plot_v2", "expected_strength", "expected_plot_index", "expected_meta_group"],
+    [
+        pytest.param(
+            PlotV2(
+                "v1_plot",
+                uint8(1),
+                uint8(32),
+                uint8(0),
+                uint16(0),
+                uint8(0),
+                bytes32.zeros,
+                None,
+                None,
+                G1Element(),
+                uint64(1),
+                uint64(2),
+                uint8(0),
+            ),
+            None,
+            0,
+            0,
+            id="v1",
+        ),
+        pytest.param(
+            PlotV2(
+                "v2_plot",
+                uint8(2),
+                uint8(0),
+                uint8(7),
+                uint16(4),
+                uint8(1),
+                bytes32.zeros,
+                None,
+                None,
+                G1Element(),
+                uint64(1),
+                uint64(2),
+                uint8(0),
+            ),
+            7,
+            4,
+            1,
+            id="v2",
+        ),
+    ],
+)
+def test_from_sync_plot(
+    plot_v2: PlotV2,
+    expected_strength: int | None,
+    expected_plot_index: int,
+    expected_meta_group: int,
+) -> None:
+    record = PlotRecord.from_sync_plot(plot_v2)
+    assert record.filename == plot_v2.filename
+    if expected_strength is None:
+        assert record.plot_param.size_v1 == plot_v2.size
+    else:
+        assert record.plot_param.strength_v2 == expected_strength
+        assert record.plot_param.plot_index == expected_plot_index
+        assert record.plot_param.meta_group == expected_meta_group

--- a/chia/_tests/plot_sync/test_plot_sync.py
+++ b/chia/_tests/plot_sync/test_plot_sync.py
@@ -24,6 +24,7 @@ from chia.farmer.farmer_service import FarmerService
 from chia.harvester.harvester import Harvester
 from chia.harvester.harvester_service import HarvesterService
 from chia.plot_sync.delta import Delta, PathListDelta, PlotListDelta
+from chia.plot_sync.plot_record import PlotRecord
 from chia.plot_sync.receiver import Receiver
 from chia.plot_sync.sender import Sender
 from chia.plot_sync.util import Constants, State
@@ -64,21 +65,25 @@ class ExpectedResult:
     callback_passed: bool = False
 
     def add_valid(self, list_plots: list[MockPlotInfo]) -> None:
-        def create_mock_plot(info: MockPlotInfo) -> Plot:
-            return Plot(
-                info.prover.get_filename(),
-                uint8(0),
-                bytes32.zeros,
-                None,
-                None,
-                G1Element(),
-                uint64(0),
-                uint64(0),
-                uint8(0),
-            )
-
         self.valid_count += len(list_plots)
-        self.valid_delta.additions.update({x.prover.get_filename(): create_mock_plot(x) for x in list_plots})
+        self.valid_delta.additions.update(
+            {
+                x.prover.get_filename(): PlotRecord.from_plot(
+                    Plot(
+                        x.prover.get_filename(),
+                        uint8(0),
+                        bytes32.zeros,
+                        None,
+                        None,
+                        G1Element(),
+                        uint64(0),
+                        uint64(0),
+                        uint8(0),
+                    )
+                )
+                for x in list_plots
+            }
+        )
 
     def remove_valid(self, list_paths: list[Path]) -> None:
         self.valid_count -= len(list_paths)
@@ -110,7 +115,12 @@ class ExpectedResult:
 
 
 def equal_param(a: PlotParam, b: PlotParam) -> bool:
-    return a.size_v1 == b.size_v1 and a.strength_v2 == b.strength_v2
+    return (
+        a.size_v1 == b.size_v1
+        and a.strength_v2 == b.strength_v2
+        and a.plot_index == b.plot_index
+        and a.meta_group == b.meta_group
+    )
 
 
 @dataclass

--- a/chia/_tests/plot_sync/test_plot_sync_v2_metadata.py
+++ b/chia/_tests/plot_sync/test_plot_sync_v2_metadata.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import cast
+
+import pytest
+from chia_rs import G1Element, PlotParam
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint8, uint16, uint32, uint64
+
+from chia._tests.plot_sync.util import get_dummy_connection
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.plot_sync.delta import Delta
+from chia.plot_sync.plot_record import PlotRecord
+from chia.plot_sync.receiver import Receiver
+from chia.plot_sync.sender import Sender, _convert_sync_plot_list, _uses_plot_v2_metadata
+from chia.plot_sync.util import State
+from chia.plotting.prover import ProverProtocol
+from chia.plotting.util import HarvestingMode, PlotInfo
+from chia.protocols.harvester_protocol import PlotSyncIdentifier, PlotSyncPlotListV2, PlotSyncStart, PlotV2
+from chia.protocols.outbound_message import NodeType
+from chia.protocols.protocol_message_types import ProtocolMessageTypes
+from chia.protocols.shared_protocol import Capability
+from chia.simulator.block_tools import BlockTools
+
+
+@dataclass
+class MockProver:
+    filename: str
+    plot_param: PlotParam
+    plot_id: bytes32
+    compression_level: uint8 | None = uint8(0)
+
+    def get_filename(self) -> str:
+        return self.filename
+
+    def get_param(self) -> PlotParam:
+        return self.plot_param
+
+    def get_id(self) -> bytes32:
+        return self.plot_id
+
+    def get_compression_level(self) -> uint8 | None:
+        return self.compression_level
+
+
+def make_plot_info(plot_param: PlotParam, filename: str) -> PlotInfo:
+    return PlotInfo(
+        prover=cast(ProverProtocol, MockProver(filename, plot_param, bytes32.zeros, uint8(0))),
+        pool_public_key=None,
+        pool_contract_puzzle_hash=None,
+        plot_public_key=G1Element(),
+        file_size=100,
+        time_modified=0.0,
+    )
+
+
+async def dummy_callback(_: bytes32, __: Delta | None) -> None:
+    pass
+
+
+def test_uses_plot_v2_metadata_without_capability(seeded_random: random.Random) -> None:
+    connection = get_dummy_connection(NodeType.FARMER, bytes32.random(seeded_random))
+    assert not _uses_plot_v2_metadata(connection)  # type: ignore[arg-type]
+    assert not _uses_plot_v2_metadata(None)
+
+
+def test_uses_plot_v2_metadata_with_capability(seeded_random: random.Random) -> None:
+    connection = get_dummy_connection(NodeType.FARMER, bytes32.random(seeded_random), [Capability.PLOT_V2_METADATA])
+    assert _uses_plot_v2_metadata(connection)  # type: ignore[arg-type]
+
+
+def test_convert_sync_plot_list_v1_and_v2() -> None:
+    v1 = make_plot_info(PlotParam.make_v1(uint8(32)), "v1.plot")
+    v2 = make_plot_info(PlotParam.make_v2(uint16(2), uint8(1), uint8(6)), "v2.plot")
+    converted = _convert_sync_plot_list([v1, v2])
+    assert len(converted) == 2
+    assert converted[0].version == uint8(1)
+    assert converted[0].size == uint8(32)
+    assert converted[1].version == uint8(2)
+    assert converted[1].strength == uint8(6)
+    assert converted[1].plot_index == uint16(2)
+    assert converted[1].meta_group == uint8(1)
+
+
+def test_process_batch_message_type(bt: BlockTools, seeded_random: random.Random) -> None:
+    sender = Sender(bt.plot_manager, HarvestingMode.CPU)
+    sender._sync_id = uint64(1)
+    sender._next_message_id = uint64(0)
+
+    plot_infos = [make_plot_info(PlotParam.make_v1(uint8(32)), "plot.dat")]
+
+    legacy_connection = get_dummy_connection(NodeType.FARMER, bytes32.random(seeded_random))
+    sender.set_connection(legacy_connection)  # type: ignore[arg-type]
+    sender.process_batch(plot_infos, 0)
+    assert len(sender._messages) == 1
+    assert sender._messages[0].message_type == ProtocolMessageTypes.plot_sync_loaded
+
+    sender._messages.clear()
+    v2_connection = get_dummy_connection(NodeType.FARMER, bytes32.random(seeded_random), [Capability.PLOT_V2_METADATA])
+    sender.set_connection(v2_connection)  # type: ignore[arg-type]
+    sender.process_batch(plot_infos, 0)
+    assert len(sender._messages) == 1
+    v2_message = sender._messages[0]
+    assert v2_message.message_type == ProtocolMessageTypes.plot_sync_loaded_v2
+
+
+@pytest.mark.anyio
+async def test_receiver_process_loaded_v2(seeded_random: random.Random) -> None:
+    receiver = Receiver(
+        get_dummy_connection(NodeType.HARVESTER, bytes32.random(seeded_random)),  # type: ignore[arg-type]
+        dummy_callback,  # type: ignore[arg-type]
+        DEFAULT_CONSTANTS,
+    )
+    await receiver.sync_started(
+        PlotSyncStart(
+            PlotSyncIdentifier(uint64(0), uint64(1), uint64(0)),
+            False,
+            uint64(0),
+            uint32(1),
+            uint8(HarvestingMode.CPU),
+        )
+    )
+
+    plot_v2 = PlotV2(
+        "new_plot",
+        uint8(2),
+        uint8(0),
+        uint8(5),
+        uint16(3),
+        uint8(2),
+        bytes32.zeros,
+        None,
+        None,
+        G1Element(),
+        uint64(100),
+        uint64(200),
+        uint8(0),
+    )
+    await receiver.process_loaded_v2(
+        PlotSyncPlotListV2(
+            PlotSyncIdentifier(uint64(0), uint64(1), uint64(1)),
+            [plot_v2],
+            True,
+        )
+    )
+
+    record = receiver._current_sync.delta.valid.additions["new_plot"]
+    assert isinstance(record, PlotRecord)
+    assert record.plot_param.strength_v2 == 5
+    assert record.plot_param.plot_index == 3
+    assert record.plot_param.meta_group == 2
+    assert receiver.current_sync().state == State.removed

--- a/chia/_tests/plot_sync/test_receiver.py
+++ b/chia/_tests/plot_sync/test_receiver.py
@@ -16,6 +16,7 @@ from chia._tests.plot_sync.util import get_dummy_connection
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR, _expected_plot_size
 from chia.plot_sync.delta import Delta
+from chia.plot_sync.plot_record import PlotRecord
 from chia.plot_sync.receiver import Receiver, Sync, get_list_or_len
 from chia.plot_sync.util import ErrorCodes, State
 from chia.plotting.util import HarvestingMode
@@ -185,9 +186,8 @@ def plot_sync_setup(seeded_random: random.Random) -> tuple[Receiver, list[SyncSt
     ]
 
     # Manually add the plots we want to remove in tests
-    receiver._plots = {plot_info.filename: plot_info for plot_info in plot_info_list[0:10]}
+    receiver._plots = {plot_info.filename: PlotRecord.from_plot(plot_info) for plot_info in plot_info_list[0:10]}
     receiver._total_plot_size = sum(plot.file_size for plot in receiver.plots().values())
-    # TODO: todo_v2_plots support v2 plots
     receiver._total_effective_plot_size = int(
         sum(
             UI_ACTUAL_SPACE_CONSTANT_FACTOR * int(_expected_plot_size(plot.param(), DEFAULT_CONSTANTS))
@@ -238,7 +238,7 @@ async def test_reset(seeded_random: random.Random) -> None:
     receiver._current_sync.next_message_id = uint64(1)
     receiver._current_sync.plots_processed = uint32(1)
     receiver._current_sync.plots_total = uint32(1)
-    receiver._current_sync.delta.valid.additions = receiver.plots().copy()
+    receiver._current_sync.delta.valid.additions = receiver.plot_records().copy()
     receiver._current_sync.delta.valid.removals = ["1"]
     receiver._current_sync.delta.invalid.additions = ["1"]
     receiver._current_sync.delta.invalid.removals = ["1"]

--- a/chia/_tests/plot_sync/util.py
+++ b/chia/_tests/plot_sync/util.py
@@ -16,6 +16,7 @@ from chia.harvester.harvester_service import HarvesterService
 from chia.plot_sync.sender import Sender
 from chia.protocols.harvester_protocol import PlotSyncIdentifier
 from chia.protocols.outbound_message import Message, NodeType
+from chia.protocols.shared_protocol import Capability
 from chia.types.peer_info import PeerInfo, UnresolvedPeerInfo
 
 
@@ -25,6 +26,7 @@ class WSChiaConnectionDummy:
     peer_node_id: bytes32
     peer_info: PeerInfo = PeerInfo("127.0.0.1", uint16(0))
     last_sent_message: Message | None = None
+    peer_capabilities: list[Capability] | None = None
 
     async def send_message(self, message: Message) -> None:
         self.last_sent_message = message
@@ -32,9 +34,16 @@ class WSChiaConnectionDummy:
     def get_peer_logging(self) -> PeerInfo:
         return self.peer_info
 
+    def has_capability(self, capability: Capability) -> bool:
+        if self.peer_capabilities is None:
+            return False
+        return capability in self.peer_capabilities
 
-def get_dummy_connection(node_type: NodeType, peer_id: bytes32) -> WSChiaConnectionDummy:
-    return WSChiaConnectionDummy(node_type, peer_id)
+
+def get_dummy_connection(
+    node_type: NodeType, peer_id: bytes32, peer_capabilities: list[Capability] | None = None
+) -> WSChiaConnectionDummy:
+    return WSChiaConnectionDummy(node_type, peer_id, peer_capabilities=peer_capabilities)
 
 
 def plot_sync_identifier(current_sync_id: uint64, message_id: uint64) -> PlotSyncIdentifier:

--- a/chia/_tests/util/test_network_protocol_test.py
+++ b/chia/_tests/util/test_network_protocol_test.py
@@ -183,6 +183,8 @@ def test_missing_messages() -> None:
         "PlotSyncIdentifier",
         "PlotSyncPathList",
         "PlotSyncPlotList",
+        "PlotSyncPlotListV2",
+        "PlotV2",
         "PlotSyncResponse",
         "PlotSyncStart",
         "PoolDifficulty",

--- a/chia/apis/farmer_stub.py
+++ b/chia/apis/farmer_stub.py
@@ -10,6 +10,7 @@ from chia.protocols.harvester_protocol import (
     PlotSyncDone,
     PlotSyncPathList,
     PlotSyncPlotList,
+    PlotSyncPlotListV2,
     PlotSyncStart,
     RespondPlots,
     RespondSignatures,
@@ -74,6 +75,11 @@ class FarmerApiStub(ApiProtocol, Protocol):
     @metadata.request(peer_required=True)
     async def plot_sync_loaded(self, message: PlotSyncPlotList, peer: WSChiaConnection) -> None:
         """Handle plot sync loaded."""
+        ...
+
+    @metadata.request(peer_required=True)
+    async def plot_sync_loaded_v2(self, message: PlotSyncPlotListV2, peer: WSChiaConnection) -> None:
+        """Handle plot sync loaded with full v2 metadata."""
         ...
 
     @metadata.request(peer_required=True)

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -22,6 +22,7 @@ from chia.protocols.harvester_protocol import (
     PlotSyncDone,
     PlotSyncPathList,
     PlotSyncPlotList,
+    PlotSyncPlotListV2,
     PlotSyncStart,
     PoolDifficulty,
     SignatureRequestSourceData,
@@ -776,6 +777,10 @@ class FarmerAPI:
     @metadata.request(peer_required=True)
     async def plot_sync_loaded(self, message: PlotSyncPlotList, peer: WSChiaConnection) -> None:
         await self.farmer.plot_sync_receivers[peer.peer_node_id].process_loaded(message)
+
+    @metadata.request(peer_required=True)
+    async def plot_sync_loaded_v2(self, message: PlotSyncPlotListV2, peer: WSChiaConnection) -> None:
+        await self.farmer.plot_sync_receivers[peer.peer_node_id].process_loaded_v2(message)
 
     @metadata.request(peer_required=True)
     async def plot_sync_removed(self, message: PlotSyncPathList, peer: WSChiaConnection) -> None:

--- a/chia/plot_sync/delta.py
+++ b/chia/plot_sync/delta.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from chia.protocols.harvester_protocol import Plot
+from chia.plot_sync.plot_record import PlotRecord
 
 
 @dataclass
 class DeltaType:
-    additions: dict[str, Plot] | list[str]
+    additions: dict[str, PlotRecord] | list[str]
     removals: list[str]
 
     def __str__(self) -> str:
@@ -23,7 +23,7 @@ class DeltaType:
 
 @dataclass
 class PlotListDelta(DeltaType):
-    additions: dict[str, Plot] = field(default_factory=dict)
+    additions: dict[str, PlotRecord] = field(default_factory=dict)
     removals: list[str] = field(default_factory=list)
 
 

--- a/chia/plot_sync/plot_record.py
+++ b/chia/plot_sync/plot_record.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from chia_rs import G1Element, PlotParam
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint8, uint64
+
+from chia.plotting.util import PlotInfo
+from chia.protocols.harvester_protocol import Plot, PlotV2
+
+
+@dataclass(frozen=True)
+class PlotRecord:
+    filename: str
+    plot_param: PlotParam
+    plot_id: bytes32
+    pool_public_key: G1Element | None
+    pool_contract_puzzle_hash: bytes32 | None
+    plot_public_key: G1Element
+    file_size: uint64
+    time_modified: uint64
+    compression_level: uint8 | None
+
+    def param(self) -> PlotParam:
+        return self.plot_param
+
+    @classmethod
+    def from_plot_info(cls, plot_info: PlotInfo) -> PlotRecord:
+        prover = plot_info.prover
+        return cls(
+            filename=prover.get_filename(),
+            plot_param=prover.get_param(),
+            plot_id=prover.get_id(),
+            pool_public_key=plot_info.pool_public_key,
+            pool_contract_puzzle_hash=plot_info.pool_contract_puzzle_hash,
+            plot_public_key=plot_info.plot_public_key,
+            file_size=uint64(plot_info.file_size),
+            time_modified=uint64(plot_info.time_modified),
+            compression_level=prover.get_compression_level(),
+        )
+
+    @classmethod
+    def from_plot(cls, plot: Plot) -> PlotRecord:
+        return cls(
+            filename=plot.filename,
+            plot_param=plot.param(),
+            plot_id=plot.plot_id,
+            pool_public_key=plot.pool_public_key,
+            pool_contract_puzzle_hash=plot.pool_contract_puzzle_hash,
+            plot_public_key=plot.plot_public_key,
+            file_size=plot.file_size,
+            time_modified=plot.time_modified,
+            compression_level=plot.compression_level,
+        )
+
+    @classmethod
+    def from_sync_plot(cls, plot: PlotV2) -> PlotRecord:
+        if plot.version == 1:
+            plot_param = PlotParam.make_v1(plot.size)
+        else:
+            plot_param = PlotParam.make_v2(plot.plot_index, plot.meta_group, plot.strength)
+        return cls(
+            filename=plot.filename,
+            plot_param=plot_param,
+            plot_id=plot.plot_id,
+            pool_public_key=plot.pool_public_key,
+            pool_contract_puzzle_hash=plot.pool_contract_puzzle_hash,
+            plot_public_key=plot.plot_public_key,
+            file_size=plot.file_size,
+            time_modified=plot.time_modified,
+            compression_level=plot.compression_level,
+        )
+
+    def to_plot(self) -> Plot:
+        if self.plot_param.size_v1 is not None:
+            size = uint8(self.plot_param.size_v1)
+        else:
+            assert self.plot_param.strength_v2 is not None
+            size = uint8(0x80 | self.plot_param.strength_v2)
+        return Plot(
+            filename=self.filename,
+            size=size,
+            plot_id=self.plot_id,
+            pool_public_key=self.pool_public_key,
+            pool_contract_puzzle_hash=self.pool_contract_puzzle_hash,
+            plot_public_key=self.plot_public_key,
+            file_size=self.file_size,
+            time_modified=self.time_modified,
+            compression_level=self.compression_level,
+        )

--- a/chia/plot_sync/receiver.py
+++ b/chia/plot_sync/receiver.py
@@ -21,6 +21,7 @@ from chia.plot_sync.exceptions import (
     PlotSyncException,
     SyncIdsMatchError,
 )
+from chia.plot_sync.plot_record import PlotRecord
 from chia.plot_sync.util import ErrorCodes, State, T_PlotSyncMessage
 from chia.plotting.util import HarvestingMode
 from chia.protocols.harvester_protocol import (
@@ -30,6 +31,7 @@ from chia.protocols.harvester_protocol import (
     PlotSyncIdentifier,
     PlotSyncPathList,
     PlotSyncPlotList,
+    PlotSyncPlotListV2,
     PlotSyncResponse,
     PlotSyncStart,
 )
@@ -84,7 +86,7 @@ class Receiver:
     _connection: WSChiaConnection
     _current_sync: Sync
     _last_sync: Sync
-    _plots: dict[str, Plot]
+    _plots: dict[str, PlotRecord]
     _invalid: list[str]
     _keys_missing: list[str]
     _duplicates: list[str]
@@ -144,6 +146,9 @@ class Receiver:
         return self._last_sync.sync_id == 0
 
     def plots(self) -> dict[str, Plot]:
+        return {filename: record.to_plot() for filename, record in self._plots.items()}
+
+    def plot_records(self) -> dict[str, PlotRecord]:
         return self._plots
 
     def invalid(self) -> list[str]:
@@ -230,7 +235,7 @@ class Receiver:
         for plot_info in plot_infos.data:
             if plot_info.filename in self._plots or plot_info.filename in self._current_sync.delta.valid.additions:
                 raise PlotAlreadyAvailableError(State.loaded, plot_info.filename)
-            self._current_sync.delta.valid.additions[plot_info.filename] = plot_info
+            self._current_sync.delta.valid.additions[plot_info.filename] = PlotRecord.from_plot(plot_info)
             self._current_sync.bump_plots_processed()
 
         # Let the callback receiver know about the sync progress updates
@@ -241,8 +246,27 @@ class Receiver:
 
         self._current_sync.bump_next_message_id()
 
+    async def _process_loaded_v2(self, plot_infos: PlotSyncPlotListV2) -> None:
+        self._validate_identifier(plot_infos.identifier)
+
+        for plot_info in plot_infos.data:
+            if plot_info.filename in self._plots or plot_info.filename in self._current_sync.delta.valid.additions:
+                raise PlotAlreadyAvailableError(State.loaded, plot_info.filename)
+            self._current_sync.delta.valid.additions[plot_info.filename] = PlotRecord.from_sync_plot(plot_info)
+            self._current_sync.bump_plots_processed()
+
+        await self.trigger_callback()
+
+        if plot_infos.final:
+            self._current_sync.state = State.removed
+
+        self._current_sync.bump_next_message_id()
+
     async def process_loaded(self, plot_infos: PlotSyncPlotList) -> None:
         await self._process(self._process_loaded, ProtocolMessageTypes.plot_sync_loaded, plot_infos)
+
+    async def process_loaded_v2(self, plot_infos: PlotSyncPlotListV2) -> None:
+        await self._process(self._process_loaded_v2, ProtocolMessageTypes.plot_sync_loaded_v2, plot_infos)
 
     async def process_path_list(
         self,
@@ -355,8 +379,8 @@ class Receiver:
 
         self._total_effective_plot_size = int(
             sum(
-                UI_ACTUAL_SPACE_CONSTANT_FACTOR * _expected_plot_size(plot.param(), self._constants)
-                for plot in self._plots.values()
+                UI_ACTUAL_SPACE_CONSTANT_FACTOR * _expected_plot_size(record.param(), self._constants)
+                for record in self._plots.values()
             )
         )
         # Save current sync as last sync and create a new current sync
@@ -382,7 +406,7 @@ class Receiver:
                 "host": self._connection.peer_info.host,
                 "port": self._connection.peer_info.port,
             },
-            "plots": get_list_or_len(list(self._plots.values()), counts_only),
+            "plots": get_list_or_len([record.to_plot() for record in self._plots.values()], counts_only),
             "failed_to_open_filenames": get_list_or_len(self._invalid, counts_only),
             "no_key_filenames": get_list_or_len(self._keys_missing, counts_only),
             "duplicates": get_list_or_len(self._duplicates, counts_only),

--- a/chia/plot_sync/sender.py
+++ b/chia/plot_sync/sender.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Generic, TypeVar
 
-from chia_rs.sized_ints import int16, uint8, uint32, uint64
+from chia_rs.sized_ints import int16, uint8, uint16, uint32, uint64
 from typing_extensions import Protocol
 
 from chia.plot_sync.exceptions import AlreadyStartedError, InvalidConnectionTypeError
@@ -22,11 +22,14 @@ from chia.protocols.harvester_protocol import (
     PlotSyncIdentifier,
     PlotSyncPathList,
     PlotSyncPlotList,
+    PlotSyncPlotListV2,
     PlotSyncResponse,
     PlotSyncStart,
+    PlotV2,
 )
 from chia.protocols.outbound_message import NodeType, make_msg
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
+from chia.protocols.shared_protocol import Capability
 from chia.server.ws_connection import WSChiaConnection
 from chia.util.batches import to_batches
 from chia.util.task_referencer import create_referenced_task
@@ -58,6 +61,56 @@ def _convert_plot_info_list(plot_infos: list[PlotInfo]) -> list[Plot]:
                 compression_level=plot_info.prover.get_compression_level(),
             )
         )
+    return converted
+
+
+def _uses_plot_v2_metadata(connection: WSChiaConnection | None) -> bool:
+    if connection is None:
+        return False
+    return connection.has_capability(Capability.PLOT_V2_METADATA)
+
+
+def _convert_sync_plot_list(plot_infos: list[PlotInfo]) -> list[PlotV2]:
+    converted: list[PlotV2] = []
+    for plot_info in plot_infos:
+        param = plot_info.prover.get_param()
+        if param.size_v1 is not None:
+            converted.append(
+                PlotV2(
+                    filename=plot_info.prover.get_filename(),
+                    version=uint8(1),
+                    size=param.size_v1,
+                    strength=uint8(0),
+                    plot_index=uint16(0),
+                    meta_group=uint8(0),
+                    plot_id=plot_info.prover.get_id(),
+                    pool_public_key=plot_info.pool_public_key,
+                    pool_contract_puzzle_hash=plot_info.pool_contract_puzzle_hash,
+                    plot_public_key=plot_info.plot_public_key,
+                    file_size=uint64(plot_info.file_size),
+                    time_modified=uint64(plot_info.time_modified),
+                    compression_level=plot_info.prover.get_compression_level(),
+                )
+            )
+        else:
+            assert param.strength_v2 is not None
+            converted.append(
+                PlotV2(
+                    filename=plot_info.prover.get_filename(),
+                    version=uint8(2),
+                    size=uint8(0),
+                    strength=param.strength_v2,
+                    plot_index=param.plot_index,
+                    meta_group=param.meta_group,
+                    plot_id=plot_info.prover.get_id(),
+                    pool_public_key=plot_info.pool_public_key,
+                    pool_contract_puzzle_hash=plot_info.pool_contract_puzzle_hash,
+                    plot_public_key=plot_info.plot_public_key,
+                    file_size=uint64(plot_info.file_size),
+                    time_modified=uint64(plot_info.time_modified),
+                    compression_level=plot_info.prover.get_compression_level(),
+                )
+            )
     return converted
 
 
@@ -292,8 +345,17 @@ class Sender:
     def process_batch(self, loaded: list[PlotInfo], remaining: int) -> None:
         log.debug(f"process_batch {self}: loaded {len(loaded)}, remaining {remaining}")
         if len(loaded) > 0 or remaining == 0:
-            converted = _convert_plot_info_list(loaded)
-            self._add_message(ProtocolMessageTypes.plot_sync_loaded, PlotSyncPlotList, converted, remaining == 0)
+            if _uses_plot_v2_metadata(self._connection):
+                converted_v2 = _convert_sync_plot_list(loaded)
+                self._add_message(
+                    ProtocolMessageTypes.plot_sync_loaded_v2,
+                    PlotSyncPlotListV2,
+                    converted_v2,
+                    remaining == 0,
+                )
+            else:
+                converted = _convert_plot_info_list(loaded)
+                self._add_message(ProtocolMessageTypes.plot_sync_loaded, PlotSyncPlotList, converted, remaining == 0)
 
     def sync_done(self, removed: list[Path], duration: float) -> None:
         log.debug(f"sync_done {self}: removed {len(removed)}, duration {duration}")

--- a/chia/protocols/harvester_protocol.py
+++ b/chia/protocols/harvester_protocol.py
@@ -230,6 +230,38 @@ class PlotSyncPlotList(Streamable):
 
 @streamable
 @dataclass(frozen=True)
+class PlotV2(Streamable):
+    filename: str
+    # 1 for v1 plots, 2 for v2 plots
+    version: uint8
+    # v1 k-size when version == 1
+    size: uint8
+    # v2 strength when version == 2
+    strength: uint8
+    plot_index: uint16
+    meta_group: uint8
+    plot_id: bytes32
+    pool_public_key: G1Element | None
+    pool_contract_puzzle_hash: bytes32 | None
+    plot_public_key: G1Element
+    file_size: uint64
+    time_modified: uint64
+    compression_level: uint8 | None
+
+
+@streamable
+@dataclass(frozen=True)
+class PlotSyncPlotListV2(Streamable):
+    identifier: PlotSyncIdentifier
+    data: list[PlotV2]
+    final: bool
+
+    def __str__(self) -> str:
+        return f"PlotSyncPlotListV2: identifier {self.identifier}, count {len(self.data)}, final {self.final}"
+
+
+@streamable
+@dataclass(frozen=True)
 class PlotSyncDone(Streamable):
     identifier: PlotSyncIdentifier
     duration: uint64

--- a/chia/protocols/protocol_message_type_to_node_type.py
+++ b/chia/protocols/protocol_message_type_to_node_type.py
@@ -21,6 +21,7 @@ ProtocolMessageTypeToNodeType: dict[ProtocolMessageTypes, set[NodeType]] = {
     ProtocolMessageTypes.respond_plots: {NodeType.HARVESTER},
     ProtocolMessageTypes.plot_sync_start: {NodeType.HARVESTER},
     ProtocolMessageTypes.plot_sync_loaded: {NodeType.HARVESTER},
+    ProtocolMessageTypes.plot_sync_loaded_v2: {NodeType.HARVESTER},
     ProtocolMessageTypes.plot_sync_removed: {NodeType.HARVESTER},
     ProtocolMessageTypes.plot_sync_invalid: {NodeType.HARVESTER},
     ProtocolMessageTypes.plot_sync_keys_missing: {NodeType.HARVESTER},

--- a/chia/protocols/protocol_message_types.py
+++ b/chia/protocols/protocol_message_types.py
@@ -93,6 +93,7 @@ class ProtocolMessageTypes(Enum):
     respond_plots = 68
     plot_sync_start = 78
     plot_sync_loaded = 79
+    plot_sync_loaded_v2 = 112
     plot_sync_removed = 80
     plot_sync_invalid = 81
     plot_sync_keys_missing = 82

--- a/chia/protocols/shared_protocol.py
+++ b/chia/protocols/shared_protocol.py
@@ -56,6 +56,14 @@ class Capability(IntEnum):
     # Settings must be non empty and window_size == 0 means unlimited.
     RATE_LIMITS_V3 = 7
 
+    # Plot sync can use PlotSyncPlotListV2 with full v2 plot metadata when both
+    # farmer and harvester support it. Legacy PlotSyncPlotList is used otherwise.
+    PLOT_V2_METADATA = 8
+
+
+_plot_v2_metadata = [
+    (uint16(Capability.PLOT_V2_METADATA.value), "1"),
+]
 
 # These are the default capabilities used in all outgoing handshakes.
 # "1" means the capability is supported and enabled.
@@ -70,8 +78,8 @@ _mempool_updates = [
 
 default_capabilities = {
     NodeType.FULL_NODE: _capabilities + _mempool_updates,
-    NodeType.HARVESTER: _capabilities,
-    NodeType.FARMER: _capabilities,
+    NodeType.HARVESTER: _capabilities + _plot_v2_metadata,
+    NodeType.FARMER: _capabilities + _plot_v2_metadata,
     NodeType.TIMELORD: _capabilities,
     NodeType.INTRODUCER: _capabilities,
     NodeType.WALLET: _capabilities,

--- a/chia/server/rate_limit_numbers.py
+++ b/chia/server/rate_limit_numbers.py
@@ -142,6 +142,7 @@ rate_limits: dict[int, dict[ProtocolMessageTypes, RLSettings | Unlimited]] = {
         ProtocolMessageTypes.respond_plots: RLSettings(True, 10, 100 * 1024 * 1024),
         ProtocolMessageTypes.plot_sync_start: RLSettings(True, 1000, 100 * 1024 * 1024),
         ProtocolMessageTypes.plot_sync_loaded: RLSettings(True, 1000, 100 * 1024 * 1024),
+        ProtocolMessageTypes.plot_sync_loaded_v2: RLSettings(True, 1000, 100 * 1024 * 1024),
         ProtocolMessageTypes.plot_sync_removed: RLSettings(True, 1000, 100 * 1024 * 1024),
         ProtocolMessageTypes.plot_sync_invalid: RLSettings(True, 1000, 100 * 1024 * 1024),
         ProtocolMessageTypes.plot_sync_keys_missing: RLSettings(True, 1000, 100 * 1024 * 1024),


### PR DESCRIPTION
## Summary
- Add `Capability.PLOT_V2_METADATA` so farmer and harvester negotiate full v2 plot metadata during plot sync.
- Introduce `PlotV2` / `PlotSyncPlotListV2` and `plot_sync_loaded_v2` for peers that both support the capability.
- Normalize plot data internally with `PlotRecord` while keeping legacy `PlotSyncPlotList` for mixed-version deployments.

## Test plan
- [x] `tools/pytest chia/_tests/plot_sync/ -n0`
- [x] `tools/pytest chia/_tests/util/test_network_protocol_test.py -n0`
- [ ] Verify farmer/harvester handshake advertises `PLOT_V2_METADATA` on a devnet pair
- [ ] Confirm legacy harvester still syncs via `plot_sync_loaded` when capability is absent