### PR TITLE
Harden cheap block parser bounds

### DIFF
--- a/chia/_tests/util/test_full_block_utils.py
+++ b/chia/_tests/util/test_full_block_utils.py
@@ -34,6 +34,8 @@ from chia.full_node.full_block_utils import (
     generator_from_block,
     get_height_and_tx_status_from_block,
     header_block_from_block,
+    skip_bytes,
+    skip_list,
     skip_reward_chain_block,
 )
 from chia.types.blockchain_format.serialized_program import SerializedProgram
@@ -136,6 +138,26 @@ def test_skip_reward_chain_block_handles_combined_optional_tag(has_icc: bool, ha
     )
     # The helper should consume exactly one serialized RewardChainBlock.
     assert len(skip_reward_chain_block(memoryview(bytes(reward_chain_block)))) == 0
+
+
+def test_skip_list_rejects_count_exceeding_remaining_buffer() -> None:
+    with pytest.raises(ValueError, match="list count 2 exceeds remaining buffer 1"):
+        skip_list(memoryview((2).to_bytes(4, "big") + b"\x00"), skip_bytes)
+
+
+def test_skip_list_rejects_short_count_prefix() -> None:
+    with pytest.raises(ValueError, match="list count prefix requires 4 bytes, remaining buffer 1"):
+        skip_list(memoryview(b"\x00"), skip_bytes)
+
+
+def test_skip_bytes_rejects_length_exceeding_remaining_buffer() -> None:
+    with pytest.raises(ValueError, match="byte length 4 exceeds remaining buffer 3"):
+        skip_bytes(memoryview((4).to_bytes(4, "big") + b"abc"))
+
+
+def test_skip_bytes_rejects_short_length_prefix() -> None:
+    with pytest.raises(ValueError, match="byte length prefix requires 4 bytes, remaining buffer 1"):
+        skip_bytes(memoryview(b"\x00"))
 
 
 def get_foliage_block_data() -> Iterator[FoliageBlockData]:
@@ -301,6 +323,41 @@ def get_full_blocks(shard: int) -> Iterator[FullBlock]:
                                                 gen,  # transactions_generator
                                                 refs_list,  # transactions_generator_ref_list
                                             )
+
+
+def test_block_info_from_block_rejects_refs_count_exceeding_remaining_buffer() -> None:
+    block_bytes = bytearray(bytes(next(get_full_blocks(0))))
+    block_bytes[-4:] = (1).to_bytes(4, "big")
+
+    with pytest.raises(ValueError, match="refs count 1 exceeds remaining buffer 0"):
+        block_info_from_block(memoryview(block_bytes))
+
+
+def test_block_info_from_block_rejects_short_refs_count_prefix() -> None:
+    block_bytes = bytearray(bytes(next(get_full_blocks(0))))
+    del block_bytes[-3:]
+
+    with pytest.raises(ValueError, match="refs count prefix requires 4 bytes, remaining buffer 1"):
+        block_info_from_block(memoryview(block_bytes))
+
+
+def test_cheap_parser_matches_round_tripped_block() -> None:
+    block = next(get_full_blocks(0))
+    block_bytes = memoryview(bytes(block))
+    round_tripped = FullBlock.from_bytes(block_bytes)
+
+    height, is_tx_block = get_height_and_tx_status_from_block(block_bytes)
+    assert height == round_tripped.height
+    assert is_tx_block == round_tripped.is_transaction_block()
+    assert generator_from_block(block_bytes) is None
+
+    block_info = block_info_from_block(block_bytes)
+    assert block_info.prev_header_hash == round_tripped.prev_header_hash
+    assert block_info.transactions_generator == round_tripped.transactions_generator
+    assert block_info.transactions_generator_ref_list == round_tripped.transactions_generator_ref_list
+
+    header_block = HeaderBlock.from_bytes(header_block_from_block(block_bytes))
+    assert header_block == get_block_header(round_tripped, None)
 
 
 @pytest.mark.anyio

--- a/chia/full_node/full_block_utils.py
+++ b/chia/full_node/full_block_utils.py
@@ -13,17 +13,24 @@ from chia.types.blockchain_format.serialized_program import SerializedProgram
 
 
 def skip_list(buf: memoryview, skip_item: Callable[[memoryview], memoryview]) -> memoryview:
+    if len(buf) < 4:
+        raise ValueError(f"list count prefix requires 4 bytes, remaining buffer {len(buf)}")
     n = int.from_bytes(buf[:4], "big", signed=False)
     buf = buf[4:]
+    if n > len(buf):
+        raise ValueError(f"list count {n} exceeds remaining buffer {len(buf)}")
     for _ in range(n):
         buf = skip_item(buf)
     return buf
 
 
 def skip_bytes(buf: memoryview) -> memoryview:
+    if len(buf) < 4:
+        raise ValueError(f"byte length prefix requires 4 bytes, remaining buffer {len(buf)}")
     n = int.from_bytes(buf[:4], "big", signed=False)
     buf = buf[4:]
-    assert n >= 0
+    if n > len(buf):
+        raise ValueError(f"byte length {n} exceeds remaining buffer {len(buf)}")
     return buf[n:]
 
 
@@ -277,8 +284,12 @@ def block_info_from_block(buf: memoryview) -> GeneratorBlockInfo:
     else:
         buf = buf[1:]
 
+    if len(buf) < 4:
+        raise ValueError(f"refs count prefix requires 4 bytes, remaining buffer {len(buf)}")
     refs_length = uint32.from_bytes(buf[:4])
     buf = buf[4:]
+    if refs_length * 4 > len(buf):
+        raise ValueError(f"refs count {refs_length} exceeds remaining buffer {len(buf)}")
 
     refs = []
     for i in range(refs_length):


### PR DESCRIPTION
### Purpose:

Fail fast on malformed or truncated local block buffers in the cheap full block parser, while preserving the canonical full-block parser fallback paths.

### Current Behavior:

The cheap parser could continue after truncated or oversized serialized count/length fields in a few fast-path helpers. Some callers already fall back to `FullBlock.from_bytes()` when the cheap parser raises.

### New Behavior:

The cheap parser now raises `ValueError` when list counts, byte lengths, or generator-ref counts cannot fit in the remaining buffer, including short count/length prefixes.

Invariants unchanged:
- Well-formed block bytes continue to parse to the same height, transaction status, generator info, refs list, and header block data.
- Callers that already fall back on cheap-parser exceptions keep using the canonical full-block parser path.
- No serialization format, database schema, or wire message shape changes.
- Malformed/truncated buffers now fail fast instead of silently advancing through an impossible count or length.

### Testing Notes:

- `ruff check chia/full_node/full_block_utils.py chia/_tests/util/test_full_block_utils.py`
- `ruff format --check chia/full_node/full_block_utils.py chia/_tests/util/test_full_block_utils.py`
- `./tools/py -m mypy chia/full_node/full_block_utils.py chia/_tests/util/test_full_block_utils.py --config-file mypy.ini`
- `unset CI && ./tools/pytest chia/_tests/util/test_full_block_utils.py::test_skip_list_rejects_count_exceeding_remaining_buffer chia/_tests/util/test_full_block_utils.py::test_skip_list_rejects_short_count_prefix chia/_tests/util/test_full_block_utils.py::test_skip_bytes_rejects_length_exceeding_remaining_buffer chia/_tests/util/test_full_block_utils.py::test_skip_bytes_rejects_short_length_prefix chia/_tests/util/test_full_block_utils.py::test_block_info_from_block_rejects_refs_count_exceeding_remaining_buffer chia/_tests/util/test_full_block_utils.py::test_block_info_from_block_rejects_short_refs_count_prefix chia/_tests/util/test_full_block_utils.py::test_cheap_parser_matches_round_tripped_block -v --override-ini="addopts=--verbose --tb=short" --cov=chia --cov-config=.coveragerc --cov-report=`
- `$HOME/Projects/dotfiles/bin/chia-diff-cover --compare-branch origin/main` - 100% diff coverage
- `pre-commit run --all-files`
- `unset CI && ./tools/pytest -m benchmark -n 0 --capture no --ignore=chia/_tests/tools/test_legacy_keyring.py chia/_tests/` was attempted twice locally and failed in unrelated hard-fork 3 test plot proof generation setup (`assert proof != b""` in `chia/simulator/block_tools.py`). The second attempt rebuilt the generated plot operation cache and failed with the same benchmark-only cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parsing hardening with existing BlockStore fallback; no wire format or schema changes, and well-formed blocks stay behavior-identical.
> 
> **Overview**
> The **cheap full-block parser** in `full_block_utils` now **fails fast** on truncated or inconsistent serialized buffers instead of advancing past impossible list counts, byte lengths, or generator-ref tails.
> 
> `skip_list` and `skip_bytes` raise **`ValueError`** when the 4-byte count/length prefix is missing or when the declared size exceeds what remains in the buffer; `skip_bytes` drops the old non-negative length assert in favor of that check. **`block_info_from_block`** applies the same rules to the **transactions generator ref list** at the end of a block.
> 
> **Tests** cover each new error path plus a round-trip check that well-formed blocks still match `FullBlock.from_bytes()` and the existing cheap-parser entry points. **`BlockStore`** already catches cheap-parser failures and falls back to the canonical parser, so behavior for valid stored blocks is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 185d396ce3cc9434f8a2a4bcaba8989f392b164c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->