### PR TITLE
[CHIA-4002] Fix off by one in cleanup (Thanks roopd3v)

### DIFF
--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1373,7 +1373,7 @@ class WalletNode:
                 await self.add_states_from_peer(list(race_cache), peer)
 
             # Clear old entries that are no longer relevant
-            cache.cleanup_race_cache(min_height=backtrack_fork_height+1)
+            cache.cleanup_race_cache(min_height=backtrack_fork_height + 1)
 
             self.wallet_state_manager.state_changed("new_block")
             self.log.info(f"Finished processing new peak of {new_peak_hb.height}")

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1373,7 +1373,7 @@ class WalletNode:
                 await self.add_states_from_peer(list(race_cache), peer)
 
             # Clear old entries that are no longer relevant
-            cache.cleanup_race_cache(min_height=backtrack_fork_height)
+            cache.cleanup_race_cache(min_height=backtrack_fork_height+1)
 
             self.wallet_state_manager.state_changed("new_block")
             self.log.info(f"Finished processing new peak of {new_peak_hb.height}")


### PR DESCRIPTION
### Purpose:

The change is an off-by-one fix that aligns cleanup with the apply loop. It is especially important after reorgs, where keeping the fork-height bucket could preserve stale coin states.

### Current Behavior:

Does not clean up coins at fork height

### New Behavior:

Cleans up coins at fork height

### Testing Notes:

N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line sync-cache cleanup change; reduces stale cached coin states after reorgs without touching wallet DB or validation logic.
> 
> **Overview**
> Fixes an off-by-one in untrusted short-sync peak handling when clearing the peer **race cache** after applying cached coin states.
> 
> After the wallet applies race-cache entries for heights `backtrack_fork_height + 1` … `new_peak_hb.height`, `cleanup_race_cache` now uses `min_height=backtrack_fork_height + 1` instead of `backtrack_fork_height`, so the fork-height bucket is removed with the rest of the already-processed heights. That matches the apply loop and avoids keeping stale coin states at the fork height after a reorg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e7c3a041385702075590caa03b05bec94a62b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->