### PR TITLE
[CHIA-4226] Fix apparmor profile

### DIFF
--- a/build_scripts/assets/deb/postinst.sh
+++ b/build_scripts/assets/deb/postinst.sh
@@ -22,7 +22,7 @@ ln -s /opt/chia/chia-blockchain /usr/bin/chia-blockchain || true
 # profile (the app runs fine there without it).
 APPARMOR_PROFILE_SOURCE='/opt/chia/resources/apparmor-profile'
 APPARMOR_PROFILE_TARGET='/etc/apparmor.d/chia-blockchain'
-if [ -f "$APPARMOR_PROFILE_SOURCE" ] && apparmor_status --enabled >/dev/null 2>&1; then
+if [ -f "$APPARMOR_PROFILE_SOURCE" ] && command -v apparmor_parser >/dev/null 2>&1 && apparmor_status --enabled >/dev/null 2>&1; then
   if apparmor_parser --skip-kernel-load --debug "$APPARMOR_PROFILE_SOURCE" >/dev/null 2>&1; then
     cp -f "$APPARMOR_PROFILE_SOURCE" "$APPARMOR_PROFILE_TARGET" || true
     # Loading a profile is meaningless inside a chroot (e.g. image builders).

--- a/build_scripts/assets/deb/postinst.sh
+++ b/build_scripts/assets/deb/postinst.sh
@@ -7,3 +7,29 @@ chown -f root:root /opt/chia/chrome-sandbox || true
 chmod -f 4755 /opt/chia/chrome-sandbox || true
 ln -s /opt/chia/resources/app.asar.unpacked/daemon/chia /usr/bin/chia || true
 ln -s /opt/chia/chia-blockchain /usr/bin/chia-blockchain || true
+
+# Install the AppArmor profile bundled by electron-builder. (Ubuntu 24.04+)
+#
+# We override electron-builder's default afterInstall script (above), which
+# means its built-in AppArmor handling is not emitted. Ubuntu 24.04+ ships
+# kernel.apparmor_restrict_unprivileged_userns=1, so the Electron renderer
+# sandbox cannot create its user namespace unless an AppArmor profile authorizes
+# it -- without this, no renderer process is spawned and the GUI never appears.
+#
+# The profile is shipped at /opt/chia/resources/apparmor-profile but is inert
+# until copied into /etc/apparmor.d/ and loaded. The compatibility dry-run keeps
+# this a no-op on Ubuntu 22.04, whose AppArmor does not support the abi/4.0
+# profile (the app runs fine there without it).
+APPARMOR_PROFILE_SOURCE='/opt/chia/resources/apparmor-profile'
+APPARMOR_PROFILE_TARGET='/etc/apparmor.d/chia-blockchain'
+if [ -f "$APPARMOR_PROFILE_SOURCE" ] && apparmor_status --enabled >/dev/null 2>&1; then
+  if apparmor_parser --skip-kernel-load --debug "$APPARMOR_PROFILE_SOURCE" >/dev/null 2>&1; then
+    cp -f "$APPARMOR_PROFILE_SOURCE" "$APPARMOR_PROFILE_TARGET" || true
+    # Loading a profile is meaningless inside a chroot (e.g. image builders).
+    if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
+      apparmor_parser --replace --write-cache --skip-read-cache "$APPARMOR_PROFILE_TARGET" || true
+    fi
+  else
+    echo "Skipping AppArmor profile install: this version of AppArmor does not support the bundled profile"
+  fi
+fi

--- a/build_scripts/assets/deb/prerm.sh
+++ b/build_scripts/assets/deb/prerm.sh
@@ -5,3 +5,12 @@ set -e
 
 unlink /usr/bin/chia || true
 unlink /usr/bin/chia-blockchain || true
+
+# Remove the AppArmor profile installed by postinst (Ubuntu 24.04+).
+APPARMOR_PROFILE_TARGET='/etc/apparmor.d/chia-blockchain'
+if [ -f "$APPARMOR_PROFILE_TARGET" ]; then
+  if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
+    apparmor_parser --remove "$APPARMOR_PROFILE_TARGET" 2>/dev/null || true
+  fi
+  rm -f "$APPARMOR_PROFILE_TARGET" || true
+fi

--- a/build_scripts/assets/rpm/postinst.sh
+++ b/build_scripts/assets/rpm/postinst.sh
@@ -5,3 +5,20 @@ set -e
 
 ln -s /opt/chia/resources/app.asar.unpacked/daemon/chia /usr/bin/chia || true
 ln -s /opt/chia/chia-blockchain /usr/bin/chia-blockchain || true
+
+# Install the AppArmor profile bundled by electron-builder, mirroring the deb
+# postinst. Most RPM distros do not ship AppArmor, so everything is gated on
+# apparmor_parser being present and AppArmor being enabled; otherwise this is a
+# no-op. See build_scripts/assets/deb/postinst.sh for the full rationale.
+APPARMOR_PROFILE_SOURCE='/opt/chia/resources/apparmor-profile'
+APPARMOR_PROFILE_TARGET='/etc/apparmor.d/chia-blockchain'
+if [ -f "$APPARMOR_PROFILE_SOURCE" ] && command -v apparmor_parser >/dev/null 2>&1 && apparmor_status --enabled >/dev/null 2>&1; then
+  if apparmor_parser --skip-kernel-load --debug "$APPARMOR_PROFILE_SOURCE" >/dev/null 2>&1; then
+    cp -f "$APPARMOR_PROFILE_SOURCE" "$APPARMOR_PROFILE_TARGET" || true
+    if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
+      apparmor_parser --replace --write-cache --skip-read-cache "$APPARMOR_PROFILE_TARGET" || true
+    fi
+  else
+    echo "Skipping AppArmor profile install: this version of AppArmor does not support the bundled profile"
+  fi
+fi

--- a/build_scripts/assets/rpm/prerm.sh
+++ b/build_scripts/assets/rpm/prerm.sh
@@ -5,3 +5,12 @@ set -e
 
 unlink /usr/bin/chia || true
 unlink /usr/bin/chia-blockchain || true
+
+# Remove the AppArmor profile installed by postinst, if present.
+APPARMOR_PROFILE_TARGET='/etc/apparmor.d/chia-blockchain'
+if [ -f "$APPARMOR_PROFILE_TARGET" ]; then
+  if command -v apparmor_parser >/dev/null 2>&1 && ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; }; then
+    apparmor_parser --remove "$APPARMOR_PROFILE_TARGET" 2>/dev/null || true
+  fi
+  rm -f "$APPARMOR_PROFILE_TARGET" || true
+fi


### PR DESCRIPTION
### Purpose:

Ship and load the bundled Electron AppArmor profile in the Linux deb/rpm packages.

### Current Behavior:

Our custom `afterInstall` scripts replace electron-builder's default, so the AppArmor profile was never installed. On Ubuntu 24.04+ (`kernel.apparmor_restrict_unprivileged_userns=1`) this blocks the renderer sandbox and the GUI fails to start.

### New Behavior:

`postinst` installs the profile to `/etc/apparmor.d/chia-blockchain` and loads it; `prerm` removes it. The profile is validated with `apparmor_parser` (older AppArmor on 22.04 is skipped) and only loaded when AppArmor is enabled and not in a chroot. RPM uses the same flow with an extra `apparmor_parser` presence check.

### Testing Notes:

Verified GUI launches on Ubuntu 24.04 with the profile installed/loaded, and that 22.04 cleanly skips it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only changes to install/remove a system AppArmor profile with guards for missing AppArmor, older parsers, and chroots; no application runtime logic changes.
> 
> **Overview**
> Linux **deb** and **rpm** package hooks now **install and load** the bundled Electron AppArmor profile from `/opt/chia/resources/apparmor-profile` into `/etc/apparmor.d/chia-blockchain`, fixing GUI startup on Ubuntu 24.04+ where unprivileged user namespaces are restricted without a profile. Custom `postinst` scripts had replaced electron-builder’s default, so this step was previously missing.
> 
> Install runs only when AppArmor is enabled, `apparmor_parser` exists, and a compatibility dry-run passes (so Ubuntu 22.04 skips unsupported **abi/4.0** profiles); loading is skipped in chroots. **`prerm`** on both formats unloads and removes the profile on uninstall.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0517f5cc8254391d849cf57e2cf7b14210c8116c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

