### PR TITLE
Add PLW0717 too-many-statements-in-try-clause to the ruff ignore list

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -22,6 +22,7 @@ ignore = [
     "PLR0917", # too-many-positional-arguments
     "PLR0916", # too-many-boolean-expressions
     "PLR0911", # too-many-return-statements
+    "PLW0717", # too-many-statements-in-try-clause
     # Should probably fix these
     "PLR6301", # no-self-use
     "PLR2004", # magic-value-comparison


### PR DESCRIPTION
Add PLW0717 too-many-statements-in-try-clause to the ruff ignore list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint configuration only; no application or security behavior changes.
> 
> **Overview**
> Adds **`PLW0717`** (`too-many-statements-in-try-clause`) to the global Ruff **`ignore`** list in `ruff.toml`, alongside the other Pylint refactor/complexity rules (e.g. `PLR0915` too-many-statements).
> 
> Ruff will no longer report this rule on the repo; behavior and thresholds elsewhere in the config are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91e276c554928c42c8c0af527f1bb4133f3fdbfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->