### PR TITLE
[CHIA-4255] Change how `offer_only` works on `create_offer_for_id`

### DIFF
--- a/chia/_tests/cmds/wallet/test_wallet.py
+++ b/chia/_tests/cmds/wallet/test_wallet.py
@@ -891,7 +891,7 @@ def test_make_offer(capsys: object, get_test_cli_clients: tuple[TestRpcClients, 
             )
 
             return CreateOfferForIDsResponse(
-                unsigned_transactions=[STD_UTX], transactions=[STD_TX], offer=created_offer, trade_record=trade_offer
+                unsigned_transactions=[STD_UTX], transactions=[STD_TX], offer=created_offer, _trade_record=trade_offer
             )
 
     inst_rpc_client = MakeOfferRpcClient()
@@ -1130,7 +1130,7 @@ def test_take_offer(capsys: object, get_test_cli_clients: tuple[TestRpcClients, 
                 unsigned_transactions=[STD_UTX],
                 transactions=[STD_TX],
                 offer=request.parsed_offer,
-                trade_record=TradeRecord(
+                _trade_record=TradeRecord(
                     confirmed_at_index=uint32(0),
                     accepted_at_time=uint64(123456789),
                     created_at_time=uint64(12345678),

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -114,7 +114,6 @@ from chia.wallet.wallet_request_types import (
     CreateNewWallet,
     CreateNewWalletType,
     CreateOfferForIDs,
-    CreateOfferForIDsResponse,
     CreateSignedTransaction,
     DefaultCAT,
     DeleteKey,
@@ -1598,8 +1597,13 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
         tx_config=wallet_environments.tx_config,
     )
     assert offer_only_res.offer is not None
-    assert not hasattr(offer_only_res, "trade_record")
-    assert offer_only_res.to_json_dict() == {"offer": offer_only_res.offer.to_bech32()}
+    assert offer_only_res.trade_record is None
+    assert offer_only_res.to_json_dict() == {
+        "offer": offer_only_res.offer.to_bech32(),
+        "transactions": [],
+        "unsigned_transactions": [],
+        "trade_record": None,
+    }
 
     driver_dict = {
         cat_asset_id: PuzzleInfo(
@@ -1662,6 +1666,7 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
             wallet_environments.tx_config,
         )
     ).trade_record
+    assert trade_record is not None
     assert TradeStatus(trade_record.status) == TradeStatus.PENDING_CONFIRM
 
     await env_1.rpc_client.cancel_offer(
@@ -1689,7 +1694,7 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
         CreateOfferForIDs(offer={str(1): "-5", str(cat_wallet_id): "1"}, fee=uint64(1)),
         tx_config=wallet_environments.tx_config,
     )
-    assert isinstance(create_res, CreateOfferForIDsResponse)
+    assert create_res.trade_record is not None
     all_offers = (await env_1.rpc_client.get_all_offers(GetAllOffers())).trade_records
     assert len(all_offers) == 2
     offer_count = await env_1.rpc_client.get_offers_count()
@@ -1780,6 +1785,7 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
         return [t.trade_id for t in trades]
 
     trade_record = (await env_1.rpc_client.get_offer(GetOffer(trade_id=offer.name()))).trade_record
+    assert trade_record is not None
     all_offers = (  # confirmed at index descending
         await env_1.rpc_client.get_all_offers(GetAllOffers(include_completed=True))
     ).trade_records

--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -1597,13 +1597,14 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
         tx_config=wallet_environments.tx_config,
     )
     assert offer_only_res.offer is not None
-    assert offer_only_res.trade_record is None
     assert offer_only_res.to_json_dict() == {
         "offer": offer_only_res.offer.to_bech32(),
         "transactions": [],
         "unsigned_transactions": [],
         "trade_record": None,
     }
+    with pytest.raises(ValueError, match=re.escape("Attempting to access trade_record on `offer_only` request")):
+        offer_only_res.trade_record
 
     driver_dict = {
         cat_asset_id: PuzzleInfo(
@@ -1666,7 +1667,6 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
             wallet_environments.tx_config,
         )
     ).trade_record
-    assert trade_record is not None
     assert TradeStatus(trade_record.status) == TradeStatus.PENDING_CONFIRM
 
     await env_1.rpc_client.cancel_offer(
@@ -1694,7 +1694,6 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
         CreateOfferForIDs(offer={str(1): "-5", str(cat_wallet_id): "1"}, fee=uint64(1)),
         tx_config=wallet_environments.tx_config,
     )
-    assert create_res.trade_record is not None
     all_offers = (await env_1.rpc_client.get_all_offers(GetAllOffers())).trade_records
     assert len(all_offers) == 2
     offer_count = await env_1.rpc_client.get_offers_count()
@@ -1785,7 +1784,6 @@ async def test_offer_endpoints(wallet_environments: WalletTestFramework, wallet_
         return [t.trade_id for t in trades]
 
     trade_record = (await env_1.rpc_client.get_offer(GetOffer(trade_id=offer.name()))).trade_record
-    assert trade_record is not None
     all_offers = (  # confirmed at index descending
         await env_1.rpc_client.get_all_offers(GetAllOffers(include_completed=True))
     ).trade_records

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -57,7 +57,6 @@ from chia.wallet.wallet_request_types import (
     CreateNewWallet,
     CreateNewWalletType,
     CreateOfferForIDs,
-    CreateOfferForIDsResponse,
     DeleteNotifications,
     DeleteUnconfirmedTransactions,
     DIDFindLostDID,
@@ -687,7 +686,7 @@ async def make_offer(
                         ).to_tx_config(units["chia"], config, fingerprint),
                         timelock_info=condition_valid_times,
                     )
-                    assert isinstance(res, CreateOfferForIDsResponse)
+                    assert res.trade_record is not None
                     if res.offer is not None:
                         file.write(res.offer.to_bech32())
                         print(f"Created offer with ID {res.trade_record.trade_id}")
@@ -936,6 +935,7 @@ async def take_offer(
                 timelock_info=condition_valid_times,
                 tx_config=CMDTXConfigLoader().to_tx_config(units["chia"], config, fingerprint),
             )
+            assert res.trade_record is not None
             if push:
                 print(f"Accepted offer with ID {res.trade_record.trade_id}")
                 print(

--- a/chia/cmds/wallet_funcs.py
+++ b/chia/cmds/wallet_funcs.py
@@ -686,7 +686,6 @@ async def make_offer(
                         ).to_tx_config(units["chia"], config, fingerprint),
                         timelock_info=condition_valid_times,
                     )
-                    assert res.trade_record is not None
                     if res.offer is not None:
                         file.write(res.offer.to_bech32())
                         print(f"Created offer with ID {res.trade_record.trade_id}")
@@ -935,7 +934,6 @@ async def take_offer(
                 timelock_info=condition_valid_times,
                 tx_config=CMDTXConfigLoader().to_tx_config(units["chia"], config, fingerprint),
             )
-            assert res.trade_record is not None
             if push:
                 print(f"Accepted offer with ID {res.trade_record.trade_id}")
                 print(

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -70,7 +70,6 @@ from chia.wallet.wallet_request_types import (
     CancelOffer,
     CreateNewDL,
     CreateOfferForIDs,
-    CreateOfferForIDsResponse,
     DLDeleteMirror,
     DLGetMirrors,
     DLHistory,
@@ -1214,7 +1213,7 @@ class DataLayer:
                 # This is not a change in behavior, the default was already implicit.
                 tx_config=DEFAULT_TX_CONFIG,
             )
-            assert isinstance(res, CreateOfferForIDsResponse)
+            assert res.trade_record is not None
 
             offer = Offer(
                 trade_id=res.trade_record.trade_id,
@@ -1303,6 +1302,7 @@ class DataLayer:
                 tx_config=DEFAULT_TX_CONFIG,
             )
         ).trade_record
+        assert trade_record is not None
 
         return trade_record
 

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -1213,7 +1213,6 @@ class DataLayer:
                 # This is not a change in behavior, the default was already implicit.
                 tx_config=DEFAULT_TX_CONFIG,
             )
-            assert res.trade_record is not None
 
             offer = Offer(
                 trade_id=res.trade_record.trade_id,
@@ -1302,7 +1301,6 @@ class DataLayer:
                 tx_config=DEFAULT_TX_CONFIG,
             )
         ).trade_record
-        assert trade_record is not None
 
         return trade_record
 

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -2129,7 +2129,8 @@ class SendTransactionMultiResponse(TransactionEndpointResponse):
 @dataclass(kw_only=True, frozen=True)
 class _OfferEndpointResponse(TransactionEndpointResponse):
     offer: Offer  # gotta figure out how to ignore this in streamable
-    trade_record: TradeRecord
+    trade_record: TradeRecord | None
+    _offer_only: bool = False
 
     def to_json_dict(self) -> dict[str, Any]:
         old_offer_override = getattr(self.offer, "json_serialization_override", None)
@@ -2137,8 +2138,9 @@ class _OfferEndpointResponse(TransactionEndpointResponse):
         try:
             response = {
                 **super().to_json_dict(),
-                "trade_record": self.trade_record.to_json_dict_convenience(),
+                "trade_record": self.trade_record.to_json_dict_convenience() if self.trade_record is not None else None,
             }
+            response.pop("_offer_only")
         except Exception:
             object.__setattr__(self.offer, "json_serialization_override", old_offer_override)
             raise
@@ -2154,7 +2156,10 @@ class _OfferEndpointResponse(TransactionEndpointResponse):
         return cls(
             **tx_endpoint.__dict__,
             offer=offer,
-            trade_record=TradeRecord.from_json_dict_convenience(json_dict["trade_record"], bytes(offer).hex()),
+            trade_record=TradeRecord.from_json_dict_convenience(json_dict["trade_record"], bytes(offer).hex())
+            if json_dict["trade_record"] is not None
+            else None,
+            _offer_only=json_dict["trade_record"] is None,
         )
 
 
@@ -2184,19 +2189,6 @@ class CreateOfferForIDs(TransactionEndpointRequest):
 @dataclass(kw_only=True, frozen=True)
 class CreateOfferForIDsResponse(_OfferEndpointResponse):
     pass
-
-
-@streamable
-@dataclass(kw_only=True, frozen=True)
-class CreateOfferForIDsOfferOnlyResponse(Streamable):
-    offer: Offer
-
-    def to_json_dict(self) -> dict[str, Any]:
-        return {"offer": self.offer.to_bech32()}
-
-    @classmethod
-    def from_json_dict(cls, json_dict: dict[str, Any]) -> Self:
-        return cls(offer=Offer.from_bech32(json_dict["offer"]))
 
 
 @streamable

--- a/chia/wallet/wallet_request_types.py
+++ b/chia/wallet/wallet_request_types.py
@@ -2129,8 +2129,13 @@ class SendTransactionMultiResponse(TransactionEndpointResponse):
 @dataclass(kw_only=True, frozen=True)
 class _OfferEndpointResponse(TransactionEndpointResponse):
     offer: Offer  # gotta figure out how to ignore this in streamable
-    trade_record: TradeRecord | None
-    _offer_only: bool = False
+    _trade_record: TradeRecord | None
+
+    @property
+    def trade_record(self) -> TradeRecord:
+        if self._trade_record is None:
+            raise ValueError("Attempting to access trade_record on `offer_only` request")
+        return self._trade_record
 
     def to_json_dict(self) -> dict[str, Any]:
         old_offer_override = getattr(self.offer, "json_serialization_override", None)
@@ -2138,9 +2143,9 @@ class _OfferEndpointResponse(TransactionEndpointResponse):
         try:
             response = {
                 **super().to_json_dict(),
-                "trade_record": self.trade_record.to_json_dict_convenience() if self.trade_record is not None else None,
+                "trade_record": self.trade_record.to_json_dict_convenience() if self._trade_record else None,
             }
-            response.pop("_offer_only")
+            response.pop("_trade_record")
         except Exception:
             object.__setattr__(self.offer, "json_serialization_override", old_offer_override)
             raise
@@ -2156,10 +2161,9 @@ class _OfferEndpointResponse(TransactionEndpointResponse):
         return cls(
             **tx_endpoint.__dict__,
             offer=offer,
-            trade_record=TradeRecord.from_json_dict_convenience(json_dict["trade_record"], bytes(offer).hex())
+            _trade_record=TradeRecord.from_json_dict_convenience(json_dict["trade_record"], bytes(offer).hex())
             if json_dict["trade_record"] is not None
             else None,
-            _offer_only=json_dict["trade_record"] is None,
         )
 
 

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -2082,8 +2082,7 @@ class WalletRpcApi:
             unsigned_transactions=[],
             transactions=[],
             offer=Offer.from_bytes(result[1].offer),
-            trade_record=result[1],
-            _offer_only=request.offer_only,
+            _trade_record=result[1],
         )
 
     @marshal
@@ -2179,7 +2178,7 @@ class WalletRpcApi:
             unsigned_transactions=[],
             transactions=[],
             offer=Offer.from_bytes(trade_record.offer),
-            trade_record=trade_record,
+            _trade_record=trade_record,
         )
 
     @marshal

--- a/chia/wallet/wallet_rpc_api.py
+++ b/chia/wallet/wallet_rpc_api.py
@@ -512,7 +512,12 @@ def tx_endpoint(
                     offer=bytes(new_offer),
                     trade_id=new_offer.name(),
                 )
-                response["trade_record"] = new_trade.to_json_dict_convenience()
+                if request.get("offer_only", False):
+                    response["trade_record"] = None
+                    response["transactions"] = []
+                    response["unsigned_transactions"] = []
+                else:
+                    response["trade_record"] = new_trade.to_json_dict_convenience()
                 if (
                     await self.service.wallet_state_manager.trade_manager.trade_store.get_trade_record(
                         old_trade_record.trade_id
@@ -529,12 +534,6 @@ def tx_endpoint(
                     await self.service.wallet_state_manager.tx_store.add_transaction_record(
                         dataclasses.replace(tx, trade_id=new_trade.trade_id)
                     )
-
-            if func.__name__ == "create_offer_for_ids" and request.get("offer_only", False):
-                response.pop("trade_record", None)
-                response.pop("transactions", None)
-                response.pop("unsigned_transactions", None)
-                return response
 
             return response
 
@@ -2084,6 +2083,7 @@ class WalletRpcApi:
             transactions=[],
             offer=Offer.from_bytes(result[1].offer),
             trade_record=result[1],
+            _offer_only=request.offer_only,
         )
 
     @marshal

--- a/chia/wallet/wallet_rpc_client.py
+++ b/chia/wallet/wallet_rpc_client.py
@@ -42,7 +42,6 @@ from chia.wallet.wallet_request_types import (
     CreateNewWallet,
     CreateNewWalletResponse,
     CreateOfferForIDs,
-    CreateOfferForIDsOfferOnlyResponse,
     CreateOfferForIDsResponse,
     CreateSignedTransaction,
     CreateSignedTransactionsResponse,
@@ -588,12 +587,10 @@ class WalletRpcClient(RpcClient):
         tx_config: TXConfig,
         extra_conditions: tuple[Condition, ...] = tuple(),
         timelock_info: ConditionValidTimes = ConditionValidTimes(),
-    ) -> CreateOfferForIDsResponse | CreateOfferForIDsOfferOnlyResponse:
+    ) -> CreateOfferForIDsResponse:
         response = await self.fetch(
             "create_offer_for_ids", request.json_serialize_for_transport(tx_config, extra_conditions, timelock_info)
         )
-        if request.offer_only:
-            return CreateOfferForIDsOfferOnlyResponse.from_json_dict(response)
         return CreateOfferForIDsResponse.from_json_dict(response)
 
     async def get_offer_summary(self, request: GetOfferSummary) -> GetOfferSummaryResponse:


### PR DESCRIPTION
This PR reworks the change from #18680 to be more in line with the paradigm of this RPC.  We want to preserve a 1-1 request to response object mapping because eventually we'll want to generate the client code and some of the RPC code and that means all of the endpoints must behave the same.  This also automatically propagates the change to `take_offer` and requires less type guards at the call sites.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes wallet RPC JSON and Python response types for offer creation; callers depending on omitted keys or the old offer-only type need to handle null trade_record and empty transaction lists.
> 
> **Overview**
> Unifies **`create_offer_for_ids`** responses so **`offer_only`** uses the same **`CreateOfferForIDsResponse`** type instead of a separate **`CreateOfferForIDsOfferOnlyResponse`**.
> 
> Offer endpoints now store **`_trade_record`** as optional; **`trade_record`** is a property that raises if it was an **`offer_only`** call. JSON for **`offer_only`** keeps the normal response shape with **`trade_record: null`** and empty **`transactions`** / **`unsigned_transactions`**, rather than omitting those fields. The RPC marshal layer sets those values explicitly instead of stripping keys and returning a trimmed dict; the wallet RPC client always deserializes to **`CreateOfferForIDsResponse`**.
> 
> Call sites drop **`isinstance(..., CreateOfferForIDsResponse)`** checks and construct responses with **`_trade_record`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fe5ab151e67171eabad706391de73ff7a7d5800. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->