### PR TITLE
[LABS-470] Fix mismatching Wallets with WalletProtocol

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -955,7 +955,7 @@ class DataLayerWallet:
     async def get_confirmed_balance(self, record_list: set[WalletCoinRecord] | None = None) -> uint128:
         return uint128(0)
 
-    async def get_unconfirmed_balance(self, record_list: set[WalletCoinRecord] | None = None) -> uint128:
+    async def get_unconfirmed_balance(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
         return uint128(0)
 
     async def get_spendable_balance(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
@@ -964,7 +964,7 @@ class DataLayerWallet:
     async def get_pending_change_balance(self) -> uint64:
         return uint64(0)
 
-    async def get_max_send_amount(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
+    async def get_max_send_amount(self, records: set[WalletCoinRecord] | None = None) -> uint128:
         return uint128(0)
 
     def get_name(self) -> str:

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -855,7 +855,7 @@ class PoolWallet:
         )
         return len(unconfirmed) > 0
 
-    async def get_confirmed_balance(self, _: object | None = None) -> uint128:
+    async def get_confirmed_balance(self, record_list: object | None = None) -> uint128:
         amount: uint128 = uint128(0)
         if (await self.get_current_state()).current.state == SELF_POOLING.value:
             unspent_coin_records: list[WalletCoinRecord] = list(
@@ -866,11 +866,11 @@ class PoolWallet:
                     amount = uint128(amount + record.coin.amount)
         return amount
 
-    async def get_unconfirmed_balance(self, record_list: object | None = None) -> uint128:
-        return await self.get_confirmed_balance(record_list)
+    async def get_unconfirmed_balance(self, unspent_records: object | None = None) -> uint128:
+        return await self.get_confirmed_balance(unspent_records)
 
-    async def get_spendable_balance(self, record_list: object | None = None) -> uint128:
-        return await self.get_confirmed_balance(record_list)
+    async def get_spendable_balance(self, unspent_records: object | None = None) -> uint128:
+        return await self.get_confirmed_balance(unspent_records)
 
     async def get_pending_change_balance(self) -> uint64:
         return uint64(0)

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -357,7 +357,7 @@ class CATWallet:
         return self.cat_info.limitations_program_hash
 
     async def coin_added(
-        self, coin: Coin, height: uint32, peer: WSChiaConnection, parent_coin_data: CATCoinData | None
+        self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: CATCoinData | None
     ) -> None:
         """Notification from wallet state manager that wallet has been received."""
         self.log.info(f"CAT wallet has been notified that {coin.name().hex()} was added")
@@ -370,7 +370,7 @@ class CATWallet:
 
         if lineage is None:
             try:
-                if parent_coin_data is None:
+                if coin_data is None:
                     # The method is not triggered after the determine_coin_type, no pre-fetched data
                     coin_state = await self.wallet_state_manager.wallet_node.get_coin_state(
                         [coin.parent_coin_info], peer=peer
@@ -380,14 +380,14 @@ class CATWallet:
                     cat_curried_args = match_cat_puzzle(uncurry_puzzle(coin_spend.puzzle_reveal))
                     if cat_curried_args is not None:
                         cat_mod_hash, tail_program_hash, cat_inner_puzzle = cat_curried_args
-                        parent_coin_data = CATCoinData(
+                        coin_data = CATCoinData(
                             bytes32(cat_mod_hash.as_atom()),
                             bytes32(tail_program_hash.as_atom()),
                             cat_inner_puzzle,
                             coin_state[0].coin.parent_coin_info,
                             uint64(coin_state[0].coin.amount),
                         )
-                await self.puzzle_solution_received(coin, parent_coin_data)
+                await self.puzzle_solution_received(coin, coin_data)
             except Exception as e:
                 self.log.debug(f"Exception: {e}, traceback: {traceback.format_exc()}")
 
@@ -438,8 +438,8 @@ class CATWallet:
 
             return derivation_record.puzzle_hash
 
-    async def get_spendable_balance(self, records: set[WalletCoinRecord] | None = None) -> uint128:
-        coins = await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), records)
+    async def get_spendable_balance(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
+        coins = await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), unspent_records)
         amount = 0
         for record in coins:
             amount += record.coin.amount

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -324,8 +324,8 @@ class DIDWallet:
 
         return uint64(addition_amount)
 
-    async def get_unconfirmed_balance(self, record_list=None) -> uint128:
-        return await self.wallet_state_manager.get_unconfirmed_balance(self.id(), record_list)
+    async def get_unconfirmed_balance(self, unspent_records=None) -> uint128:
+        return await self.wallet_state_manager.get_unconfirmed_balance(self.id(), unspent_records)
 
     async def select_coins(
         self,
@@ -352,12 +352,12 @@ class DIDWallet:
     # We can improve this interface by passing in the CoinSpend, as well
     # We need to change DID Wallet coin_added to expect p2 spends as well as recovery spends,
     # or only call it in the recovery spend case
-    async def coin_added(self, coin: Coin, _: uint32, peer: WSChiaConnection, parent_coin_data: DIDCoinData | None):
+    async def coin_added(self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: DIDCoinData | None):
         """Notification from wallet state manager that wallet has been received."""
         parent = self.get_parent_for_coin(coin)
-        if parent_coin_data is not None:
-            assert isinstance(parent_coin_data, DIDCoinData)
-            did_data: DIDCoinData = parent_coin_data
+        if coin_data is not None:
+            assert isinstance(coin_data, DIDCoinData)
+            did_data: DIDCoinData = coin_data
         else:
             parent_state: CoinState = (
                 await self.wallet_state_manager.wallet_node.get_coin_state(
@@ -1034,12 +1034,12 @@ class DIDWallet:
         )
         return spendable_am
 
-    async def get_max_send_amount(self, records: set[WalletCoinRecord] | None = None):
+    async def get_max_send_amount(self, records: set[WalletCoinRecord] | None = None) -> uint128:
         spendable: list[WalletCoinRecord] = list(
             await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), records)
         )
         max_send_amount = sum(cr.coin.amount for cr in spendable)
-        return max_send_amount
+        return uint128(max_send_amount)
 
     async def add_parent(self, name: bytes32, parent: LineageProof | None):
         self.log.info(f"Adding parent {name}: {parent}")

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -147,7 +147,7 @@ class NFTWallet:
         """The NFT wallet doesn't really have a balance."""
         return uint128(0)
 
-    async def get_unconfirmed_balance(self, record_list: set[WalletCoinRecord] | None = None) -> uint128:
+    async def get_unconfirmed_balance(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
         """The NFT wallet doesn't really have a balance."""
         return uint128(0)
 
@@ -169,15 +169,15 @@ class NFTWallet:
         return nft_coin
 
     async def coin_added(
-        self, coin: Coin, height: uint32, peer: WSChiaConnection, parent_coin_data: NFTCoinData | None
+        self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: NFTCoinData | None
     ) -> None:
         """Notification from wallet state manager that wallet has been received."""
         self.log.info(f"NFT wallet %s has been notified that {coin} was added", self.get_name())
         if await self.nft_store.exists(coin.name()):
             # already added
             return
-        assert isinstance(parent_coin_data, NFTCoinData), f"Invalid NFT coin data: {parent_coin_data}"
-        await self.puzzle_solution_received(coin, parent_coin_data, peer)
+        assert isinstance(coin_data, NFTCoinData), f"Invalid NFT coin data: {coin_data}"
+        await self.puzzle_solution_received(coin, coin_data, peer)
 
     async def puzzle_solution_received(self, coin: Coin, data: NFTCoinData, peer: WSChiaConnection) -> None:
         self.log.debug("Puzzle solution received to wallet: %s", self.wallet_info)

--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -601,7 +601,7 @@ class VCWallet:
         """The VC wallet doesn't really have a balance."""
         return uint128(0)  # pragma: no cover
 
-    async def get_unconfirmed_balance(self, record_list: set[WalletCoinRecord] | None = None) -> uint128:
+    async def get_unconfirmed_balance(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
         """The VC wallet doesn't really have a balance."""
         return uint128(0)  # pragma: no cover
 


### PR DESCRIPTION
Many wallets used different names for parameters than the `WalletProtocol` which mypy apparently doesn't treat as an error because they're positional.  If we wanted to lock this down with mypy, we'd need to make all of the methods kw-only which is a much larger refactor than just fixing what we find right now.  This was reported to me by my editor via pyright.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parameter renames only; no behavioral or logic changes to wallet operations.
> 
> **Overview**
> Renames method parameters across several wallet implementations so they match **`WalletProtocol`** signatures, fixing pyright/editor warnings that mypy does not catch for positional-only arguments.
> 
> Balance helpers now use **`unspent_records`** instead of **`record_list`** on `get_unconfirmed_balance` and `get_spendable_balance` (data layer, pool, CAT, DID, NFT, VC wallets). **`get_confirmed_balance`** on pool wallet drops the ignored `_` in favor of **`record_list`**. **`get_max_send_amount`** on data layer wallet uses **`records`** instead of **`unspent_records`**.
> 
> **`coin_added`** callbacks rename **`parent_coin_data`** to **`coin_data`** in CAT, DID, and NFT wallets, with DID also restoring the **`height`** parameter name instead of `_`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13d5338c1e2b1d948dd25f3f2df56a076a0666a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->