### PR TITLE
[CHIA-4256] Make farmer resilient to malformed pool difficulty responses

### DIFF
--- a/chia/_tests/farmer_harvester/test_farmer.py
+++ b/chia/_tests/farmer_harvester/test_farmer.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from time import time
 from types import TracebackType
 from typing import Any, cast
-from unittest.mock import ANY
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 from chia_rs import AugSchemeMPL, G1Element, G2Element, PlotParam, PrivateKey, ProofOfSpace
@@ -17,7 +17,7 @@ from typing_extensions import Self
 from yarl import URL
 
 from chia import __version__
-from chia._tests.conftest import HarvesterFarmerEnvironment
+from chia._tests.conftest import FarmerOneHarvester, HarvesterFarmerEnvironment
 from chia._tests.util.misc import DataCase, Marks, datacases
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.farmer.farmer import UPDATE_POOL_FARMER_INFO_INTERVAL, Farmer, increment_pool_stats, strip_old_entries
@@ -679,8 +679,12 @@ class DummyPoolResponse:
     error_code: int | None = None
     error_message: str | None = None
     new_difficulty: int | None = None
+    raw_response: dict[str, Any] | None = None
 
     async def text(self) -> str:
+        if self.raw_response is not None:
+            return json.dumps(self.raw_response)
+
         json_dict: dict[str, Any] = dict()
         if self.error_code:
             json_dict["error_code"] = self.error_code
@@ -873,6 +877,17 @@ class PoolStateCase:
             }
         ),
     ),
+    PoolStateCase(
+        "malformed_new_difficulty",
+        DummyPoolResponse(True, 200, raw_response={"new_difficulty": -1}),
+        override_pool_state(
+            {
+                "points_found_since_start": 1,
+                "points_found_24h": [1],
+                "current_difficulty": uint64(1),
+            }
+        ),
+    ),
 )
 @pytest.mark.anyio
 async def test_farmer_pool_response(
@@ -902,6 +917,11 @@ async def test_farmer_pool_response(
 
     pool_response = case.pool_response
     expected_pool_state = case.expected_pool_state
+
+    if "current_difficulty" in expected_pool_state:
+        farmer_api.farmer.pool_state[p2_singleton_puzzle_hash]["current_difficulty"] = expected_pool_state[
+            "current_difficulty"
+        ]
 
     mock_http_post = mocker.patch("aiohttp.ClientSession.post", return_value=pool_response)
 
@@ -940,6 +960,11 @@ async def test_farmer_pool_response(
     assert_stats_24h("stale_partials_24h")
     assert_stats_since_start("missing_partials_since_start")
     assert_stats_24h("missing_partials_24h")
+    if "current_difficulty" in expected_pool_state:
+        assert (
+            farmer_api.farmer.pool_state[p2_singleton_puzzle_hash]["current_difficulty"]
+            == expected_pool_state["current_difficulty"]
+        )
 
 
 def make_pool_info() -> dict[str, Any]:
@@ -1210,6 +1235,120 @@ async def test_farmer_pool_info_config_update(
         root_path=farmer_service.root_path, p2_singleton_puzzle_hash=p2_singleton_puzzle_hash
     ) as pool_config:
         assert pool_config.pool_url == case.expected_pool_url_in_config
+
+
+@pytest.mark.anyio
+async def test_update_pool_state_ignores_malformed_pool_info_difficulty(
+    mocker: MockerFixture,
+    farmer_one_harvester: tuple[list[HarvesterService], FarmerService, BlockTools],
+) -> None:
+    _, farmer_service, _ = farmer_one_harvester
+    p2_singleton_puzzle_hash = bytes32.fromhex("302e05a1e6af431c22043ae2a9a8f71148c955c372697cb8ab348160976283df")
+    farmer_service._node.authentication_keys = {
+        p2_singleton_puzzle_hash: PrivateKey.from_bytes(
+            bytes.fromhex("11ed596eb95b31364a9185e948f6b66be30415f816819449d5d40751dc70e786")
+        ),
+    }
+    farmer_service._node.pool_state[p2_singleton_puzzle_hash] = make_pool_state(
+        p2_singleton_puzzle_hash,
+        overrides={
+            "current_difficulty": uint64(42),
+            "next_farmer_update": time() + UPDATE_POOL_FARMER_INFO_INTERVAL,
+        },
+    )
+    PoolingShareState(
+        owner_public_key=G1Element.from_bytes(
+            bytes.fromhex(
+                "84c3fcf9d5581c1ddc702cb0f3b4a06043303b334dd993ab42b2c320ebfa98e5ce558448615b3f69638ba92cf7f43da5"
+            )
+        ),
+        p2_singleton_puzzle_hash=p2_singleton_puzzle_hash,
+        payout_instructions="c2b08e41d766da4116e388357ed957d04ad754623a915f3fd65188a8746cf3e8",
+        pool_url="https://endpoint-1.pool-domain.tld/some-path",
+        launcher_id=bytes32.from_hexstr("ae4ef3b9bfe68949691281a015a9c16630fc8f66d48c19ca548fb80768791afa"),
+        target_puzzle_hash=bytes32.from_hexstr("344587cf06a39db471d2cc027504e8688a0a67cce961253500c956c73603fd58"),
+        key_derivation_index=-1,
+    ).add(root_path=farmer_service.root_path)
+    bad_pool_info = make_pool_info()
+    bad_pool_info["minimum_difficulty"] = -1
+    mock_http_get = mocker.patch(
+        "aiohttp.ClientSession.get",
+        return_value=DummyPoolInfoResponse(
+            ok=True,
+            status=200,
+            url=URL("https://endpoint-1.pool-domain.tld/some-path"),
+            pool_info=bad_pool_info,
+        ),
+    )
+
+    await farmer_service._node.update_pool_state()
+
+    mock_http_get.assert_called_once()
+    assert farmer_service._node.pool_state[p2_singleton_puzzle_hash]["current_difficulty"] == uint64(42)
+
+
+@pytest.mark.anyio
+async def test_new_signage_point_skips_pool_with_invalid_difficulty(
+    mocker: MockerFixture,
+    farmer_one_harvester: FarmerOneHarvester,
+) -> None:
+    _, farmer_service, _ = farmer_one_harvester
+    farmer_api = farmer_service._api
+    send_mock = mocker.patch.object(farmer_service._server, "send_to_all_if", new_callable=AsyncMock)
+
+    sp, _, _ = create_valid_pos(farmer_api.farmer)
+    farmer_api.farmer.sps = {}
+    valid_p2 = bytes32.fromhex("302e05a1e6af431c22043ae2a9a8f71148c955c372697cb8ab348160976283df")
+    invalid_p2 = bytes32(std_hash(b"invalid_pool_difficulty"))
+    invalid_pool_config = PoolingShareState(
+        launcher_id=bytes32.fromhex("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+        pool_url="https://bad-pool.example",
+        payout_instructions="c2b08e41d766da4116e388357ed957d04ad754623a915f3fd65188a8746cf3e8",
+        target_puzzle_hash=bytes32.fromhex("344587cf06a39db471d2cc027504e8688a0a67cce961253500c956c73603fd58"),
+        p2_singleton_puzzle_hash=invalid_p2,
+        owner_public_key=G1Element.from_bytes(
+            bytes.fromhex(
+                "8348455278ecec68325b6754b1f3218cde1511ca9393197e7876d7ae04af1c4dd86b0c50601cf5daeb034e8f7c226537"
+            )
+        ),
+        key_derivation_index=-1,
+    )
+    farmer_api.farmer.pool_state[invalid_p2] = make_pool_state(
+        invalid_p2,
+        overrides={
+            "current_difficulty": -1,
+            "pool_config": invalid_pool_config,
+            "authentication_token_timeout": uint8(5),
+        },
+    )
+    self_pool_p2 = bytes32(std_hash(b"self_pool"))
+    self_pool_config = PoolingShareState(
+        launcher_id=bytes32.fromhex("1122334455667788990011223344556677889900112233445566778899001122"),
+        pool_url="",
+        payout_instructions="c2b08e41d766da4116e388357ed957d04ad754623a915f3fd65188a8746cf3e8",
+        target_puzzle_hash=bytes32.fromhex("344587cf06a39db471d2cc027504e8688a0a67cce961253500c956c73603fd58"),
+        p2_singleton_puzzle_hash=self_pool_p2,
+        owner_public_key=G1Element.from_bytes(
+            bytes.fromhex(
+                "8348455278ecec68325b6754b1f3218cde1511ca9393197e7876d7ae04af1c4dd86b0c50601cf5daeb034e8f7c226537"
+            )
+        ),
+        key_derivation_index=-1,
+    )
+    farmer_api.farmer.pool_state[self_pool_p2] = make_pool_state(
+        self_pool_p2,
+        overrides={
+            "pool_config": self_pool_config,
+        },
+    )
+
+    await farmer_api.new_signage_point(sp)
+
+    assert send_mock.await_count == 2
+    nsp = harvester_protocol.NewSignagePointHarvester.from_bytes(send_mock.await_args_list[0].args[0][0].data)
+    assert len(nsp.pool_difficulties) == 1
+    assert nsp.pool_difficulties[0].pool_contract_puzzle_hash == valid_p2
+    assert nsp.pool_difficulties[0].difficulty == uint64(1)
 
 
 @dataclass

--- a/chia/_tests/farmer_harvester/test_farmer.py
+++ b/chia/_tests/farmer_harvester/test_farmer.py
@@ -885,6 +885,8 @@ class PoolStateCase:
                 "points_found_since_start": 1,
                 "points_found_24h": [1],
                 "current_difficulty": uint64(1),
+                "invalid_partials_since_start": 1,
+                "invalid_partials_24h": [1],
             }
         ),
     ),

--- a/chia/_tests/farmer_harvester/test_farmer.py
+++ b/chia/_tests/farmer_harvester/test_farmer.py
@@ -1050,6 +1050,8 @@ class PoolInfoCase(DataCase):
     initial_pool_url_in_config: str
     pool_response: DummyPoolInfoResponse
     expected_pool_url_in_config: str
+    initial_current_difficulty: uint64 | None = None
+    expected_current_difficulty: uint64 | None = None
     marks: Marks = ()
 
     @property
@@ -1195,6 +1197,32 @@ class PoolInfoCase(DataCase):
         ),
         expected_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
     ),
+    PoolInfoCase(
+        "malformed_minimum_difficulty",
+        initial_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
+        pool_response=DummyPoolInfoResponse(
+            ok=True,
+            status=200,
+            url=URL("https://endpoint-1.pool-domain.tld/some-path"),
+            pool_info={**make_pool_info(), "minimum_difficulty": -1},
+        ),
+        expected_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
+        initial_current_difficulty=uint64(42),
+        expected_current_difficulty=uint64(42),
+    ),
+    PoolInfoCase(
+        "error_code_in_response",
+        initial_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
+        pool_response=DummyPoolInfoResponse(
+            ok=True,
+            status=200,
+            url=URL("https://endpoint-1.pool-domain.tld/some-path"),
+            pool_info={**make_pool_info(), "error_code": 1, "error_message": "pool unavailable"},
+        ),
+        expected_pool_url_in_config="https://endpoint-1.pool-domain.tld/some-path",
+        initial_current_difficulty=uint64(42),
+        expected_current_difficulty=uint64(42),
+    ),
 )
 @pytest.mark.anyio
 async def test_farmer_pool_info_config_update(
@@ -1209,11 +1237,14 @@ async def test_farmer_pool_info_config_update(
             bytes.fromhex("11ed596eb95b31364a9185e948f6b66be30415f816819449d5d40751dc70e786")
         ),
     }
+    pool_state_overrides: dict[str, Any] = {
+        "next_farmer_update": time() + UPDATE_POOL_FARMER_INFO_INTERVAL,
+    }
+    if case.initial_current_difficulty is not None:
+        pool_state_overrides["current_difficulty"] = case.initial_current_difficulty
     farmer_service._node.pool_state[p2_singleton_puzzle_hash] = make_pool_state(
         p2_singleton_puzzle_hash,
-        overrides={
-            "next_farmer_update": time() + UPDATE_POOL_FARMER_INFO_INTERVAL,
-        },
+        overrides=pool_state_overrides,
     )
     PoolingShareState(
         owner_public_key=G1Element.from_bytes(
@@ -1237,107 +1268,11 @@ async def test_farmer_pool_info_config_update(
         root_path=farmer_service.root_path, p2_singleton_puzzle_hash=p2_singleton_puzzle_hash
     ) as pool_config:
         assert pool_config.pool_url == case.expected_pool_url_in_config
-
-
-@pytest.mark.anyio
-async def test_update_pool_state_ignores_malformed_pool_info_difficulty(
-    mocker: MockerFixture,
-    farmer_one_harvester: tuple[list[HarvesterService], FarmerService, BlockTools],
-) -> None:
-    _, farmer_service, _ = farmer_one_harvester
-    p2_singleton_puzzle_hash = bytes32.fromhex("302e05a1e6af431c22043ae2a9a8f71148c955c372697cb8ab348160976283df")
-    farmer_service._node.authentication_keys = {
-        p2_singleton_puzzle_hash: PrivateKey.from_bytes(
-            bytes.fromhex("11ed596eb95b31364a9185e948f6b66be30415f816819449d5d40751dc70e786")
-        ),
-    }
-    farmer_service._node.pool_state[p2_singleton_puzzle_hash] = make_pool_state(
-        p2_singleton_puzzle_hash,
-        overrides={
-            "current_difficulty": uint64(42),
-            "next_farmer_update": time() + UPDATE_POOL_FARMER_INFO_INTERVAL,
-        },
-    )
-    PoolingShareState(
-        owner_public_key=G1Element.from_bytes(
-            bytes.fromhex(
-                "84c3fcf9d5581c1ddc702cb0f3b4a06043303b334dd993ab42b2c320ebfa98e5ce558448615b3f69638ba92cf7f43da5"
-            )
-        ),
-        p2_singleton_puzzle_hash=p2_singleton_puzzle_hash,
-        payout_instructions="c2b08e41d766da4116e388357ed957d04ad754623a915f3fd65188a8746cf3e8",
-        pool_url="https://endpoint-1.pool-domain.tld/some-path",
-        launcher_id=bytes32.from_hexstr("ae4ef3b9bfe68949691281a015a9c16630fc8f66d48c19ca548fb80768791afa"),
-        target_puzzle_hash=bytes32.from_hexstr("344587cf06a39db471d2cc027504e8688a0a67cce961253500c956c73603fd58"),
-        key_derivation_index=-1,
-    ).add(root_path=farmer_service.root_path)
-    bad_pool_info = make_pool_info()
-    bad_pool_info["minimum_difficulty"] = -1
-    mock_http_get = mocker.patch(
-        "aiohttp.ClientSession.get",
-        return_value=DummyPoolInfoResponse(
-            ok=True,
-            status=200,
-            url=URL("https://endpoint-1.pool-domain.tld/some-path"),
-            pool_info=bad_pool_info,
-        ),
-    )
-
-    await farmer_service._node.update_pool_state()
-
-    mock_http_get.assert_called_once()
-    assert farmer_service._node.pool_state[p2_singleton_puzzle_hash]["current_difficulty"] == uint64(42)
-
-
-@pytest.mark.anyio
-async def test_update_pool_state_ignores_pool_info_error_code(
-    mocker: MockerFixture,
-    farmer_one_harvester: tuple[list[HarvesterService], FarmerService, BlockTools],
-) -> None:
-    _, farmer_service, _ = farmer_one_harvester
-    p2_singleton_puzzle_hash = bytes32.fromhex("302e05a1e6af431c22043ae2a9a8f71148c955c372697cb8ab348160976283df")
-    farmer_service._node.authentication_keys = {
-        p2_singleton_puzzle_hash: PrivateKey.from_bytes(
-            bytes.fromhex("11ed596eb95b31364a9185e948f6b66be30415f816819449d5d40751dc70e786")
-        ),
-    }
-    farmer_service._node.pool_state[p2_singleton_puzzle_hash] = make_pool_state(
-        p2_singleton_puzzle_hash,
-        overrides={
-            "current_difficulty": uint64(42),
-            "next_farmer_update": time() + UPDATE_POOL_FARMER_INFO_INTERVAL,
-        },
-    )
-    PoolingShareState(
-        owner_public_key=G1Element.from_bytes(
-            bytes.fromhex(
-                "84c3fcf9d5581c1ddc702cb0f3b4a06043303b334dd993ab42b2c320ebfa98e5ce558448615b3f69638ba92cf7f43da5"
-            )
-        ),
-        p2_singleton_puzzle_hash=p2_singleton_puzzle_hash,
-        payout_instructions="c2b08e41d766da4116e388357ed957d04ad754623a915f3fd65188a8746cf3e8",
-        pool_url="https://endpoint-1.pool-domain.tld/some-path",
-        launcher_id=bytes32.from_hexstr("ae4ef3b9bfe68949691281a015a9c16630fc8f66d48c19ca548fb80768791afa"),
-        target_puzzle_hash=bytes32.from_hexstr("344587cf06a39db471d2cc027504e8688a0a67cce961253500c956c73603fd58"),
-        key_derivation_index=-1,
-    ).add(root_path=farmer_service.root_path)
-    error_pool_info = make_pool_info()
-    error_pool_info["error_code"] = 1
-    error_pool_info["error_message"] = "pool unavailable"
-    mock_http_get = mocker.patch(
-        "aiohttp.ClientSession.get",
-        return_value=DummyPoolInfoResponse(
-            ok=True,
-            status=200,
-            url=URL("https://endpoint-1.pool-domain.tld/some-path"),
-            pool_info=error_pool_info,
-        ),
-    )
-
-    await farmer_service._node.update_pool_state()
-
-    mock_http_get.assert_called_once()
-    assert farmer_service._node.pool_state[p2_singleton_puzzle_hash]["current_difficulty"] == uint64(42)
+    if case.expected_current_difficulty is not None:
+        assert (
+            farmer_service._node.pool_state[p2_singleton_puzzle_hash]["current_difficulty"]
+            == case.expected_current_difficulty
+        )
 
 
 @pytest.mark.anyio

--- a/chia/_tests/farmer_harvester/test_farmer.py
+++ b/chia/_tests/farmer_harvester/test_farmer.py
@@ -1290,6 +1290,57 @@ async def test_update_pool_state_ignores_malformed_pool_info_difficulty(
 
 
 @pytest.mark.anyio
+async def test_update_pool_state_ignores_pool_info_error_code(
+    mocker: MockerFixture,
+    farmer_one_harvester: tuple[list[HarvesterService], FarmerService, BlockTools],
+) -> None:
+    _, farmer_service, _ = farmer_one_harvester
+    p2_singleton_puzzle_hash = bytes32.fromhex("302e05a1e6af431c22043ae2a9a8f71148c955c372697cb8ab348160976283df")
+    farmer_service._node.authentication_keys = {
+        p2_singleton_puzzle_hash: PrivateKey.from_bytes(
+            bytes.fromhex("11ed596eb95b31364a9185e948f6b66be30415f816819449d5d40751dc70e786")
+        ),
+    }
+    farmer_service._node.pool_state[p2_singleton_puzzle_hash] = make_pool_state(
+        p2_singleton_puzzle_hash,
+        overrides={
+            "current_difficulty": uint64(42),
+            "next_farmer_update": time() + UPDATE_POOL_FARMER_INFO_INTERVAL,
+        },
+    )
+    PoolingShareState(
+        owner_public_key=G1Element.from_bytes(
+            bytes.fromhex(
+                "84c3fcf9d5581c1ddc702cb0f3b4a06043303b334dd993ab42b2c320ebfa98e5ce558448615b3f69638ba92cf7f43da5"
+            )
+        ),
+        p2_singleton_puzzle_hash=p2_singleton_puzzle_hash,
+        payout_instructions="c2b08e41d766da4116e388357ed957d04ad754623a915f3fd65188a8746cf3e8",
+        pool_url="https://endpoint-1.pool-domain.tld/some-path",
+        launcher_id=bytes32.from_hexstr("ae4ef3b9bfe68949691281a015a9c16630fc8f66d48c19ca548fb80768791afa"),
+        target_puzzle_hash=bytes32.from_hexstr("344587cf06a39db471d2cc027504e8688a0a67cce961253500c956c73603fd58"),
+        key_derivation_index=-1,
+    ).add(root_path=farmer_service.root_path)
+    error_pool_info = make_pool_info()
+    error_pool_info["error_code"] = 1
+    error_pool_info["error_message"] = "pool unavailable"
+    mock_http_get = mocker.patch(
+        "aiohttp.ClientSession.get",
+        return_value=DummyPoolInfoResponse(
+            ok=True,
+            status=200,
+            url=URL("https://endpoint-1.pool-domain.tld/some-path"),
+            pool_info=error_pool_info,
+        ),
+    )
+
+    await farmer_service._node.update_pool_state()
+
+    mock_http_get.assert_called_once()
+    assert farmer_service._node.pool_state[p2_singleton_puzzle_hash]["current_difficulty"] == uint64(42)
+
+
+@pytest.mark.anyio
 async def test_new_signage_point_skips_pool_with_invalid_difficulty(
     mocker: MockerFixture,
     farmer_one_harvester: FarmerOneHarvester,

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -355,6 +355,12 @@ class Farmer:
                     if resp.ok:
                         response: dict[str, Any] = json.loads(await resp.text())
                         self.log.info(f"GET /pool_info response: {response}")
+                        if "error_code" in response:
+                            self.handle_failed_pool_response(
+                                pool_config.p2_singleton_puzzle_hash,
+                                f"Error in GET /pool_info {pool_config.pool_url}, {response}",
+                            )
+                            return None
                         try:
                             pool_info = GetPoolInfoResponse.from_json_dict(response)
                         except Exception as e:

--- a/chia/farmer/farmer.py
+++ b/chia/farmer/farmer.py
@@ -28,6 +28,7 @@ from chia.protocols.pool_protocol import (
     AuthenticationPayload,
     ErrorResponse,
     GetFarmerResponse,
+    GetPoolInfoResponse,
     PoolErrorCode,
     PostFarmerPayload,
     PostFarmerRequest,
@@ -68,7 +69,7 @@ UPDATE_POOL_FARMER_INFO_INTERVAL: int = 300
 
 @dataclass(frozen=True)
 class GetPoolInfoResult:
-    pool_info: dict[str, Any]
+    pool_info: GetPoolInfoResponse
     new_pool_url: str | None
 
 
@@ -354,6 +355,14 @@ class Farmer:
                     if resp.ok:
                         response: dict[str, Any] = json.loads(await resp.text())
                         self.log.info(f"GET /pool_info response: {response}")
+                        try:
+                            pool_info = GetPoolInfoResponse.from_json_dict(response)
+                        except Exception as e:
+                            self.handle_failed_pool_response(
+                                pool_config.p2_singleton_puzzle_hash,
+                                f"Invalid GET /pool_info response {pool_config.pool_url}, {e}",
+                            )
+                            return None
                         new_pool_url: str | None = None
                         response_url_str = f"{resp.url}"
                         if (
@@ -363,7 +372,7 @@ class Farmer:
                         ):
                             new_pool_url = response_url_str.replace("/pool_info", "")
 
-                        return GetPoolInfoResult(pool_info=response, new_pool_url=new_pool_url)
+                        return GetPoolInfoResult(pool_info=pool_info, new_pool_url=new_pool_url)
                     else:
                         self.handle_failed_pool_response(
                             pool_config.p2_singleton_puzzle_hash,
@@ -592,12 +601,12 @@ class Farmer:
                     pool_state["next_pool_info_update"] = time.time() + UPDATE_POOL_INFO_INTERVAL
                     # Makes a GET request to the pool to get the updated information
                     pool_info_result = await self._pool_get_pool_info(pool_config)
-                    if pool_info_result is not None and "error_code" not in pool_info_result.pool_info:
+                    if pool_info_result is not None:
                         pool_info = pool_info_result.pool_info
-                        pool_state["authentication_token_timeout"] = pool_info["authentication_token_timeout"]
+                        pool_state["authentication_token_timeout"] = pool_info.authentication_token_timeout
                         # Only update the first time from GET /pool_info, gets updated from GET /farmer later
                         if pool_state["current_difficulty"] is None:
-                            pool_state["current_difficulty"] = pool_info["minimum_difficulty"]
+                            pool_state["current_difficulty"] = pool_info.minimum_difficulty
                     else:
                         pool_state["next_pool_info_update"] = time.time() + UPDATE_POOL_INFO_FAILURE_RETRY_INTERVAL
 

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -431,6 +431,12 @@ class FarmerAPI:
                                 partial_response = PostPartialResponse.from_json_dict(pool_response)
                             except Exception as e:
                                 self.farmer.log.error(f"Invalid pool partial response: {e}")
+                                increment_pool_stats(
+                                    self.farmer.pool_state,
+                                    p2_singleton_puzzle_hash,
+                                    "invalid_partials",
+                                    time.time(),
+                                )
                                 return
 
                             increment_pool_stats(

--- a/chia/farmer/farmer_api.py
+++ b/chia/farmer/farmer_api.py
@@ -32,6 +32,7 @@ from chia.protocols.pool_protocol import (
     PoolErrorCode,
     PostPartialPayload,
     PostPartialRequest,
+    PostPartialResponse,
     get_current_authentication_token,
 )
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
@@ -426,13 +427,19 @@ class FarmerAPI:
                                     )
                                 return
 
+                            try:
+                                partial_response = PostPartialResponse.from_json_dict(pool_response)
+                            except Exception as e:
+                                self.farmer.log.error(f"Invalid pool partial response: {e}")
+                                return
+
                             increment_pool_stats(
                                 self.farmer.pool_state,
                                 p2_singleton_puzzle_hash,
                                 "valid_partials",
                                 time.time(),
                             )
-                            new_difficulty = pool_response["new_difficulty"]
+                            new_difficulty = partial_response.new_difficulty
                             increment_pool_stats(
                                 self.farmer.pool_state,
                                 p2_singleton_puzzle_hash,
@@ -629,13 +636,21 @@ class FarmerAPI:
                         f"{pool_dict['pool_config'].pool_url} "
                     )
                     continue
-                pool_difficulties.append(
-                    PoolDifficulty(
-                        pool_dict["current_difficulty"],
-                        self.farmer.constants.POOL_SUB_SLOT_ITERS,
-                        p2_singleton_puzzle_hash,
+                try:
+                    pool_difficulties.append(
+                        PoolDifficulty(
+                            pool_dict["current_difficulty"],
+                            self.farmer.constants.POOL_SUB_SLOT_ITERS,
+                            p2_singleton_puzzle_hash,
+                        )
                     )
-                )
+                except Exception as e:
+                    self.farmer.log.warning(
+                        f"Invalid pool difficulty for {p2_singleton_puzzle_hash}, "
+                        f"check communication with the pool, skipping this pool: "
+                        f"{pool_dict['pool_config'].pool_url}, {e}"
+                    )
+                    continue
 
             message2 = harvester_protocol.NewSignagePointHarvester2(
                 new_signage_point.challenge_hash,


### PR DESCRIPTION
## Summary

When a pool HTTP server returns a `difficulty` or `new_difficulty` value that cannot be represented as `uint64`, the farmer could fail to build signage-point messages for harvesters — affecting all plots, including solo and self-pool plots unrelated to the misbehaving pool.

This change adds two layers of protection:

- **Boundary validation:** `GET /pool_info` and `POST /partial` responses are now parsed through the existing typed schemas (`GetPoolInfoResponse`, `PostPartialResponse`), consistent with the existing `GET /farmer` path. Values that fail validation are logged and rejected; `current_difficulty` is left unchanged.
- **Per-pool fault isolation:** In `new_signage_point`, a pool whose stored difficulty cannot be coerced into `PoolDifficulty` is skipped with a warning instead of aborting delivery to harvesters for other pools and plots.

## Test plan

- [x] `test_update_pool_state_ignores_malformed_pool_info_difficulty` — invalid `minimum_difficulty` does not corrupt stored difficulty
- [x] `test_update_pool_state_ignores_pool_info_error_code` — `error_code` in pool_info response is rejected
- [x] `test_farmer_pool_response[malformed_new_difficulty]` — invalid `new_difficulty` in POST /partial is rejected and counted as invalid partial
- [x] `test_new_signage_point_skips_pool_with_invalid_difficulty` — valid pool and self-pool plots still receive signage points when another pool has bad difficulty
- [x] `ruff check`, `ruff format --check`, `mypy` on changed files
- [x] `pytest chia/_tests/farmer_harvester/ -k "signage_point or difficulty or malformed"`
- [x] Local diff coverage gate passes at 100%

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core farmer pooling and harvester messaging paths; behavior change is defensive but affects how partials and difficulties are accepted from pools.
> 
> **Overview**
> Prevents a misbehaving pool from breaking farmer→harvester signage points when HTTP responses contain difficulty values that are not valid `uint64`.
> 
> **GET /pool_info** is now validated with `GetPoolInfoResponse` (matching the existing **GET /farmer** pattern): responses with `error_code` or schema/typing failures are logged, recorded as pool errors where appropriate, and do not update `current_difficulty` or auth timeout from bad payloads.
> 
> **POST /partial** success bodies are parsed via `PostPartialResponse` before applying `new_difficulty`; invalid JSON shapes count as invalid partials and leave stored difficulty unchanged.
> 
> In **`new_signage_point`**, building `PoolDifficulty` for each pool is wrapped so a pool with corrupt stored difficulty is skipped with a warning instead of failing the whole signage-point broadcast to harvesters.
> 
> Tests cover malformed `new_difficulty`, bad `minimum_difficulty`, pool_info `error_code`, and signage-point delivery when one pool has invalid difficulty while others remain included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb35dc27470663fcbdb535174be9e67a324dd063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->