### PR TITLE
compact vdf cache

### DIFF
--- a/chia/_tests/core/full_node/test_compact_vdf_cache.py
+++ b/chia/_tests/core/full_node/test_compact_vdf_cache.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from chia.full_node.compact_vdf_cache import CachedCompactVDF, CompactVDFCache
+from chia.types.blockchain_format.classgroup import ClassgroupElement
+from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFInfo, VDFProof
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint64, uint8
+
+
+def _entry(header_hash: bytes, field_vdf: CompressibleVDFField = CompressibleVDFField.CC_IP_VDF) -> CachedCompactVDF:
+    return CachedCompactVDF(
+        VDFInfo(bytes32(header_hash), uint64(100), ClassgroupElement.get_default_element()),
+        VDFProof(uint8(0), b"proof", True),
+        bytes32(header_hash),
+        field_vdf,
+    )
+
+
+def test_compact_vdf_cache_add_and_contains() -> None:
+    cache = CompactVDFCache(2)
+    entry = _entry(b"\x01" * 32)
+    assert cache.add(entry) is True
+    assert cache.contains(entry.header_hash, entry.field_vdf, entry.vdf_info)
+    assert cache.get_proof(entry.header_hash, entry.field_vdf, entry.vdf_info) == entry.vdf_proof
+    assert len(cache) == 1
+
+
+def test_compact_vdf_cache_rejects_when_full() -> None:
+    cache = CompactVDFCache(2)
+    assert cache.add(_entry(b"\x01" * 32)) is True
+    assert cache.add(_entry(b"\x02" * 32)) is True
+    assert cache.is_full()
+    assert cache.add(_entry(b"\x03" * 32)) is False
+    assert len(cache) == 2
+
+
+def test_compact_vdf_cache_disabled() -> None:
+    cache = CompactVDFCache(0)
+    assert cache.enabled is False
+    assert cache.is_full() is False
+    assert cache.add(_entry(b"\x01" * 32)) is False
+
+
+def test_compact_vdf_cache_clear() -> None:
+    cache = CompactVDFCache(10)
+    entry = _entry(b"\x01" * 32)
+    assert cache.add(entry) is True
+    assert entry.header_hash in cache.modified_header_hashes()
+    cache.clear()
+    assert len(cache) == 0
+    assert cache.modified_header_hashes() == set()
+
+
+def test_compact_vdf_cache_get_entries_for_block() -> None:
+    cache = CompactVDFCache(10)
+    entry1 = _entry(b"\x01" * 32, CompressibleVDFField.CC_IP_VDF)
+    entry2 = _entry(b"\x01" * 32, CompressibleVDFField.CC_SP_VDF)
+    entry3 = _entry(b"\x02" * 32, CompressibleVDFField.CC_IP_VDF)
+    assert cache.add(entry1) is True
+    assert cache.add(entry2) is True
+    assert cache.add(entry3) is True
+    block1_entries = cache.get_entries_for_block(bytes32(b"\x01" * 32))
+    assert len(block1_entries) == 2
+    assert entry1 in block1_entries
+    assert entry2 in block1_entries

--- a/chia/_tests/core/full_node/test_compact_vdf_cache.py
+++ b/chia/_tests/core/full_node/test_compact_vdf_cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from chia.full_node.compact_vdf_cache import CompactVDFCache
-from chia.types.blockchain_format.vdf import VDFProof
+from chia.full_node.compact_vdf_cache import CachedCompactVDF, CompactVDFCache
+from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFProof
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8
 
@@ -14,18 +14,22 @@ def test_compact_vdf_cache_add_and_get() -> None:
     cache = CompactVDFCache(2)
     header_hash = bytes32(b"\x01" * 32)
     proof = _proof()
-    assert cache.add(header_hash, proof) is True
+    assert cache.add(header_hash, CompressibleVDFField.CC_IP_VDF, uint8(0), proof) is True
     assert cache.has_block(header_hash)
-    assert cache.get(header_hash) == proof
+    assert cache.get_proofs(header_hash) == (CachedCompactVDF(CompressibleVDFField.CC_IP_VDF, uint8(0), proof),)
     assert len(cache) == 1
 
 
 def test_compact_vdf_cache_rejects_when_full() -> None:
     cache = CompactVDFCache(2)
-    assert cache.add(bytes32(b"\x01" * 32), _proof(b"a")) is True
-    assert cache.add(bytes32(b"\x02" * 32), _proof(b"b")) is True
+    assert cache.add(bytes32(b"\x01" * 32), CompressibleVDFField.CC_IP_VDF, uint8(0), _proof(b"a")) is True
+    assert (
+        cache.add(bytes32(b"\x02" * 32), CompressibleVDFField.CC_IP_VDF, uint8(0), _proof(b"b")) is True
+    )
     assert cache.is_full()
-    assert cache.add(bytes32(b"\x03" * 32), _proof(b"c")) is False
+    assert (
+        cache.add(bytes32(b"\x03" * 32), CompressibleVDFField.CC_IP_VDF, uint8(0), _proof(b"c")) is False
+    )
     assert len(cache) == 2
 
 
@@ -33,24 +37,37 @@ def test_compact_vdf_cache_disabled() -> None:
     cache = CompactVDFCache(0)
     assert cache.enabled is False
     assert cache.is_full() is False
-    assert cache.add(bytes32(b"\x01" * 32), _proof()) is False
+    assert cache.add(bytes32(b"\x01" * 32), CompressibleVDFField.CC_IP_VDF, uint8(0), _proof()) is False
 
 
-def test_compact_vdf_cache_add_updates_existing_header_hash() -> None:
+def test_compact_vdf_cache_add_multiple_fields_same_block() -> None:
+    cache = CompactVDFCache(10)
+    header_hash = bytes32(b"\x01" * 32)
+    ip_proof = _proof(b"ip")
+    sp_proof = _proof(b"sp")
+    assert cache.add(header_hash, CompressibleVDFField.CC_IP_VDF, uint8(0), ip_proof) is True
+    assert cache.add(header_hash, CompressibleVDFField.CC_SP_VDF, uint8(0), sp_proof) is True
+    assert len(cache) == 2
+    proofs = {cached.field_vdf: cached.vdf_proof for cached in cache.get_proofs(header_hash)}
+    assert proofs[CompressibleVDFField.CC_IP_VDF] == ip_proof
+    assert proofs[CompressibleVDFField.CC_SP_VDF] == sp_proof
+
+
+def test_compact_vdf_cache_add_updates_existing_slot() -> None:
     cache = CompactVDFCache(10)
     header_hash = bytes32(b"\x01" * 32)
     proof1 = _proof(b"one")
     proof2 = _proof(b"two")
-    assert cache.add(header_hash, proof1) is True
-    assert cache.add(header_hash, proof2) is True
+    assert cache.add(header_hash, CompressibleVDFField.CC_IP_VDF, uint8(0), proof1) is True
+    assert cache.add(header_hash, CompressibleVDFField.CC_IP_VDF, uint8(0), proof2) is True
     assert len(cache) == 1
-    assert cache.get(header_hash) == proof2
+    assert cache.get_proofs(header_hash)[0].vdf_proof == proof2
 
 
 def test_compact_vdf_cache_clear() -> None:
     cache = CompactVDFCache(10)
     header_hash = bytes32(b"\x01" * 32)
-    assert cache.add(header_hash, _proof()) is True
+    assert cache.add(header_hash, CompressibleVDFField.CC_IP_VDF, uint8(0), _proof()) is True
     assert header_hash in cache.modified_header_hashes()
     cache.clear()
     assert len(cache) == 0
@@ -61,8 +78,9 @@ def test_compact_vdf_cache_remove_block() -> None:
     cache = CompactVDFCache(10)
     block1 = bytes32(b"\x01" * 32)
     block2 = bytes32(b"\x02" * 32)
-    assert cache.add(block1, _proof(b"a")) is True
-    assert cache.add(block2, _proof(b"b")) is True
+    assert cache.add(block1, CompressibleVDFField.CC_IP_VDF, uint8(0), _proof(b"a")) is True
+    assert cache.add(block1, CompressibleVDFField.CC_SP_VDF, uint8(0), _proof(b"b")) is True
+    assert cache.add(block2, CompressibleVDFField.CC_IP_VDF, uint8(0), _proof(b"c")) is True
     cache.remove_block(block1)
     assert len(cache) == 1
     assert not cache.has_block(block1)

--- a/chia/_tests/core/full_node/test_compact_vdf_cache.py
+++ b/chia/_tests/core/full_node/test_compact_vdf_cache.py
@@ -1,36 +1,31 @@
 from __future__ import annotations
 
-from chia.full_node.compact_vdf_cache import CachedCompactVDF, CompactVDFCache
-from chia.types.blockchain_format.classgroup import ClassgroupElement
-from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFInfo, VDFProof
+from chia.full_node.compact_vdf_cache import CompactVDFCache
+from chia.types.blockchain_format.vdf import VDFProof
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint64, uint8
+from chia_rs.sized_ints import uint8
 
 
-def _entry(header_hash: bytes, field_vdf: CompressibleVDFField = CompressibleVDFField.CC_IP_VDF) -> CachedCompactVDF:
-    return CachedCompactVDF(
-        VDFInfo(bytes32(header_hash), uint64(100), ClassgroupElement.get_default_element()),
-        VDFProof(uint8(0), b"proof", True),
-        bytes32(header_hash),
-        field_vdf,
-    )
+def _proof(data: bytes = b"proof") -> VDFProof:
+    return VDFProof(uint8(0), data, True)
 
 
 def test_compact_vdf_cache_add_and_get() -> None:
     cache = CompactVDFCache(2)
-    entry = _entry(b"\x01" * 32)
-    assert cache.add(entry) is True
-    assert cache.has_block(entry.header_hash)
-    assert cache.get(entry.header_hash) == entry
+    header_hash = bytes32(b"\x01" * 32)
+    proof = _proof()
+    assert cache.add(header_hash, proof) is True
+    assert cache.has_block(header_hash)
+    assert cache.get(header_hash) == proof
     assert len(cache) == 1
 
 
 def test_compact_vdf_cache_rejects_when_full() -> None:
     cache = CompactVDFCache(2)
-    assert cache.add(_entry(b"\x01" * 32)) is True
-    assert cache.add(_entry(b"\x02" * 32)) is True
+    assert cache.add(bytes32(b"\x01" * 32), _proof(b"a")) is True
+    assert cache.add(bytes32(b"\x02" * 32), _proof(b"b")) is True
     assert cache.is_full()
-    assert cache.add(_entry(b"\x03" * 32)) is False
+    assert cache.add(bytes32(b"\x03" * 32), _proof(b"c")) is False
     assert len(cache) == 2
 
 
@@ -38,25 +33,25 @@ def test_compact_vdf_cache_disabled() -> None:
     cache = CompactVDFCache(0)
     assert cache.enabled is False
     assert cache.is_full() is False
-    assert cache.add(_entry(b"\x01" * 32)) is False
+    assert cache.add(bytes32(b"\x01" * 32), _proof()) is False
 
 
 def test_compact_vdf_cache_add_updates_existing_header_hash() -> None:
     cache = CompactVDFCache(10)
     header_hash = bytes32(b"\x01" * 32)
-    entry1 = _entry(header_hash, CompressibleVDFField.CC_IP_VDF)
-    entry2 = _entry(header_hash, CompressibleVDFField.CC_SP_VDF)
-    assert cache.add(entry1) is True
-    assert cache.add(entry2) is True
+    proof1 = _proof(b"one")
+    proof2 = _proof(b"two")
+    assert cache.add(header_hash, proof1) is True
+    assert cache.add(header_hash, proof2) is True
     assert len(cache) == 1
-    assert cache.get(header_hash) == entry2
+    assert cache.get(header_hash) == proof2
 
 
 def test_compact_vdf_cache_clear() -> None:
     cache = CompactVDFCache(10)
-    entry = _entry(b"\x01" * 32)
-    assert cache.add(entry) is True
-    assert entry.header_hash in cache.modified_header_hashes()
+    header_hash = bytes32(b"\x01" * 32)
+    assert cache.add(header_hash, _proof()) is True
+    assert header_hash in cache.modified_header_hashes()
     cache.clear()
     assert len(cache) == 0
     assert cache.modified_header_hashes() == set()
@@ -66,8 +61,8 @@ def test_compact_vdf_cache_remove_block() -> None:
     cache = CompactVDFCache(10)
     block1 = bytes32(b"\x01" * 32)
     block2 = bytes32(b"\x02" * 32)
-    assert cache.add(_entry(block1, CompressibleVDFField.CC_IP_VDF)) is True
-    assert cache.add(_entry(block2, CompressibleVDFField.CC_IP_VDF)) is True
+    assert cache.add(block1, _proof(b"a")) is True
+    assert cache.add(block2, _proof(b"b")) is True
     cache.remove_block(block1)
     assert len(cache) == 1
     assert not cache.has_block(block1)

--- a/chia/_tests/core/full_node/test_compact_vdf_cache.py
+++ b/chia/_tests/core/full_node/test_compact_vdf_cache.py
@@ -16,12 +16,12 @@ def _entry(header_hash: bytes, field_vdf: CompressibleVDFField = CompressibleVDF
     )
 
 
-def test_compact_vdf_cache_add_and_contains() -> None:
+def test_compact_vdf_cache_add_and_get() -> None:
     cache = CompactVDFCache(2)
     entry = _entry(b"\x01" * 32)
     assert cache.add(entry) is True
-    assert cache.contains(entry.header_hash, entry.field_vdf, entry.vdf_info)
-    assert cache.get_proof(entry.header_hash, entry.field_vdf, entry.vdf_info) == entry.vdf_proof
+    assert cache.has_block(entry.header_hash)
+    assert cache.get(entry.header_hash) == entry
     assert len(cache) == 1
 
 
@@ -41,6 +41,17 @@ def test_compact_vdf_cache_disabled() -> None:
     assert cache.add(_entry(b"\x01" * 32)) is False
 
 
+def test_compact_vdf_cache_add_updates_existing_header_hash() -> None:
+    cache = CompactVDFCache(10)
+    header_hash = bytes32(b"\x01" * 32)
+    entry1 = _entry(header_hash, CompressibleVDFField.CC_IP_VDF)
+    entry2 = _entry(header_hash, CompressibleVDFField.CC_SP_VDF)
+    assert cache.add(entry1) is True
+    assert cache.add(entry2) is True
+    assert len(cache) == 1
+    assert cache.get(header_hash) == entry2
+
+
 def test_compact_vdf_cache_clear() -> None:
     cache = CompactVDFCache(10)
     entry = _entry(b"\x01" * 32)
@@ -51,34 +62,11 @@ def test_compact_vdf_cache_clear() -> None:
     assert cache.modified_header_hashes() == set()
 
 
-def test_compact_vdf_cache_get_entries_for_block() -> None:
-    cache = CompactVDFCache(10)
-    entry1 = _entry(b"\x01" * 32, CompressibleVDFField.CC_IP_VDF)
-    entry2 = _entry(b"\x01" * 32, CompressibleVDFField.CC_SP_VDF)
-    entry3 = _entry(b"\x02" * 32, CompressibleVDFField.CC_IP_VDF)
-    assert cache.add(entry1) is True
-    assert cache.add(entry2) is True
-    assert cache.add(entry3) is True
-    block1_entries = cache.get_entries_for_block(bytes32(b"\x01" * 32))
-    assert len(block1_entries) == 2
-    assert entry1 in block1_entries
-    assert entry2 in block1_entries
-
-
-def test_compact_vdf_cache_has_block() -> None:
-    cache = CompactVDFCache(10)
-    assert cache.has_block(bytes32(b"\x01" * 32)) is False
-    assert cache.add(_entry(b"\x01" * 32)) is True
-    assert cache.has_block(bytes32(b"\x01" * 32)) is True
-    assert cache.has_block(bytes32(b"\x02" * 32)) is False
-
-
 def test_compact_vdf_cache_remove_block() -> None:
     cache = CompactVDFCache(10)
     block1 = bytes32(b"\x01" * 32)
     block2 = bytes32(b"\x02" * 32)
     assert cache.add(_entry(block1, CompressibleVDFField.CC_IP_VDF)) is True
-    assert cache.add(_entry(block1, CompressibleVDFField.CC_SP_VDF)) is True
     assert cache.add(_entry(block2, CompressibleVDFField.CC_IP_VDF)) is True
     cache.remove_block(block1)
     assert len(cache) == 1

--- a/chia/_tests/core/full_node/test_compact_vdf_cache.py
+++ b/chia/_tests/core/full_node/test_compact_vdf_cache.py
@@ -63,3 +63,16 @@ def test_compact_vdf_cache_get_entries_for_block() -> None:
     assert len(block1_entries) == 2
     assert entry1 in block1_entries
     assert entry2 in block1_entries
+
+
+def test_compact_vdf_cache_remove_block() -> None:
+    cache = CompactVDFCache(10)
+    block1 = bytes32(b"\x01" * 32)
+    block2 = bytes32(b"\x02" * 32)
+    assert cache.add(_entry(block1, CompressibleVDFField.CC_IP_VDF)) is True
+    assert cache.add(_entry(block1, CompressibleVDFField.CC_SP_VDF)) is True
+    assert cache.add(_entry(block2, CompressibleVDFField.CC_IP_VDF)) is True
+    cache.remove_block(block1)
+    assert len(cache) == 1
+    assert block1 not in cache.modified_header_hashes()
+    assert block2 in cache.modified_header_hashes()

--- a/chia/_tests/core/full_node/test_compact_vdf_cache.py
+++ b/chia/_tests/core/full_node/test_compact_vdf_cache.py
@@ -65,6 +65,14 @@ def test_compact_vdf_cache_get_entries_for_block() -> None:
     assert entry2 in block1_entries
 
 
+def test_compact_vdf_cache_has_block() -> None:
+    cache = CompactVDFCache(10)
+    assert cache.has_block(bytes32(b"\x01" * 32)) is False
+    assert cache.add(_entry(b"\x01" * 32)) is True
+    assert cache.has_block(bytes32(b"\x01" * 32)) is True
+    assert cache.has_block(bytes32(b"\x02" * 32)) is False
+
+
 def test_compact_vdf_cache_remove_block() -> None:
     cache = CompactVDFCache(10)
     block1 = bytes32(b"\x01" * 32)
@@ -74,5 +82,5 @@ def test_compact_vdf_cache_remove_block() -> None:
     assert cache.add(_entry(block2, CompressibleVDFField.CC_IP_VDF)) is True
     cache.remove_block(block1)
     assert len(cache) == 1
-    assert block1 not in cache.modified_header_hashes()
-    assert block2 in cache.modified_header_hashes()
+    assert not cache.has_block(block1)
+    assert cache.has_block(block2)

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2788,7 +2788,7 @@ async def test_compact_vdf_cache_read_through(
         assert db_block is not None
         original_proof = db_block.finished_sub_slots[0].proofs.challenge_chain_slot_proof
         full_node_1.full_node._apply_proof_to_block(
-            db_block, eos_vdf_info, eos_vdf_proof, CompressibleVDFField.CC_EOS_VDF
+            db_block, eos_vdf_proof, CompressibleVDFField.CC_EOS_VDF
         )
         assert db_block.finished_sub_slots[0].proofs.challenge_chain_slot_proof == original_proof
 

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2768,6 +2768,82 @@ async def test_compact_vdf_cache_read_through(
     assert header_block is not None
     assert not await full_node_1.full_node._needs_compact_proof(vdf_info, header_block, CompressibleVDFField.CC_IP_VDF)
 
+    # _get_block_with_cached_proofs should refresh block_cache for later get_full_block callers
+    full_node_1.full_node.block_store.block_cache.remove(block.header_hash)
+    await full_node_1.full_node._get_block_with_cached_proofs(block.header_hash)
+    reloaded = await full_node_1.full_node.block_store.get_full_block(block.header_hash)
+    assert reloaded is not None
+    assert reloaded.challenge_chain_ip_proof.normalized_to_identity
+
+    if block.finished_sub_slots:
+        sub_slot = block.finished_sub_slots[0]
+        eos_vdf_info, eos_vdf_proof = get_vdf_info_and_proof(
+            bt.constants,
+            ClassgroupElement.get_default_element(),
+            sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf.challenge,
+            sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf.number_of_iterations,
+            True,
+        )
+        db_block = await full_node_1.full_node.block_store.get_full_block(block.header_hash)
+        assert db_block is not None
+        original_proof = db_block.finished_sub_slots[0].proofs.challenge_chain_slot_proof
+        full_node_1.full_node._apply_proof_to_block(
+            db_block, eos_vdf_info, eos_vdf_proof, CompressibleVDFField.CC_EOS_VDF
+        )
+        assert db_block.finished_sub_slots[0].proofs.challenge_chain_slot_proof == original_proof
+
+        full_node_1.full_node.block_store.block_cache.remove(block.header_hash)
+        cached_block = await full_node_1.full_node.block_store.get_full_block(block.header_hash)
+        assert cached_block is not None
+        cached_proof = cached_block.finished_sub_slots[0].proofs.challenge_chain_slot_proof
+        full_node_1.full_node._apply_cached_proofs_to_block(cached_block)
+        assert cached_block.finished_sub_slots[0].proofs.challenge_chain_slot_proof == cached_proof
+
+
+@pytest.mark.anyio
+async def test_compact_vdf_cache_flush_applies_pending_proofs(
+    setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+) -> None:
+    nodes, _, bt = setup_two_nodes_fixture
+    full_node_1 = nodes[0]
+    blocks = bt.get_consecutive_blocks(num_blocks=10, skip_slots=3)
+    block = blocks[0]
+    for b in blocks:
+        await full_node_1.full_node.add_block(b)
+
+    full_node_1.full_node.compact_vdf_cache = CompactVDFCache(100)
+
+    vdf_info, vdf_proof = get_vdf_info_and_proof(
+        bt.constants,
+        ClassgroupElement.get_default_element(),
+        block.reward_chain_block.challenge_chain_ip_vdf.challenge,
+        block.reward_chain_block.challenge_chain_ip_vdf.number_of_iterations,
+        True,
+    )
+    compact_proof = timelord_protocol.RespondCompactProofOfTime(
+        vdf_info,
+        vdf_proof,
+        block.header_hash,
+        block.height,
+        uint8(CompressibleVDFField.CC_IP_VDF),
+    )
+    await full_node_1.full_node.add_compact_proof_of_time(compact_proof)
+    assert len(full_node_1.full_node.compact_vdf_cache) == 1
+
+    # Repopulate block_cache from DB with the still-uncompact block.
+    full_node_1.full_node.block_store.block_cache.remove(block.header_hash)
+    stale_cached = await full_node_1.full_node.block_store.get_full_block(block.header_hash)
+    assert stale_cached is not None
+    assert not stale_cached.challenge_chain_ip_proof.normalized_to_identity
+
+    await full_node_1.full_node.flush_compact_vdf_cache()
+    assert len(full_node_1.full_node.compact_vdf_cache) == 0
+
+    full_node_1.full_node.block_store.block_cache.remove(block.header_hash)
+    persisted = await full_node_1.full_node.block_store.get_full_block(block.header_hash)
+    assert persisted is not None
+    assert persisted.challenge_chain_ip_proof.normalized_to_identity
+
 
 @pytest.mark.anyio
 async def test_compact_protocol_invalid_messages(

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2846,6 +2846,54 @@ async def test_compact_vdf_cache_flush_applies_pending_proofs(
 
 
 @pytest.mark.anyio
+async def test_request_block_serves_cached_compact_proofs(
+    setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+) -> None:
+    nodes, _, bt = setup_two_nodes_fixture
+    full_node_1 = nodes[0]
+    blocks = bt.get_consecutive_blocks(num_blocks=10, skip_slots=3)
+    block = blocks[0]
+    for b in blocks:
+        await full_node_1.full_node.add_block(b)
+
+    full_node_1.full_node.compact_vdf_cache = CompactVDFCache(100)
+
+    vdf_info, vdf_proof = get_vdf_info_and_proof(
+        bt.constants,
+        ClassgroupElement.get_default_element(),
+        block.reward_chain_block.challenge_chain_ip_vdf.challenge,
+        block.reward_chain_block.challenge_chain_ip_vdf.number_of_iterations,
+        True,
+    )
+    compact_proof = timelord_protocol.RespondCompactProofOfTime(
+        vdf_info,
+        vdf_proof,
+        block.header_hash,
+        block.height,
+        uint8(CompressibleVDFField.CC_IP_VDF),
+    )
+    await full_node_1.full_node.add_compact_proof_of_time(compact_proof)
+
+    full_node_1.full_node.block_store.block_cache.remove(block.header_hash)
+    stale_cached = await full_node_1.full_node.block_store.get_full_block(block.header_hash)
+    assert stale_cached is not None
+    assert not stale_cached.challenge_chain_ip_proof.normalized_to_identity
+
+    response = await full_node_1.request_block(fnp.RequestBlock(block.height, True))
+    assert response is not None
+    served = fnp.RespondBlock.from_bytes(response.data)
+    assert served.block.challenge_chain_ip_proof.normalized_to_identity
+
+    response = await full_node_1.request_blocks(
+        fnp.RequestBlocks(block.height, block.height, include_transaction_block=True)
+    )
+    assert response is not None
+    served_blocks = fnp.RespondBlocks.from_bytes(response.data)
+    assert len(served_blocks.blocks) == 1
+    assert served_blocks.blocks[0].challenge_chain_ip_proof.normalized_to_identity
+
+
+@pytest.mark.anyio
 async def test_compact_protocol_invalid_messages(
     setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
     self_hostname: str,

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2795,9 +2795,8 @@ async def test_compact_vdf_cache_read_through(
         full_node_1.full_node.block_store.block_cache.remove(block.header_hash)
         cached_block = await full_node_1.full_node.block_store.get_full_block(block.header_hash)
         assert cached_block is not None
-        cached_proof = cached_block.finished_sub_slots[0].proofs.challenge_chain_slot_proof
-        full_node_1.full_node._apply_cached_proofs_to_block(cached_block)
-        assert cached_block.finished_sub_slots[0].proofs.challenge_chain_slot_proof == cached_proof
+        assert not cached_block.challenge_chain_ip_proof.normalized_to_identity
+        assert full_node_1.full_node.compact_vdf_cache.get(block.header_hash) is not None
 
 
 @pytest.mark.anyio

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -52,6 +52,7 @@ from chia._tests.util.setup_nodes import (
     setup_simulators_and_wallets,
 )
 from chia._tests.util.time_out_assert import time_out_assert, time_out_assert_custom_interval, time_out_messages
+from chia.full_node.compact_vdf_cache import CompactVDFCache
 from chia.consensus.augmented_chain import AugmentedBlockchain
 from chia.consensus.block_body_validation import ForkInfo
 from chia.consensus.blockchain import Blockchain
@@ -2696,6 +2697,7 @@ async def test_compact_protocol(
     assert cc_eos_count == 3 and icc_eos_count == 3
     for compact_proof in timelord_protocol_finished:
         await full_node_1.full_node.add_compact_proof_of_time(compact_proof)
+    await full_node_1.full_node.flush_compact_vdf_cache()
     stored_blocks = await full_node_1.get_all_full_blocks()
     cc_eos_compact_count = 0
     icc_eos_compact_count = 0
@@ -2724,6 +2726,51 @@ async def test_compact_protocol(
         peak = full_node_2.full_node.blockchain.get_peak()
         assert peak is not None
         assert peak.height == height
+
+
+@pytest.mark.anyio
+async def test_compact_vdf_cache_read_through(
+    setup_two_nodes_fixture: tuple[list[FullNodeSimulator], list[tuple[WalletNode, ChiaServer]], BlockTools],
+) -> None:
+    nodes, _, bt = setup_two_nodes_fixture
+    full_node_1 = nodes[0]
+    blocks = bt.get_consecutive_blocks(num_blocks=10, skip_slots=3)
+    block = blocks[0]
+    for b in blocks:
+        await full_node_1.full_node.add_block(b)
+
+    full_node_1.full_node.compact_vdf_cache = CompactVDFCache(100)
+
+    vdf_info, vdf_proof = get_vdf_info_and_proof(
+        bt.constants,
+        ClassgroupElement.get_default_element(),
+        block.reward_chain_block.challenge_chain_ip_vdf.challenge,
+        block.reward_chain_block.challenge_chain_ip_vdf.number_of_iterations,
+        True,
+    )
+    compact_proof = timelord_protocol.RespondCompactProofOfTime(
+        vdf_info,
+        vdf_proof,
+        block.header_hash,
+        block.height,
+        uint8(CompressibleVDFField.CC_IP_VDF),
+    )
+    await full_node_1.full_node.add_compact_proof_of_time(compact_proof)
+    assert len(full_node_1.full_node.compact_vdf_cache) == 1
+
+    full_node_1.full_node.block_store.block_cache.remove(block.header_hash)
+
+    request = fnp.RequestCompactVDF(
+        block.height, block.header_hash, uint8(CompressibleVDFField.CC_IP_VDF), vdf_info
+    )
+    returned = await full_node_1.full_node.request_compact_vdf(request, bytes32.zeros)
+    assert returned == vdf_proof
+
+    header_block = await full_node_1.full_node._get_header_block_with_cached_proofs(block.height, block.header_hash)
+    assert header_block is not None
+    assert not await full_node_1.full_node._needs_compact_proof(
+        vdf_info, header_block, CompressibleVDFField.CC_IP_VDF
+    )
 
 
 @pytest.mark.anyio
@@ -3042,6 +3089,7 @@ async def test_respond_compact_proof_message_limit(
         *[coro(full_node_1, respond_compact_proof) for respond_compact_proof in finished_compact_proofs]
     )
     await tasks
+    await full_node_1.full_node.flush_compact_vdf_cache()
     stored_blocks = await full_node_1.get_all_full_blocks()
     compactified = 0
     for block in stored_blocks:
@@ -3052,6 +3100,7 @@ async def test_respond_compact_proof_message_limit(
     # The other full node receives the compact messages one at a time.
     for respond_compact_proof in finished_compact_proofs:
         await full_node_2.full_node.add_compact_proof_of_time(respond_compact_proof)
+    await full_node_2.full_node.flush_compact_vdf_cache()
     stored_blocks = await full_node_2.get_all_full_blocks()
     compactified = 0
     for block in stored_blocks:

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2787,9 +2787,7 @@ async def test_compact_vdf_cache_read_through(
         db_block = await full_node_1.full_node.block_store.get_full_block(block.header_hash)
         assert db_block is not None
         original_proof = db_block.finished_sub_slots[0].proofs.challenge_chain_slot_proof
-        full_node_1.full_node._apply_proof_to_block(
-            db_block, eos_vdf_proof, CompressibleVDFField.CC_EOS_VDF
-        )
+        full_node_1.full_node._apply_proof_to_block(db_block, eos_vdf_proof)
         assert db_block.finished_sub_slots[0].proofs.challenge_chain_slot_proof == original_proof
 
         full_node_1.full_node.block_store.block_cache.remove(block.header_hash)

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2760,17 +2760,13 @@ async def test_compact_vdf_cache_read_through(
 
     full_node_1.full_node.block_store.block_cache.remove(block.header_hash)
 
-    request = fnp.RequestCompactVDF(
-        block.height, block.header_hash, uint8(CompressibleVDFField.CC_IP_VDF), vdf_info
-    )
+    request = fnp.RequestCompactVDF(block.height, block.header_hash, uint8(CompressibleVDFField.CC_IP_VDF), vdf_info)
     returned = await full_node_1.full_node.request_compact_vdf(request, bytes32.zeros)
     assert returned == vdf_proof
 
     header_block = await full_node_1.full_node._get_header_block_with_cached_proofs(block.height, block.header_hash)
     assert header_block is not None
-    assert not await full_node_1.full_node._needs_compact_proof(
-        vdf_info, header_block, CompressibleVDFField.CC_IP_VDF
-    )
+    assert not await full_node_1.full_node._needs_compact_proof(vdf_info, header_block, CompressibleVDFField.CC_IP_VDF)
 
 
 @pytest.mark.anyio

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2787,14 +2787,16 @@ async def test_compact_vdf_cache_read_through(
         db_block = await full_node_1.full_node.block_store.get_full_block(block.header_hash)
         assert db_block is not None
         original_proof = db_block.finished_sub_slots[0].proofs.challenge_chain_slot_proof
-        full_node_1.full_node._apply_proof_to_block(db_block, eos_vdf_proof)
+        full_node_1.full_node._apply_proof_to_block(
+            db_block, eos_vdf_proof, CompressibleVDFField.CC_EOS_VDF, 0
+        )
         assert db_block.finished_sub_slots[0].proofs.challenge_chain_slot_proof == original_proof
 
         full_node_1.full_node.block_store.block_cache.remove(block.header_hash)
         cached_block = await full_node_1.full_node.block_store.get_full_block(block.header_hash)
         assert cached_block is not None
         assert not cached_block.challenge_chain_ip_proof.normalized_to_identity
-        assert full_node_1.full_node.compact_vdf_cache.get(block.header_hash) is not None
+        assert full_node_1.full_node.compact_vdf_cache.has_block(block.header_hash)
 
 
 @pytest.mark.anyio

--- a/chia/full_node/compact_vdf_cache.py
+++ b/chia/full_node/compact_vdf_cache.py
@@ -19,8 +19,8 @@ class CompactVDFCache:
 
     def __init__(self, capacity: int) -> None:
         self._capacity = capacity
-        self._entries: dict[tuple[bytes32, int, bytes], CachedCompactVDF] = {}
-        self._modified_blocks: set[bytes32] = set()
+        self._by_header_hash: dict[bytes32, dict[tuple[int, bytes], CachedCompactVDF]] = {}
+        self._count = 0
 
     @property
     def capacity(self) -> int:
@@ -31,45 +31,64 @@ class CompactVDFCache:
         return self._capacity > 0
 
     def is_full(self) -> bool:
-        return self.enabled and len(self._entries) >= self._capacity
+        return self.enabled and self._count >= self._capacity
 
     def __len__(self) -> int:
-        return len(self._entries)
+        return self._count
 
     @staticmethod
-    def _key(header_hash: bytes32, field_vdf: CompressibleVDFField, vdf_info: VDFInfo) -> tuple[bytes32, int, bytes]:
-        return header_hash, int(field_vdf), bytes(vdf_info)
+    def _proof_key(field_vdf: CompressibleVDFField, vdf_info: VDFInfo) -> tuple[int, bytes]:
+        return int(field_vdf), bytes(vdf_info)
+
+    def has_block(self, header_hash: bytes32) -> bool:
+        block_entries = self._by_header_hash.get(header_hash)
+        return block_entries is not None and len(block_entries) > 0
 
     def contains(self, header_hash: bytes32, field_vdf: CompressibleVDFField, vdf_info: VDFInfo) -> bool:
-        return self._key(header_hash, field_vdf, vdf_info) in self._entries
+        block_entries = self._by_header_hash.get(header_hash)
+        if block_entries is None:
+            return False
+        return self._proof_key(field_vdf, vdf_info) in block_entries
 
-    def get_proof(self, header_hash: bytes32, field_vdf: CompressibleVDFField, vdf_info: VDFInfo) -> VDFProof | None:
-        entry = self._entries.get(self._key(header_hash, field_vdf, vdf_info))
+    def get_proof(
+        self, header_hash: bytes32, field_vdf: CompressibleVDFField, vdf_info: VDFInfo
+    ) -> VDFProof | None:
+        block_entries = self._by_header_hash.get(header_hash)
+        if block_entries is None:
+            return None
+        entry = block_entries.get(self._proof_key(field_vdf, vdf_info))
         return entry.vdf_proof if entry is not None else None
 
     def get_entries_for_block(self, header_hash: bytes32) -> list[CachedCompactVDF]:
-        return [entry for entry in self._entries.values() if entry.header_hash == header_hash]
+        block_entries = self._by_header_hash.get(header_hash)
+        if block_entries is None:
+            return []
+        return list(block_entries.values())
 
     def add(self, entry: CachedCompactVDF) -> bool:
         if not self.enabled:
             return False
-        key = self._key(entry.header_hash, entry.field_vdf, entry.vdf_info)
-        if key in self._entries:
+        proof_key = self._proof_key(entry.field_vdf, entry.vdf_info)
+        block_entries = self._by_header_hash.get(entry.header_hash)
+        if block_entries is not None and proof_key in block_entries:
             return True
         if self.is_full():
             return False
-        self._entries[key] = entry
-        self._modified_blocks.add(entry.header_hash)
+        if block_entries is None:
+            block_entries = {}
+            self._by_header_hash[entry.header_hash] = block_entries
+        block_entries[proof_key] = entry
+        self._count += 1
         return True
 
     def modified_header_hashes(self) -> set[bytes32]:
-        return set(self._modified_blocks)
+        return set(self._by_header_hash)
 
     def remove_block(self, header_hash: bytes32) -> None:
-        for entry in self.get_entries_for_block(header_hash):
-            self._entries.pop(self._key(entry.header_hash, entry.field_vdf, entry.vdf_info), None)
-        self._modified_blocks.discard(header_hash)
+        block_entries = self._by_header_hash.pop(header_hash, None)
+        if block_entries is not None:
+            self._count -= len(block_entries)
 
     def clear(self) -> None:
-        self._entries.clear()
-        self._modified_blocks.clear()
+        self._by_header_hash.clear()
+        self._count = 0

--- a/chia/full_node/compact_vdf_cache.py
+++ b/chia/full_node/compact_vdf_cache.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFInfo, VDFProof
+from chia_rs.sized_bytes import bytes32
+
+
+@dataclass(frozen=True)
+class CachedCompactVDF:
+    vdf_info: VDFInfo
+    vdf_proof: VDFProof
+    header_hash: bytes32
+    field_vdf: CompressibleVDFField
+
+
+class CompactVDFCache:
+    """Bounded in-memory cache of compact VDF proofs pending database flush."""
+
+    def __init__(self, capacity: int) -> None:
+        self._capacity = capacity
+        self._entries: dict[tuple[bytes32, int, bytes], CachedCompactVDF] = {}
+        self._modified_blocks: set[bytes32] = set()
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
+    @property
+    def enabled(self) -> bool:
+        return self._capacity > 0
+
+    def is_full(self) -> bool:
+        return self.enabled and len(self._entries) >= self._capacity
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    @staticmethod
+    def _key(header_hash: bytes32, field_vdf: CompressibleVDFField, vdf_info: VDFInfo) -> tuple[bytes32, int, bytes]:
+        return header_hash, int(field_vdf), bytes(vdf_info)
+
+    def contains(self, header_hash: bytes32, field_vdf: CompressibleVDFField, vdf_info: VDFInfo) -> bool:
+        return self._key(header_hash, field_vdf, vdf_info) in self._entries
+
+    def get_proof(
+        self, header_hash: bytes32, field_vdf: CompressibleVDFField, vdf_info: VDFInfo
+    ) -> VDFProof | None:
+        entry = self._entries.get(self._key(header_hash, field_vdf, vdf_info))
+        return entry.vdf_proof if entry is not None else None
+
+    def get_entries_for_block(self, header_hash: bytes32) -> list[CachedCompactVDF]:
+        return [entry for entry in self._entries.values() if entry.header_hash == header_hash]
+
+    def add(self, entry: CachedCompactVDF) -> bool:
+        if not self.enabled:
+            return False
+        key = self._key(entry.header_hash, entry.field_vdf, entry.vdf_info)
+        if key in self._entries:
+            return True
+        if self.is_full():
+            return False
+        self._entries[key] = entry
+        self._modified_blocks.add(entry.header_hash)
+        return True
+
+    def modified_header_hashes(self) -> set[bytes32]:
+        return set(self._modified_blocks)
+
+    def clear(self) -> None:
+        self._entries.clear()
+        self._modified_blocks.clear()

--- a/chia/full_node/compact_vdf_cache.py
+++ b/chia/full_node/compact_vdf_cache.py
@@ -1,18 +1,35 @@
 from __future__ import annotations
 
-from chia.types.blockchain_format.vdf import VDFProof
+from dataclasses import dataclass
+
+from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFProof
 from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint8
+
+
+@dataclass(frozen=True)
+class CompactVDFProofSlot:
+    field_vdf: CompressibleVDFField
+    sub_slot_index: uint8
+
+
+@dataclass(frozen=True)
+class CachedCompactVDF:
+    field_vdf: CompressibleVDFField
+    sub_slot_index: uint8
+    vdf_proof: VDFProof
 
 
 class CompactVDFCache:
     """Bounded in-memory cache of compact VDF proofs pending database flush.
 
-    At most one cached compact VDF proof per block header hash.
+    Multiple compact VDF proofs may be cached per block, keyed by field and
+    sub-slot index (0 for reward-chain fields).
     """
 
     def __init__(self, capacity: int) -> None:
         self._capacity = capacity
-        self._vdf_proof_by_header_hash: dict[bytes32, VDFProof] = {}
+        self._proofs_by_block: dict[bytes32, dict[CompactVDFProofSlot, VDFProof]] = {}
 
     @property
     def capacity(self) -> int:
@@ -23,33 +40,49 @@ class CompactVDFCache:
         return self._capacity > 0
 
     def is_full(self) -> bool:
-        return self.enabled and len(self._vdf_proof_by_header_hash) >= self._capacity
+        return self.enabled and len(self) >= self._capacity
 
     def __len__(self) -> int:
-        return len(self._vdf_proof_by_header_hash)
+        return sum(len(slots) for slots in self._proofs_by_block.values())
 
     def has_block(self, header_hash: bytes32) -> bool:
-        return header_hash in self._vdf_proof_by_header_hash
+        return header_hash in self._proofs_by_block
 
-    def get(self, header_hash: bytes32) -> VDFProof | None:
-        return self._vdf_proof_by_header_hash.get(header_hash)
+    def get_proofs(self, header_hash: bytes32) -> tuple[CachedCompactVDF, ...]:
+        slots = self._proofs_by_block.get(header_hash)
+        if slots is None:
+            return ()
+        return tuple(
+            CachedCompactVDF(slot.field_vdf, slot.sub_slot_index, proof) for slot, proof in slots.items()
+        )
 
-    def add(self, header_hash: bytes32, vdf_proof: VDFProof) -> bool:
+    def add(
+        self,
+        header_hash: bytes32,
+        field_vdf: CompressibleVDFField,
+        sub_slot_index: uint8,
+        vdf_proof: VDFProof,
+    ) -> bool:
         if not self.enabled:
             return False
-        if header_hash in self._vdf_proof_by_header_hash:
-            self._vdf_proof_by_header_hash[header_hash] = vdf_proof
+        slot = CompactVDFProofSlot(field_vdf, sub_slot_index)
+        block_proofs = self._proofs_by_block.get(header_hash)
+        if block_proofs is not None and slot in block_proofs:
+            block_proofs[slot] = vdf_proof
             return True
         if self.is_full():
             return False
-        self._vdf_proof_by_header_hash[header_hash] = vdf_proof
+        if block_proofs is None:
+            self._proofs_by_block[header_hash] = {slot: vdf_proof}
+        else:
+            block_proofs[slot] = vdf_proof
         return True
 
     def modified_header_hashes(self) -> set[bytes32]:
-        return set(self._vdf_proof_by_header_hash)
+        return set(self._proofs_by_block)
 
     def remove_block(self, header_hash: bytes32) -> None:
-        self._vdf_proof_by_header_hash.pop(header_hash, None)
+        self._proofs_by_block.pop(header_hash, None)
 
     def clear(self) -> None:
-        self._vdf_proof_by_header_hash.clear()
+        self._proofs_by_block.clear()

--- a/chia/full_node/compact_vdf_cache.py
+++ b/chia/full_node/compact_vdf_cache.py
@@ -43,9 +43,7 @@ class CompactVDFCache:
     def contains(self, header_hash: bytes32, field_vdf: CompressibleVDFField, vdf_info: VDFInfo) -> bool:
         return self._key(header_hash, field_vdf, vdf_info) in self._entries
 
-    def get_proof(
-        self, header_hash: bytes32, field_vdf: CompressibleVDFField, vdf_info: VDFInfo
-    ) -> VDFProof | None:
+    def get_proof(self, header_hash: bytes32, field_vdf: CompressibleVDFField, vdf_info: VDFInfo) -> VDFProof | None:
         entry = self._entries.get(self._key(header_hash, field_vdf, vdf_info))
         return entry.vdf_proof if entry is not None else None
 

--- a/chia/full_node/compact_vdf_cache.py
+++ b/chia/full_node/compact_vdf_cache.py
@@ -1,3 +1,59 @@
+"""Bounded in-memory cache of compact VDF proofs pending database flush.
+
+When enabled, accepted compact proofs are stored here instead of being written
+to the database immediately. On node shutdown, ``FullNode.flush_compact_vdf_cache``
+persists all cached proofs. While the cache is full, new compact proofs are
+rejected.
+
+Cache structure
+---------------
+::
+
+    dict[header_hash → dict[(field_vdf, sub_slot_index) → VDFProof]]
+
+- **Capacity** counts total pending proofs across all blocks, not blocks.
+- **Lookup** by ``header_hash`` is O(1); applying cached proofs to a block is
+  O(k) where k is the number of proofs cached for that block (typically a
+  small constant).
+
+Slot key
+--------
+Each cached proof is keyed by:
+
+- ``field_vdf`` (``CompressibleVDFField``, 1 byte on the wire): which
+  compressible field (CC_EOS, ICC_EOS, CC_SP, CC_IP).
+- ``sub_slot_index`` (``uint8``): index into ``finished_sub_slots`` for EOS
+  fields; ``0`` for reward-chain fields (CC_SP, CC_IP).
+
+Multiple proofs per block are supported before flush (for example several EOS
+sub-slots plus SP and IP on the same block).
+
+What is stored vs. what is already on the block
+------------------------------------------------
++----------------------------+----------------------------------+
+| Cached                     | Already on the block             |
++============================+==================================+
+| ``field_vdf``              | VDF info (challenge, iterations, |
+| ``sub_slot_index``         | output) at each slot             |
+| compact ``VDFProof``       | full proof being replaced        |
++----------------------------+----------------------------------+
+
+VDF info is not duplicated in the cache. On accept, ``FullNode`` resolves
+``sub_slot_index`` from the block's existing VDF info, then patches only the
+proof field when serving or flushing.
+
+Replacement and eviction
+------------------------
+- ``add()`` overwrites an existing ``(header_hash, field_vdf, sub_slot_index)``
+  entry without increasing the capacity count. This should not happen in normal
+  operation: ``FullNode._can_accept_compact_proof`` rejects duplicate compact
+  proofs for a slot before ``add()`` is called. The overwrite exists only so
+  ``add()`` is idempotent if the same slot is inserted twice.
+- ``remove_block`` drops every cached proof for a block after a successful flush.
+- ``CompactVDFCache(0)`` disables caching; proofs are written to the database
+  immediately.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -21,11 +77,7 @@ class CachedCompactVDF:
 
 
 class CompactVDFCache:
-    """Bounded in-memory cache of compact VDF proofs pending database flush.
-
-    Multiple compact VDF proofs may be cached per block, keyed by field and
-    sub-slot index (0 for reward-chain fields).
-    """
+    """See module docstring for design and invariants."""
 
     def __init__(self, capacity: int) -> None:
         self._capacity = capacity

--- a/chia/full_node/compact_vdf_cache.py
+++ b/chia/full_node/compact_vdf_cache.py
@@ -15,12 +15,14 @@ class CachedCompactVDF:
 
 
 class CompactVDFCache:
-    """Bounded in-memory cache of compact VDF proofs pending database flush."""
+    """Bounded in-memory cache of compact VDF proofs pending database flush.
+
+    At most one cached compact VDF per block header hash.
+    """
 
     def __init__(self, capacity: int) -> None:
         self._capacity = capacity
-        self._by_header_hash: dict[bytes32, dict[tuple[int, bytes], CachedCompactVDF]] = {}
-        self._count = 0
+        self._vdf_by_header_hash: dict[bytes32, CachedCompactVDF] = {}
 
     @property
     def capacity(self) -> int:
@@ -31,64 +33,33 @@ class CompactVDFCache:
         return self._capacity > 0
 
     def is_full(self) -> bool:
-        return self.enabled and self._count >= self._capacity
+        return self.enabled and len(self._vdf_by_header_hash) >= self._capacity
 
     def __len__(self) -> int:
-        return self._count
-
-    @staticmethod
-    def _proof_key(field_vdf: CompressibleVDFField, vdf_info: VDFInfo) -> tuple[int, bytes]:
-        return int(field_vdf), bytes(vdf_info)
+        return len(self._vdf_by_header_hash)
 
     def has_block(self, header_hash: bytes32) -> bool:
-        block_entries = self._by_header_hash.get(header_hash)
-        return block_entries is not None and len(block_entries) > 0
+        return header_hash in self._vdf_by_header_hash
 
-    def contains(self, header_hash: bytes32, field_vdf: CompressibleVDFField, vdf_info: VDFInfo) -> bool:
-        block_entries = self._by_header_hash.get(header_hash)
-        if block_entries is None:
-            return False
-        return self._proof_key(field_vdf, vdf_info) in block_entries
-
-    def get_proof(
-        self, header_hash: bytes32, field_vdf: CompressibleVDFField, vdf_info: VDFInfo
-    ) -> VDFProof | None:
-        block_entries = self._by_header_hash.get(header_hash)
-        if block_entries is None:
-            return None
-        entry = block_entries.get(self._proof_key(field_vdf, vdf_info))
-        return entry.vdf_proof if entry is not None else None
-
-    def get_entries_for_block(self, header_hash: bytes32) -> list[CachedCompactVDF]:
-        block_entries = self._by_header_hash.get(header_hash)
-        if block_entries is None:
-            return []
-        return list(block_entries.values())
+    def get(self, header_hash: bytes32) -> CachedCompactVDF | None:
+        return self._vdf_by_header_hash.get(header_hash)
 
     def add(self, entry: CachedCompactVDF) -> bool:
         if not self.enabled:
             return False
-        proof_key = self._proof_key(entry.field_vdf, entry.vdf_info)
-        block_entries = self._by_header_hash.get(entry.header_hash)
-        if block_entries is not None and proof_key in block_entries:
+        if entry.header_hash in self._vdf_by_header_hash:
+            self._vdf_by_header_hash[entry.header_hash] = entry
             return True
         if self.is_full():
             return False
-        if block_entries is None:
-            block_entries = {}
-            self._by_header_hash[entry.header_hash] = block_entries
-        block_entries[proof_key] = entry
-        self._count += 1
+        self._vdf_by_header_hash[entry.header_hash] = entry
         return True
 
     def modified_header_hashes(self) -> set[bytes32]:
-        return set(self._by_header_hash)
+        return set(self._vdf_by_header_hash)
 
     def remove_block(self, header_hash: bytes32) -> None:
-        block_entries = self._by_header_hash.pop(header_hash, None)
-        if block_entries is not None:
-            self._count -= len(block_entries)
+        self._vdf_by_header_hash.pop(header_hash, None)
 
     def clear(self) -> None:
-        self._by_header_hash.clear()
-        self._count = 0
+        self._vdf_by_header_hash.clear()

--- a/chia/full_node/compact_vdf_cache.py
+++ b/chia/full_node/compact_vdf_cache.py
@@ -1,28 +1,18 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-from chia.types.blockchain_format.vdf import CompressibleVDFField, VDFInfo, VDFProof
+from chia.types.blockchain_format.vdf import VDFProof
 from chia_rs.sized_bytes import bytes32
-
-
-@dataclass(frozen=True)
-class CachedCompactVDF:
-    vdf_info: VDFInfo
-    vdf_proof: VDFProof
-    header_hash: bytes32
-    field_vdf: CompressibleVDFField
 
 
 class CompactVDFCache:
     """Bounded in-memory cache of compact VDF proofs pending database flush.
 
-    At most one cached compact VDF per block header hash.
+    At most one cached compact VDF proof per block header hash.
     """
 
     def __init__(self, capacity: int) -> None:
         self._capacity = capacity
-        self._vdf_by_header_hash: dict[bytes32, CachedCompactVDF] = {}
+        self._vdf_proof_by_header_hash: dict[bytes32, VDFProof] = {}
 
     @property
     def capacity(self) -> int:
@@ -33,33 +23,33 @@ class CompactVDFCache:
         return self._capacity > 0
 
     def is_full(self) -> bool:
-        return self.enabled and len(self._vdf_by_header_hash) >= self._capacity
+        return self.enabled and len(self._vdf_proof_by_header_hash) >= self._capacity
 
     def __len__(self) -> int:
-        return len(self._vdf_by_header_hash)
+        return len(self._vdf_proof_by_header_hash)
 
     def has_block(self, header_hash: bytes32) -> bool:
-        return header_hash in self._vdf_by_header_hash
+        return header_hash in self._vdf_proof_by_header_hash
 
-    def get(self, header_hash: bytes32) -> CachedCompactVDF | None:
-        return self._vdf_by_header_hash.get(header_hash)
+    def get(self, header_hash: bytes32) -> VDFProof | None:
+        return self._vdf_proof_by_header_hash.get(header_hash)
 
-    def add(self, entry: CachedCompactVDF) -> bool:
+    def add(self, header_hash: bytes32, vdf_proof: VDFProof) -> bool:
         if not self.enabled:
             return False
-        if entry.header_hash in self._vdf_by_header_hash:
-            self._vdf_by_header_hash[entry.header_hash] = entry
+        if header_hash in self._vdf_proof_by_header_hash:
+            self._vdf_proof_by_header_hash[header_hash] = vdf_proof
             return True
         if self.is_full():
             return False
-        self._vdf_by_header_hash[entry.header_hash] = entry
+        self._vdf_proof_by_header_hash[header_hash] = vdf_proof
         return True
 
     def modified_header_hashes(self) -> set[bytes32]:
-        return set(self._vdf_by_header_hash)
+        return set(self._vdf_proof_by_header_hash)
 
     def remove_block(self, header_hash: bytes32) -> None:
-        self._vdf_by_header_hash.pop(header_hash, None)
+        self._vdf_proof_by_header_hash.pop(header_hash, None)
 
     def clear(self) -> None:
-        self._vdf_by_header_hash.clear()
+        self._vdf_proof_by_header_hash.clear()

--- a/chia/full_node/compact_vdf_cache.py
+++ b/chia/full_node/compact_vdf_cache.py
@@ -65,6 +65,11 @@ class CompactVDFCache:
     def modified_header_hashes(self) -> set[bytes32]:
         return set(self._modified_blocks)
 
+    def remove_block(self, header_hash: bytes32) -> None:
+        for entry in self.get_entries_for_block(header_hash):
+            self._entries.pop(self._key(entry.header_hash, entry.field_vdf, entry.vdf_info), None)
+        self._modified_blocks.discard(header_hash)
+
     def clear(self) -> None:
         self._entries.clear()
         self._modified_blocks.clear()

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -3242,28 +3242,31 @@ class FullNode:
             self.log.info(f"Duplicate compact proof. Height: {height}. Header hash: {header_hash}.")
         return is_new_proof
 
-    def _apply_cached_proofs_to_block(self, block: FullBlock) -> FullBlock:
-        if not self.compact_vdf_cache.enabled:
+    def _apply_cached_vdf_to_block(self, block: FullBlock) -> FullBlock:
+        cached = self.compact_vdf_cache.get(block.header_hash)
+        if cached is None:
             return block
-        entries = self.compact_vdf_cache.get_entries_for_block(block.header_hash)
-        if not entries:
-            return block
-        result = FullBlock.from_bytes(bytes(block))
-        for entry in entries:
-            updated = self._apply_proof_to_block(result, entry.vdf_info, entry.vdf_proof, entry.field_vdf)
-            if updated is not None:
-                result = updated
-        return result
+        merged = self._apply_proof_to_block(block, cached.vdf_info, cached.vdf_proof, cached.field_vdf)
+        return merged if merged is not None else block
 
     async def _get_block_with_cached_proofs(self, header_hash: bytes32) -> FullBlock | None:
-        block = await self.block_store.get_full_block(header_hash)
-        if block is None:
-            return None
-        if not self.compact_vdf_cache.enabled or not self.compact_vdf_cache.has_block(header_hash):
-            return block
-        merged = self._apply_cached_proofs_to_block(block)
-        self.block_store.block_cache.put(header_hash, merged)
-        return merged
+        cached_vdf = self.compact_vdf_cache.get(header_hash)
+        if cached_vdf is not None:
+            cached_block = self.block_store.get_block_from_cache(header_hash)
+            if cached_block is not None:
+                header_block = get_block_header(cached_block)
+                if not await self._needs_compact_proof(
+                    cached_vdf.vdf_info, header_block, cached_vdf.field_vdf
+                ):
+                    return cached_block
+                self.block_store.block_cache.remove(header_hash)
+            block = await self.block_store.get_full_block(header_hash)
+            if block is None:
+                return None
+            merged = self._apply_cached_vdf_to_block(block)
+            self.block_store.block_cache.put(header_hash, merged)
+            return merged
+        return await self.block_store.get_full_block(header_hash)
 
     async def get_full_block(self, header_hash: bytes32) -> FullBlock | None:
         return await self._get_block_with_cached_proofs(header_hash)
@@ -3371,7 +3374,9 @@ class FullNode:
         new_block = self._apply_proof_to_block(block, vdf_info, vdf_proof, field_vdf)
         if new_block is None:
             return False
-        if not self.compact_vdf_cache.add(CachedCompactVDF(vdf_info, vdf_proof, header_hash, field_vdf)):
+        if not self.compact_vdf_cache.add(
+            CachedCompactVDF(vdf_info, vdf_proof, header_hash, field_vdf)
+        ):
             return False
         self.block_store.block_cache.put(header_hash, new_block)
         return True
@@ -3392,7 +3397,7 @@ class FullNode:
             return
         if self._block_store is None or self._blockchain is None or self._db_wrapper is None:
             return
-        self.log.info(f"Flushing {len(self.compact_vdf_cache)} cached compact VDF proofs to database")
+        self.log.info(f"Flushing {len(self.compact_vdf_cache)} cached compact VDFs to database")
         async with self.blockchain.compact_proof_lock:
             flushed_blocks = 0
             failed_blocks = 0
@@ -3416,7 +3421,7 @@ class FullNode:
             if failed_blocks > 0:
                 self.log.error(
                     f"Failed to flush compact VDF cache for {failed_blocks} blocks; "
-                    f"{len(self.compact_vdf_cache)} cached proofs remain in memory"
+                    f"{len(self.compact_vdf_cache)} cached compact VDFs remain in memory"
                 )
             elif flushed_blocks > 0:
                 self.log.info(f"Flushed compact VDF proofs for {flushed_blocks} blocks")

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -3246,23 +3246,14 @@ class FullNode:
     def _proof_is_compact(proof: VDFProof) -> bool:
         return proof.witness_type == 0 and proof.normalized_to_identity
 
-    def _apply_proof_to_block(
-        self,
-        block: FullBlock,
-        vdf_proof: VDFProof,
-        field_vdf: CompressibleVDFField | None = None,
-    ) -> FullBlock | None:
+    def _apply_proof_to_block(self, block: FullBlock, vdf_proof: VDFProof) -> FullBlock | None:
         start = ClassgroupElement.get_default_element()
-        if field_vdf is not None:
-            field_types = [field_vdf]
-        else:
-            # Prefer reward-chain fields before sub-slot fields when scanning.
-            field_types = [
-                CompressibleVDFField.CC_IP_VDF,
-                CompressibleVDFField.CC_SP_VDF,
-                CompressibleVDFField.CC_EOS_VDF,
-                CompressibleVDFField.ICC_EOS_VDF,
-            ]
+        field_types = [
+            CompressibleVDFField.CC_IP_VDF,
+            CompressibleVDFField.CC_SP_VDF,
+            CompressibleVDFField.CC_EOS_VDF,
+            CompressibleVDFField.ICC_EOS_VDF,
+        ]
 
         for field in field_types:
             if field == CompressibleVDFField.CC_EOS_VDF:
@@ -3303,20 +3294,18 @@ class FullNode:
             elif field == CompressibleVDFField.CC_SP_VDF:
                 if block.challenge_chain_sp_proof is None or self._proof_is_compact(block.challenge_chain_sp_proof):
                     continue
-                if block.reward_chain_block.challenge_chain_sp_vdf is None:
+                sp_vdf = block.reward_chain_block.challenge_chain_sp_vdf
+                if sp_vdf is None:
                     continue
-                if field_vdf is None:
-                    sp_vdf = block.reward_chain_block.challenge_chain_sp_vdf
-                    if not validate_vdf(vdf_proof, self.constants, start, sp_vdf):
-                        continue
+                if not validate_vdf(vdf_proof, self.constants, start, sp_vdf):
+                    continue
                 return block.replace(challenge_chain_sp_proof=vdf_proof)
             elif field == CompressibleVDFField.CC_IP_VDF:
                 if self._proof_is_compact(block.challenge_chain_ip_proof):
                     continue
-                if field_vdf is None:
-                    ip_vdf = block.reward_chain_block.challenge_chain_ip_vdf
-                    if not validate_vdf(vdf_proof, self.constants, start, ip_vdf):
-                        continue
+                ip_vdf = block.reward_chain_block.challenge_chain_ip_vdf
+                if not validate_vdf(vdf_proof, self.constants, start, ip_vdf):
+                    continue
                 return block.replace(challenge_chain_ip_proof=vdf_proof)
         return None
 
@@ -3374,7 +3363,7 @@ class FullNode:
         if block is None:
             return False
 
-        new_block = self._apply_proof_to_block(block, vdf_proof, field_vdf)
+        new_block = self._apply_proof_to_block(block, vdf_proof)
         if new_block is None:
             return False
         async with self.db_wrapper.writer():
@@ -3399,7 +3388,7 @@ class FullNode:
         if block is None:
             return False
 
-        new_block = self._apply_proof_to_block(block, vdf_proof, field_vdf)
+        new_block = self._apply_proof_to_block(block, vdf_proof)
         if new_block is None:
             return False
         if not self.compact_vdf_cache.add(header_hash, vdf_proof):

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -47,12 +47,14 @@ from chia.consensus.blockchain_interface import BlockchainInterface
 from chia.consensus.coin_store_protocol import CoinStoreProtocol
 from chia.consensus.condition_tools import pkm_pairs
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
+from chia.consensus.generator_tools import get_block_header
 from chia.consensus.get_block_challenge import post_hard_fork2
 from chia.consensus.make_sub_epoch_summary import next_sub_epoch_summary
 from chia.consensus.multiprocess_validation import PreValidationResult, pre_validate_block
 from chia.consensus.pot_iterations import calculate_sp_iters
 from chia.consensus.signage_point import SignagePoint
 from chia.full_node.block_store import BlockStore
+from chia.full_node.compact_vdf_cache import CachedCompactVDF, CompactVDFCache
 from chia.full_node.check_fork_next_block import check_fork_next_block
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.full_node_api import FullNodeAPI
@@ -148,6 +150,7 @@ class FullNode:
     sync_store: SyncStore = dataclasses.field(default_factory=SyncStore)
     uncompact_task: asyncio.Task[None] | None = None
     compact_vdf_requests: set[bytes32] = dataclasses.field(default_factory=set)
+    compact_vdf_cache: CompactVDFCache = dataclasses.field(default_factory=lambda: CompactVDFCache(0))
     # TODO: Logging isn't setup yet so the log entries related to parsing the
     #       config would end up on stdout if handled here.
     multiprocessing_context: BaseContext | None = None
@@ -271,6 +274,7 @@ class FullNode:
             self._block_store = await BlockStore.create(self.db_wrapper)
             self._hint_store = await HintStore.create(self.db_wrapper)
             self._coin_store = await CoinStore.create(self.db_wrapper)
+            self.compact_vdf_cache = CompactVDFCache(self.config.get("compact_vdf_cache_size", 460800))
             self.log.info("Initializing blockchain from disk")
             start_time = time.monotonic()
             single_threaded = self.config.get("single_threaded", False)
@@ -423,6 +427,7 @@ class FullNode:
                                 self.log.info(f"Awaiting long sync task {one_sync_task.get_name()}")
                                 await one_sync_task
                     await asyncio.gather(*self._segment_task_list, return_exceptions=True)
+                    await self.flush_compact_vdf_cache()
 
     @property
     def block_store(self) -> BlockStore:
@@ -3211,6 +3216,9 @@ class FullNode:
         - Checks if the provided vdf_info is correct, assuming it refers to the start of sub-slot.
         - Checks if the existing proof was non-compact. Ignore this proof if we already have a compact proof.
         """
+        if self.compact_vdf_cache.enabled and self.compact_vdf_cache.is_full():
+            self.log.debug("Compact VDF cache full, not accepting compact proofs")
+            return False
         is_fully_compactified = await self.block_store.is_fully_compactified(header_hash)
         if is_fully_compactified is None or is_fully_compactified:
             self.log.info(f"Already compactified block: {header_hash}. Ignoring.")
@@ -3225,7 +3233,7 @@ class FullNode:
         if not validate_vdf(vdf_proof, self.constants, ClassgroupElement.get_default_element(), vdf_info):
             self.log.error(f"Received compact vdf proof is not valid: {vdf_proof}.")
             return False
-        header_block = await self.blockchain.get_header_block_by_height(height, header_hash, tx_filter=False)
+        header_block = await self._get_header_block_with_cached_proofs(height, header_hash, tx_filter=False)
         if header_block is None:
             self.log.error(f"Can't find block for given compact vdf. Height: {height} Header hash: {header_hash}")
             return False
@@ -3234,18 +3242,38 @@ class FullNode:
             self.log.info(f"Duplicate compact proof. Height: {height}. Header hash: {header_hash}.")
         return is_new_proof
 
-    # returns True if we ended up replacing the proof, and False otherwise
-    async def _replace_proof(
-        self,
-        vdf_info: VDFInfo,
-        vdf_proof: VDFProof,
-        header_hash: bytes32,
-        field_vdf: CompressibleVDFField,
-    ) -> bool:
+    def _apply_cached_proofs_to_block(self, block: FullBlock) -> FullBlock:
+        if not self.compact_vdf_cache.enabled:
+            return block
+        for entry in self.compact_vdf_cache.get_entries_for_block(block.header_hash):
+            updated = self._apply_proof_to_block(block, entry.vdf_info, entry.vdf_proof, entry.field_vdf)
+            if updated is not None:
+                block = updated
+        return block
+
+    async def _get_block_with_cached_proofs(self, header_hash: bytes32) -> FullBlock | None:
         block = await self.block_store.get_full_block(header_hash)
         if block is None:
-            return False
+            return None
+        return self._apply_cached_proofs_to_block(block)
 
+    async def _get_header_block_with_cached_proofs(
+        self, height: int, header_hash: bytes32, tx_filter: bool = False
+    ) -> HeaderBlock | None:
+        if tx_filter:
+            return await self.blockchain.get_header_block_by_height(height, header_hash, tx_filter)
+        block = await self._get_block_with_cached_proofs(header_hash)
+        if block is None or block.height != height or block.header_hash != header_hash:
+            return None
+        return get_block_header(block)
+
+    def _apply_proof_to_block(
+        self,
+        block: FullBlock,
+        vdf_info: VDFInfo,
+        vdf_proof: VDFProof,
+        field_vdf: CompressibleVDFField,
+    ) -> FullBlock | None:
         new_block = None
 
         if field_vdf == CompressibleVDFField.CC_EOS_VDF:
@@ -3276,6 +3304,21 @@ class FullNode:
         if field_vdf == CompressibleVDFField.CC_IP_VDF:
             if block.reward_chain_block.challenge_chain_ip_vdf == vdf_info:
                 new_block = block.replace(challenge_chain_ip_proof=vdf_proof)
+        return new_block
+
+    # returns True if we ended up replacing the proof, and False otherwise
+    async def _replace_proof(
+        self,
+        vdf_info: VDFInfo,
+        vdf_proof: VDFProof,
+        header_hash: bytes32,
+        field_vdf: CompressibleVDFField,
+    ) -> bool:
+        block = await self.block_store.get_full_block(header_hash)
+        if block is None:
+            return False
+
+        new_block = self._apply_proof_to_block(block, vdf_info, vdf_proof, field_vdf)
         if new_block is None:
             return False
         async with self.db_wrapper.writer():
@@ -3289,6 +3332,63 @@ class FullNode:
                 )
                 raise
 
+    async def _cache_compact_proof(
+        self,
+        vdf_info: VDFInfo,
+        vdf_proof: VDFProof,
+        header_hash: bytes32,
+        field_vdf: CompressibleVDFField,
+    ) -> bool:
+        block = await self._get_block_with_cached_proofs(header_hash)
+        if block is None:
+            return False
+
+        new_block = self._apply_proof_to_block(block, vdf_info, vdf_proof, field_vdf)
+        if new_block is None:
+            return False
+        if not self.compact_vdf_cache.add(
+            CachedCompactVDF(vdf_info, vdf_proof, header_hash, field_vdf)
+        ):
+            return False
+        self.block_store.block_cache.put(header_hash, new_block)
+        return True
+
+    async def _store_compact_proof(
+        self,
+        vdf_info: VDFInfo,
+        vdf_proof: VDFProof,
+        header_hash: bytes32,
+        field_vdf: CompressibleVDFField,
+    ) -> bool:
+        if self.compact_vdf_cache.enabled:
+            return await self._cache_compact_proof(vdf_info, vdf_proof, header_hash, field_vdf)
+        return await self._replace_proof(vdf_info, vdf_proof, header_hash, field_vdf)
+
+    async def flush_compact_vdf_cache(self) -> None:
+        if not self.compact_vdf_cache.enabled or len(self.compact_vdf_cache) == 0:
+            return
+        if self._block_store is None or self._blockchain is None or self._db_wrapper is None:
+            return
+        self.log.info(f"Flushing {len(self.compact_vdf_cache)} cached compact VDF proofs to database")
+        async with self.blockchain.compact_proof_lock:
+            for header_hash in self.compact_vdf_cache.modified_header_hashes():
+                block = self.block_store.get_block_from_cache(header_hash)
+                if block is None:
+                    block = await self._get_block_with_cached_proofs(header_hash)
+                if block is None:
+                    self.log.error(f"Could not flush cached compact VDF for block {header_hash}")
+                    continue
+                async with self.db_wrapper.writer():
+                    try:
+                        await self.block_store.replace_proof(header_hash, block)
+                    except BaseException as e:
+                        self.log.error(
+                            f"flush_compact_vdf_cache error while adding block {header_hash} height {block.height},"
+                            f" rolling back: {e} {traceback.format_exc()}"
+                        )
+                        raise
+            self.compact_vdf_cache.clear()
+
     async def add_compact_proof_of_time(self, request: timelord_protocol.RespondCompactProofOfTime) -> None:
         peak = self.blockchain.get_peak()
         if peak is None or peak.height - request.height < 5:
@@ -3301,9 +3401,14 @@ class FullNode:
         ):
             return None
         async with self.blockchain.compact_proof_lock:
-            replaced = await self._replace_proof(request.vdf_info, request.vdf_proof, request.header_hash, field_vdf)
+            replaced = await self._store_compact_proof(
+                request.vdf_info, request.vdf_proof, request.header_hash, field_vdf
+            )
         if not replaced:
-            self.log.error(f"Could not replace compact proof: {request.height}")
+            if self.compact_vdf_cache.enabled and self.compact_vdf_cache.is_full():
+                self.log.warning("Compact VDF cache full, rejecting compact proof of time")
+            else:
+                self.log.error(f"Could not replace compact proof: {request.height}")
             return None
         self.log.info(f"Replaced compact proof at height {request.height}")
         msg = make_msg(
@@ -3314,6 +3419,9 @@ class FullNode:
             await self.server.send_to_all([msg], NodeType.FULL_NODE)
 
     async def new_compact_vdf(self, request: full_node_protocol.NewCompactVDF, peer: WSChiaConnection) -> None:
+        if self.compact_vdf_cache.enabled and self.compact_vdf_cache.is_full():
+            self.log.debug("Compact VDF cache full, ignoring new_compact_vdf")
+            return None
         peak = self.blockchain.get_peak()
         if peak is None or peak.height - request.height < 5:
             self.log.info(f"Ignoring new_compact_vdf, height {request.height} too recent.")
@@ -3321,7 +3429,7 @@ class FullNode:
         is_fully_compactified = await self.block_store.is_fully_compactified(request.header_hash)
         if is_fully_compactified is None or is_fully_compactified:
             return None
-        header_block = await self.blockchain.get_header_block_by_height(
+        header_block = await self._get_header_block_with_cached_proofs(
             request.height, request.header_hash, tx_filter=False
         )
         if header_block is None:
@@ -3344,7 +3452,7 @@ class FullNode:
     async def request_compact_vdf(
         self, request: full_node_protocol.RequestCompactVDF, peer_id: bytes32
     ) -> VDFProof | None:
-        header_block = await self.blockchain.get_header_block_by_height(
+        header_block = await self._get_header_block_with_cached_proofs(
             request.height, request.header_hash, tx_filter=False
         )
         if header_block is None:
@@ -3388,9 +3496,14 @@ class FullNode:
         async with self.blockchain.compact_proof_lock:
             if self.blockchain.seen_compact_proofs(request.vdf_info, request.height):
                 return None
-            replaced = await self._replace_proof(request.vdf_info, request.vdf_proof, request.header_hash, field_vdf)
+            replaced = await self._store_compact_proof(
+                request.vdf_info, request.vdf_proof, request.header_hash, field_vdf
+            )
         if not replaced:
-            self.log.error(f"Could not replace compact proof: {request.height}")
+            if self.compact_vdf_cache.enabled and self.compact_vdf_cache.is_full():
+                self.log.warning("Compact VDF cache full, rejecting compact vdf")
+            else:
+                self.log.error(f"Could not replace compact proof: {request.height}")
             return None
         msg = make_msg(
             ProtocolMessageTypes.new_compact_vdf,

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -3265,6 +3265,15 @@ class FullNode:
         self.block_store.block_cache.put(header_hash, merged)
         return merged
 
+    async def get_full_block(self, header_hash: bytes32) -> FullBlock | None:
+        return await self._get_block_with_cached_proofs(header_hash)
+
+    async def get_full_block_bytes(self, header_hash: bytes32) -> bytes | None:
+        block = await self._get_block_with_cached_proofs(header_hash)
+        if block is None:
+            return None
+        return bytes(block)
+
     async def _get_header_block_with_cached_proofs(
         self, height: int, header_hash: bytes32, tx_filter: bool = False
     ) -> HeaderBlock | None:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -54,7 +54,7 @@ from chia.consensus.multiprocess_validation import PreValidationResult, pre_vali
 from chia.consensus.pot_iterations import calculate_sp_iters
 from chia.consensus.signage_point import SignagePoint
 from chia.full_node.block_store import BlockStore
-from chia.full_node.compact_vdf_cache import CachedCompactVDF, CompactVDFCache
+from chia.full_node.compact_vdf_cache import CompactVDFCache
 from chia.full_node.check_fork_next_block import check_fork_next_block
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.full_node_api import FullNodeAPI
@@ -3242,23 +3242,98 @@ class FullNode:
             self.log.info(f"Duplicate compact proof. Height: {height}. Header hash: {header_hash}.")
         return is_new_proof
 
+    @staticmethod
+    def _proof_is_compact(proof: VDFProof) -> bool:
+        return proof.witness_type == 0 and proof.normalized_to_identity
+
+    def _apply_proof_to_block(
+        self,
+        block: FullBlock,
+        vdf_proof: VDFProof,
+        field_vdf: CompressibleVDFField | None = None,
+    ) -> FullBlock | None:
+        start = ClassgroupElement.get_default_element()
+        if field_vdf is not None:
+            field_types = [field_vdf]
+        else:
+            # Prefer reward-chain fields before sub-slot fields when scanning.
+            field_types = [
+                CompressibleVDFField.CC_IP_VDF,
+                CompressibleVDFField.CC_SP_VDF,
+                CompressibleVDFField.CC_EOS_VDF,
+                CompressibleVDFField.ICC_EOS_VDF,
+            ]
+
+        for field in field_types:
+            if field == CompressibleVDFField.CC_EOS_VDF:
+                for index, sub_slot in enumerate(block.finished_sub_slots):
+                    if self._proof_is_compact(sub_slot.proofs.challenge_chain_slot_proof):
+                        continue
+                    vdf_info = sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf
+                    if not validate_vdf(vdf_proof, self.constants, start, vdf_info):
+                        continue
+                    new_proofs = sub_slot.proofs.replace(challenge_chain_slot_proof=vdf_proof)
+                    new_subslot = sub_slot.replace(proofs=new_proofs)
+                    return block.replace(
+                        finished_sub_slots=[
+                            *block.finished_sub_slots[:index],
+                            new_subslot,
+                            *block.finished_sub_slots[index + 1 :],
+                        ]
+                    )
+            elif field == CompressibleVDFField.ICC_EOS_VDF:
+                for index, sub_slot in enumerate(block.finished_sub_slots):
+                    if sub_slot.infused_challenge_chain is None:
+                        continue
+                    assert sub_slot.proofs.infused_challenge_chain_slot_proof is not None
+                    if self._proof_is_compact(sub_slot.proofs.infused_challenge_chain_slot_proof):
+                        continue
+                    vdf_info = sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf
+                    if not validate_vdf(vdf_proof, self.constants, start, vdf_info):
+                        continue
+                    new_proofs = sub_slot.proofs.replace(infused_challenge_chain_slot_proof=vdf_proof)
+                    new_subslot = sub_slot.replace(proofs=new_proofs)
+                    return block.replace(
+                        finished_sub_slots=[
+                            *block.finished_sub_slots[:index],
+                            new_subslot,
+                            *block.finished_sub_slots[index + 1 :],
+                        ]
+                    )
+            elif field == CompressibleVDFField.CC_SP_VDF:
+                if block.challenge_chain_sp_proof is None or self._proof_is_compact(block.challenge_chain_sp_proof):
+                    continue
+                if block.reward_chain_block.challenge_chain_sp_vdf is None:
+                    continue
+                if field_vdf is None:
+                    sp_vdf = block.reward_chain_block.challenge_chain_sp_vdf
+                    if not validate_vdf(vdf_proof, self.constants, start, sp_vdf):
+                        continue
+                return block.replace(challenge_chain_sp_proof=vdf_proof)
+            elif field == CompressibleVDFField.CC_IP_VDF:
+                if self._proof_is_compact(block.challenge_chain_ip_proof):
+                    continue
+                if field_vdf is None:
+                    ip_vdf = block.reward_chain_block.challenge_chain_ip_vdf
+                    if not validate_vdf(vdf_proof, self.constants, start, ip_vdf):
+                        continue
+                return block.replace(challenge_chain_ip_proof=vdf_proof)
+        return None
+
     def _apply_cached_vdf_to_block(self, block: FullBlock) -> FullBlock:
-        cached = self.compact_vdf_cache.get(block.header_hash)
-        if cached is None:
+        vdf_proof = self.compact_vdf_cache.get(block.header_hash)
+        if vdf_proof is None:
             return block
-        merged = self._apply_proof_to_block(block, cached.vdf_info, cached.vdf_proof, cached.field_vdf)
+        merged = self._apply_proof_to_block(block, vdf_proof)
         return merged if merged is not None else block
 
     async def _get_block_with_cached_proofs(self, header_hash: bytes32) -> FullBlock | None:
-        cached_vdf = self.compact_vdf_cache.get(header_hash)
-        if cached_vdf is not None:
+        cached_vdf_proof = self.compact_vdf_cache.get(header_hash)
+        if cached_vdf_proof is not None:
             cached_block = self.block_store.get_block_from_cache(header_hash)
+            if cached_block is not None and self._apply_proof_to_block(cached_block, cached_vdf_proof) is None:
+                return cached_block
             if cached_block is not None:
-                header_block = get_block_header(cached_block)
-                if not await self._needs_compact_proof(
-                    cached_vdf.vdf_info, header_block, cached_vdf.field_vdf
-                ):
-                    return cached_block
                 self.block_store.block_cache.remove(header_hash)
             block = await self.block_store.get_full_block(header_hash)
             if block is None:
@@ -3287,53 +3362,6 @@ class FullNode:
             return None
         return get_block_header(block)
 
-    def _apply_proof_to_block(
-        self,
-        block: FullBlock,
-        vdf_info: VDFInfo,
-        vdf_proof: VDFProof,
-        field_vdf: CompressibleVDFField,
-    ) -> FullBlock | None:
-        new_block = None
-
-        if field_vdf == CompressibleVDFField.CC_EOS_VDF:
-            for index, sub_slot in enumerate(block.finished_sub_slots):
-                if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
-                    new_proofs = sub_slot.proofs.replace(challenge_chain_slot_proof=vdf_proof)
-                    new_subslot = sub_slot.replace(proofs=new_proofs)
-                    new_block = block.replace(
-                        finished_sub_slots=[
-                            *block.finished_sub_slots[:index],
-                            new_subslot,
-                            *block.finished_sub_slots[index + 1 :],
-                        ]
-                    )
-                    break
-        if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
-            for index, sub_slot in enumerate(block.finished_sub_slots):
-                if (
-                    sub_slot.infused_challenge_chain is not None
-                    and sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf == vdf_info
-                ):
-                    new_proofs = sub_slot.proofs.replace(infused_challenge_chain_slot_proof=vdf_proof)
-                    new_subslot = sub_slot.replace(proofs=new_proofs)
-                    new_block = block.replace(
-                        finished_sub_slots=[
-                            *block.finished_sub_slots[:index],
-                            new_subslot,
-                            *block.finished_sub_slots[index + 1 :],
-                        ]
-                    )
-                    break
-        if field_vdf == CompressibleVDFField.CC_SP_VDF:
-            if block.reward_chain_block.challenge_chain_sp_vdf == vdf_info:
-                assert block.challenge_chain_sp_proof is not None
-                new_block = block.replace(challenge_chain_sp_proof=vdf_proof)
-        if field_vdf == CompressibleVDFField.CC_IP_VDF:
-            if block.reward_chain_block.challenge_chain_ip_vdf == vdf_info:
-                new_block = block.replace(challenge_chain_ip_proof=vdf_proof)
-        return new_block
-
     # returns True if we ended up replacing the proof, and False otherwise
     async def _replace_proof(
         self,
@@ -3346,7 +3374,7 @@ class FullNode:
         if block is None:
             return False
 
-        new_block = self._apply_proof_to_block(block, vdf_info, vdf_proof, field_vdf)
+        new_block = self._apply_proof_to_block(block, vdf_proof, field_vdf)
         if new_block is None:
             return False
         async with self.db_wrapper.writer():
@@ -3371,12 +3399,10 @@ class FullNode:
         if block is None:
             return False
 
-        new_block = self._apply_proof_to_block(block, vdf_info, vdf_proof, field_vdf)
+        new_block = self._apply_proof_to_block(block, vdf_proof, field_vdf)
         if new_block is None:
             return False
-        if not self.compact_vdf_cache.add(
-            CachedCompactVDF(vdf_info, vdf_proof, header_hash, field_vdf)
-        ):
+        if not self.compact_vdf_cache.add(header_hash, vdf_proof):
             return False
         self.block_store.block_cache.put(header_hash, new_block)
         return True

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -3242,92 +3242,107 @@ class FullNode:
             self.log.info(f"Duplicate compact proof. Height: {height}. Header hash: {header_hash}.")
         return is_new_proof
 
+    def _compact_vdf_sub_slot_index(
+        self, header_block: HeaderBlock, field_vdf: CompressibleVDFField, vdf_info: VDFInfo
+    ) -> int | None:
+        if field_vdf == CompressibleVDFField.CC_EOS_VDF:
+            for index, sub_slot in enumerate(header_block.finished_sub_slots):
+                if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
+                    return index
+            return None
+        if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
+            for index, sub_slot in enumerate(header_block.finished_sub_slots):
+                if (
+                    sub_slot.infused_challenge_chain is not None
+                    and sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf == vdf_info
+                ):
+                    return index
+            return None
+        if field_vdf in (CompressibleVDFField.CC_SP_VDF, CompressibleVDFField.CC_IP_VDF):
+            return 0
+        return None
+
     @staticmethod
     def _proof_is_compact(proof: VDFProof) -> bool:
         return proof.witness_type == 0 and proof.normalized_to_identity
 
-    def _apply_proof_to_block(self, block: FullBlock, vdf_proof: VDFProof) -> FullBlock | None:
-        start = ClassgroupElement.get_default_element()
-        field_types = [
-            CompressibleVDFField.CC_IP_VDF,
-            CompressibleVDFField.CC_SP_VDF,
-            CompressibleVDFField.CC_EOS_VDF,
-            CompressibleVDFField.ICC_EOS_VDF,
-        ]
+    def _cached_proof_applied_on_block(
+        self, block: FullBlock, field_vdf: CompressibleVDFField, sub_slot_index: int
+    ) -> bool:
+        if field_vdf == CompressibleVDFField.CC_IP_VDF:
+            return self._proof_is_compact(block.challenge_chain_ip_proof)
+        if field_vdf == CompressibleVDFField.CC_SP_VDF:
+            return block.challenge_chain_sp_proof is not None and self._proof_is_compact(
+                block.challenge_chain_sp_proof
+            )
+        if field_vdf == CompressibleVDFField.CC_EOS_VDF:
+            return self._proof_is_compact(
+                block.finished_sub_slots[sub_slot_index].proofs.challenge_chain_slot_proof
+            )
+        if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
+            sub_slot = block.finished_sub_slots[sub_slot_index]
+            assert sub_slot.proofs.infused_challenge_chain_slot_proof is not None
+            return self._proof_is_compact(sub_slot.proofs.infused_challenge_chain_slot_proof)
+        return False
 
-        for field in field_types:
-            if field == CompressibleVDFField.CC_EOS_VDF:
-                for index, sub_slot in enumerate(block.finished_sub_slots):
-                    if self._proof_is_compact(sub_slot.proofs.challenge_chain_slot_proof):
-                        continue
-                    vdf_info = sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf
-                    if not validate_vdf(vdf_proof, self.constants, start, vdf_info):
-                        continue
-                    new_proofs = sub_slot.proofs.replace(challenge_chain_slot_proof=vdf_proof)
-                    new_subslot = sub_slot.replace(proofs=new_proofs)
-                    return block.replace(
-                        finished_sub_slots=[
-                            *block.finished_sub_slots[:index],
-                            new_subslot,
-                            *block.finished_sub_slots[index + 1 :],
-                        ]
-                    )
-            elif field == CompressibleVDFField.ICC_EOS_VDF:
-                for index, sub_slot in enumerate(block.finished_sub_slots):
-                    if sub_slot.infused_challenge_chain is None:
-                        continue
-                    assert sub_slot.proofs.infused_challenge_chain_slot_proof is not None
-                    if self._proof_is_compact(sub_slot.proofs.infused_challenge_chain_slot_proof):
-                        continue
-                    vdf_info = sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf
-                    if not validate_vdf(vdf_proof, self.constants, start, vdf_info):
-                        continue
-                    new_proofs = sub_slot.proofs.replace(infused_challenge_chain_slot_proof=vdf_proof)
-                    new_subslot = sub_slot.replace(proofs=new_proofs)
-                    return block.replace(
-                        finished_sub_slots=[
-                            *block.finished_sub_slots[:index],
-                            new_subslot,
-                            *block.finished_sub_slots[index + 1 :],
-                        ]
-                    )
-            elif field == CompressibleVDFField.CC_SP_VDF:
-                if block.challenge_chain_sp_proof is None or self._proof_is_compact(block.challenge_chain_sp_proof):
-                    continue
-                sp_vdf = block.reward_chain_block.challenge_chain_sp_vdf
-                if sp_vdf is None:
-                    continue
-                if not validate_vdf(vdf_proof, self.constants, start, sp_vdf):
-                    continue
-                return block.replace(challenge_chain_sp_proof=vdf_proof)
-            elif field == CompressibleVDFField.CC_IP_VDF:
-                if self._proof_is_compact(block.challenge_chain_ip_proof):
-                    continue
-                ip_vdf = block.reward_chain_block.challenge_chain_ip_vdf
-                if not validate_vdf(vdf_proof, self.constants, start, ip_vdf):
-                    continue
-                return block.replace(challenge_chain_ip_proof=vdf_proof)
-        return None
+    def _apply_proof_to_block(
+        self,
+        block: FullBlock,
+        vdf_proof: VDFProof,
+        field_vdf: CompressibleVDFField,
+        sub_slot_index: int,
+    ) -> FullBlock:
+        if field_vdf == CompressibleVDFField.CC_IP_VDF:
+            return block.replace(challenge_chain_ip_proof=vdf_proof)
+        if field_vdf == CompressibleVDFField.CC_SP_VDF:
+            return block.replace(challenge_chain_sp_proof=vdf_proof)
+        if field_vdf == CompressibleVDFField.CC_EOS_VDF:
+            sub_slot = block.finished_sub_slots[sub_slot_index]
+            new_proofs = sub_slot.proofs.replace(challenge_chain_slot_proof=vdf_proof)
+            new_subslot = sub_slot.replace(proofs=new_proofs)
+            return block.replace(
+                finished_sub_slots=[
+                    *block.finished_sub_slots[:sub_slot_index],
+                    new_subslot,
+                    *block.finished_sub_slots[sub_slot_index + 1 :],
+                ]
+            )
+        sub_slot = block.finished_sub_slots[sub_slot_index]
+        new_proofs = sub_slot.proofs.replace(infused_challenge_chain_slot_proof=vdf_proof)
+        new_subslot = sub_slot.replace(proofs=new_proofs)
+        return block.replace(
+            finished_sub_slots=[
+                *block.finished_sub_slots[:sub_slot_index],
+                new_subslot,
+                *block.finished_sub_slots[sub_slot_index + 1 :],
+            ]
+        )
 
-    def _apply_cached_vdf_to_block(self, block: FullBlock) -> FullBlock:
-        vdf_proof = self.compact_vdf_cache.get(block.header_hash)
-        if vdf_proof is None:
-            return block
-        merged = self._apply_proof_to_block(block, vdf_proof)
-        return merged if merged is not None else block
+    def _all_cached_proofs_applied(self, block: FullBlock, header_hash: bytes32) -> bool:
+        for cached in self.compact_vdf_cache.get_proofs(header_hash):
+            if not self._cached_proof_applied_on_block(block, cached.field_vdf, cached.sub_slot_index):
+                return False
+        return True
+
+    def _apply_cached_proofs_to_block(self, block: FullBlock) -> FullBlock:
+        merged = block
+        for cached in self.compact_vdf_cache.get_proofs(block.header_hash):
+            merged = self._apply_proof_to_block(
+                merged, cached.vdf_proof, cached.field_vdf, cached.sub_slot_index
+            )
+        return merged
 
     async def _get_block_with_cached_proofs(self, header_hash: bytes32) -> FullBlock | None:
-        cached_vdf_proof = self.compact_vdf_cache.get(header_hash)
-        if cached_vdf_proof is not None:
+        if self.compact_vdf_cache.has_block(header_hash):
             cached_block = self.block_store.get_block_from_cache(header_hash)
-            if cached_block is not None and self._apply_proof_to_block(cached_block, cached_vdf_proof) is None:
+            if cached_block is not None and self._all_cached_proofs_applied(cached_block, header_hash):
                 return cached_block
             if cached_block is not None:
                 self.block_store.block_cache.remove(header_hash)
             block = await self.block_store.get_full_block(header_hash)
             if block is None:
                 return None
-            merged = self._apply_cached_vdf_to_block(block)
+            merged = self._apply_cached_proofs_to_block(block)
             self.block_store.block_cache.put(header_hash, merged)
             return merged
         return await self.block_store.get_full_block(header_hash)
@@ -3363,9 +3378,11 @@ class FullNode:
         if block is None:
             return False
 
-        new_block = self._apply_proof_to_block(block, vdf_proof)
-        if new_block is None:
+        header_block = get_block_header(block)
+        sub_slot_index = self._compact_vdf_sub_slot_index(header_block, field_vdf, vdf_info)
+        if sub_slot_index is None:
             return False
+        new_block = self._apply_proof_to_block(block, vdf_proof, field_vdf, sub_slot_index)
         async with self.db_wrapper.writer():
             try:
                 await self.block_store.replace_proof(header_hash, new_block)
@@ -3388,10 +3405,12 @@ class FullNode:
         if block is None:
             return False
 
-        new_block = self._apply_proof_to_block(block, vdf_proof)
-        if new_block is None:
+        header_block = get_block_header(block)
+        sub_slot_index = self._compact_vdf_sub_slot_index(header_block, field_vdf, vdf_info)
+        if sub_slot_index is None:
             return False
-        if not self.compact_vdf_cache.add(header_hash, vdf_proof):
+        new_block = self._apply_proof_to_block(block, vdf_proof, field_vdf, sub_slot_index)
+        if not self.compact_vdf_cache.add(header_hash, field_vdf, uint8(sub_slot_index), vdf_proof):
             return False
         self.block_store.block_cache.put(header_hash, new_block)
         return True

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -3346,9 +3346,7 @@ class FullNode:
         new_block = self._apply_proof_to_block(block, vdf_info, vdf_proof, field_vdf)
         if new_block is None:
             return False
-        if not self.compact_vdf_cache.add(
-            CachedCompactVDF(vdf_info, vdf_proof, header_hash, field_vdf)
-        ):
+        if not self.compact_vdf_cache.add(CachedCompactVDF(vdf_info, vdf_proof, header_hash, field_vdf)):
             return False
         self.block_store.block_cache.put(header_hash, new_block)
         return True

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -3259,7 +3259,7 @@ class FullNode:
         block = await self.block_store.get_full_block(header_hash)
         if block is None:
             return None
-        if not self.compact_vdf_cache.enabled or len(self.compact_vdf_cache.get_entries_for_block(header_hash)) == 0:
+        if not self.compact_vdf_cache.enabled or not self.compact_vdf_cache.has_block(header_hash):
             return block
         merged = self._apply_cached_proofs_to_block(block)
         self.block_store.block_cache.put(header_hash, merged)

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -3245,17 +3245,25 @@ class FullNode:
     def _apply_cached_proofs_to_block(self, block: FullBlock) -> FullBlock:
         if not self.compact_vdf_cache.enabled:
             return block
-        for entry in self.compact_vdf_cache.get_entries_for_block(block.header_hash):
-            updated = self._apply_proof_to_block(block, entry.vdf_info, entry.vdf_proof, entry.field_vdf)
+        entries = self.compact_vdf_cache.get_entries_for_block(block.header_hash)
+        if not entries:
+            return block
+        result = FullBlock.from_bytes(bytes(block))
+        for entry in entries:
+            updated = self._apply_proof_to_block(result, entry.vdf_info, entry.vdf_proof, entry.field_vdf)
             if updated is not None:
-                block = updated
-        return block
+                result = updated
+        return result
 
     async def _get_block_with_cached_proofs(self, header_hash: bytes32) -> FullBlock | None:
         block = await self.block_store.get_full_block(header_hash)
         if block is None:
             return None
-        return self._apply_cached_proofs_to_block(block)
+        if not self.compact_vdf_cache.enabled or len(self.compact_vdf_cache.get_entries_for_block(header_hash)) == 0:
+            return block
+        merged = self._apply_cached_proofs_to_block(block)
+        self.block_store.block_cache.put(header_hash, merged)
+        return merged
 
     async def _get_header_block_with_cached_proofs(
         self, height: int, header_hash: bytes32, tx_filter: bool = False
@@ -3281,9 +3289,13 @@ class FullNode:
                 if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
                     new_proofs = sub_slot.proofs.replace(challenge_chain_slot_proof=vdf_proof)
                     new_subslot = sub_slot.replace(proofs=new_proofs)
-                    new_finished_subslots = block.finished_sub_slots
-                    new_finished_subslots[index] = new_subslot
-                    new_block = block.replace(finished_sub_slots=new_finished_subslots)
+                    new_block = block.replace(
+                        finished_sub_slots=[
+                            *block.finished_sub_slots[:index],
+                            new_subslot,
+                            *block.finished_sub_slots[index + 1 :],
+                        ]
+                    )
                     break
         if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
             for index, sub_slot in enumerate(block.finished_sub_slots):
@@ -3293,9 +3305,13 @@ class FullNode:
                 ):
                     new_proofs = sub_slot.proofs.replace(infused_challenge_chain_slot_proof=vdf_proof)
                     new_subslot = sub_slot.replace(proofs=new_proofs)
-                    new_finished_subslots = block.finished_sub_slots
-                    new_finished_subslots[index] = new_subslot
-                    new_block = block.replace(finished_sub_slots=new_finished_subslots)
+                    new_block = block.replace(
+                        finished_sub_slots=[
+                            *block.finished_sub_slots[:index],
+                            new_subslot,
+                            *block.finished_sub_slots[index + 1 :],
+                        ]
+                    )
                     break
         if field_vdf == CompressibleVDFField.CC_SP_VDF:
             if block.reward_chain_block.challenge_chain_sp_vdf == vdf_info:
@@ -3369,11 +3385,12 @@ class FullNode:
             return
         self.log.info(f"Flushing {len(self.compact_vdf_cache)} cached compact VDF proofs to database")
         async with self.blockchain.compact_proof_lock:
+            flushed_blocks = 0
+            failed_blocks = 0
             for header_hash in self.compact_vdf_cache.modified_header_hashes():
-                block = self.block_store.get_block_from_cache(header_hash)
+                block = await self._get_block_with_cached_proofs(header_hash)
                 if block is None:
-                    block = await self._get_block_with_cached_proofs(header_hash)
-                if block is None:
+                    failed_blocks += 1
                     self.log.error(f"Could not flush cached compact VDF for block {header_hash}")
                     continue
                 async with self.db_wrapper.writer():
@@ -3385,7 +3402,15 @@ class FullNode:
                             f" rolling back: {e} {traceback.format_exc()}"
                         )
                         raise
-            self.compact_vdf_cache.clear()
+                self.compact_vdf_cache.remove_block(header_hash)
+                flushed_blocks += 1
+            if failed_blocks > 0:
+                self.log.error(
+                    f"Failed to flush compact VDF cache for {failed_blocks} blocks; "
+                    f"{len(self.compact_vdf_cache)} cached proofs remain in memory"
+                )
+            elif flushed_blocks > 0:
+                self.log.info(f"Flushed compact VDF proofs for {flushed_blocks} blocks")
 
     async def add_compact_proof_of_time(self, request: timelord_protocol.RespondCompactProofOfTime) -> None:
         peak = self.blockchain.get_peak()

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -411,7 +411,7 @@ class FullNodeAPI:
         if header_hash is None:
             return make_msg(ProtocolMessageTypes.reject_block, RejectBlock(request.height))
 
-        block: FullBlock | None = await self.full_node.block_store.get_full_block(header_hash)
+        block: FullBlock | None = await self.full_node.get_full_block(header_hash)
         if block is not None:
             if not request.include_transaction_block and block.transactions_generator is not None:
                 block = block.replace(transactions_generator=None)
@@ -444,7 +444,7 @@ class FullNodeAPI:
                     reject = RejectBlocks(request.start_height, request.end_height)
                     return make_msg(ProtocolMessageTypes.reject_blocks, reject)
 
-                block: FullBlock | None = await self.full_node.block_store.get_full_block(header_hash_i)
+                block: FullBlock | None = await self.full_node.get_full_block(header_hash_i)
                 if block is None:
                     reject = RejectBlocks(request.start_height, request.end_height)
                     return make_msg(ProtocolMessageTypes.reject_blocks, reject)
@@ -461,7 +461,7 @@ class FullNodeAPI:
                 if header_hash_i is None:
                     reject = RejectBlocks(request.start_height, request.end_height)
                     return make_msg(ProtocolMessageTypes.reject_blocks, reject)
-                block_bytes: bytes | None = await self.full_node.block_store.get_full_block_bytes(header_hash_i)
+                block_bytes: bytes | None = await self.full_node.get_full_block_bytes(header_hash_i)
                 if block_bytes is None:
                     reject = RejectBlocks(request.start_height, request.end_height)
                     msg = make_msg(ProtocolMessageTypes.reject_blocks, reject)
@@ -1345,7 +1345,7 @@ class FullNodeAPI:
         if header_hash is None:
             msg = make_msg(ProtocolMessageTypes.reject_header_request, RejectHeaderRequest(request.height))
             return msg
-        block: FullBlock | None = await self.full_node.block_store.get_full_block(header_hash)
+        block: FullBlock | None = await self.full_node.get_full_block(header_hash)
         if block is None:
             return None
 
@@ -1478,7 +1478,7 @@ class FullNodeAPI:
 
         try:
             async with self.wallet_sync_api_sem.acquire():
-                block: FullBlock | None = await self.full_node.block_store.get_full_block(request.header_hash)
+                block: FullBlock | None = await self.full_node.get_full_block(request.header_hash)
 
                 # We lock so that the coin store does not get modified
                 peak_height = self.full_node.blockchain.get_peak_height()

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -404,6 +404,9 @@ full_node:
   send_uncompact_interval: 0
   # At every 'send_uncompact_interval' seconds, send blueboxes 'target_uncompact_proofs' proofs to be normalized.
   target_uncompact_proofs: 100
+  # Maximum number of compact VDF proofs to cache in memory before rejecting new ones.
+  # Cached proofs are flushed to the database on node shutdown.
+  compact_vdf_cache_size: 460800
   # Setting this flag as True, blueboxes will sanitize only data needed in weight proof calculation, as opposed to whole blocks.
   # Default is set to False, as the network needs only one or two blueboxes like this.
   sanitize_weight_proof_only: False


### PR DESCRIPTION
DO NOT MERGE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when compact VDF proofs are persisted and what blocks/peers see before flush; a crash before shutdown flush could leave proofs only in memory, though validation paths still gate acceptance.
> 
> **Overview**
> Adds a **bounded in-memory `CompactVDFCache`** so accepted compact VDF proofs can be held in RAM instead of writing to the block DB on every accept. Capacity is configured via **`compact_vdf_cache_size`** (default **460800** proofs; **0** keeps the old immediate-write behavior).
> 
> **`FullNode`** routes compact proof storage through **`_store_compact_proof`**: when caching is on, proofs are merged into the in-memory block cache; **`flush_compact_vdf_cache`** persists them with **`replace_proof`** on shutdown (and tests call flush explicitly). While the cache is full, new compact proofs are **rejected** (accept checks, **`new_compact_vdf`**, and related paths).
> 
> **Read path**: **`get_full_block`**, **`get_full_block_bytes`**, and header helpers apply cached proofs so peers still get compactified blocks and **`request_compact_vdf`** can answer from cache even when the DB copy is still uncompact. **`full_node_api`** block requests now use these methods instead of **`block_store`** alone.
> 
> Proof patching is refactored into shared helpers (**`_apply_proof_to_block`**, sub-slot index resolution). Unit tests cover the cache; integration tests cover flush, read-through, and **`request_block`** / **`request_blocks`** serving cached proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9e47abc9bfb925ea8bba07e3b0eb73658405c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->