### PR TITLE
CHIA-4254 Do not require peer anymore for some wallet node APIs

### DIFF
--- a/chia/apis/wallet_stub.py
+++ b/chia/apis/wallet_stub.py
@@ -44,13 +44,13 @@ class WalletNodeApiStub(ApiProtocol, Protocol):
         """Check if the wallet is ready."""
         ...
 
-    @metadata.request(peer_required=True)
-    async def respond_removals(self, response: RespondRemovals, peer: WSChiaConnection) -> None:
+    @metadata.request()
+    async def respond_removals(self, response: RespondRemovals) -> None:
         """Handle removals response from full node."""
         ...
 
-    @metadata.request(peer_required=True)
-    async def reject_removals_request(self, response: RejectRemovalsRequest, peer: WSChiaConnection) -> None:
+    @metadata.request()
+    async def reject_removals_request(self, response: RejectRemovalsRequest) -> None:
         """Handle reject removals request from full node."""
         ...
 
@@ -74,8 +74,8 @@ class WalletNodeApiStub(ApiProtocol, Protocol):
         """Handle block header response from full node."""
         ...
 
-    @metadata.request(peer_required=True)
-    async def respond_additions(self, response: RespondAdditions, peer: WSChiaConnection) -> None:
+    @metadata.request()
+    async def respond_additions(self, response: RespondAdditions) -> None:
         """Handle additions response from full node."""
         ...
 

--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -33,12 +33,12 @@ class WalletNodeAPI:
     def ready(self) -> bool:
         return self.wallet_node.logged_in
 
-    @metadata.request(peer_required=True)
-    async def respond_removals(self, response: wallet_protocol.RespondRemovals, peer: WSChiaConnection):
+    @metadata.request()
+    async def respond_removals(self, response: wallet_protocol.RespondRemovals):
         pass
 
-    @metadata.request(peer_required=True)
-    async def reject_removals_request(self, response: wallet_protocol.RejectRemovalsRequest, peer: WSChiaConnection):
+    @metadata.request()
+    async def reject_removals_request(self, response: wallet_protocol.RejectRemovalsRequest):
         """
         The full node has rejected our request for removals.
         """
@@ -89,8 +89,8 @@ class WalletNodeAPI:
     async def respond_block_header(self, response: wallet_protocol.RespondBlockHeader):
         pass
 
-    @metadata.request(peer_required=True)
-    async def respond_additions(self, response: wallet_protocol.RespondAdditions, peer: WSChiaConnection):
+    @metadata.request()
+    async def respond_additions(self, response: wallet_protocol.RespondAdditions):
         pass
 
     @metadata.request()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata and signature-only changes on stub/no-op handlers; no business logic or peer-dependent behavior was altered.
> 
> **Overview**
> **CHIA-4254** relaxes API metadata for four wallet full-node message handlers that never used the connection: `respond_removals`, `reject_removals_request`, `respond_additions`, and the matching stub in `wallet_stub.py`.
> 
> Each handler drops `@metadata.request(peer_required=True)` in favor of `@metadata.request()` and removes the `peer: WSChiaConnection` argument so signatures match the no-op implementations. **Peer is still required** for handlers that actually use it (e.g. `transaction_ack`, `new_peak_wallet`, `coin_state_update`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c20633088ac803a5a1d3b3c91b8b952c24711f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->