### PR TITLE
[LABS-471] Remove contravariant from WalletProtocol

### DIFF
--- a/chia/_tests/wallet/rpc/test_wallet_rpc.py
+++ b/chia/_tests/wallet/rpc/test_wallet_rpc.py
@@ -249,7 +249,7 @@ async def assert_push_tx_error(node_rpc: FullNodeRpcClient, tx: TransactionRecor
             raise ValueError from error
 
 
-async def assert_get_balance(rpc_client: WalletRpcClient, wallet_node: WalletNode, wallet: WalletProtocol[Any]) -> None:
+async def assert_get_balance(rpc_client: WalletRpcClient, wallet_node: WalletNode, wallet: WalletProtocol) -> None:
     expected_balance = await wallet_node.get_balance(wallet.id())
     expected_balance_dict = expected_balance.to_json_dict()
     expected_balance_dict.setdefault("pending_approval_balance", None)

--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -955,7 +955,7 @@ class DataLayerWallet:
     async def get_confirmed_balance(self, record_list: set[WalletCoinRecord] | None = None) -> uint128:
         return uint128(0)
 
-    async def get_unconfirmed_balance(self, record_list: set[WalletCoinRecord] | None = None) -> uint128:
+    async def get_unconfirmed_balance(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
         return uint128(0)
 
     async def get_spendable_balance(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
@@ -964,7 +964,7 @@ class DataLayerWallet:
     async def get_pending_change_balance(self) -> uint64:
         return uint64(0)
 
-    async def get_max_send_amount(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
+    async def get_max_send_amount(self, records: set[WalletCoinRecord] | None = None) -> uint128:
         return uint128(0)
 
     def get_name(self) -> str:

--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -108,7 +108,7 @@ class DataLayerSummary(Streamable):
 class DataLayerWallet:
     if TYPE_CHECKING:
         # TODO Create DataLayer coin data model if necessary
-        _protocol_check: ClassVar[WalletProtocol[object]] = cast("DataLayerWallet", None)
+        _protocol_check: ClassVar[WalletProtocol] = cast("DataLayerWallet", None)
 
     wallet_state_manager: WalletStateManager
     log: logging.Logger

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -63,7 +63,7 @@ class PoolWallet:
     if TYPE_CHECKING:
         from chia.wallet.wallet_protocol import WalletProtocol
 
-        _protocol_check: ClassVar[WalletProtocol[object]] = cast("PoolWallet", None)
+        _protocol_check: ClassVar[WalletProtocol] = cast("PoolWallet", None)
 
     MINIMUM_INITIAL_BALANCE: ClassVar[int] = 1
     MINIMUM_RELATIVE_LOCK_HEIGHT: ClassVar[int] = 5

--- a/chia/pools/pool_wallet.py
+++ b/chia/pools/pool_wallet.py
@@ -855,7 +855,7 @@ class PoolWallet:
         )
         return len(unconfirmed) > 0
 
-    async def get_confirmed_balance(self, _: object | None = None) -> uint128:
+    async def get_confirmed_balance(self, record_list: object | None = None) -> uint128:
         amount: uint128 = uint128(0)
         if (await self.get_current_state()).current.state == SELF_POOLING.value:
             unspent_coin_records: list[WalletCoinRecord] = list(
@@ -866,11 +866,11 @@ class PoolWallet:
                     amount = uint128(amount + record.coin.amount)
         return amount
 
-    async def get_unconfirmed_balance(self, record_list: object | None = None) -> uint128:
-        return await self.get_confirmed_balance(record_list)
+    async def get_unconfirmed_balance(self, unspent_records: object | None = None) -> uint128:
+        return await self.get_confirmed_balance(unspent_records)
 
-    async def get_spendable_balance(self, record_list: object | None = None) -> uint128:
-        return await self.get_confirmed_balance(record_list)
+    async def get_spendable_balance(self, unspent_records: object | None = None) -> uint128:
+        return await self.get_confirmed_balance(unspent_records)
 
     async def get_pending_change_balance(self) -> uint64:
         return uint64(0)

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -357,7 +357,7 @@ class CATWallet:
         return self.cat_info.limitations_program_hash
 
     async def coin_added(
-        self, coin: Coin, height: uint32, peer: WSChiaConnection, parent_coin_data: CATCoinData | None
+        self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: CATCoinData | None
     ) -> None:
         """Notification from wallet state manager that wallet has been received."""
         self.log.info(f"CAT wallet has been notified that {coin.name().hex()} was added")
@@ -370,7 +370,7 @@ class CATWallet:
 
         if lineage is None:
             try:
-                if parent_coin_data is None:
+                if coin_data is None:
                     # The method is not triggered after the determine_coin_type, no pre-fetched data
                     coin_state = await self.wallet_state_manager.wallet_node.get_coin_state(
                         [coin.parent_coin_info], peer=peer
@@ -380,14 +380,14 @@ class CATWallet:
                     cat_curried_args = match_cat_puzzle(uncurry_puzzle(coin_spend.puzzle_reveal))
                     if cat_curried_args is not None:
                         cat_mod_hash, tail_program_hash, cat_inner_puzzle = cat_curried_args
-                        parent_coin_data = CATCoinData(
+                        coin_data = CATCoinData(
                             bytes32(cat_mod_hash.as_atom()),
                             bytes32(tail_program_hash.as_atom()),
                             cat_inner_puzzle,
                             coin_state[0].coin.parent_coin_info,
                             uint64(coin_state[0].coin.amount),
                         )
-                await self.puzzle_solution_received(coin, parent_coin_data)
+                await self.puzzle_solution_received(coin, coin_data)
             except Exception as e:
                 self.log.debug(f"Exception: {e}, traceback: {traceback.format_exc()}")
 
@@ -438,8 +438,8 @@ class CATWallet:
 
             return derivation_record.puzzle_hash
 
-    async def get_spendable_balance(self, records: set[WalletCoinRecord] | None = None) -> uint128:
-        coins = await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), records)
+    async def get_spendable_balance(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
+        coins = await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), unspent_records)
         amount = 0
         for record in coins:
             amount += record.coin.amount

--- a/chia/wallet/cat_wallet/cat_wallet.py
+++ b/chia/wallet/cat_wallet/cat_wallet.py
@@ -83,7 +83,7 @@ def not_ephemeral_additions(sp: WalletSpendBundle) -> list[Coin]:
 
 class CATWallet:
     if TYPE_CHECKING:
-        _protocol_check: ClassVar[WalletProtocol[CATCoinData]] = cast("CATWallet", None)
+        _protocol_check: ClassVar[WalletProtocol] = cast("CATWallet", None)
 
     wallet_state_manager: WalletStateManager
     log: logging.Logger
@@ -356,11 +356,11 @@ class CATWallet:
     def get_asset_id(self) -> bytes32:
         return self.cat_info.limitations_program_hash
 
-    async def coin_added(
-        self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: CATCoinData | None
-    ) -> None:
+    async def coin_added(self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: object | None) -> None:
         """Notification from wallet state manager that wallet has been received."""
         self.log.info(f"CAT wallet has been notified that {coin.name().hex()} was added")
+        if coin_data is not None:
+            assert isinstance(coin_data, CATCoinData)
 
         inner_puzzle = await self.inner_puzzle_for_cat_puzhash(coin.puzzle_hash)
         lineage_proof = LineageProof(coin.parent_coin_info, inner_puzzle.get_tree_hash(), uint64(coin.amount))

--- a/chia/wallet/cat_wallet/r_cat_wallet.py
+++ b/chia/wallet/cat_wallet/r_cat_wallet.py
@@ -14,7 +14,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
 from chia.util.streamable import Streamable, streamable
 from chia.wallet.cat_wallet.cat_constants import DEFAULT_CATS
-from chia.wallet.cat_wallet.cat_info import CATCoinData, RCATInfo
+from chia.wallet.cat_wallet.cat_info import RCATInfo
 from chia.wallet.cat_wallet.cat_utils import (
     CAT_MOD,
     CAT_MOD_HASH,
@@ -56,7 +56,7 @@ class RCATMetadata(Streamable):
 
 class RCATWallet(CATWallet):
     if TYPE_CHECKING:
-        _protocol_check: ClassVar[WalletProtocol[CATCoinData]] = cast("RCATWallet", None)
+        _protocol_check: ClassVar[WalletProtocol] = cast("RCATWallet", None)
 
     wallet_state_manager: WalletStateManager
     log: logging.Logger

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -324,8 +324,8 @@ class DIDWallet:
 
         return uint64(addition_amount)
 
-    async def get_unconfirmed_balance(self, record_list=None) -> uint128:
-        return await self.wallet_state_manager.get_unconfirmed_balance(self.id(), record_list)
+    async def get_unconfirmed_balance(self, unspent_records=None) -> uint128:
+        return await self.wallet_state_manager.get_unconfirmed_balance(self.id(), unspent_records)
 
     async def select_coins(
         self,
@@ -352,12 +352,12 @@ class DIDWallet:
     # We can improve this interface by passing in the CoinSpend, as well
     # We need to change DID Wallet coin_added to expect p2 spends as well as recovery spends,
     # or only call it in the recovery spend case
-    async def coin_added(self, coin: Coin, _: uint32, peer: WSChiaConnection, parent_coin_data: DIDCoinData | None):
+    async def coin_added(self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: DIDCoinData | None):
         """Notification from wallet state manager that wallet has been received."""
         parent = self.get_parent_for_coin(coin)
-        if parent_coin_data is not None:
-            assert isinstance(parent_coin_data, DIDCoinData)
-            did_data: DIDCoinData = parent_coin_data
+        if coin_data is not None:
+            assert isinstance(coin_data, DIDCoinData)
+            did_data: DIDCoinData = coin_data
         else:
             parent_state: CoinState = (
                 await self.wallet_state_manager.wallet_node.get_coin_state(
@@ -1034,12 +1034,12 @@ class DIDWallet:
         )
         return spendable_am
 
-    async def get_max_send_amount(self, records: set[WalletCoinRecord] | None = None):
+    async def get_max_send_amount(self, records: set[WalletCoinRecord] | None = None) -> uint128:
         spendable: list[WalletCoinRecord] = list(
             await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), records)
         )
         max_send_amount = sum(cr.coin.amount for cr in spendable)
-        return max_send_amount
+        return uint128(max_send_amount)
 
     async def add_parent(self, name: bytes32, parent: LineageProof | None):
         self.log.info(f"Adding parent {name}: {parent}")

--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -56,7 +56,7 @@ from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 class DIDWallet:
     if TYPE_CHECKING:
         if TYPE_CHECKING:
-            _protocol_check: ClassVar[WalletProtocol[DIDCoinData]] = cast("DIDWallet", None)
+            _protocol_check: ClassVar[WalletProtocol] = cast("DIDWallet", None)
 
     wallet_state_manager: Any
     log: logging.Logger
@@ -352,7 +352,7 @@ class DIDWallet:
     # We can improve this interface by passing in the CoinSpend, as well
     # We need to change DID Wallet coin_added to expect p2 spends as well as recovery spends,
     # or only call it in the recovery spend case
-    async def coin_added(self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: DIDCoinData | None):
+    async def coin_added(self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: object | None):
         """Notification from wallet state manager that wallet has been received."""
         parent = self.get_parent_for_coin(coin)
         if coin_data is not None:

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -70,7 +70,7 @@ def compute_royalty_amount(offered_amount: int, royalty_split: int, percentage: 
 
 class NFTWallet:
     if TYPE_CHECKING:
-        _protocol_check: ClassVar[WalletProtocol[NFTCoinData]] = cast("NFTWallet", None)
+        _protocol_check: ClassVar[WalletProtocol] = cast("NFTWallet", None)
 
     wallet_state_manager: Any
     log: logging.Logger
@@ -168,9 +168,7 @@ class NFTWallet:
             raise KeyError(f"Couldn't find coin with id: {nft_coin_id}")
         return nft_coin
 
-    async def coin_added(
-        self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: NFTCoinData | None
-    ) -> None:
+    async def coin_added(self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: object | None) -> None:
         """Notification from wallet state manager that wallet has been received."""
         self.log.info(f"NFT wallet %s has been notified that {coin} was added", self.get_name())
         if await self.nft_store.exists(coin.name()):

--- a/chia/wallet/nft_wallet/nft_wallet.py
+++ b/chia/wallet/nft_wallet/nft_wallet.py
@@ -147,7 +147,7 @@ class NFTWallet:
         """The NFT wallet doesn't really have a balance."""
         return uint128(0)
 
-    async def get_unconfirmed_balance(self, record_list: set[WalletCoinRecord] | None = None) -> uint128:
+    async def get_unconfirmed_balance(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
         """The NFT wallet doesn't really have a balance."""
         return uint128(0)
 
@@ -169,15 +169,15 @@ class NFTWallet:
         return nft_coin
 
     async def coin_added(
-        self, coin: Coin, height: uint32, peer: WSChiaConnection, parent_coin_data: NFTCoinData | None
+        self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: NFTCoinData | None
     ) -> None:
         """Notification from wallet state manager that wallet has been received."""
         self.log.info(f"NFT wallet %s has been notified that {coin} was added", self.get_name())
         if await self.nft_store.exists(coin.name()):
             # already added
             return
-        assert isinstance(parent_coin_data, NFTCoinData), f"Invalid NFT coin data: {parent_coin_data}"
-        await self.puzzle_solution_received(coin, parent_coin_data, peer)
+        assert isinstance(coin_data, NFTCoinData), f"Invalid NFT coin data: {coin_data}"
+        await self.puzzle_solution_received(coin, coin_data, peer)
 
     async def puzzle_solution_received(self, coin: Coin, data: NFTCoinData, peer: WSChiaConnection) -> None:
         self.log.debug("Puzzle solution received to wallet: %s", self.wallet_info)

--- a/chia/wallet/remote_wallet/remote_wallet.py
+++ b/chia/wallet/remote_wallet/remote_wallet.py
@@ -22,7 +22,7 @@ from chia.wallet.wallet_protocol import WalletProtocol
 # Furthermore the wallet will act mainly as a sentinel for CoinRecords that are related to the remote wallet.
 class RemoteWallet:
     if TYPE_CHECKING:
-        _protocol_check: ClassVar[WalletProtocol[object]] = cast("RemoteWallet", None)
+        _protocol_check: ClassVar[WalletProtocol] = cast("RemoteWallet", None)
 
     wallet_state_manager: Any
     log: logging.Logger

--- a/chia/wallet/trade_manager.py
+++ b/chia/wallet/trade_manager.py
@@ -825,7 +825,7 @@ class TradeManager:
 
         for asset_id, amount in arbitrage.items():
             if asset_id is None:
-                wallet: WalletProtocol[Any] | None = self.wallet_state_manager.main_wallet
+                wallet: WalletProtocol | None = self.wallet_state_manager.main_wallet
                 assert wallet is not None
                 key: bytes32 | int = int(wallet.id())
             else:

--- a/chia/wallet/util/wallet_types.py
+++ b/chia/wallet/util/wallet_types.py
@@ -61,7 +61,7 @@ class WalletIdentifier:
     type: WalletType
 
     @classmethod
-    def create(cls, wallet: WalletProtocol[T_contra]) -> WalletIdentifier:
+    def create(cls, wallet: WalletProtocol) -> WalletIdentifier:
         return cls(wallet.id(), wallet.type())
 
 

--- a/chia/wallet/vc_wallet/cr_cat_wallet.py
+++ b/chia/wallet/vc_wallet/cr_cat_wallet.py
@@ -16,7 +16,7 @@ from chia.types.blockchain_format.program import Program
 from chia.util.byte_types import hexstr_to_bytes
 from chia.util.hash import std_hash
 from chia.util.streamable import VersionedBlob
-from chia.wallet.cat_wallet.cat_info import CATCoinData, CRCATInfo
+from chia.wallet.cat_wallet.cat_info import CRCATInfo
 from chia.wallet.cat_wallet.cat_utils import CAT_MOD_HASH, CAT_MOD_HASH_HASH, construct_cat_puzzle
 from chia.wallet.cat_wallet.cat_wallet import CATWallet
 from chia.wallet.coin_selection import select_coins
@@ -205,9 +205,7 @@ class CRCATWallet(CATWallet):
     async def set_tail_program(self, tail_program: str) -> None:  # pragma: no cover
         raise NotImplementedError("set_tail_program is a legacy method and is not available on CR-CAT wallets")
 
-    async def coin_added(
-        self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: CATCoinData | None
-    ) -> None:
+    async def coin_added(self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: object | None) -> None:
         """Notification from wallet state manager that wallet has been received."""
         self.log.info(f"CR-CAT wallet has been notified that {coin.name().hex()} was added")
         try:
@@ -868,4 +866,4 @@ class CRCATWallet(CATWallet):
 
 
 if TYPE_CHECKING:
-    _dummy: WalletProtocol[CATCoinData] = CRCATWallet()
+    _dummy: WalletProtocol = CRCATWallet()

--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -630,4 +630,4 @@ class VCWallet:
 
 
 if TYPE_CHECKING:
-    _dummy: WalletProtocol[VerifiedCredential] = VCWallet()  # pragma: no cover
+    _dummy: WalletProtocol = VCWallet()  # pragma: no cover

--- a/chia/wallet/vc_wallet/vc_wallet.py
+++ b/chia/wallet/vc_wallet/vc_wallet.py
@@ -601,7 +601,7 @@ class VCWallet:
         """The VC wallet doesn't really have a balance."""
         return uint128(0)  # pragma: no cover
 
-    async def get_unconfirmed_balance(self, record_list: set[WalletCoinRecord] | None = None) -> uint128:
+    async def get_unconfirmed_balance(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
         """The VC wallet doesn't really have a balance."""
         return uint128(0)  # pragma: no cover
 

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -27,7 +27,6 @@ from chia.wallet.derive_keys import (
     _derive_path_unhardened,
     master_sk_to_singleton_owner_sk,
 )
-from chia.wallet.puzzles.clawback.metadata import ClawbackMetadata
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
     DEFAULT_HIDDEN_PUZZLE_HASH,
     calculate_synthetic_offset,
@@ -65,7 +64,7 @@ if TYPE_CHECKING:
 
 class Wallet:
     if TYPE_CHECKING:
-        _protocol_check: ClassVar[WalletProtocol[ClawbackMetadata]] = cast("Wallet", None)
+        _protocol_check: ClassVar[WalletProtocol] = cast("Wallet", None)
 
     wallet_info: WalletInfo
     wallet_state_manager: WalletStateManager

--- a/chia/wallet/wallet_protocol.py
+++ b/chia/wallet/wallet_protocol.py
@@ -24,14 +24,14 @@ if TYPE_CHECKING:
 T_contra = TypeVar("T_contra", contravariant=True)
 
 
-class WalletProtocol(Protocol[T_contra]):
+class WalletProtocol(Protocol):
     @classmethod
     def type(cls) -> WalletType: ...
 
     def id(self) -> uint32: ...
 
     async def coin_added(
-        self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: T_contra | None
+        self, coin: Coin, height: uint32, peer: WSChiaConnection, coin_data: object | None
     ) -> None: ...
 
     async def select_coins(

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -150,7 +150,7 @@ from chia.wallet.wallet_transaction_store import WalletTransactionStore
 from chia.wallet.wallet_user_store import WalletUserStore
 from chia.wallet.wsm_apis import CreateMorePuzzleHashesResult, GetUnusedDerivationRecordResult
 
-TWalletType = TypeVar("TWalletType", bound=WalletProtocol[Any])
+TWalletType = TypeVar("TWalletType", bound=WalletProtocol)
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_node import WalletNode
@@ -195,7 +195,7 @@ class WalletStateManager:
     db_wrapper: DBWrapper2
 
     main_wallet: Wallet
-    wallets: dict[uint32, WalletProtocol[Any]]
+    wallets: dict[uint32, WalletProtocol]
     private_key: PrivateKey | None
     root_pubkey: G1Element
 
@@ -306,7 +306,7 @@ class WalletStateManager:
 
         pool_config.perform_migration_from_old_config(root_path=self.root_path)
 
-        wallet: WalletProtocol[Any] | None = None
+        wallet: WalletProtocol | None = None
         for wallet_info in await self.get_all_wallet_info_entries():
             wallet_type = WalletType(wallet_info.type)
             if wallet_type == WalletType.STANDARD_WALLET:
@@ -2488,7 +2488,7 @@ class WalletStateManager:
         result = await self.coin_store.get_coin_records(**kwargs)
         return [await self.get_coin_record_by_wallet_record(record) for record in result.records]
 
-    async def get_wallet_for_coin(self, coin_id: bytes32) -> WalletProtocol[Any] | None:
+    async def get_wallet_for_coin(self, coin_id: bytes32) -> WalletProtocol | None:
         coin_record = await self.coin_store.get_coin_record(coin_id)
         if coin_record is None:
             return None
@@ -2543,7 +2543,7 @@ class WalletStateManager:
     async def get_all_wallet_info_entries(self, wallet_type: WalletType | None = None) -> list[WalletInfo]:
         return await self.user_store.get_all_wallet_info_entries(wallet_type)
 
-    async def get_wallet_for_asset_id(self, asset_id: bytes32) -> WalletProtocol[Any] | None:
+    async def get_wallet_for_asset_id(self, asset_id: bytes32) -> WalletProtocol | None:
         for wallet_id, wallet in self.wallets.items():
             if wallet.type() in {WalletType.CAT, WalletType.CRCAT, WalletType.RCAT}:
                 assert isinstance(wallet, CATWallet)
@@ -2560,7 +2560,7 @@ class WalletStateManager:
                     return wallet
         return None
 
-    async def get_wallet_for_puzzle_info(self, puzzle_driver: PuzzleInfo) -> WalletProtocol[Any] | None:
+    async def get_wallet_for_puzzle_info(self, puzzle_driver: PuzzleInfo) -> WalletProtocol | None:
         for wallet in self.wallets.values():
             match_function = getattr(wallet, "match_puzzle_info", None)
             if match_function is not None and callable(match_function):
@@ -2581,7 +2581,7 @@ class WalletStateManager:
                 },
             )
 
-    async def add_new_wallet(self, wallet: WalletProtocol[Any]) -> None:
+    async def add_new_wallet(self, wallet: WalletProtocol) -> None:
         self.wallets[wallet.id()] = wallet
         result = await self.create_more_puzzle_hashes()
         await result.commit(self)


### PR DESCRIPTION
This contravariant type variable was likely made with good intentions to help with the `coin_added` method taking a bunch of different types across the different wallets.  However, in practice, the code doesn't really have many opportunities for this type guard to be worthwhile and most wallets just assert that their `coin_data` is the type they expect it to be anyways.  This was complicating other areas of the code however where you couldn't narrow the wallet protocol types because of the contravariance of the protocol, even when nowhere near the `coin_added` method.  Here's an example where the `isinstance` led some (advanced) type checkers to think that there was no valid type that the wallet could be because of the contravariance:
https://github.com/Chia-Network/chia-blockchain/blob/ad7df9a605e7f34948a4a789e0c7e7d9bf68fdde/chia/wallet/wallet_state_manager.py#L2524-L2526


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static typing changes only; runtime wallet behavior is preserved via existing asserts and isinstance checks in coin_added handlers.
> 
> **Overview**
> **`WalletProtocol`** is no longer generic (`WalletProtocol[T]` → **`WalletProtocol`**). The **`coin_added`** **`coin_data`** parameter is typed as **`object | None`** on the protocol instead of a per-wallet type parameter.
> 
> All wallet implementations and call sites drop **`WalletProtocol[Any]`** / **`WalletProtocol[CATCoinData]`**-style annotations (state manager wallet map, trade manager, **`WalletIdentifier.create`**, TYPE_CHECKING **`_protocol_check`** stubs, RPC test helper). Wallets that still need typed coin data use **`isinstance`** at runtime (e.g. **`CATWallet`**, **`DIDWallet`**); **`CRCATWallet`** / **`RCATWallet`** drop unused **`CATCoinData`** imports where **`coin_added`** no longer names that type in the signature.
> 
> This is a typing-only refactor aimed at fixing incorrect narrowing when **`isinstance`** checks wallets elsewhere in the codebase (contravariance on **`coin_added`** made some type checkers reject valid wallet unions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21094a8510a56c96d90481115f4588901d351a4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->