### PR TITLE
CHIA-4273 Annotate wallet_node_api.py

### DIFF
--- a/chia/wallet/wallet_node_api.py
+++ b/chia/wallet/wallet_node_api.py
@@ -26,7 +26,7 @@ class WalletNodeAPI:
     wallet_node: WalletNode
     metadata: ClassVar[ApiMetadata] = ApiMetadata()
 
-    def __init__(self, wallet_node) -> None:
+    def __init__(self, wallet_node: WalletNode) -> None:
         self.log = logging.getLogger(__name__)
         self.wallet_node = wallet_node
 
@@ -34,23 +34,23 @@ class WalletNodeAPI:
         return self.wallet_node.logged_in
 
     @metadata.request()
-    async def respond_removals(self, response: wallet_protocol.RespondRemovals):
+    async def respond_removals(self, response: wallet_protocol.RespondRemovals) -> None:
         pass
 
     @metadata.request()
-    async def reject_removals_request(self, response: wallet_protocol.RejectRemovalsRequest):
+    async def reject_removals_request(self, response: wallet_protocol.RejectRemovalsRequest) -> None:
         """
         The full node has rejected our request for removals.
         """
 
     @metadata.request()
-    async def reject_additions_request(self, response: wallet_protocol.RejectAdditionsRequest):
+    async def reject_additions_request(self, response: wallet_protocol.RejectAdditionsRequest) -> None:
         """
         The full node has rejected our request for additions.
         """
 
     @metadata.request(peer_required=True, execute_task=True)
-    async def new_peak_wallet(self, peak: wallet_protocol.NewPeakWallet, peer: WSChiaConnection):
+    async def new_peak_wallet(self, peak: wallet_protocol.NewPeakWallet, peer: WSChiaConnection) -> None:
         """
         The full node sent as a new peak
         """
@@ -80,25 +80,25 @@ class WalletNodeAPI:
         await self.wallet_node.new_peak_queue.new_peak_wallet(peak, peer)
 
     @metadata.request()
-    async def reject_header_request(self, response: wallet_protocol.RejectHeaderRequest):
+    async def reject_header_request(self, response: wallet_protocol.RejectHeaderRequest) -> None:
         """
         The full node has rejected our request for a header.
         """
 
     @metadata.request()
-    async def respond_block_header(self, response: wallet_protocol.RespondBlockHeader):
+    async def respond_block_header(self, response: wallet_protocol.RespondBlockHeader) -> None:
         pass
 
     @metadata.request()
-    async def respond_additions(self, response: wallet_protocol.RespondAdditions):
+    async def respond_additions(self, response: wallet_protocol.RespondAdditions) -> None:
         pass
 
     @metadata.request()
-    async def respond_proof_of_weight(self, response: full_node_protocol.RespondProofOfWeight):
+    async def respond_proof_of_weight(self, response: full_node_protocol.RespondProofOfWeight) -> None:
         pass
 
     @metadata.request(peer_required=True)
-    async def transaction_ack(self, ack: wallet_protocol.TransactionAck, peer: WSChiaConnection):
+    async def transaction_ack(self, ack: wallet_protocol.TransactionAck, peer: WSChiaConnection) -> None:
         """
         This is an ack for our previous SendTransaction call. This removes the transaction from
         the send queue if we have sent it to enough nodes.
@@ -120,14 +120,14 @@ class WalletNodeAPI:
                 self.wallet_node.log.debug(
                     "Ignoring unsolicited transaction ack from peer %s for tx %s", name, ack.txid
                 )
-                return None
+                return
 
             status = MempoolInclusionStatus(ack.status)
             try:
                 wallet_state_manager = self.wallet_node.wallet_state_manager
             except RuntimeError as e:
                 if "not assigned" in str(e):
-                    return None
+                    return
                 raise
 
             if status == MempoolInclusionStatus.SUCCESS:
@@ -150,7 +150,7 @@ class WalletNodeAPI:
     @metadata.request(peer_required=True)
     async def respond_peers_introducer(
         self, request: introducer_protocol.RespondPeersIntroducer, peer: WSChiaConnection
-    ):
+    ) -> None:
         if self.wallet_node.wallet_peers is not None:
             await self.wallet_node.wallet_peers.add_peers(request.peer_list, peer.get_peer_info(), False)
 
@@ -158,60 +158,58 @@ class WalletNodeAPI:
             await peer.close()
 
     @metadata.request(peer_required=True)
-    async def respond_peers(self, request: full_node_protocol.RespondPeers, peer: WSChiaConnection):
+    async def respond_peers(self, request: full_node_protocol.RespondPeers, peer: WSChiaConnection) -> None:
         if self.wallet_node.wallet_peers is None:
-            return None
+            return
 
         self.log.info(f"Wallet received {len(request.peer_list)} peers.")
         await self.wallet_node.wallet_peers.add_peers(request.peer_list, peer.get_peer_info(), True)
 
-        return None
-
     @metadata.request()
-    async def respond_puzzle_solution(self, request: wallet_protocol.RespondPuzzleSolution):
+    async def respond_puzzle_solution(self, request: wallet_protocol.RespondPuzzleSolution) -> None:
         self.log.error("Unexpected message `respond_puzzle_solution`. Peer might be slow to respond")
 
     @metadata.request()
-    async def reject_puzzle_solution(self, request: wallet_protocol.RejectPuzzleSolution):
+    async def reject_puzzle_solution(self, request: wallet_protocol.RejectPuzzleSolution) -> None:
         self.log.warning(f"Reject puzzle solution: {request}")
 
     @metadata.request()
-    async def respond_header_blocks(self, request: wallet_protocol.RespondHeaderBlocks):
+    async def respond_header_blocks(self, request: wallet_protocol.RespondHeaderBlocks) -> None:
         pass
 
     @metadata.request()
-    async def respond_block_headers(self, request: wallet_protocol.RespondBlockHeaders):
+    async def respond_block_headers(self, request: wallet_protocol.RespondBlockHeaders) -> None:
         pass
 
     @metadata.request()
-    async def reject_header_blocks(self, request: wallet_protocol.RejectHeaderBlocks):
+    async def reject_header_blocks(self, request: wallet_protocol.RejectHeaderBlocks) -> None:
         self.log.warning(f"Reject header blocks: {request}")
 
     @metadata.request()
-    async def reject_block_headers(self, request: wallet_protocol.RejectBlockHeaders):
+    async def reject_block_headers(self, request: wallet_protocol.RejectBlockHeaders) -> None:
         pass
 
     @metadata.request(peer_required=True, execute_task=True)
-    async def coin_state_update(self, request: wallet_protocol.CoinStateUpdate, peer: WSChiaConnection):
+    async def coin_state_update(self, request: wallet_protocol.CoinStateUpdate, peer: WSChiaConnection) -> None:
         await self.wallet_node.new_peak_queue.full_node_state_updated(request, peer)
 
     # TODO: Review this hinting issue around this rust type not being a Streamable
     #       subclass, as you might expect it wouldn't be.  Maybe we can get the
     #       protocol working right back at the api.request definition.
     @metadata.request()  # type: ignore[type-var]
-    async def respond_to_ph_updates(self, request: RespondToPhUpdates):
+    async def respond_to_ph_updates(self, request: RespondToPhUpdates) -> None:
         pass
 
     @metadata.request()
-    async def respond_to_coin_updates(self, request: wallet_protocol.RespondToCoinUpdates):
+    async def respond_to_coin_updates(self, request: wallet_protocol.RespondToCoinUpdates) -> None:
         pass
 
     @metadata.request()
-    async def respond_children(self, request: wallet_protocol.RespondChildren):
+    async def respond_children(self, request: wallet_protocol.RespondChildren) -> None:
         pass
 
     @metadata.request()
-    async def respond_ses_hashes(self, request: wallet_protocol.RespondSESInfo):
+    async def respond_ses_hashes(self, request: wallet_protocol.RespondSESInfo) -> None:
         pass
 
     @metadata.request()

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -19,7 +19,6 @@ chia.wallet.util.debug_spend_bundle
 chia.wallet.util.new_peak_queue
 chia.wallet.wallet_coin_store
 chia.wallet.wallet_interested_store
-chia.wallet.wallet_node_api
 chia.wallet.wallet_puzzle_store
 chia.wallet.wallet_transaction_store
 chia._tests.clvm.test_puzzles


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Annotation-only changes with equivalent early returns; no intended runtime behavior change.
> 
> **Overview**
> Adds **mypy-friendly type hints** across `WalletNodeAPI`: `WalletNode` on `__init__`, and `-> None` on protocol handler methods that were previously untyped.
> 
> Early-exit paths in `transaction_ack` and `respond_peers` now use bare `return` instead of `return None`, matching the annotated `None` return type. A trailing `return None` at the end of `respond_peers` was removed as redundant.
> 
> **`chia.wallet.wallet_node_api` is removed from `mypy-exclusions.txt`**, so the module is included in strict mypy checking going forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7d176bc8cd55f0156007a24df1fb8ca99ec23b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->