### PR TITLE
CHIA-4275 Annotate did_wallet.py

### DIFF
--- a/chia/wallet/did_wallet/did_wallet.py
+++ b/chia/wallet/did_wallet/did_wallet.py
@@ -5,7 +5,7 @@ import json
 import logging
 import re
 import time
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from chia_rs import AugSchemeMPL, CoinSpend, CoinState, G1Element, G2Element
 from chia_rs.sized_bytes import bytes32
@@ -23,7 +23,6 @@ from chia.wallet.conditions import (
     CreateCoin,
     CreateCoinAnnouncement,
 )
-from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.did_wallet import did_wallet_puzzles
 from chia.wallet.did_wallet.did_info import DIDCoinData, DIDInfo, did_recovery_is_nil
 from chia.wallet.did_wallet.did_wallet_puzzles import match_did_puzzle, uncurry_innerpuz
@@ -52,13 +51,16 @@ from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_protocol import GSTOptionalArgs, WalletProtocol
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
+if TYPE_CHECKING:
+    from chia.wallet.wallet_state_manager import WalletStateManager
+
 
 class DIDWallet:
     if TYPE_CHECKING:
         if TYPE_CHECKING:
             _protocol_check: ClassVar[WalletProtocol[DIDCoinData]] = cast("DIDWallet", None)
 
-    wallet_state_manager: Any
+    wallet_state_manager: WalletStateManager
     log: logging.Logger
     wallet_info: WalletInfo
     did_info: DIDInfo
@@ -69,7 +71,7 @@ class DIDWallet:
 
     @staticmethod
     async def create_new_did_wallet(
-        wallet_state_manager: Any,
+        wallet_state_manager: WalletStateManager,
         wallet: Wallet,
         amount: uint64,
         action_scope: WalletActionScope,
@@ -77,7 +79,7 @@ class DIDWallet:
         name: str | None = None,
         fee: uint64 = uint64(0),
         extra_conditions: tuple[Condition, ...] = tuple(),
-    ):
+    ) -> DIDWallet:
         """
         Create a brand new DID wallet
         This must be called under the wallet state manager lock
@@ -136,11 +138,8 @@ class DIDWallet:
 
     @staticmethod
     async def create_new_did_wallet_from_recovery(
-        wallet_state_manager: Any,
-        wallet: Wallet,
-        backup_data: str,
-        name: str | None = None,
-    ):
+        wallet_state_manager: WalletStateManager, wallet: Wallet, backup_data: str, name: str | None = None
+    ) -> DIDWallet:
         """
         Create a DID wallet from a backup file
         :param wallet_state_manager: Wallet state manager
@@ -176,13 +175,13 @@ class DIDWallet:
 
     @staticmethod
     async def create_new_did_wallet_from_coin_spend(
-        wallet_state_manager: Any,
+        wallet_state_manager: WalletStateManager,
         wallet: Wallet,
         launch_coin: Coin,
         inner_puzzle: Program,
         coin_spend: CoinSpend,
         name: str | None = None,
-    ):
+    ) -> DIDWallet:
         """
         Create a DID wallet from a transfer
         :param wallet_state_manager: Wallet state manager
@@ -251,11 +250,8 @@ class DIDWallet:
 
     @staticmethod
     async def create(
-        wallet_state_manager: Any,
-        wallet: Wallet,
-        wallet_info: WalletInfo,
-        name: str | None = None,
-    ):
+        wallet_state_manager: WalletStateManager, wallet: Wallet, wallet_info: WalletInfo, name: str | None = None
+    ) -> DIDWallet:
         """
         Create a DID wallet based on the local database
         :param wallet_state_manager: Wallet state manager
@@ -283,7 +279,7 @@ class DIDWallet:
     def id(self) -> uint32:
         return self.wallet_info.id
 
-    async def get_confirmed_balance(self, record_list=None) -> uint128:
+    async def get_confirmed_balance(self, record_list: set[WalletCoinRecord] | None = None) -> uint128:
         if record_list is None:
             record_list = await self.wallet_state_manager.coin_store.get_unspent_coins_for_wallet(self.id())
 
@@ -324,7 +320,7 @@ class DIDWallet:
 
         return uint64(addition_amount)
 
-    async def get_unconfirmed_balance(self, record_list=None) -> uint128:
+    async def get_unconfirmed_balance(self, record_list: set[WalletCoinRecord] | None = None) -> uint128:
         return await self.wallet_state_manager.get_unconfirmed_balance(self.id(), record_list)
 
     async def select_coins(
@@ -352,7 +348,9 @@ class DIDWallet:
     # We can improve this interface by passing in the CoinSpend, as well
     # We need to change DID Wallet coin_added to expect p2 spends as well as recovery spends,
     # or only call it in the recovery spend case
-    async def coin_added(self, coin: Coin, _: uint32, peer: WSChiaConnection, parent_coin_data: DIDCoinData | None):
+    async def coin_added(
+        self, coin: Coin, _: uint32, peer: WSChiaConnection, parent_coin_data: DIDCoinData | None
+    ) -> None:
         """Notification from wallet state manager that wallet has been received."""
         parent = self.get_parent_for_coin(coin)
         if parent_coin_data is not None:
@@ -445,7 +443,7 @@ class DIDWallet:
         output_str += f":{self.did_info.metadata}"
         return output_str
 
-    async def load_parent(self, did_info: DIDInfo):
+    async def load_parent(self, did_info: DIDInfo) -> None:
         """
         Load the parent info when importing a DID
         :param did_info: DID info
@@ -555,7 +553,7 @@ class DIDWallet:
         assert core is not None
         return core.hex()
 
-    async def set_name(self, new_name: str):
+    async def set_name(self, new_name: str) -> None:
         new_info = dataclasses.replace(self.wallet_info, name=new_name)
         self.wallet_info = new_info
         await self.wallet_state_manager.user_store.update_wallet(self.wallet_info)
@@ -824,7 +822,7 @@ class DIDWallet:
             recovery_list_hash=self.reset_recovery_list(),
         )
 
-    async def get_innerpuz_for_new_innerhash(self, pubkey: G1Element):
+    async def get_innerpuz_for_new_innerhash(self, pubkey: G1Element) -> Program:
         """
         Get the inner puzzle for a new owner
         :param pubkey: Pubkey
@@ -843,9 +841,7 @@ class DIDWallet:
         )
 
     async def inner_puzzle_for_did_puzzle(self, did_hash: bytes32) -> Program:
-        record: DerivationRecord = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(
-            did_hash
-        )
+        record = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(did_hash)
         assert self.did_info.origin_coin is not None
         assert self.did_info.current_inner is not None
         uncurried_args = uncurry_innerpuz(self.did_info.current_inner)
@@ -855,7 +851,8 @@ class DIDWallet:
             record = await self.wallet_state_manager.puzzle_store.get_derivation_record_for_puzzle_hash(
                 p2_puzzle.get_tree_hash()
             )
-
+        if record is None:
+            raise RuntimeError(f"Could not find derived inner puzzle for did_hash {did_hash}")
         inner_puzzle: Program = did_wallet_puzzles.create_innerpuz(
             p2_puzzle_or_hash=puzzle_for_pk(record.pubkey),
             recovery_list=self.did_info.backup_ids,
@@ -883,7 +880,7 @@ class DIDWallet:
 
         return og_recovery_list_hash
 
-    def get_parent_for_coin(self, coin) -> LineageProof | None:
+    def get_parent_for_coin(self, coin: Coin) -> LineageProof | None:
         parent_info = None
         for name, ccparent in self.did_info.parent_info:
             if name == coin.parent_coin_info:
@@ -1000,12 +997,8 @@ class DIDWallet:
             interface.side_effects.transactions.append(did_record)
 
     async def generate_eve_spend(
-        self,
-        coin: Coin,
-        full_puzzle: Program,
-        innerpuz: Program,
-        extra_conditions: tuple[Condition, ...] = tuple(),
-    ):
+        self, coin: Coin, full_puzzle: Program, innerpuz: Program, extra_conditions: tuple[Condition, ...] = tuple()
+    ) -> WalletSpendBundle:
         assert self.did_info.origin_coin is not None
         uncurried = did_wallet_puzzles.uncurry_innerpuz(innerpuz)
         assert uncurried is not None
@@ -1028,20 +1021,20 @@ class DIDWallet:
         unsigned_spend_bundle = WalletSpendBundle(list_of_coinspends, G2Element())
         return unsigned_spend_bundle
 
-    async def get_spendable_balance(self, unspent_records=None) -> uint128:
+    async def get_spendable_balance(self, unspent_records: set[WalletCoinRecord] | None = None) -> uint128:
         spendable_am = await self.wallet_state_manager.get_confirmed_spendable_balance_for_wallet(
             self.wallet_info.id, unspent_records
         )
         return spendable_am
 
-    async def get_max_send_amount(self, records: set[WalletCoinRecord] | None = None):
+    async def get_max_send_amount(self, records: set[WalletCoinRecord] | None = None) -> uint128:
         spendable: list[WalletCoinRecord] = list(
             await self.wallet_state_manager.get_spendable_coins_for_wallet(self.id(), records)
         )
         max_send_amount = sum(cr.coin.amount for cr in spendable)
-        return max_send_amount
+        return uint128(max_send_amount)
 
-    async def add_parent(self, name: bytes32, parent: LineageProof | None):
+    async def add_parent(self, name: bytes32, parent: LineageProof | None) -> None:
         self.log.info(f"Adding parent {name}: {parent}")
         current_list = self.did_info.parent_info.copy()
         current_list.append((name, parent))
@@ -1079,7 +1072,7 @@ class DIDWallet:
         await self.wallet_state_manager.update_wallet_puzzle_hashes(self.wallet_info.id)
         return True
 
-    async def save_info(self, did_info: DIDInfo):
+    async def save_info(self, did_info: DIDInfo) -> None:
         self.did_info = did_info
         current_info = self.wallet_info
         data_str = json.dumps(did_info.to_json_dict())
@@ -1100,7 +1093,7 @@ class DIDWallet:
                     max_num = int(matched.group(1))
         return f"Profile {max_num + 1}"
 
-    def check_existed_did(self):
+    def check_existed_did(self) -> None:
         """
         Check if the current DID is existed
         :return: None
@@ -1108,6 +1101,9 @@ class DIDWallet:
         for wallet in self.wallet_state_manager.wallets.values():
             if (
                 wallet.type() == WalletType.DECENTRALIZED_ID
+                and isinstance(wallet, DIDWallet)
+                and self.did_info.origin_coin is not None
+                and wallet.did_info.origin_coin is not None
                 and self.did_info.origin_coin.name() == wallet.did_info.origin_coin.name()
             ):
                 self.log.warning(f"DID {self.did_info.origin_coin} already existed, ignore the wallet creation.")

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -12,7 +12,6 @@ chia.simulator.keyring
 chia.simulator.wallet_tools
 chia.ssl.create_ssl
 chia.types.blockchain_format.program
-chia.wallet.did_wallet.did_wallet
 chia.wallet.puzzles.load_clvm
 chia.wallet.trading.trade_store
 chia.wallet.util.debug_spend_bundle


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are mostly annotations; the new RuntimeError and isinstance/null guards only affect failure paths and typing, not normal DID spend flows.
> 
> **Overview**
> Adds **static typing** across `did_wallet.py` so mypy can check it without excluding the module from `mypy-exclusions.txt`.
> 
> `wallet_state_manager` is typed as `WalletStateManager` (via `TYPE_CHECKING`) instead of `Any`, factory and balance helpers get explicit return types (`DIDWallet`, `uint128`, `Program`, `WalletSpendBundle`, etc.), and optional coin-record parameters are annotated as `set[WalletCoinRecord] | None`.
> 
> **`inner_puzzle_for_did_puzzle`** now raises **`RuntimeError`** when no derivation record exists for the DID or p2 puzzle hash, instead of proceeding with a missing record. **`check_existed_did`** narrows wallets with `isinstance(wallet, DIDWallet)` and guards `origin_coin` before comparing launcher IDs. **`get_max_send_amount`** wraps the sum in **`uint128`** for a consistent return type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c3f19675ff2a91fc856a97c076d2b799429045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->