### PR TITLE
Fix DataLayer unsubscribe leaving leftover roots and self-heal blobless stores

### DIFF
--- a/chia/_tests/core/data_layer/test_data_rpc.py
+++ b/chia/_tests/core/data_layer/test_data_rpc.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import random
+import shutil
 import sqlite3
 import sys
 import time
@@ -2436,6 +2437,289 @@ async def test_unsubscribe_removes_files(
 
         filenames = {path.name for path in store_path.iterdir()}
         assert len(filenames) == (2 * update_count if retain else 0)
+
+
+async def _build_synced_store(
+    data_layer: DataLayer,
+    data_rpc_api: DataLayerRpcApi,
+    full_node_api: FullNodeSimulator,
+    ph: bytes32,
+    wallet_rpc_api: WalletRpcApi,
+    manage_data_interval: int,
+    update_count: int = 5,
+) -> bytes32:
+    res = await data_rpc_api.create_data_store({})
+    assert res is not None
+    store_id = bytes32.from_hexstr(res["id"])
+    await farm_block_check_singleton(data_layer, full_node_api, ph, store_id, wallet=wallet_rpc_api.service)
+    # Self-subscribe with a dummy URL: download_file short-circuits on the locally-served
+    # .dat files (same folder), so a reset store re-syncs without a real server.
+    await data_rpc_api.subscribe(request={"id": store_id.hex(), "urls": ["http://127.0.0.1/8000"]})
+    for batch_count in range(update_count):
+        key = batch_count.to_bytes(2, "big")
+        value = batch_count.to_bytes(2, "big")
+        changelist = [{"action": "insert", "key": key.hex(), "value": value.hex()}]
+        res = await data_rpc_api.batch_update({"id": store_id.hex(), "changelist": changelist})
+        await farm_block_with_spend(full_node_api, ph, res["tx_id"], wallet_rpc_api)
+        await asyncio.sleep(manage_data_interval * 2)
+    return store_id
+
+
+async def _keys_values_count(data_rpc_api: DataLayerRpcApi, store_id: bytes32) -> int:
+    res = await data_rpc_api.get_keys_values({"id": store_id.hex()})
+    return len(res["keys_values"])
+
+
+@pytest.mark.parametrize("delete_mode", ["file", "store_dir"])
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
+@pytest.mark.anyio
+async def test_fetch_and_validate_heals_missing_blob(
+    self_hostname: str,
+    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    tmp_path: Path,
+    delete_mode: str,
+) -> None:
+    wallet_rpc_api, full_node_api, wallet_rpc_port, ph, bt = await init_wallet_and_node(
+        self_hostname, one_wallet_and_one_simulator_services
+    )
+    manage_data_interval = 5
+    async with init_data_layer(
+        wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path, manage_data_interval=manage_data_interval
+    ) as data_layer:
+        data_rpc_api = DataLayerRpcApi(data_layer)
+        store_id = await _build_synced_store(
+            data_layer, data_rpc_api, full_node_api, ph, wallet_rpc_api, manage_data_interval
+        )
+        assert await _keys_values_count(data_rpc_api, store_id) > 0
+
+        store = data_layer.data_store
+        root = await store.get_tree_root(store_id)
+        assert root.node_hash is not None
+        synced_generation = root.generation
+
+        # A committed root whose on-disk blob is gone. "file" deletes just the current blob;
+        # "store_dir" removes the whole per-store merkle directory, exercising the heal for a
+        # missing blob file and for a missing per-store directory.
+        if delete_mode == "file":
+            store.get_merkle_path(store_id=store_id, root_hash=root.node_hash).unlink()
+        else:
+            shutil.rmtree(store.get_merkle_path(store_id=store_id, root_hash=None))
+        store.recent_merkle_blobs.clear()
+        assert store.merkle_blob_available(store_id, root.node_hash) is False
+
+        await data_layer.fetch_and_validate(store_id)
+
+        healed_root = await store.get_tree_root(store_id)
+        assert healed_root.node_hash == root.node_hash
+        assert healed_root.generation == synced_generation
+        assert store.merkle_blob_available(store_id, healed_root.node_hash) is True
+        # Evict again so a non-empty result cannot come from a warm cache masking a bad heal.
+        store.recent_merkle_blobs.clear()
+        assert await _keys_values_count(data_rpc_api, store_id) > 0
+
+
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
+@pytest.mark.anyio
+async def test_fetch_and_validate_heals_when_chain_advanced(
+    self_hostname: str,
+    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    tmp_path: Path,
+) -> None:
+    wallet_rpc_api, full_node_api, wallet_rpc_port, ph, bt = await init_wallet_and_node(
+        self_hostname, one_wallet_and_one_simulator_services
+    )
+    manage_data_interval = 5
+    async with init_data_layer(
+        wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path, manage_data_interval=manage_data_interval
+    ) as data_layer:
+        data_rpc_api = DataLayerRpcApi(data_layer)
+        store_id = await _build_synced_store(
+            data_layer, data_rpc_api, full_node_api, ph, wallet_rpc_api, manage_data_interval
+        )
+        store = data_layer.data_store
+        chain_generation = (await store.get_tree_root(store_id)).generation
+        assert chain_generation > 1
+
+        # Roll the local store back behind the chain and remove the blob dir entirely:
+        # local gen N != chain gen M, so a missing blob at a non-matching generation triggers the heal.
+        target_generation = chain_generation - 2
+        await store.rollback_to_generation(store_id, target_generation)
+        rolled_back_root = await store.get_tree_root(store_id)
+        assert rolled_back_root.generation == target_generation
+        assert rolled_back_root.node_hash is not None
+        shutil.rmtree(store.get_merkle_path(store_id=store_id, root_hash=None))
+        store.recent_merkle_blobs.clear()
+
+        await data_layer.fetch_and_validate(store_id)
+
+        healed_root = await store.get_tree_root(store_id)
+        assert healed_root.generation == chain_generation
+        assert store.merkle_blob_available(store_id, healed_root.node_hash) is True
+        store.recent_merkle_blobs.clear()
+        assert await _keys_values_count(data_rpc_api, store_id) > 0
+
+
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
+@pytest.mark.anyio
+async def test_fetch_and_validate_resets_when_no_local_root(
+    self_hostname: str,
+    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    tmp_path: Path,
+) -> None:
+    wallet_rpc_api, full_node_api, wallet_rpc_port, ph, bt = await init_wallet_and_node(
+        self_hostname, one_wallet_and_one_simulator_services
+    )
+    manage_data_interval = 5
+    async with init_data_layer(
+        wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path, manage_data_interval=manage_data_interval
+    ) as data_layer:
+        data_rpc_api = DataLayerRpcApi(data_layer)
+        store_id = await _build_synced_store(
+            data_layer, data_rpc_api, full_node_api, ph, wallet_rpc_api, manage_data_interval
+        )
+        store = data_layer.data_store
+        chain_generation = (await store.get_tree_root(store_id)).generation
+
+        # Wipe every root row so store_id_exists is False: drives the `root is None` reset branch.
+        await store.clear_store_roots(store_id)
+        assert await store.store_id_exists(store_id) is False
+        store.recent_merkle_blobs.clear()
+
+        await data_layer.fetch_and_validate(store_id)
+
+        assert await store.store_id_exists(store_id) is True
+        assert (await store.get_tree_root(store_id)).generation == chain_generation
+        store.recent_merkle_blobs.clear()
+        assert await _keys_values_count(data_rpc_api, store_id) > 0
+
+
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
+@pytest.mark.anyio
+async def test_fetch_and_validate_skips_heal_when_local_ahead(
+    self_hostname: str,
+    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    tmp_path: Path,
+) -> None:
+    wallet_rpc_api, full_node_api, wallet_rpc_port, ph, bt = await init_wallet_and_node(
+        self_hostname, one_wallet_and_one_simulator_services
+    )
+    manage_data_interval = 5
+    async with init_data_layer(
+        wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path, manage_data_interval=manage_data_interval
+    ) as data_layer:
+        data_rpc_api = DataLayerRpcApi(data_layer)
+        store_id = await _build_synced_store(
+            data_layer, data_rpc_api, full_node_api, ph, wallet_rpc_api, manage_data_interval
+        )
+        store = data_layer.data_store
+        root = await store.get_tree_root(store_id)
+        assert root.node_hash is not None
+
+        # Drop the served URL so no servers are available: the heal reset runs before the
+        # server loop, so it would still fire if guard A were missing, but a local-ahead store
+        # with a missing blob otherwise hits unrelated downstream file-writing.
+        await store.remove_subscriptions(store_id, ["http://127.0.0.1/8000"])
+        assert await store.get_available_servers_for_store(store_id, int(time.time())) == []
+
+        # Push the local committed generation past the chain, then drop the blob. Guard A must
+        # preserve this local-ahead history rather than resetting it to gen 0.
+        await store.shift_root_generations(store_id, shift_size=1)
+        ahead_root = await store.get_tree_root(store_id)
+        assert ahead_root.generation == root.generation + 1
+        store.get_merkle_path(store_id=store_id, root_hash=ahead_root.node_hash).unlink()
+        store.recent_merkle_blobs.clear()
+        assert store.merkle_blob_available(store_id, ahead_root.node_hash) is False
+
+        await data_layer.fetch_and_validate(store_id)
+
+        unchanged_root = await store.get_tree_root(store_id)
+        assert unchanged_root.generation == ahead_root.generation
+        assert unchanged_root.node_hash == ahead_root.node_hash
+
+
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
+@pytest.mark.anyio
+async def test_fetch_and_validate_skips_heal_on_global_dir_loss(
+    self_hostname: str,
+    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    tmp_path: Path,
+) -> None:
+    wallet_rpc_api, full_node_api, wallet_rpc_port, ph, bt = await init_wallet_and_node(
+        self_hostname, one_wallet_and_one_simulator_services
+    )
+    manage_data_interval = 5
+    async with init_data_layer(
+        wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path, manage_data_interval=manage_data_interval
+    ) as data_layer:
+        data_rpc_api = DataLayerRpcApi(data_layer)
+        store_id = await _build_synced_store(
+            data_layer, data_rpc_api, full_node_api, ph, wallet_rpc_api, manage_data_interval
+        )
+        store = data_layer.data_store
+        root = await store.get_tree_root(store_id)
+        assert root.node_hash is not None
+        synced_generation = root.generation
+
+        # Whole blob volume gone (e.g. unmounted): guard B must skip the reset to avoid a mass
+        # re-sync of every store; this is an environment fault, not a per-store missing-blob condition.
+        shutil.rmtree(store.merkle_blobs_path)
+        store.recent_merkle_blobs.clear()
+        assert store.merkle_blobs_path.is_dir() is False
+
+        await data_layer.fetch_and_validate(store_id)
+
+        skipped_root = await store.get_tree_root(store_id)
+        assert skipped_root.generation == synced_generation
+        assert skipped_root.node_hash == root.node_hash
+        # If guard B were removed, the heal would reset to gen 0 and the resync would recreate
+        # the blobs root via mkdir(parents=True); its continued absence proves no reset ran.
+        assert store.merkle_blobs_path.is_dir() is False
+        assert store.merkle_blob_available(store_id, root.node_hash) is False
+
+        # Once the volume is back, the next pass heals the now-missing per-store blob.
+        store.merkle_blobs_path.mkdir(parents=True, exist_ok=True)
+        store.recent_merkle_blobs.clear()
+        await data_layer.fetch_and_validate(store_id)
+        healed_root = await store.get_tree_root(store_id)
+        assert healed_root.generation == synced_generation
+        assert store.merkle_blob_available(store_id, healed_root.node_hash) is True
+
+
+@pytest.mark.limit_consensus_modes(reason="does not depend on consensus rules")
+@pytest.mark.anyio
+async def test_fetch_and_validate_heals_with_zero_servers_leaves_empty_gen0(
+    self_hostname: str,
+    one_wallet_and_one_simulator_services: SimulatorsAndWalletsServices,
+    tmp_path: Path,
+) -> None:
+    wallet_rpc_api, full_node_api, wallet_rpc_port, ph, bt = await init_wallet_and_node(
+        self_hostname, one_wallet_and_one_simulator_services
+    )
+    manage_data_interval = 5
+    async with init_data_layer(
+        wallet_rpc_port=wallet_rpc_port, bt=bt, db_path=tmp_path, manage_data_interval=manage_data_interval
+    ) as data_layer:
+        data_rpc_api = DataLayerRpcApi(data_layer)
+        store_id = await _build_synced_store(
+            data_layer, data_rpc_api, full_node_api, ph, wallet_rpc_api, manage_data_interval
+        )
+        store = data_layer.data_store
+        root = await store.get_tree_root(store_id)
+        assert root.node_hash is not None
+
+        # Drop the served URL so there is no resync source, then corrupt the current blob.
+        await store.remove_subscriptions(store_id, ["http://127.0.0.1/8000"])
+        assert await store.get_available_servers_for_store(store_id, int(time.time())) == []
+        store.get_merkle_path(store_id=store_id, root_hash=root.node_hash).unlink()
+        store.recent_merkle_blobs.clear()
+
+        await data_layer.fetch_and_validate(store_id)
+
+        # The reset runs even with no download source: the store lands on a clean empty gen-0
+        # (so it is no longer falsely "synced") and heals later once a server is available.
+        reset_root = await store.get_tree_root(store_id)
+        assert reset_root.generation == 0
+        assert reset_root.node_hash is None
 
 
 @pytest.mark.parametrize(argnames="layer", argvalues=list(InterfaceLayer))

--- a/chia/_tests/core/data_layer/test_data_store.py
+++ b/chia/_tests/core/data_layer/test_data_store.py
@@ -1126,7 +1126,7 @@ async def test_unsubscribe_clears_databases(data_store: DataStore, store_id: byt
         )
     await data_store.add_node_hashes(store_id)
 
-    tables = ["ids", "nodes"]
+    tables = ["root", "ids", "nodes"]
     for table in tables:
         async with data_store.db_wrapper.reader() as reader:
             async with reader.execute(f"SELECT COUNT(*) FROM {table}") as cursor:
@@ -1142,6 +1142,122 @@ async def test_unsubscribe_clears_databases(data_store: DataStore, store_id: byt
                 row_count = await cursor.fetchone()
                 assert row_count is not None
                 assert row_count[0] == 0
+
+    # With root rows gone the store no longer advertises any committed generation,
+    # so a later re-subscribe restarts cleanly from generation 0.
+    assert await data_store.store_id_exists(store_id) is False
+    with pytest.raises(Exception, match="No generations found for store ID"):
+        await data_store.get_tree_root(store_id)
+
+
+@pytest.mark.anyio
+async def test_unsubscribe_then_resubscribe_starts_clean(data_store: DataStore, store_id: bytes32) -> None:
+    await data_store.subscribe(Subscription(store_id, []))
+    await add_0123_example(data_store, store_id)
+    await data_store.add_node_hashes(store_id)
+    assert await data_store.store_id_exists(store_id) is True
+
+    await data_store.unsubscribe(store_id)
+
+    for table in ["root", "ids", "nodes"]:
+        async with data_store.db_wrapper.reader() as reader:
+            async with reader.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE {'tree_id' if table == 'root' else 'store_id'} == ?",
+                (store_id,),
+            ) as cursor:
+                row_count = await cursor.fetchone()
+                assert row_count is not None
+                assert row_count[0] == 0
+    assert await data_store.store_id_exists(store_id) is False
+
+    # Pure data-store re-subscribe (no manage-data loop): subscribe only inserts a
+    # subscription row, so the store stays at zero committed roots until a real sync.
+    await data_store.subscribe(Subscription(store_id, []))
+    assert await data_store.store_id_exists(store_id) is False
+
+
+@pytest.mark.anyio
+async def test_unsubscribe_clears_unconfirmed_keys_values(data_store: DataStore, store_id: bytes32) -> None:
+    await data_store.subscribe(Subscription(store_id, []))
+    data_store.unconfirmed_keys_values[store_id] = [bytes32.zeros]
+    assert store_id in data_store.unconfirmed_keys_values
+
+    await data_store.unsubscribe(store_id)
+
+    assert store_id not in data_store.unconfirmed_keys_values
+
+
+@pytest.mark.anyio
+async def test_clear_store_roots_wipes_all_roots(data_store: DataStore, store_id: bytes32) -> None:
+    await add_0123_example(data_store, store_id)
+    await data_store.add_node_hashes(store_id)
+    await data_store.create_tree(store_id=store_id, status=Status.PENDING)
+    assert await data_store.get_pending_root(store_id=store_id) is not None
+    assert await data_store.store_id_exists(store_id) is True
+
+    await data_store.clear_store_roots(store_id=store_id)
+
+    assert await data_store.store_id_exists(store_id) is False
+    assert await data_store.get_pending_root(store_id=store_id) is None
+    for table in ["root", "nodes"]:
+        async with data_store.db_wrapper.reader() as reader:
+            async with reader.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE {'tree_id' if table == 'root' else 'store_id'} == ?",
+                (store_id,),
+            ) as cursor:
+                row_count = await cursor.fetchone()
+                assert row_count is not None
+                assert row_count[0] == 0
+
+
+@pytest.mark.anyio
+async def test_reset_store_to_empty_root_reseeds_gen0(data_store: DataStore, store_id: bytes32) -> None:
+    await add_0123_example(data_store, store_id)
+    await data_store.add_node_hashes(store_id)
+    assert (await data_store.get_tree_root(store_id)).generation > 0
+
+    await data_store.reset_store_to_empty_root(store_id)
+
+    root = await data_store.get_tree_root(store_id)
+    assert root.generation == 0
+    assert root.node_hash is None
+    assert await data_store.get_tree_generation(store_id) == 0
+    assert await data_store.store_id_exists(store_id) is True
+
+
+@pytest.mark.anyio
+async def test_reset_store_to_empty_root_with_pending_gen0_root(raw_data_store: DataStore, store_id: bytes32) -> None:
+    # store_id has no COMMITTED root, only a leftover PENDING gen-0 row. A bare create_tree
+    # here would blind-INSERT gen 0 and collide on PRIMARY KEY(tree_id, generation); the
+    # reset must clear pending roots first.
+    await raw_data_store.create_tree(store_id=store_id, status=Status.PENDING)
+    assert await raw_data_store.get_pending_root(store_id=store_id) is not None
+    assert await raw_data_store.store_id_exists(store_id) is False
+
+    await raw_data_store.reset_store_to_empty_root(store_id)
+
+    root = await raw_data_store.get_tree_root(store_id)
+    assert root.generation == 0
+    assert root.node_hash is None
+    assert await raw_data_store.get_pending_root(store_id=store_id) is None
+
+
+@pytest.mark.anyio
+async def test_merkle_blob_available_ignores_cache(data_store: DataStore, store_id: bytes32) -> None:
+    data_store.recent_merkle_blobs = LRUCache(capacity=128)
+    await add_0123_example(data_store, store_id)
+    root = await data_store.get_tree_root(store_id)
+    assert root.node_hash is not None
+
+    # Warm the cache, then delete the on-disk blob: merkle_blob_available must report the
+    # blob absent by checking the disk, not by consulting the still-warm cache.
+    await data_store.get_merkle_blob(store_id=store_id, root_hash=root.node_hash)
+    assert data_store.recent_merkle_blobs.get((store_id, root.node_hash)) is not None
+    data_store.get_merkle_path(store_id=store_id, root_hash=root.node_hash).unlink()
+
+    assert data_store.merkle_blob_available(store_id, root.node_hash) is False
+    # None means "empty tree", which has no on-disk blob, so the helper reports unavailable.
+    assert data_store.merkle_blob_available(store_id, None) is False
 
 
 @pytest.mark.anyio

--- a/chia/data_layer/data_layer.py
+++ b/chia/data_layer/data_layer.py
@@ -616,8 +616,40 @@ class DataLayer:
 
         await self._update_confirmation_status(store_id=store_id)
 
-        if not await self.data_store.store_id_exists(store_id=store_id):
-            await self.data_store.create_tree(store_id=store_id, status=Status.COMMITTED)
+        root = None
+        if await self.data_store.store_id_exists(store_id=store_id):
+            root = await self.data_store.get_tree_root(store_id=store_id)
+
+        if root is None:
+            # store_id_exists is COMMITTED-only, so a leftover PENDING gen-0 row would make a
+            # bare create_tree default to gen 0 and blind-INSERT, colliding on
+            # PRIMARY KEY(tree_id, generation). reset_store_to_empty_root clears pending roots
+            # first, so it is collision-safe.
+            await self.data_store.reset_store_to_empty_root(store_id)
+        elif (
+            root.node_hash is not None
+            # Guard A: leave a local-ahead store untouched; it heals once the chain catches up.
+            and root.generation <= singleton_record.generation
+            # Sync call on purpose (see merkle_blob_available); a missing blob file at any
+            # generation, including a whole per-store directory absence, triggers the heal.
+            and not self.data_store.merkle_blob_available(store_id, root.node_hash)
+        ):
+            # Guard B is the GLOBAL blobs root (parent of every per-store dir). If it is missing
+            # the whole volume is unavailable, so skip the reset to avoid a mass re-sync of every
+            # store and surface the environment fault instead of silently healing.
+            if self.data_store.merkle_blobs_path.is_dir():
+                # Runs outside subscription_lock; the reset only fires when the committed root's
+                # blob is already missing on disk, so it cannot discard a healthy store's work.
+                self.log.warning(
+                    f"Detected committed root with missing blob for {store_id} at generation "
+                    f"{root.generation}; resetting and resyncing."
+                )
+                await self.data_store.reset_store_to_empty_root(store_id)
+            else:
+                self.log.warning(
+                    f"Merkle blobs path {self.data_store.merkle_blobs_path} is missing; skipping "
+                    f"self-heal for {store_id} — check the storage volume."
+                )
 
         timestamp = int(time.time())
         servers_info = await self.data_store.get_available_servers_for_store(store_id, timestamp)

--- a/chia/data_layer/data_store.py
+++ b/chia/data_layer/data_store.py
@@ -535,6 +535,14 @@ class DataStore:
 
         return merkle_blob
 
+    def merkle_blob_available(self, store_id: bytes32, root_hash: bytes32 | None) -> bool:
+        # Cheap on-disk presence check that bypasses recent_merkle_blobs: a cached blob
+        # would otherwise mask an on-disk deletion. Sync on purpose (no parse, O(1) stat);
+        # an async def here would make the heal gate's `not <coroutine>` always False.
+        if root_hash is None:
+            return False
+        return self.get_merkle_path(store_id=store_id, root_hash=root_hash).is_file()
+
     def get_bytes_path(self, bytes_: bytes) -> Path:
         raw = bytes_.hex()
         segment_sizes = [2, 2, 2]
@@ -921,6 +929,28 @@ class DataStore:
         await self._insert_root(store_id=store_id, node_hash=None, status=status)
 
         return True
+
+    async def clear_store_roots(self, store_id: bytes32) -> None:
+        async with self.db_wrapper.writer() as writer:
+            # No status filter: removes COMMITTED, PENDING, and PENDING_BATCH roots in one
+            # statement, so unsubscribe/heal leave zero per-store state in `root`/`nodes`.
+            await writer.execute(
+                "DELETE FROM root WHERE tree_id == :tree_id",
+                {"tree_id": store_id},
+            )
+            await writer.execute(
+                "DELETE FROM nodes WHERE store_id == :store_id",
+                {"store_id": store_id},
+            )
+
+    async def reset_store_to_empty_root(self, store_id: bytes32) -> None:
+        # Single atomic wipe + reseed: clear_store_roots and create_tree both join this
+        # task's writer transaction, so a crash mid-reset leaves either the old state or a
+        # clean committed gen-0 root, never a partial state. Clearing pending roots first
+        # avoids a PRIMARY KEY(tree_id, generation) collision with a leftover PENDING gen-0.
+        async with self.db_wrapper.writer():
+            await self.clear_store_roots(store_id=store_id)
+            await self.create_tree(store_id=store_id, status=Status.COMMITTED)
 
     async def table_is_empty(self, store_id: bytes32) -> bool:
         tree_root = await self.get_tree_root(store_id=store_id)
@@ -1735,16 +1765,21 @@ class DataStore:
                 "DELETE FROM ids WHERE store_id == :store_id",
                 {"store_id": store_id},
             )
-            await writer.execute(
-                "DELETE FROM nodes WHERE store_id == :store_id",
-                {"store_id": store_id},
-            )
+            # Clear all root/nodes rows so re-subscribe restarts from generation 0; a leftover
+            # committed root would otherwise advertise sync while the blobs below are gone.
+            await self.clear_store_roots(store_id=store_id)
 
-            with contextlib.suppress(FileNotFoundError):
-                shutil.rmtree(self.get_merkle_path(store_id=store_id, root_hash=None))
+        self.unconfirmed_keys_values.pop(store_id, None)
 
-            with contextlib.suppress(FileNotFoundError):
-                shutil.rmtree(self.get_key_value_path(store_id=store_id, blob_hash=None))
+        # rmtree runs after the SQL commit on purpose: deleting blobs before commit would,
+        # on a commit failure, restore the root rows while the blobs are already gone,
+        # recreating the synced-but-blobless state. Post-commit failure leaves only orphaned
+        # dirs with a clean DB, which a fresh gen-0 subscribe ignores.
+        with contextlib.suppress(FileNotFoundError):
+            shutil.rmtree(self.get_merkle_path(store_id=store_id, root_hash=None))
+
+        with contextlib.suppress(FileNotFoundError):
+            shutil.rmtree(self.get_key_value_path(store_id=store_id, blob_hash=None))
 
     async def rollback_to_generation(self, store_id: bytes32, target_generation: int) -> None:
         async with self.db_wrapper.writer() as writer:

--- a/chia/util/lru_cache.py
+++ b/chia/util/lru_cache.py
@@ -33,6 +33,9 @@ class LRUCache(Generic[K, V]):
     def remove(self, key: K) -> None:
         self.cache.pop(key)
 
+    def clear(self) -> None:
+        self.cache.clear()
+
     def get_capacity(self) -> int:
         return self.capacity
 


### PR DESCRIPTION
### Purpose:

`unsubscribe` was asymmetric. It deleted the `subscriptions` and `ids` rows and removed the on-disk Merkle/key-value blob files, but it left the store's `root` and `nodes` rows behind. After a later re-subscribe, the leftover **committed** root advertised the store as already synced while its on-disk blobs were gone — a permanently broken "synced-but-blobless" store that never recovered on its own.

This PR makes unsubscribe symmetric and adds a defense-in-depth self-heal so an already-corrupted store repairs itself on the next sync pass.

No breaking changes: public RPC/CLI surface is unchanged; behavior changes are confined to internal DataLayer/DataStore state management.

### Current Behavior:

- `unsubscribe` leaves committed `root`/`nodes` rows for the store.
- Re-subscribing to a previously unsubscribed store reuses the stale committed root, reports the store as synced, but has no blobs on disk, so reads/operations fail and the store never resyncs.

### New Behavior:

- **Symmetric unsubscribe:** all `root`/`nodes` rows are cleared inside the same writer transaction as the `subscriptions`/`ids` deletes. Blob directories are removed only *after* the SQL commit, so a commit failure can never recreate the synced-but-blobless state. `unconfirmed_keys_values` is also cleared for the store.
- **Atomic wipe-and-reseed:** new `DataStore.clear_store_roots` and `DataStore.reset_store_to_empty_root` reset a store to a committed generation-0 root in a single transaction (pending roots cleared first to avoid a gen-0 primary-key collision).
- **Self-heal in `fetch_and_validate`:** resets to gen-0 when no committed root exists, or when a committed root's blob is missing on disk. The blob-missing heal is guarded so it does not fire for a local-ahead store (heals once the chain catches up) and is skipped (with a distinct warning) when the global Merkle blobs volume is entirely absent, to avoid a mass re-sync on an unmounted volume.
- New `DataStore.merkle_blob_available` performs a sync, cache-bypassing on-disk presence check, and `LRUCache` gains a public `clear()`.

### Testing Notes:

- `chia/_tests/core/data_layer/test_data_store.py`: extended `test_unsubscribe_clears_databases` (now also asserts `root` rows gone, `store_id_exists` False, `get_tree_root` raises); added tests for re-subscribe starting clean, `clear_store_roots`, `reset_store_to_empty_root` (including a leftover PENDING gen-0 root), `merkle_blob_available` cache-bypass, and `unconfirmed_keys_values` cleanup.
- `chia/_tests/core/data_layer/test_data_rpc.py`: added simulator-backed regression tests covering heal on a missing blob file and on a missing per-store directory, heal when the chain has advanced, reset when no local root exists, heal-to-empty-gen0 with zero servers, and guard tests proving the heal is skipped for local-ahead stores and for a missing global blobs volume.
- Full local validation pipeline run: ruff, ruff format, mypy, targeted pytest, benchmarks, 100% diff coverage, and pre-commit all-files — all green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core DataLayer persistence and sync recovery paths; behavior is guarded and RPC surface is unchanged, but incorrect heal logic could still reset or skip resync for live stores.
> 
> **Overview**
> Fixes **synced-but-blobless** DataLayer stores after unsubscribe or missing Merkle files by clearing DB state on unsubscribe and resetting/resyncing during `fetch_and_validate` when roots and on-disk blobs disagree.
> 
> **Unsubscribe** now wipes all `root`/`nodes` rows (via new `clear_store_roots`) in the same transaction as subscription/ids deletes, drops `unconfirmed_keys_values`, and removes blob dirs only **after** SQL commit so a failed commit cannot leave committed roots without blobs.
> 
> **Self-heal in `fetch_and_validate`:** uses `reset_store_to_empty_root` when there is no committed root, or when the committed root’s blob is absent (`merkle_blob_available`, cache-bypassing disk check). Skips reset when the local generation is ahead of chain or when the global Merkle blobs directory is missing (volume fault). **`LRUCache.clear()`** added for tests/eviction.
> 
> Broad **unit and simulator RPC tests** cover heal paths, guard behavior, unsubscribe/re-subscribe, and reset helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921180e7e84137ee3ffaad200f728fd5ef609d36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->