### PR TITLE
CHIA-4253 Use bad_element in test_invalid_rc_sub_slot_vdf

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -1043,7 +1043,15 @@ class TestBlockHeaderValidation:
                     recursive_replace(
                         block.finished_sub_slots[-1].reward_chain,
                         "end_of_slot_vdf.output",
-                        ClassgroupElement.get_default_element(),
+                        # Don't use the default element here. With BlockTools'
+                        # tiny 16-bit test because of the small discriminant in
+                        # tests, byte-distinct ClassgroupElement encodings can
+                        # reduce to the same classgroup element in the native
+                        # VDF verifier. Some RC EOS outputs therefore still
+                        # verify after replacement with the default element
+                        # and the block is rejected later because the
+                        # serialized reward sub-slot hash changed.
+                        bad_element,
                     ),
                 )
                 block_bad_2 = recursive_replace(


### PR DESCRIPTION
Fixed by Almog to address:

```
_ TestBlockHeaderValidation.test_invalid_rc_sub_slot_vdf[ConsensusMode.HARD_FORK_3_0] _
[gw1] linux -- Python 3.12.13 /home/runner/work/chia-blockchain/chia-blockchain/.venv/bin/python
.venv/lib/python3.12/site-packages/chia/_tests/blockchain/test_blockchain.py:1052: in test_invalid_rc_sub_slot_vdf
    await _validate_and_add_block(empty_blockchain, block_bad_2, expected_error=Err.INVALID_RC_EOS_VDF)
.venv/lib/python3.12/site-packages/chia/_tests/blockchain/blockchain_test_utils.py:102: in _validate_and_add_block
    raise AssertionError(f"Expected {expected_error} but got {Err(results.error)}")
E   AssertionError: Expected Err.INVALID_RC_EOS_VDF but got Err.INVALID_RC_IP_VDF
```

Almog explained:

Use `bad_element` instead of the default element here.

With `BlockTools`' tiny 16-bit test because of the small discriminant in tests, byte-distinct `ClassgroupElement` encodings can reduce to the same classgroup element in the native VDF verifier.

Some RC EOS outputs therefore still verify after replacement with the default element and the block is rejected later because the serialized reward sub-slot hash changed.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to invalid VDF fixture data; no production consensus or validation logic is modified.
> 
> **Overview**
> Fixes **`test_invalid_rc_sub_slot_vdf`** under **`ConsensusMode.HARD_FORK_3_0`**, where the “bad output” case expected **`Err.INVALID_RC_EOS_VDF`** but sometimes got **`Err.INVALID_RC_IP_VDF`**.
> 
> The test now corrupts the reward-chain end-of-slot VDF output with the module-level **`bad_element`** instead of **`ClassgroupElement.get_default_element()`**, with comments explaining that in BlockTools’ small test discriminant, distinct encodings can collapse to the same classgroup element in the native VDF verifier—so the default element could still verify and rejection moved to a later hash/check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2608fe57f9c75582f91db3df983fbf2de4524545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->