### PR TITLE
add configuration option to advertize rate limits v3 support

### DIFF
--- a/chia/_tests/core/server/test_server.py
+++ b/chia/_tests/core/server/test_server.py
@@ -28,7 +28,7 @@ from chia.full_node.start_full_node import create_full_node_service
 from chia.protocols.full_node_protocol import RejectBlock, RequestBlock, RequestTransaction
 from chia.protocols.outbound_message import Message, NodeType, make_msg
 from chia.protocols.protocol_message_types import ProtocolMessageTypes
-from chia.protocols.shared_protocol import Error, protocol_version
+from chia.protocols.shared_protocol import Capability, Error, protocol_version
 from chia.protocols.wallet_protocol import RejectHeaderRequest
 from chia.server.api_protocol import ApiMetadata
 from chia.server.server import ChiaServer, ssl_context_for_client
@@ -392,10 +392,13 @@ async def test_call_api_of_specific_for_missing_peer(
 
 @pytest.mark.limit_consensus_modes(reason="save time")
 @pytest.mark.anyio
-async def test_get_peer_info(bt: BlockTools) -> None:
-    wallet_service = create_wallet_service(
-        bt.root_path, bt.config, bt.constants, keychain=None, connect_to_daemon=False
-    )
+@pytest.mark.parametrize("rate_limits_config", [None, 2, 3], ids=["default", "v2", "v3"])
+async def test_get_peer_info(bt: BlockTools, rate_limits_config: int | None) -> None:
+    config = bt.config.copy()
+    if rate_limits_config is not None:
+        config["rate_limits"] = rate_limits_config
+
+    wallet_service = create_wallet_service(bt.root_path, config, bt.constants, keychain=None, connect_to_daemon=False)
 
     # Wallet server should not have a port or peer info
     with pytest.raises(ValueError, match="Port not set"):
@@ -406,9 +409,19 @@ async def test_get_peer_info(bt: BlockTools) -> None:
     # Full node server should have a local port
     # testing get_peer_info() directly is flakey because it depends on IP lookup
     # from either chia or aws
-    node_service = await create_full_node_service(bt.root_path, bt.config, bt.constants, connect_to_daemon=False)
+    node_service = await create_full_node_service(bt.root_path, config, bt.constants, connect_to_daemon=False)
     local_port = node_service._server.get_port()
     assert local_port is not None
+
+    from chia.server.capabilities import known_active_capabilities
+
+    expect_v3 = rate_limits_config is not None and rate_limits_config >= 3
+    for server in [wallet_service._server, node_service._server]:
+        advertised = known_active_capabilities(server._local_capabilities_for_handshake)
+        if expect_v3:
+            assert Capability.RATE_LIMITS_V3 in advertised
+        else:
+            assert Capability.RATE_LIMITS_V3 not in advertised
 
 
 class FakeConnection:

--- a/chia/protocols/shared_protocol.py
+++ b/chia/protocols/shared_protocol.py
@@ -67,6 +67,9 @@ _capabilities: list[tuple[uint16, str]] = [
 _mempool_updates = [
     (uint16(Capability.MEMPOOL_UPDATES.value), "1"),
 ]
+_rate_limits_v3 = [
+    (uint16(Capability.RATE_LIMITS_V3.value), "1"),
+]
 
 default_capabilities = {
     NodeType.FULL_NODE: _capabilities + _mempool_updates,

--- a/chia/server/start_service.py
+++ b/chia/server/start_service.py
@@ -14,7 +14,7 @@ from chia_rs.sized_ints import uint16
 
 from chia.daemon.server import service_launch_lock_path
 from chia.protocols.outbound_message import NodeType
-from chia.protocols.shared_protocol import default_capabilities
+from chia.protocols.shared_protocol import _rate_limits_v3, default_capabilities
 from chia.rpc.rpc_server import RpcApiProtocol, RpcServer, RpcServiceProtocol, start_rpc_server
 from chia.server.api_protocol import ApiMetadata, ApiProtocol
 from chia.server.chia_policy import set_chia_policy
@@ -105,6 +105,8 @@ class Service(Generic[_T_RpcServiceProtocol, _T_ApiProtocol, _T_RpcApiProtocol])
             inbound_rlp = self.service_config.get("inbound_rate_limit_percent", inbound_rlp)
             outbound_rlp = 60
         capabilities_to_use: list[tuple[uint16, str]] = default_capabilities[node_type]
+        if self.config.get("rate_limits", 2) >= 3:
+            capabilities_to_use = capabilities_to_use + _rate_limits_v3  # noqa: PLR6104 -- += would mutate the shared default_capabilities list
         if override_capabilities is not None:
             capabilities_to_use = override_capabilities
 

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -11,6 +11,7 @@ daemon_heartbeat: 300 # sets the heartbeat for ping/ping interval and timeouts
 daemon_allow_tls_1_2: False # if True, allow TLS 1.2 for daemon connections
 inbound_rate_limit_percent: 100
 outbound_rate_limit_percent: 30
+# rate_limits: 3  # set to 3 to enable rate limits v3 (default: 2)
 
 network_overrides: &network_overrides
   constants:


### PR DESCRIPTION
### Purpose:

Allow testing rate-limits v3. This is intended as a temporary setting, to be removed once v3 is the default.

### Current Behavior:

We advertize support for rate limits v2.

### New Behavior:

When the configuration option is set, we advertize support for rate limits v3.

### Testing Notes:

manual testing and unit test


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is off by default; changes only which capabilities are advertised at handshake, with no change to rate-limit enforcement unless peers negotiate v3.
> 
> **Overview**
> Adds an optional top-level **`rate_limits`** config (default **2**) so nodes can **advertise `Capability.RATE_LIMITS_V3`** in outgoing handshakes when set to **3 or higher**, intended as a temporary switch before v3 becomes the default.
> 
> **`Service`** startup now appends the v3 capability tuple to the per-node handshake list when enabled, using list concatenation so shared **`default_capabilities`** is not mutated. **`shared_protocol`** exposes a reusable **`_rate_limits_v3`** capability fragment, and **`initial-config.yaml`** documents the commented **`rate_limits: 3`** knob.
> 
> **`test_get_peer_info`** is parametrized over default / v2 / v3 config and asserts wallet and full-node servers include or omit **`RATE_LIMITS_V3`** in advertised capabilities accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ec07183131d7ac41d93c6873306bb7a18e07857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->