### PR TITLE
full_node: explicit None check in short_sync_batch instead of naked assert

### DIFF
--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from typing import Any, cast
 
 import pytest
 from chia_rs import ConsensusConstants, FullBlock, SubEpochSummary
+from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint16, uint32, uint64
 
 from chia._tests.conftest import ConsensusMode
@@ -15,6 +17,7 @@ from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols import full_node_protocol
 from chia.protocols.shared_protocol import Capability
 from chia.server.server import ChiaServer
+from chia.server.ws_connection import WSChiaConnection
 from chia.simulator.block_tools import BlockTools
 from chia.types.peer_info import PeerInfo
 from chia.util.hash import std_hash
@@ -216,6 +219,36 @@ async def test_batch_sync(
         on_connect=full_node_2.full_node.on_connect,
     )
     await time_out_assert(60, node_height_exactly, True, full_node_2, num_blocks - 1)
+
+
+@pytest.mark.anyio
+async def test_short_sync_batch_returns_false_on_disconnected_first_block(
+    two_nodes: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
+) -> None:
+    # When the first block of a downloaded batch has a parent we do not have in our
+    # database, short_sync_batch falls back to long sync by returning False (as its
+    # docstring promises) rather than raising.
+    _full_node_1, full_node_2, _server_1, _server_2, bt = two_nodes
+    node = full_node_2.full_node
+    blocks = bt.get_consecutive_blocks(2)
+    disconnected_block = blocks[-1]  # height > 0 and its parent is not in node's database
+
+    class _FakePeer:
+        peer_node_id = bytes32(b"\x01" * 32)
+
+        def get_peer_logging(self) -> PeerInfo:
+            return PeerInfo("127.0.0.1", uint16(0))
+
+        async def call_api(
+            self, api_function: Any, request: full_node_protocol.RequestBlocks
+        ) -> full_node_protocol.RespondBlocks:
+            return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [disconnected_block])
+
+    peer = cast(WSChiaConnection, _FakePeer())
+    # start_height == 0 skips the fork-point probe, exercising the batch loop's parent check directly.
+    result = await node.short_sync_batch(peer, uint32(0), uint32(1))
+    assert result is False
+    assert peer.peer_node_id not in node.sync_store.batch_syncing
 
 
 @pytest.mark.anyio

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -678,7 +678,9 @@ class FullNode:
                     prev_b = None
                     if response.blocks[0].height > 0:
                         prev_b = await self.blockchain.get_block_record_from_db(response.blocks[0].prev_header_hash)
-                        assert prev_b is not None
+                        if prev_b is None:
+                            # First block of the batch is not connected to our chain; fall back to long sync.
+                            return False
                     new_slot = len(response.blocks[0].finished_sub_slots) > 0
                     ssi, diff = get_next_sub_slot_iters_and_difficulty(
                         self.constants, new_slot, prev_b, self.blockchain


### PR DESCRIPTION
### Purpose:

Code-hygiene / correctness follow-up. `short_sync_batch` used a naked `assert prev_b is not None`
on a value derived from peer-supplied blocks. This aligns the function with its own docstring and
with the explicit check already present in `add_block` (where the sibling `assert prev_b is not None`
was previously replaced with an `if prev_b is None: raise ...`).

This is not a node-crash fix: any exception from this P2P-reachable path is already caught by
`WSChiaConnection._api_call`, which just closes/bans the peer for a short period while the node keeps
running. The change is about expressing the documented fallback explicitly rather than relying on an
assert.

### Current Behavior:

When the first block of a downloaded batch has a parent that is not in our database, `short_sync_batch`
raises `AssertionError` (`assert prev_b is not None`).

### New Behavior:

`short_sync_batch` returns `False` in that case, which is exactly what the function's docstring already
promises: "If the first block that we download is not connected to our chain, we return False and do an
expensive long sync instead." The surrounding `try/finally` still removes the peer from
`sync_store.batch_syncing`, so the early `return False` is safe.

Invariants unchanged:
- Happy-path batch sync behavior is unchanged (only the disconnected-first-block case differs).
- Caller contract is unchanged: `False` already means "fall back to long sync".
- No change to rounding/precision or `None` vs falsy/zero semantics elsewhere.
- The only behavior change is error-vs-fallback: a raised `AssertionError` becomes the documented
  `return False`.

### Testing Notes:

- Added `test_short_sync_batch_returns_false_on_disconnected_first_block`, which feeds a batch whose
  first block's parent is absent from the node's DB and asserts `short_sync_batch` returns `False` and
  cleans up `sync_store.batch_syncing`.
- Local validation: `ruff check`, `ruff format --check`, `mypy` (repo config), and `pre-commit run
  --all-files` all pass. Targeted full-sync tests and the benchmark suite pass except for
  `ConsensusMode.HARD_FORK_3_0*` variants, which fail during block generation
  (`block_tools.load_block_list` -> `assert required_iters is not None`) for unrelated, unchanged tests
  too in this local environment; CI exercises all consensus modes.
- Local diff coverage gate: 100% on changed lines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches P2P batch sync logic on peer-supplied blocks, but the change is a narrow error-path fix that preserves the documented False/long-sync contract and does not alter successful batch validation.
> 
> **Overview**
> **`short_sync_batch`** now treats a missing parent for the first block in a downloaded batch as a documented fallback: it **`return False`** (trigger long sync) instead of **`assert prev_b is not None`**, matching the function docstring and the explicit check pattern used in **`add_block`**.
> 
> A new full-sync test drives **`short_sync_batch`** with a fake peer that returns a block whose parent is absent from the node DB, and asserts **`False`** plus cleanup of **`sync_store.batch_syncing`**.
> 
> Happy-path batch sync is unchanged; only the disconnected-first-block-in-batch case moves from **`AssertionError`** to the existing **`False`** caller contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 970f55e2dc98790553c038640c1e676ef4b37dab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->