### PR TITLE
[LABS-469] Sanity check that PlotNFT memos match actual inner puzzle

### DIFF
--- a/chia/_tests/pools/test_plotnft_v2_drivers.py
+++ b/chia/_tests/pools/test_plotnft_v2_drivers.py
@@ -4,7 +4,7 @@ import re
 from typing import Literal
 
 import pytest
-from chia_rs import Coin, CoinSpend, G2Element, PrivateKey
+from chia_rs import Coin, CoinSpend, G1Element, G2Element, PrivateKey
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
@@ -490,6 +490,40 @@ def test_plotnft_errors() -> None:
                                         (
                                             PuzzleWithRestrictions.spec_namespace,
                                             [None, [[None, bytes32.zeros, None]], None, [bytes32.zeros, None]],
+                                        ),
+                                    )
+                                ),
+                            ).to_program()
+                        ],
+                    )
+                )
+            ),
+            genesis_challenge=bytes32.zeros,
+        )
+
+    with pytest.raises(GetNextPlotNFTError, match=re.escape("Invalid memoization of PlotNFT")):
+        PlotNFT.get_next_from_coin_spend(
+            coin_spend=FAUX_SPEND,
+            pre_uncurry=wrap_inner_puz(
+                Program.to(
+                    (
+                        1,
+                        [
+                            CreateCoin(
+                                puzzle_hash=bytes32.zeros,
+                                amount=uint64(1),
+                                memo_blob=Program.to(
+                                    (
+                                        bytes32.zeros,
+                                        (
+                                            PuzzleWithRestrictions.spec_namespace,
+                                            [
+                                                None,
+                                                [[None, bytes32.zeros, None]],
+                                                None,
+                                                [bytes32.zeros, None],
+                                                [G1Element()],
+                                            ],
                                         ),
                                     )
                                 ),

--- a/chia/pools/plotnft_drivers.py
+++ b/chia/pools/plotnft_drivers.py
@@ -507,6 +507,8 @@ class PlotNFT(PlotNFTPuzzle):
                 exiting=exiting,
                 genesis_challenge=genesis_challenge,
             )
+            if plotnft_puzzle.inner_puzzle_hash() != singleton_create_coin.puzzle_hash:
+                raise GetNextPlotNFTError("Invalid memoization of PlotNFT")
 
         return cls(
             coin=Coin(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small defensive validation in PlotNFT parsing/sync; no auth or consensus changes, only stricter error handling on malformed memos.
> 
> **Overview**
> Adds a **sanity check** when `PlotNFT.get_next_from_coin_spend` rebuilds state from `CreateCoin` memo data: after constructing a `PlotNFTPuzzle` from the memo, it now requires that puzzle’s `inner_puzzle_hash()` equals the `CreateCoin`’s `puzzle_hash`. A mismatch raises `GetNextPlotNFTError("Invalid memoization of PlotNFT")`.
> 
> Tests extend `test_plotnft_errors` with a memo case that parses but disagrees with the coin destination (extra `G1Element` in additional memos), plus the `G1Element` import needed to build that fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a2630b100bf1264250100f1ad162d0751e0803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->