### PR TITLE
Improve macOS Intel CI timeout headroom

### DIFF
--- a/.github/workflows/test-single.yml
+++ b/.github/workflows/test-single.yml
@@ -261,13 +261,13 @@ jobs:
         run: |
           mv chia/ notchia/
 
-      - name: Test blockchain code with pytest with windows and 3.13 and reruns
-        if: matrix.os.name == 'windows' && matrix.python.name == '3.13'
+      - name: Test blockchain code with pytest with reruns
+        if: matrix.os.matrix == 'macos-intel' || (matrix.os.name == 'windows' && matrix.python.name == '3.13')
         run: |
-          pytest --reruns 1 --cov=chia --cov-config=.coveragerc --cov-report= -o 'junit_suite_name=${{ env.JOB_FILE_NAME }}' --junitxml='junit-data/junit.${{ env.JOB_FILE_NAME }}.xml' --durations=10 ${{ matrix.configuration.pytest_parallel_args[matrix.os.matrix] }} -m "not benchmark" ${{ env.ENABLE_PYTEST_MONITOR }} ${{ matrix.configuration.test_files }}
+          pytest --reruns 1 --reruns-delay 1 --cov=chia --cov-config=.coveragerc --cov-report= -o 'junit_suite_name=${{ env.JOB_FILE_NAME }}' --junitxml='junit-data/junit.${{ env.JOB_FILE_NAME }}.xml' --durations=10 ${{ matrix.configuration.pytest_parallel_args[matrix.os.matrix] }} -m "not benchmark" ${{ env.ENABLE_PYTEST_MONITOR }} ${{ matrix.configuration.test_files }}
 
       - name: Test blockchain code with pytest
-        if: ${{ !(matrix.os.name == 'windows' && matrix.python.name == '3.13') }}
+        if: ${{ !(matrix.os.matrix == 'macos-intel' || (matrix.os.name == 'windows' && matrix.python.name == '3.13')) }}
         env:
           ENABLE_PYTEST_MONITOR: ${{ matrix.os.matrix == 'ubuntu' && matrix.configuration.enable_pytest_monitor || '' }}
         run: |

--- a/chia/util/timing.py
+++ b/chia/util/timing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import sys
 import time
 from collections.abc import Callable, Iterator
@@ -24,9 +25,23 @@ system_delays = {
 }
 
 
+def _github_darwin_system_delay() -> int:
+    machine = platform.machine().lower()
+    runner_arch = os.environ.get("RUNNER_ARCH", "").lower()
+    arch = machine or runner_arch
+    if arch in {"x86_64", "amd64", "x64"}:
+        # Intel macOS runners are slower; tune as the hosted runner tier changes.
+        return 40
+
+    return system_delays["github"]["darwin"]
+
+
 if os.environ.get("GITHUB_ACTIONS") == "true":
     # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-    _system_delay = system_delays["github"][sys.platform]
+    if sys.platform == "darwin":
+        _system_delay = _github_darwin_system_delay()
+    else:
+        _system_delay = system_delays["github"][sys.platform]
 else:
     try:
         _system_delay = system_delays["local"][sys.platform]


### PR DESCRIPTION
### Purpose:

Reduce macOS Intel CI flakes caused by slow runner timing headroom without changing test assertions, end-state checks, or per-test logic.

### Current Behavior:

Only the Windows Python 3.13 job gets one pytest rerun, while macOS Intel runs without retries. GitHub Actions Darwin timeout padding is also flat across Intel and Apple Silicon.

### New Behavior:

macOS Intel jobs now use the same single pytest rerun envelope as the existing Windows Python 3.13 job, with a 1-second rerun delay. The no-rerun pytest step remains the exact negation of that condition.

GitHub Actions Darwin timeout padding is architecture-aware: Apple Silicon remains at 20 seconds, while Intel Darwin uses 40 seconds. Detection uses platform.machine(), falling back to RUNNER_ARCH when needed.

Invariants unchanged:
- Test assertions and end-state checks are unchanged.
- wait_transaction_records_entered_mempool's default timeout is unchanged.
- adjusted_timeout(None) still returns None.
- Linux, Windows, and local timeout padding values are unchanged.

### Testing Notes:

- YAML parse check for .github/workflows/test-single.yml: passed
- ./tools/py manage-mypy.py build-mypy-ini && ./tools/py -m mypy chia/util/timing.py --config-file mypy.ini: passed
- ./tools/py -m ruff check chia/util/timing.py && ./tools/py -m ruff format --check chia/util/timing.py: passed
- unset CI && ./tools/pytest --ignore=chia/_tests/tools/test_legacy_keyring.py chia/_tests/ -k timing -q: 4 passed
- unset CI && ./tools/pytest chia/_tests/util/test_timing.py chia/_tests/util/test_misc.py chia/_tests/util/test_async_pool.py chia/_tests/util/test_priority_mutex.py -q: 188 passed
- Coverage-enabled targeted util tests: 188 passed
- Host adjusted_timeout probe: x86_64 6
- Darwin probe: x86_64 -> 45, arm64 -> 25, RUNNER_ARCH=X64 -> 45, RUNNER_ARCH=ARM64 -> 25
- pre-commit run --files chia/util/timing.py .github/workflows/test-single.yml: passed
- chia-diff-cover --compare-branch origin/main: 100%

Benchmark note: the cached benchmark run had 157 passed with 4 failures and 2 errors in hard-fork block-cache loading (assert required_iters is not None). A fresh CHIA_ROOT rerun progressed past the earlier stale-cache failure but was stopped locally because it exceeded the useful local wait time; CI should run the full benchmark gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI workflow conditions and GitHub Actions Darwin timeout padding in `timing.py`; test assertions and other platform delays are unchanged.
> 
> **Overview**
> **CI** now treats **macOS Intel** like the existing **Windows + Python 3.13** path: one pytest rerun with a **1s** delay between attempts. The no-rerun step is the negation of that combined condition (renamed from a Windows-only reruns step).
> 
> **`adjusted_timeout`** on GitHub Actions **Darwin** uses **40s** system padding on **Intel** (`x86_64` / `amd64` / `x64` via `platform.machine()` or `RUNNER_ARCH`), while **Apple Silicon** stays at the prior **20s** `darwin` value. Linux, Windows, and local padding are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bb668c539909dc919df24c00a71a19e0cc7f507. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->