### PR TITLE
Remote Compact VDF Proofs

### DIFF
--- a/CHIPs/chip-remote-compact-vdf-proofs.md
+++ b/CHIPs/chip-remote-compact-vdf-proofs.md
@@ -70,8 +70,6 @@ Header validation remains the ultimate check. A malicious archive can at worst c
 - `sub_slot_index` — index into `finished_sub_slots` for `CC_EOS` / `ICC_EOS` (omitted for `CC_SP` / `CC_IP`)
 - `witness` — bytes for `VDFProof(witness_type=0, witness, normalized_to_identity=true)`
 
-When `sub_slot_index` is present, lookup is O(1) and does not run `validate_vdf` at apply time; cryptographic verification happens once in header validation.
-
 ### Why disable P2P compact VDF handlers
 
 When remote compact VDF is enabled, serving and requesting compact proofs from peers is redundant and adds load during sync. The reference implementation turns `new_compact_vdf`, `request_compact_vdf`, and `respond_compact_vdf` into no-ops. Timelord `RequestCompactProofOfTime` bluebox for live blocks is unchanged.

--- a/CHIPs/chip-remote-compact-vdf-proofs.md
+++ b/CHIPs/chip-remote-compact-vdf-proofs.md
@@ -1,0 +1,252 @@
+CHIP Number | TBD
+:------------|:----
+Title | Remote compact VDF proofs for full node sync
+Description | Optional full node behavior to fetch pre-compacted challenge-chain VDF witnesses over HTTP and apply them before block validation, replacing peer-to-peer compact VDF gossip for this path.
+Author | TBD
+Editor | TBD
+Comments-URI | TBD
+Status | Draft
+Category | Informational
+Sub-Category | Informative
+Created | 2026-06-24
+Requires | None
+Replaces | None
+Superseded-By | None
+
+## Abstract
+
+This CHIP specifies an optional full node optimization that downloads compact VDF proof data from static HTTP files, applies the proofs to incoming blocks before header validation, and persists the compactified block bytes. The on-chain consensus rules are unchanged: compact proofs must already be valid under existing header validation, and block identity (`header_hash`) is unchanged because VDF witnesses are not part of the foliage hash.
+
+The proposal also defines a JSON-lines **compactvdf** file format for publishing compact witnesses in height-indexed chunks, and recommends disabling full-node handling of the legacy peer-to-peer compact VDF protocol messages when using the remote path exclusively.
+
+## Motivation
+
+Chia blocks store large Wesolowski VDF witnesses for compressible challenge-chain fields (`CC_EOS`, `ICC_EOS`, `CC_SP`, `CC_IP`). Timelord bluebox already produces compact witnesses (`witness_type = 0`, `normalized_to_identity = true`) that are consensus-valid replacements for the full proofs.
+
+Today, compactification of historical blocks on full nodes relies primarily on:
+
+1. Timelord bluebox driven by `RequestCompactProofOfTime` messages from the full node, and
+2. Peer-to-peer `new_compact_vdf` / `request_compact_vdf` / `respond_compact_vdf` gossip between full nodes.
+
+Both paths are operationally heavy during long sync: many round trips, semaphore-limited handlers, and redundant work when the same compact witnesses could be served from a static archive.
+
+A static **compactvdf** file per 10,000 main-chain heights allows a full node to:
+
+- Prefetch one HTTP object per height range while syncing,
+- Apply all matching compact witnesses to a block in memory before `pre_validate_block`,
+- Store already-compact blocks in `full_blocks`, reducing database size and future validation cost.
+
+This does not replace timelord bluebox for live chain extension; it complements it for catch-up sync and for operators who publish compact witness archives.
+
+## Backwards Compatibility
+
+**Consensus:** No change. Existing `CompressibleVDFField` values, `VDFProof` wire format, and header validation rules are used as-is. A node that does not implement this CHIP continues to accept blocks with either full or compact witnesses.
+
+**Network:** Full nodes that disable P2P compact VDF handlers no longer participate in compact witness gossip. They remain fully compatible with the chain as long as they can still validate blocks (with full witnesses from peers, or with compact witnesses applied locally from HTTP).
+
+**Configuration:** Disabled by default when `remote_compact_vdf_base_url` is empty. Nodes without the config key behave as today.
+
+**File format:** Entries without `sub_slot_index` remain supported via legacy lookup (candidate enumeration with `validate_vdf`).
+
+## Rationale
+
+### Why HTTP files instead of P2P compact VDF messages
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| P2P `respond_compact_vdf` | Decentralized, no trusted host | High chatter, hard to cache, easy to spam during sync |
+| Static compactvdf files | Cacheable, predictable bandwidth, simple CDN hosting | Requires a publisher; trust in file integrity (mitigated by validation) |
+
+Header validation remains the ultimate check. A malicious archive can at worst cause validation failure; it cannot forge a valid block with an invalid witness.
+
+### Why apply before validation, not after
+
+`header_hash` is `foliage.get_hash()` and does not include VDF proof bytes. Replacing witnesses therefore does not change block identity. The same in-memory `FullBlock` object must be both validated and persisted; applying compact proofs before `pre_validate_block` guarantees the validated bytes match the stored bytes.
+
+### Why omit `vdf_info` from the file
+
+`VDFInfo` (140 bytes: challenge, iterations, output) is already present on the block and is not modified by compactification. The file carries only the new witness plus enough metadata to locate the correct proof slot:
+
+- `header_hash` — block identity
+- `field_vdf` — which compressible field (`CompressibleVDFField`)
+- `sub_slot_index` — index into `finished_sub_slots` for `CC_EOS` / `ICC_EOS` (omitted for `CC_SP` / `CC_IP`)
+- `witness` — bytes for `VDFProof(witness_type=0, witness, normalized_to_identity=true)`
+
+When `sub_slot_index` is present, lookup is O(1) and does not run `validate_vdf` at apply time; cryptographic verification happens once in header validation.
+
+### Why disable P2P compact VDF handlers
+
+When remote compact VDF is enabled, serving and requesting compact proofs from peers is redundant and adds load during sync. The reference implementation turns `new_compact_vdf`, `request_compact_vdf`, and `respond_compact_vdf` into no-ops. Timelord `RequestCompactProofOfTime` bluebox for live blocks is unchanged.
+
+## Specification
+
+### Configuration
+
+Add to the `full_node` section of `config.yaml`:
+
+```yaml
+full_node:
+  # Base URL for compact VDF archives. Files are fetched from:
+  #   {remote_compact_vdf_base_url}/compactvdf-{start}to{end}
+  # where [start, end] is an inclusive 10,000-block height range.
+  # Set to empty string to disable.
+  remote_compact_vdf_base_url: ""
+```
+
+Default in reference implementation: `https://www.xchos.com/vdfs` (operators may override).
+
+### HTTP object naming and caching
+
+- **Chunk size:** `10_000` blocks (`COMPACT_VDF_HEIGHT_CHUNK_SIZE`).
+- **URL for block at height `h`:**
+  ```
+  {base_url without trailing slash}/compactvdf-{start}to{end}
+  ```
+  where `start = (h // 10000) * 10000` and `end = start + 9999`.
+- **Method:** `GET`
+- **Success:** HTTP `200`, body is UTF-8 text (JSON lines).
+- **Missing chunk:** HTTP `404` — node proceeds with the uncompacted block.
+- **Caching:** Implementations SHOULD cache the parsed entries for the current chunk in memory and evict other chunks when sync height moves to a new range.
+
+### compactvdf file format
+
+JSON Lines (one JSON object per line, UTF-8). Empty lines are ignored. Invalid lines SHOULD be logged and skipped.
+
+#### Entry schema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `header_hash` | `bytes32` hex string (`0x…`) | yes | Block header hash |
+| `field_vdf` | `uint8` | yes | `CompressibleVDFField` value (see below) |
+| `witness` | bytes hex string (`0x…`) | yes | Compact witness bytes |
+| `sub_slot_index` | `uint8` | no | Index into `finished_sub_slots` for EOS fields |
+
+Legacy entries may nest witness under `vdf_proof.witness`; parsers SHOULD accept both forms.
+
+#### `field_vdf` values
+
+Matches existing `CompressibleVDFField` in `chia/types/blockchain_format/vdf.py`:
+
+| Value | Name | Proof field updated |
+|-------|------|---------------------|
+| 1 | `CC_EOS_VDF` | `finished_sub_slots[i].proofs.challenge_chain_slot_proof` |
+| 2 | `ICC_EOS_VDF` | `finished_sub_slots[i].proofs.infused_challenge_chain_slot_proof` |
+| 3 | `CC_SP_VDF` | `challenge_chain_sp_proof` |
+| 4 | `CC_IP_VDF` | `challenge_chain_ip_proof` |
+
+Reward-chain proofs (`reward_chain_slot_proof`, `reward_chain_sp_proof`, `reward_chain_ip_proof`) are **not** in scope; they are not compressible under the existing enum.
+
+#### Compact proof form
+
+Each `witness` is applied as:
+
+```python
+VDFProof(uint8(0), witness, normalized_to_identity=True)
+```
+
+#### Example lines
+
+```json
+{"header_hash":"0xabc…","field_vdf":1,"witness":"0x…","sub_slot_index":0}
+{"header_hash":"0xabc…","field_vdf":4,"witness":"0x…"}
+```
+
+### Lookup and apply algorithm
+
+For each entry matching `block.header_hash`:
+
+1. `vdf_proof = compact_vdf_proof(entry.witness)`
+2. If `sub_slot_index` is set: `vdf_info = vdf_info_for_sub_slot(block, field_vdf, sub_slot_index)`
+3. Else: `vdf_info = find_vdf_info_for_proof(block, field_vdf, vdf_proof, constants)` (legacy; uses `validate_vdf` over candidates)
+4. If `vdf_info` is `None`, skip entry
+5. If `needs_compact_proof(vdf_info, block, field_vdf)` is false, skip (already compact)
+6. `block = apply_compact_proof_to_block(block, vdf_info, vdf_proof, field_vdf)` — MUST copy `finished_sub_slots` before mutating sub-slots
+
+Implementations MUST NOT treat a failed lookup as a consensus failure; skip and continue.
+
+### Full node integration points
+
+Remote compact VDF apply MUST run **outside** the blockchain mutex and **before** header validation on the same `FullBlock` instance:
+
+| Path | When |
+|------|------|
+| Live block ingestion | `add_block`, before `pre_validate_block` |
+| Batch sync | `validate_blocks` inner loop, after `skip_blocks`, before `prevalidate_blocks` |
+
+`prevalidate_blocks` itself is unchanged from mainline (per-block futures, no apply inside).
+
+### `is_fully_compactified` database flag
+
+When persisting blocks, `full_blocks.is_fully_compactified` SHOULD be computed with the same predicate as header compactness:
+
+- All `challenge_chain_slot_proof` and present `infused_challenge_chain_slot_proof` in finished sub-slots are compact
+- `challenge_chain_sp_proof` is compact if present
+- `challenge_chain_ip_proof` is compact
+
+Use a shared helper (`is_fully_compactified_header_block`) rather than `FullBlock.is_fully_compactified()` if the rust and python predicates must stay aligned.
+
+### P2P protocol handling (reference behavior)
+
+When relying on remote compact VDF exclusively, full node API handlers for these message types MAY be disabled (no-op):
+
+- `ProtocolMessageTypes.new_compact_vdf` (42)
+- `ProtocolMessageTypes.request_compact_vdf` (40)
+- `ProtocolMessageTypes.respond_compact_vdf` (41)
+
+Timelord messages (`request_compact_proof_of_time`, `respond_compact_proof_of_time`) are unaffected.
+
+## Reference Implementation
+
+Implemented in `chia-blockchain` (branch vs. `main`, excluding offline tooling):
+
+| Module | Role |
+|--------|------|
+| `chia/full_node/compact_vdf_file.py` | `CompactVdfEntry`, parse/apply helpers, `is_fully_compactified_header_block` |
+| `chia/full_node/remote_compact_vdf.py` | HTTP fetch, chunk cache, `apply_compact_vdf_entries` |
+| `chia/full_node/full_node.py` | Config wiring, `block_with_remote_compact_vdfs`, sync + `add_block` hooks, `_replace_proof` refactor |
+| `chia/full_node/full_node_api.py` | P2P compact VDF handlers disabled (no-op) |
+| `chia/full_node/block_store.py` | `is_fully_compactified` via shared helper |
+| `chia/util/initial-config.yaml` | `remote_compact_vdf_base_url` default |
+
+### Pseudocode (sync path)
+
+```
+blocks_to_validate = skip_blocks(...)
+for i in range(len(blocks_to_validate)):
+    blocks_to_validate[i] = await block_with_remote_compact_vdfs(blocks_to_validate[i])
+for block in blocks_to_validate:
+    futures.extend(await prevalidate_blocks(blockchain, [block], vs, summaries))
+```
+
+### Pseudocode (apply)
+
+```
+async def block_with_remote_compact_vdfs(block):
+    entries = await fetch_remote_compact_vdf_entries(base_url, block.height)
+    return await apply_compact_vdf_entries(constants, block, entries, pool)
+```
+
+## Security
+
+**Trust model:** The HTTP publisher is untrusted. Invalid witnesses MUST NOT be persisted as valid blocks because `pre_validate_block` / header validation still runs `validate_vdf` on all proofs.
+
+**Integrity:** Use HTTPS for remote archives. Operators MAY pin URLs or mirror files locally.
+
+**Denial of service:** Missing or corrupt files MUST NOT panic the node; worst case is slower sync with full-size witnesses. Implementations SHOULD bound HTTP timeouts (reference: 30 seconds per chunk).
+
+**Privacy:** Full nodes reveal to the HTTP server which height ranges they fetch (coarse, 10k blocks).
+
+**P2P surface reduction:** Disabling compact VDF gossip removes a class of unsolicited-proof handling during sync; timelord and normal block propagation are unchanged.
+
+## Test Plan
+
+- Parse compactvdf JSON lines (with and without `sub_slot_index`, legacy `vdf_proof` nesting)
+- Apply entries to a block with uncompacted CC/ICC/SP/IP proofs; verify `header_hash` unchanged
+- Verify compactified block passes `pre_validate_block`
+- Verify invalid witness from file fails validation, block not added
+- Sync pipeline applies remote proofs before prevalidation futures
+- `is_fully_compactified` set correctly in `full_blocks` after apply
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/CHIPs/chip-remote-compact-vdf-proofs.md
+++ b/CHIPs/chip-remote-compact-vdf-proofs.md
@@ -197,7 +197,9 @@ Timelord messages (`request_compact_proof_of_time`, `respond_compact_proof_of_ti
 
 ## Reference Implementation
 
-Implemented in `chia-blockchain` (branch vs. `main`, excluding offline tooling):
+Pull request: [Chia-Network/chia-blockchain#21046](https://github.com/Chia-Network/chia-blockchain/pull/21046)
+
+Implemented in `chia-blockchain` (excluding offline tooling):
 
 | Module | Role |
 |--------|------|

--- a/CHIPs/chip-remote-compact-vdf-proofs.md
+++ b/CHIPs/chip-remote-compact-vdf-proofs.md
@@ -46,8 +46,6 @@ This does not replace timelord bluebox for live chain extension; it complements 
 
 **Configuration:** Disabled by default when `remote_compact_vdf_base_url` is empty. Nodes without the config key behave as today.
 
-**File format:** Entries without `sub_slot_index` remain supported via legacy lookup (candidate enumeration with `validate_vdf`).
-
 ## Rationale
 
 ### Why HTTP files instead of P2P compact VDF messages
@@ -121,8 +119,6 @@ JSON Lines (one JSON object per line, UTF-8). Empty lines are ignored. Invalid l
 | `witness` | bytes hex string (`0x…`) | yes | Compact witness bytes |
 | `sub_slot_index` | `uint8` | no | Index into `finished_sub_slots` for EOS fields |
 
-Legacy entries may nest witness under `vdf_proof.witness`; parsers SHOULD accept both forms.
-
 #### `field_vdf` values
 
 Matches existing `CompressibleVDFField` in `chia/types/blockchain_format/vdf.py`:
@@ -157,7 +153,7 @@ For each entry matching `block.header_hash`:
 
 1. `vdf_proof = compact_vdf_proof(entry.witness)`
 2. If `sub_slot_index` is set: `vdf_info = vdf_info_for_sub_slot(block, field_vdf, sub_slot_index)`
-3. Else: `vdf_info = find_vdf_info_for_proof(block, field_vdf, vdf_proof, constants)` (legacy; uses `validate_vdf` over candidates)
+3. Else: `vdf_info = find_vdf_info_for_proof(block, field_vdf, vdf_proof, constants)`
 4. If `vdf_info` is `None`, skip entry
 5. If `needs_compact_proof(vdf_info, block, field_vdf)` is false, skip (already compact)
 6. `block = apply_compact_proof_to_block(block, vdf_info, vdf_proof, field_vdf)` — MUST copy `finished_sub_slots` before mutating sub-slots
@@ -242,7 +238,7 @@ async def block_with_remote_compact_vdfs(block):
 
 ## Test Plan
 
-- Parse compactvdf JSON lines (with and without `sub_slot_index`, legacy `vdf_proof` nesting)
+- Parse compactvdf JSON lines
 - Apply entries to a block with uncompacted CC/ICC/SP/IP proofs; verify `header_hash` unchanged
 - Verify compactified block passes `pre_validate_block`
 - Verify invalid witness from file fails validation, block not added

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -31,8 +31,6 @@ from chia.consensus.pot_iterations import (
     is_overflow_block,
     validate_pospace_and_get_required_iters,
 )
-from chia.full_node.compact_vdf_file import CompactVdfEntry
-from chia.full_node.remote_compact_vdf import apply_compact_vdf_entries
 from chia.types.blockchain_format.coin import Coin
 from chia.types.generator_types import BlockGenerator
 from chia.types.validation_state import ValidationState
@@ -181,7 +179,6 @@ async def pre_validate_block(
     skip_commitment_validation: bool = False,
     nice: _SupportsLessThan = (0,),
     dedicated: bool = True,
-    remote_compact_vdf_entries: list[CompactVdfEntry] | None = None,
 ) -> Awaitable[PreValidationResult]:
     """
     This method must be called under the blockchain lock
@@ -279,8 +276,6 @@ async def pre_validate_block(
             previous_generators = block_generator.generator_refs
     except ValueError:
         return return_error(Err.FAILED_GETTING_GENERATOR_MULTIPROCESSING)
-
-    block = await apply_compact_vdf_entries(constants, block, remote_compact_vdf_entries, pool)
 
     readonly_blockchain = blockchain.read_only_snapshot()
 

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -31,7 +31,8 @@ from chia.consensus.pot_iterations import (
     is_overflow_block,
     validate_pospace_and_get_required_iters,
 )
-from chia.full_node.remote_compact_vdf import apply_remote_compact_vdfs
+from chia.full_node.compact_vdf_file import CompactVdfEntry
+from chia.full_node.remote_compact_vdf import apply_compact_vdf_entries
 from chia.types.blockchain_format.coin import Coin
 from chia.types.generator_types import BlockGenerator
 from chia.types.validation_state import ValidationState
@@ -180,7 +181,7 @@ async def pre_validate_block(
     skip_commitment_validation: bool = False,
     nice: _SupportsLessThan = (0,),
     dedicated: bool = True,
-    remote_compact_vdf_base_url: str | None = None,
+    remote_compact_vdf_entries: list[CompactVdfEntry] | None = None,
 ) -> Awaitable[PreValidationResult]:
     """
     This method must be called under the blockchain lock
@@ -279,7 +280,7 @@ async def pre_validate_block(
     except ValueError:
         return return_error(Err.FAILED_GETTING_GENERATOR_MULTIPROCESSING)
 
-    block = await apply_remote_compact_vdfs(constants, block, remote_compact_vdf_base_url, pool)
+    block = await apply_compact_vdf_entries(constants, block, remote_compact_vdf_entries, pool)
 
     readonly_blockchain = blockchain.read_only_snapshot()
 

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -31,6 +31,7 @@ from chia.consensus.pot_iterations import (
     is_overflow_block,
     validate_pospace_and_get_required_iters,
 )
+from chia.full_node.remote_compact_vdf import apply_remote_compact_vdfs
 from chia.types.blockchain_format.coin import Coin
 from chia.types.generator_types import BlockGenerator
 from chia.types.validation_state import ValidationState
@@ -179,6 +180,7 @@ async def pre_validate_block(
     skip_commitment_validation: bool = False,
     nice: _SupportsLessThan = (0,),
     dedicated: bool = True,
+    remote_compact_vdf_base_url: str | None = None,
 ) -> Awaitable[PreValidationResult]:
     """
     This method must be called under the blockchain lock
@@ -276,6 +278,8 @@ async def pre_validate_block(
             previous_generators = block_generator.generator_refs
     except ValueError:
         return return_error(Err.FAILED_GETTING_GENERATOR_MULTIPROCESSING)
+
+    block = await apply_remote_compact_vdfs(constants, block, remote_compact_vdf_base_url, pool)
 
     readonly_blockchain = blockchain.read_only_snapshot()
 

--- a/chia/full_node/block_store.py
+++ b/chia/full_node/block_store.py
@@ -12,6 +12,7 @@ from chia_rs import BlockRecord, FullBlock, SubEpochChallengeSegment, SubEpochSe
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32
 
+from chia.full_node.compact_vdf_file import is_fully_compactified_header_block
 from chia.full_node.full_block_utils import GeneratorBlockInfo, block_info_from_block, generator_from_block
 from chia.util.batches import to_batches
 from chia.util.db_wrapper import DBWrapper2, execute_fetchone
@@ -125,7 +126,7 @@ class BlockStore:
                 "UPDATE full_blocks SET block=?,is_fully_compactified=? WHERE header_hash=?",
                 (
                     block_bytes,
-                    int(block.is_fully_compactified()),
+                    int(is_fully_compactified_header_block(block)),
                     header_hash,
                 ),
             )
@@ -154,7 +155,7 @@ class BlockStore:
                     block.prev_header_hash,
                     block.height,
                     ses,
-                    int(block.is_fully_compactified()),
+                    int(is_fully_compactified_header_block(block)),
                     False,  # in_main_chain
                     compress(block),
                     bytes(block_record),

--- a/chia/full_node/compact_vdf_file.py
+++ b/chia/full_node/compact_vdf_file.py
@@ -5,8 +5,8 @@ Used when applying compact VDF proofs from remote compactvdf files during block
 validation, and when replacing proofs on stored blocks (e.g. from the timelord).
 
 Each compact proof record contains: header_hash, field_vdf, witness (witness_type 0
-and normalized_to_identity true). vdf_info is recovered from the block at apply time
-via find_vdf_info_for_proof().
+and normalized_to_identity true), and optionally sub_slot_index for CC_EOS / ICC_EOS
+entries. vdf_info is recovered from the block at apply time via find_vdf_info_for_entry().
 """
 from __future__ import annotations
 
@@ -33,6 +33,7 @@ class CompactVdfEntry(Streamable):
     header_hash: bytes32
     field_vdf: uint8
     witness: bytes
+    sub_slot_index: uint8 | None = None
 
 
 def compact_vdf_proof(witness: bytes) -> VDFProof:
@@ -73,6 +74,36 @@ def _vdf_info_candidates(block: FullBlock | HeaderBlock, field_vdf: Compressible
     if field_vdf == CompressibleVDFField.CC_IP_VDF:
         return [block.reward_chain_block.challenge_chain_ip_vdf]
     return []
+
+
+def vdf_info_for_sub_slot(
+    block: FullBlock | HeaderBlock,
+    field_vdf: CompressibleVDFField,
+    sub_slot_index: uint8,
+) -> VDFInfo | None:
+    index = int(sub_slot_index)
+    if index >= len(block.finished_sub_slots):
+        return None
+    sub_slot = block.finished_sub_slots[index]
+    if field_vdf == CompressibleVDFField.CC_EOS_VDF:
+        return sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf
+    if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
+        if sub_slot.infused_challenge_chain is None:
+            return None
+        return sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf
+    return None
+
+
+def find_vdf_info_for_entry(
+    block: FullBlock | HeaderBlock,
+    field_vdf: CompressibleVDFField,
+    vdf_proof: VDFProof,
+    constants: ConsensusConstants,
+    sub_slot_index: uint8 | None = None,
+) -> VDFInfo | None:
+    if sub_slot_index is not None:
+        return vdf_info_for_sub_slot(block, field_vdf, sub_slot_index)
+    return find_vdf_info_for_proof(block, field_vdf, vdf_proof, constants)
 
 
 def find_vdf_info_for_proof(
@@ -188,6 +219,7 @@ def _entry_from_json_dict(data: dict[str, object]) -> CompactVdfEntry:
                 "header_hash": data["header_hash"],
                 "field_vdf": data["field_vdf"],
                 "witness": vdf_proof["witness"],
+                "sub_slot_index": data.get("sub_slot_index"),
             }
         )
     raise ValueError("missing witness")

--- a/chia/full_node/compact_vdf_file.py
+++ b/chia/full_node/compact_vdf_file.py
@@ -1,94 +1,29 @@
 """
-Deferred persistence for compact VDF proofs.
+Compact VDF proof helpers.
 
-Database writes
----------------
-Compact VDF handling does write to the DB, but only on startup — not when
-proofs are received.
+Used when applying compact VDF proofs from remote compactvdf files during block
+validation, and when replacing proofs on stored blocks (e.g. from the timelord).
 
-While the node is running (add_compact_vdf / add_compact_proof_of_time):
-- Updates the block cache only (put_block_in_cache).
-- Appends a line to compactvdf.
-- Does not call replace_proof or touch SQLite.
-
-On the next startup (process_compact_vdf_file):
-- Reads compactvdf, validates and applies each proof.
-- Flushes each block to the DB via block_store.replace_proof() (updates
-  full_blocks.block and is_fully_compactified).
-- Deletes compactvdf when done.
-
-During a single run, callers that read blocks via the block cache (e.g.
-get_all_full_blocks) see compactified proofs immediately. The DB still holds
-the old proofs until restart processes the file.
-
-Runtime (receiving compact VDFs)
---------------------------------
-When a compact VDF is validated (via add_compact_vdf or add_compact_proof_of_time):
-
-1. The proof is merged into the block in the block cache only (no DB write).
-2. A record is appended to {db_folder}/compactvdf (with a network suffix on
-   testnets, matching the height-to-hash file naming).
-
-Each line is a JSON object with: header_hash, field_vdf, witness (compact proofs
-always use witness_type 0 and normalized_to_identity true). vdf_info is not
-stored; it is recovered from the block at import time.
-
-Multiple VDFs per block
------------------------
-A block can have several CC_EOS_VDF or ICC_EOS_VDF entries (one per finished
-sub-slot, and ICC only where infused_challenge_chain is present). CC_SP_VDF and
-CC_IP_VDF are at most one per block.
-
-The file does not use a sub-slot index or other explicit slot ID. Entries with
-the same header_hash and field_vdf are distinguished by witness: each sub-slot
-has a different proof, so each line has different witness bytes.
-
-On import, find_vdf_info_for_proof loads all vdf_info candidates for that
-field_vdf from the block, reconstructs VDFProof(uint8(0), witness, True), and
-validates the witness against each candidate until one matches. That matched
-vdf_info selects which sub-slot (or reward-chain field) apply_compact_proof_to_block
-updates. Slot selection is implicit: the witness is cryptographically bound to
-one sub-slot's vdf_info (challenge, iterations, output).
-
-Startup (near height-to-hash processing)
-----------------------------------------
-Right after BlockHeightMap.create() in full_node.manage():
-
-1. Read all entries from compactvdf.
-2. Sort by block hash and group consecutive entries per block.
-3. For each entry: validate the VDF in parallel (thread pool), then apply proofs
-   to each block sequentially, processing blocks in batches of 1000 to limit memory.
-4. After all entries for a block are processed, flush that block to the DB
-   once via replace_proof.
-5. After all batches complete, checkpoint the WAL into the main database
-   (PRAGMA wal_checkpoint(TRUNCATE)).
-6. Delete the compactvdf file when done.
+Each compact proof record contains: header_hash, field_vdf, witness (witness_type 0
+and normalized_to_identity true). vdf_info is recovered from the block at apply time
+via find_vdf_info_for_proof().
 """
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
-import time
 from dataclasses import dataclass
-from itertools import groupby
-from pathlib import Path
 
-import aiofiles
 from chia_rs import ConsensusConstants, FullBlock, HeaderBlock, VDFInfo, VDFProof
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8
 
-from chia.full_node.block_store import BlockStore
 from chia.types.blockchain_format.classgroup import ClassgroupElement
 from chia.types.blockchain_format.vdf import CompressibleVDFField, validate_vdf
-from chia.util.db_wrapper import DBWrapper2
-from chia.util.priority_thread_pool_executor import Executor
 from chia.util.streamable import Streamable, streamable
 
 log = logging.getLogger(__name__)
 
-COMPACT_VDF_BATCH_SIZE = 1000
 COMPACT_VDF_HEIGHT_CHUNK_SIZE = 10000
 
 
@@ -102,11 +37,6 @@ class CompactVdfEntry(Streamable):
 
 def compact_vdf_proof(witness: bytes) -> VDFProof:
     return VDFProof(uint8(0), witness, True)
-
-
-def compact_vdf_filename(blockchain_dir: Path, selected_network: str | None = None) -> Path:
-    suffix = "" if (selected_network is None or selected_network == "mainnet") else f"-{selected_network}"
-    return blockchain_dir / f"compactvdf{suffix}"
 
 
 def _vdf_info_candidates(block: FullBlock | HeaderBlock, field_vdf: CompressibleVDFField) -> list[VDFInfo]:
@@ -260,209 +190,3 @@ def _parse_entries(text: str) -> list[CompactVdfEntry]:
 
 def parse_compact_vdf_entries(text: str) -> list[CompactVdfEntry]:
     return _parse_entries(text)
-
-
-async def read_all_entries(path: Path) -> list[CompactVdfEntry]:
-    try:
-        async with aiofiles.open(path, encoding="utf-8") as f:
-            text = await f.read()
-    except FileNotFoundError:
-        return []
-    if len(text) == 0:
-        return []
-    return _parse_entries(text)
-
-
-async def append_entry(path: Path, entry: CompactVdfEntry, lock: asyncio.Lock) -> None:
-    line = json.dumps(entry.to_json_dict(), sort_keys=True) + "\n"
-    async with lock:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        async with aiofiles.open(path, "a", encoding="utf-8") as f:
-            await f.write(line)
-
-
-async def _wal_checkpoint_truncate(db_wrapper: DBWrapper2) -> float:
-    start = time.monotonic()
-    async with db_wrapper.writer() as conn:
-        async with conn.execute("PRAGMA wal_checkpoint(TRUNCATE)") as cursor:
-            await cursor.fetchone()
-    return time.monotonic() - start
-
-
-def _ordered_unique_header_hashes(entries: list[CompactVdfEntry]) -> list[bytes32]:
-    unique: list[bytes32] = []
-    seen: set[bytes32] = set()
-    for entry in entries:
-        if entry.header_hash not in seen:
-            seen.add(entry.header_hash)
-            unique.append(entry.header_hash)
-    return unique
-
-
-async def _process_compact_vdf_batch(
-    batch_entries: list[CompactVdfEntry],
-    block_store: BlockStore,
-    constants: ConsensusConstants,
-    pool: Executor,
-    blocks_total: int,
-    blocks_processed: int,
-) -> tuple[int, int, float, float, float]:
-    batch_hashes = {entry.header_hash for entry in batch_entries}
-    blocks: dict[bytes32, FullBlock] = {}
-    db_read_seconds = 0.0
-    for header_hash in batch_hashes:
-        db_read_start = time.monotonic()
-        block = await block_store.get_full_block(header_hash)
-        db_read_seconds += time.monotonic() - db_read_start
-        if block is None:
-            log.error(f"Can't find block for pending compact VDF. Header hash: {header_hash}")
-            continue
-        log.info(f"Read block height {block.height} header_hash {header_hash}")
-        blocks[header_hash] = block
-
-    validation_futures: list[asyncio.Future[VDFInfo | None]] = []
-    validation_entries: list[CompactVdfEntry] = []
-    deduped_batch_entries: list[CompactVdfEntry] = []
-    seen_entry_keys: set[tuple[bytes32, bytes, uint8]] = set()
-    for entry in batch_entries:
-        entry_key = (entry.header_hash, entry.witness, entry.field_vdf)
-        if entry_key in seen_entry_keys:
-            log.debug(
-                f"Skipping duplicate compact VDF entry for block {entry.header_hash} "
-                f"field_vdf {entry.field_vdf}"
-            )
-            continue
-        seen_entry_keys.add(entry_key)
-        deduped_batch_entries.append(entry)
-        block = blocks.get(entry.header_hash)
-        if block is None:
-            continue
-        field_vdf = CompressibleVDFField(int(entry.field_vdf))
-        vdf_proof = compact_vdf_proof(entry.witness)
-        validation_futures.append(
-            pool.run_in_loop(find_vdf_info_for_proof, block, field_vdf, vdf_proof, constants)
-        )
-        validation_entries.append(entry)
-
-    vdf_start = time.monotonic()
-    validation_results: list[VDFInfo | None] = []
-    if len(validation_futures) > 0:
-        validation_results = list(await asyncio.gather(*validation_futures))
-    vdf_seconds = time.monotonic() - vdf_start
-
-    entry_vdf_info: dict[tuple[bytes32, bytes, uint8], VDFInfo | None] = {}
-    for entry, vdf_info in zip(validation_entries, validation_results, strict=True):
-        entry_vdf_info[(entry.header_hash, entry.witness, entry.field_vdf)] = vdf_info
-
-    entries_applied = 0
-    db_flush_seconds = 0.0
-    for header_hash, group_iter in groupby(deduped_batch_entries, key=lambda entry: entry.header_hash):
-        block_entries = list(group_iter)
-        block = blocks.get(header_hash)
-        if block is None:
-            continue
-
-        applied_for_block = 0
-        for entry in block_entries:
-            field_vdf = CompressibleVDFField(int(entry.field_vdf))
-            vdf_proof = compact_vdf_proof(entry.witness)
-            vdf_info = entry_vdf_info.get((entry.header_hash, entry.witness, entry.field_vdf))
-            if vdf_info is None:
-                log.error(f"Pending compact VDF proof is not valid for block {header_hash}")
-                continue
-            if not needs_compact_proof(vdf_info, block, field_vdf):
-                log.info(f"Duplicate pending compact proof for block {header_hash}")
-                continue
-            new_block = apply_compact_proof_to_block(block, vdf_info, vdf_proof, field_vdf)
-            if new_block is None:
-                log.error(f"Could not apply pending compact proof for block {header_hash}")
-                continue
-            block = new_block
-            applied_for_block += 1
-            entries_applied += 1
-
-        blocks_processed += 1
-        progress_msg = (
-            f"Processed block {blocks_processed}/{blocks_total} "
-            f"height {block.height} header_hash {header_hash} "
-            f"applied {applied_for_block}/{len(block_entries)} proofs, flushing to DB"
-        )
-        log.info(progress_msg)
-        db_flush_start = time.monotonic()
-        async with block_store.db_wrapper.writer():
-            await block_store.replace_proof(header_hash, block)
-        db_flush_seconds += time.monotonic() - db_flush_start
-
-    return blocks_processed, entries_applied, vdf_seconds, db_read_seconds, db_flush_seconds
-
-
-async def process_compact_vdf_file(
-    path: Path,
-    block_store: BlockStore,
-    constants: ConsensusConstants,
-    pool: Executor,
-) -> None:
-    entries = await read_all_entries(path)
-    if len(entries) == 0:
-        if path.exists():
-            path.unlink()
-        return
-
-    entries.sort(key=lambda entry: entry.header_hash)
-    unique_header_hashes = _ordered_unique_header_hashes(entries)
-    blocks_total = len(unique_header_hashes)
-    start_time = time.monotonic()
-    log.info(
-        f"Starting compact VDF file processing: {len(entries)} entries "
-        f"across {blocks_total} blocks from {path}"
-    )
-    blocks_processed = 0
-    entries_applied = 0
-    vdf_seconds = 0.0
-    db_read_seconds = 0.0
-    db_flush_seconds = 0.0
-
-    num_batches = (blocks_total + COMPACT_VDF_BATCH_SIZE - 1) // COMPACT_VDF_BATCH_SIZE
-    for batch_index in range(num_batches):
-        batch_start = batch_index * COMPACT_VDF_BATCH_SIZE
-        batch_hash_set = set(unique_header_hashes[batch_start : batch_start + COMPACT_VDF_BATCH_SIZE])
-        batch_entries = [entry for entry in entries if entry.header_hash in batch_hash_set]
-        log.info(
-            f"Compact VDF batch {batch_index + 1}/{num_batches}: "
-            f"{len(batch_hash_set)} blocks, {len(batch_entries)} entries"
-        )
-        (
-            blocks_processed,
-            batch_entries_applied,
-            batch_vdf_seconds,
-            batch_db_read_seconds,
-            batch_db_flush_seconds,
-        ) = await _process_compact_vdf_batch(
-            batch_entries,
-            block_store,
-            constants,
-            pool,
-            blocks_total,
-            blocks_processed,
-        )
-        entries_applied += batch_entries_applied
-        vdf_seconds += batch_vdf_seconds
-        db_read_seconds += batch_db_read_seconds
-        db_flush_seconds += batch_db_flush_seconds
-
-    wal_checkpoint_seconds = 0.0
-    if blocks_processed > 0:
-        wal_checkpoint_seconds = await _wal_checkpoint_truncate(block_store.db_wrapper)
-
-    path.unlink()
-    elapsed = time.monotonic() - start_time
-    other_seconds = max(
-        0.0, elapsed - vdf_seconds - db_read_seconds - db_flush_seconds - wal_checkpoint_seconds
-    )
-    log.info(
-        f"Finished processing compact VDF file: {entries_applied} proofs applied "
-        f"across {blocks_processed} blocks, time taken: {elapsed:.2f}s "
-        f"(vdf {vdf_seconds:.2f}s, db read {db_read_seconds:.2f}s, "
-        f"db flush {db_flush_seconds:.2f}s, wal checkpoint {wal_checkpoint_seconds:.2f}s, "
-        f"other {other_seconds:.2f}s), removed {path}"
-    )

--- a/chia/full_node/compact_vdf_file.py
+++ b/chia/full_node/compact_vdf_file.py
@@ -39,6 +39,24 @@ def compact_vdf_proof(witness: bytes) -> VDFProof:
     return VDFProof(uint8(0), witness, True)
 
 
+def is_compact_vdf_proof(proof: VDFProof) -> bool:
+    return proof.witness_type == 0 and proof.normalized_to_identity
+
+
+def is_fully_compactified_header_block(header_block: HeaderBlock) -> bool:
+    for sub_slot in header_block.finished_sub_slots:
+        if not is_compact_vdf_proof(sub_slot.proofs.challenge_chain_slot_proof):
+            return False
+        icc_proof = sub_slot.proofs.infused_challenge_chain_slot_proof
+        if icc_proof is not None and not is_compact_vdf_proof(icc_proof):
+            return False
+    if header_block.challenge_chain_sp_proof is not None and not is_compact_vdf_proof(
+        header_block.challenge_chain_sp_proof
+    ):
+        return False
+    return is_compact_vdf_proof(header_block.challenge_chain_ip_proof)
+
+
 def _vdf_info_candidates(block: FullBlock | HeaderBlock, field_vdf: CompressibleVDFField) -> list[VDFInfo]:
     if field_vdf == CompressibleVDFField.CC_EOS_VDF:
         return [sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf for sub_slot in block.finished_sub_slots]

--- a/chia/full_node/compact_vdf_file.py
+++ b/chia/full_node/compact_vdf_file.py
@@ -220,6 +220,13 @@ def apply_compact_proof_to_block(
     if field_vdf == CompressibleVDFField.CC_IP_VDF:
         if block.reward_chain_block.challenge_chain_ip_vdf == vdf_info:
             new_block = block.replace(challenge_chain_ip_proof=vdf_proof)
+    if new_block is not None:
+        log.info(
+            "Replaced uncompacted VDF with compact proof for block %s height %s field_vdf %s",
+            block.header_hash,
+            block.height,
+            field_vdf.name,
+        )
     return new_block
 
 

--- a/chia/full_node/compact_vdf_file.py
+++ b/chia/full_node/compact_vdf_file.py
@@ -1,0 +1,461 @@
+"""
+Deferred persistence for compact VDF proofs.
+
+Database writes
+---------------
+Compact VDF handling does write to the DB, but only on startup — not when
+proofs are received.
+
+While the node is running (add_compact_vdf / add_compact_proof_of_time):
+- Updates the block cache only (put_block_in_cache).
+- Appends a line to compactvdf.
+- Does not call replace_proof or touch SQLite.
+
+On the next startup (process_compact_vdf_file):
+- Reads compactvdf, validates and applies each proof.
+- Flushes each block to the DB via block_store.replace_proof() (updates
+  full_blocks.block and is_fully_compactified).
+- Deletes compactvdf when done.
+
+During a single run, callers that read blocks via the block cache (e.g.
+get_all_full_blocks) see compactified proofs immediately. The DB still holds
+the old proofs until restart processes the file.
+
+Runtime (receiving compact VDFs)
+--------------------------------
+When a compact VDF is validated (via add_compact_vdf or add_compact_proof_of_time):
+
+1. The proof is merged into the block in the block cache only (no DB write).
+2. A record is appended to {db_folder}/compactvdf (with a network suffix on
+   testnets, matching the height-to-hash file naming).
+
+Each line is a JSON object with: header_hash, field_vdf, witness (compact proofs
+always use witness_type 0 and normalized_to_identity true). vdf_info is not
+stored; it is recovered from the block at import time.
+
+Multiple VDFs per block
+-----------------------
+A block can have several CC_EOS_VDF or ICC_EOS_VDF entries (one per finished
+sub-slot, and ICC only where infused_challenge_chain is present). CC_SP_VDF and
+CC_IP_VDF are at most one per block.
+
+The file does not use a sub-slot index or other explicit slot ID. Entries with
+the same header_hash and field_vdf are distinguished by witness: each sub-slot
+has a different proof, so each line has different witness bytes.
+
+On import, find_vdf_info_for_proof loads all vdf_info candidates for that
+field_vdf from the block, reconstructs VDFProof(uint8(0), witness, True), and
+validates the witness against each candidate until one matches. That matched
+vdf_info selects which sub-slot (or reward-chain field) apply_compact_proof_to_block
+updates. Slot selection is implicit: the witness is cryptographically bound to
+one sub-slot's vdf_info (challenge, iterations, output).
+
+Startup (near height-to-hash processing)
+----------------------------------------
+Right after BlockHeightMap.create() in full_node.manage():
+
+1. Read all entries from compactvdf.
+2. Sort by block hash and group consecutive entries per block.
+3. For each entry: validate the VDF in parallel (thread pool), then apply proofs
+   to each block sequentially, processing blocks in batches of 1000 to limit memory.
+4. After all entries for a block are processed, flush that block to the DB
+   once via replace_proof.
+5. After all batches complete, checkpoint the WAL into the main database
+   (PRAGMA wal_checkpoint(TRUNCATE)).
+6. Delete the compactvdf file when done.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from itertools import groupby
+from pathlib import Path
+
+import aiofiles
+from chia_rs import ConsensusConstants, FullBlock, HeaderBlock, VDFInfo, VDFProof
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint8
+
+from chia.full_node.block_store import BlockStore
+from chia.types.blockchain_format.classgroup import ClassgroupElement
+from chia.types.blockchain_format.vdf import CompressibleVDFField, validate_vdf
+from chia.util.db_wrapper import DBWrapper2
+from chia.util.priority_thread_pool_executor import Executor
+from chia.util.streamable import Streamable, streamable
+
+log = logging.getLogger(__name__)
+
+COMPACT_VDF_BATCH_SIZE = 1000
+COMPACT_VDF_HEIGHT_CHUNK_SIZE = 10000
+
+
+@streamable
+@dataclass(frozen=True)
+class CompactVdfEntry(Streamable):
+    header_hash: bytes32
+    field_vdf: uint8
+    witness: bytes
+
+
+def compact_vdf_proof(witness: bytes) -> VDFProof:
+    return VDFProof(uint8(0), witness, True)
+
+
+def compact_vdf_filename(blockchain_dir: Path, selected_network: str | None = None) -> Path:
+    suffix = "" if (selected_network is None or selected_network == "mainnet") else f"-{selected_network}"
+    return blockchain_dir / f"compactvdf{suffix}"
+
+
+def _vdf_info_candidates(block: FullBlock | HeaderBlock, field_vdf: CompressibleVDFField) -> list[VDFInfo]:
+    if field_vdf == CompressibleVDFField.CC_EOS_VDF:
+        return [sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf for sub_slot in block.finished_sub_slots]
+    if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
+        return [
+            sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf
+            for sub_slot in block.finished_sub_slots
+            if sub_slot.infused_challenge_chain is not None
+        ]
+    if field_vdf == CompressibleVDFField.CC_SP_VDF:
+        if block.reward_chain_block.challenge_chain_sp_vdf is None:
+            return []
+        return [block.reward_chain_block.challenge_chain_sp_vdf]
+    if field_vdf == CompressibleVDFField.CC_IP_VDF:
+        return [block.reward_chain_block.challenge_chain_ip_vdf]
+    return []
+
+
+def find_vdf_info_for_proof(
+    block: FullBlock | HeaderBlock,
+    field_vdf: CompressibleVDFField,
+    vdf_proof: VDFProof,
+    constants: ConsensusConstants,
+) -> VDFInfo | None:
+    for vdf_info in _vdf_info_candidates(block, field_vdf):
+        if validate_vdf(vdf_proof, constants, ClassgroupElement.get_default_element(), vdf_info):
+            return vdf_info
+    return None
+
+
+def needs_compact_proof(vdf_info: VDFInfo, header_block: HeaderBlock, field_vdf: CompressibleVDFField) -> bool:
+    if field_vdf == CompressibleVDFField.CC_EOS_VDF:
+        for sub_slot in header_block.finished_sub_slots:
+            if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
+                if (
+                    sub_slot.proofs.challenge_chain_slot_proof.witness_type == 0
+                    and sub_slot.proofs.challenge_chain_slot_proof.normalized_to_identity
+                ):
+                    return False
+                return True
+    if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
+        for sub_slot in header_block.finished_sub_slots:
+            if (
+                sub_slot.infused_challenge_chain is not None
+                and sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf == vdf_info
+            ):
+                assert sub_slot.proofs.infused_challenge_chain_slot_proof is not None
+                if (
+                    sub_slot.proofs.infused_challenge_chain_slot_proof.witness_type == 0
+                    and sub_slot.proofs.infused_challenge_chain_slot_proof.normalized_to_identity
+                ):
+                    return False
+                return True
+    if field_vdf == CompressibleVDFField.CC_SP_VDF:
+        if header_block.reward_chain_block.challenge_chain_sp_vdf is None:
+            return False
+        if vdf_info == header_block.reward_chain_block.challenge_chain_sp_vdf:
+            assert header_block.challenge_chain_sp_proof is not None
+            if (
+                header_block.challenge_chain_sp_proof.witness_type == 0
+                and header_block.challenge_chain_sp_proof.normalized_to_identity
+            ):
+                return False
+            return True
+    if field_vdf == CompressibleVDFField.CC_IP_VDF:
+        if vdf_info == header_block.reward_chain_block.challenge_chain_ip_vdf:
+            if (
+                header_block.challenge_chain_ip_proof.witness_type == 0
+                and header_block.challenge_chain_ip_proof.normalized_to_identity
+            ):
+                return False
+            return True
+    return False
+
+
+def apply_compact_proof_to_block(
+    block: FullBlock,
+    vdf_info: VDFInfo,
+    vdf_proof: VDFProof,
+    field_vdf: CompressibleVDFField,
+) -> FullBlock | None:
+    new_block = None
+
+    if field_vdf == CompressibleVDFField.CC_EOS_VDF:
+        for index, sub_slot in enumerate(block.finished_sub_slots):
+            if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
+                new_proofs = sub_slot.proofs.replace(challenge_chain_slot_proof=vdf_proof)
+                new_subslot = sub_slot.replace(proofs=new_proofs)
+                new_finished_subslots = block.finished_sub_slots
+                new_finished_subslots[index] = new_subslot
+                new_block = block.replace(finished_sub_slots=new_finished_subslots)
+                break
+    if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
+        for index, sub_slot in enumerate(block.finished_sub_slots):
+            if (
+                sub_slot.infused_challenge_chain is not None
+                and sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf == vdf_info
+            ):
+                new_proofs = sub_slot.proofs.replace(infused_challenge_chain_slot_proof=vdf_proof)
+                new_subslot = sub_slot.replace(proofs=new_proofs)
+                new_finished_subslots = block.finished_sub_slots
+                new_finished_subslots[index] = new_subslot
+                new_block = block.replace(finished_sub_slots=new_finished_subslots)
+                break
+    if field_vdf == CompressibleVDFField.CC_SP_VDF:
+        if block.reward_chain_block.challenge_chain_sp_vdf == vdf_info:
+            assert block.challenge_chain_sp_proof is not None
+            new_block = block.replace(challenge_chain_sp_proof=vdf_proof)
+    if field_vdf == CompressibleVDFField.CC_IP_VDF:
+        if block.reward_chain_block.challenge_chain_ip_vdf == vdf_info:
+            new_block = block.replace(challenge_chain_ip_proof=vdf_proof)
+    return new_block
+
+
+def _entry_from_json_dict(data: dict[str, object]) -> CompactVdfEntry:
+    if "witness" in data:
+        return CompactVdfEntry.from_json_dict(data)
+    vdf_proof = data.get("vdf_proof")
+    if isinstance(vdf_proof, dict) and "witness" in vdf_proof:
+        return CompactVdfEntry.from_json_dict(
+            {
+                "header_hash": data["header_hash"],
+                "field_vdf": data["field_vdf"],
+                "witness": vdf_proof["witness"],
+            }
+        )
+    raise ValueError("missing witness")
+
+
+def _parse_entries(text: str) -> list[CompactVdfEntry]:
+    entries: list[CompactVdfEntry] = []
+    for line_no, line in enumerate(text.splitlines(), 1):
+        stripped = line.strip()
+        if len(stripped) == 0:
+            continue
+        try:
+            entries.append(_entry_from_json_dict(json.loads(stripped)))
+        except Exception as e:
+            log.warning(f"Skipping invalid compactvdf line {line_no}: {e}")
+    return entries
+
+
+def parse_compact_vdf_entries(text: str) -> list[CompactVdfEntry]:
+    return _parse_entries(text)
+
+
+async def read_all_entries(path: Path) -> list[CompactVdfEntry]:
+    try:
+        async with aiofiles.open(path, encoding="utf-8") as f:
+            text = await f.read()
+    except FileNotFoundError:
+        return []
+    if len(text) == 0:
+        return []
+    return _parse_entries(text)
+
+
+async def append_entry(path: Path, entry: CompactVdfEntry, lock: asyncio.Lock) -> None:
+    line = json.dumps(entry.to_json_dict(), sort_keys=True) + "\n"
+    async with lock:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        async with aiofiles.open(path, "a", encoding="utf-8") as f:
+            await f.write(line)
+
+
+async def _wal_checkpoint_truncate(db_wrapper: DBWrapper2) -> float:
+    start = time.monotonic()
+    async with db_wrapper.writer() as conn:
+        async with conn.execute("PRAGMA wal_checkpoint(TRUNCATE)") as cursor:
+            await cursor.fetchone()
+    return time.monotonic() - start
+
+
+def _ordered_unique_header_hashes(entries: list[CompactVdfEntry]) -> list[bytes32]:
+    unique: list[bytes32] = []
+    seen: set[bytes32] = set()
+    for entry in entries:
+        if entry.header_hash not in seen:
+            seen.add(entry.header_hash)
+            unique.append(entry.header_hash)
+    return unique
+
+
+async def _process_compact_vdf_batch(
+    batch_entries: list[CompactVdfEntry],
+    block_store: BlockStore,
+    constants: ConsensusConstants,
+    pool: Executor,
+    blocks_total: int,
+    blocks_processed: int,
+) -> tuple[int, int, float, float, float]:
+    batch_hashes = {entry.header_hash for entry in batch_entries}
+    blocks: dict[bytes32, FullBlock] = {}
+    db_read_seconds = 0.0
+    for header_hash in batch_hashes:
+        db_read_start = time.monotonic()
+        block = await block_store.get_full_block(header_hash)
+        db_read_seconds += time.monotonic() - db_read_start
+        if block is None:
+            log.error(f"Can't find block for pending compact VDF. Header hash: {header_hash}")
+            continue
+        log.info(f"Read block height {block.height} header_hash {header_hash}")
+        blocks[header_hash] = block
+
+    validation_futures: list[asyncio.Future[VDFInfo | None]] = []
+    validation_entries: list[CompactVdfEntry] = []
+    deduped_batch_entries: list[CompactVdfEntry] = []
+    seen_entry_keys: set[tuple[bytes32, bytes, uint8]] = set()
+    for entry in batch_entries:
+        entry_key = (entry.header_hash, entry.witness, entry.field_vdf)
+        if entry_key in seen_entry_keys:
+            log.debug(
+                f"Skipping duplicate compact VDF entry for block {entry.header_hash} "
+                f"field_vdf {entry.field_vdf}"
+            )
+            continue
+        seen_entry_keys.add(entry_key)
+        deduped_batch_entries.append(entry)
+        block = blocks.get(entry.header_hash)
+        if block is None:
+            continue
+        field_vdf = CompressibleVDFField(int(entry.field_vdf))
+        vdf_proof = compact_vdf_proof(entry.witness)
+        validation_futures.append(
+            pool.run_in_loop(find_vdf_info_for_proof, block, field_vdf, vdf_proof, constants)
+        )
+        validation_entries.append(entry)
+
+    vdf_start = time.monotonic()
+    validation_results: list[VDFInfo | None] = []
+    if len(validation_futures) > 0:
+        validation_results = list(await asyncio.gather(*validation_futures))
+    vdf_seconds = time.monotonic() - vdf_start
+
+    entry_vdf_info: dict[tuple[bytes32, bytes, uint8], VDFInfo | None] = {}
+    for entry, vdf_info in zip(validation_entries, validation_results, strict=True):
+        entry_vdf_info[(entry.header_hash, entry.witness, entry.field_vdf)] = vdf_info
+
+    entries_applied = 0
+    db_flush_seconds = 0.0
+    for header_hash, group_iter in groupby(deduped_batch_entries, key=lambda entry: entry.header_hash):
+        block_entries = list(group_iter)
+        block = blocks.get(header_hash)
+        if block is None:
+            continue
+
+        applied_for_block = 0
+        for entry in block_entries:
+            field_vdf = CompressibleVDFField(int(entry.field_vdf))
+            vdf_proof = compact_vdf_proof(entry.witness)
+            vdf_info = entry_vdf_info.get((entry.header_hash, entry.witness, entry.field_vdf))
+            if vdf_info is None:
+                log.error(f"Pending compact VDF proof is not valid for block {header_hash}")
+                continue
+            if not needs_compact_proof(vdf_info, block, field_vdf):
+                log.info(f"Duplicate pending compact proof for block {header_hash}")
+                continue
+            new_block = apply_compact_proof_to_block(block, vdf_info, vdf_proof, field_vdf)
+            if new_block is None:
+                log.error(f"Could not apply pending compact proof for block {header_hash}")
+                continue
+            block = new_block
+            applied_for_block += 1
+            entries_applied += 1
+
+        blocks_processed += 1
+        progress_msg = (
+            f"Processed block {blocks_processed}/{blocks_total} "
+            f"height {block.height} header_hash {header_hash} "
+            f"applied {applied_for_block}/{len(block_entries)} proofs, flushing to DB"
+        )
+        log.info(progress_msg)
+        db_flush_start = time.monotonic()
+        async with block_store.db_wrapper.writer():
+            await block_store.replace_proof(header_hash, block)
+        db_flush_seconds += time.monotonic() - db_flush_start
+
+    return blocks_processed, entries_applied, vdf_seconds, db_read_seconds, db_flush_seconds
+
+
+async def process_compact_vdf_file(
+    path: Path,
+    block_store: BlockStore,
+    constants: ConsensusConstants,
+    pool: Executor,
+) -> None:
+    entries = await read_all_entries(path)
+    if len(entries) == 0:
+        if path.exists():
+            path.unlink()
+        return
+
+    entries.sort(key=lambda entry: entry.header_hash)
+    unique_header_hashes = _ordered_unique_header_hashes(entries)
+    blocks_total = len(unique_header_hashes)
+    start_time = time.monotonic()
+    log.info(
+        f"Starting compact VDF file processing: {len(entries)} entries "
+        f"across {blocks_total} blocks from {path}"
+    )
+    blocks_processed = 0
+    entries_applied = 0
+    vdf_seconds = 0.0
+    db_read_seconds = 0.0
+    db_flush_seconds = 0.0
+
+    num_batches = (blocks_total + COMPACT_VDF_BATCH_SIZE - 1) // COMPACT_VDF_BATCH_SIZE
+    for batch_index in range(num_batches):
+        batch_start = batch_index * COMPACT_VDF_BATCH_SIZE
+        batch_hash_set = set(unique_header_hashes[batch_start : batch_start + COMPACT_VDF_BATCH_SIZE])
+        batch_entries = [entry for entry in entries if entry.header_hash in batch_hash_set]
+        log.info(
+            f"Compact VDF batch {batch_index + 1}/{num_batches}: "
+            f"{len(batch_hash_set)} blocks, {len(batch_entries)} entries"
+        )
+        (
+            blocks_processed,
+            batch_entries_applied,
+            batch_vdf_seconds,
+            batch_db_read_seconds,
+            batch_db_flush_seconds,
+        ) = await _process_compact_vdf_batch(
+            batch_entries,
+            block_store,
+            constants,
+            pool,
+            blocks_total,
+            blocks_processed,
+        )
+        entries_applied += batch_entries_applied
+        vdf_seconds += batch_vdf_seconds
+        db_read_seconds += batch_db_read_seconds
+        db_flush_seconds += batch_db_flush_seconds
+
+    wal_checkpoint_seconds = 0.0
+    if blocks_processed > 0:
+        wal_checkpoint_seconds = await _wal_checkpoint_truncate(block_store.db_wrapper)
+
+    path.unlink()
+    elapsed = time.monotonic() - start_time
+    other_seconds = max(
+        0.0, elapsed - vdf_seconds - db_read_seconds - db_flush_seconds - wal_checkpoint_seconds
+    )
+    log.info(
+        f"Finished processing compact VDF file: {entries_applied} proofs applied "
+        f"across {blocks_processed} blocks, time taken: {elapsed:.2f}s "
+        f"(vdf {vdf_seconds:.2f}s, db read {db_read_seconds:.2f}s, "
+        f"db flush {db_flush_seconds:.2f}s, wal checkpoint {wal_checkpoint_seconds:.2f}s, "
+        f"other {other_seconds:.2f}s), removed {path}"
+    )

--- a/chia/full_node/compact_vdf_file.py
+++ b/chia/full_node/compact_vdf_file.py
@@ -176,7 +176,7 @@ def apply_compact_proof_to_block(
             if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
                 new_proofs = sub_slot.proofs.replace(challenge_chain_slot_proof=vdf_proof)
                 new_subslot = sub_slot.replace(proofs=new_proofs)
-                new_finished_subslots = block.finished_sub_slots
+                new_finished_subslots = list(block.finished_sub_slots)
                 new_finished_subslots[index] = new_subslot
                 new_block = block.replace(finished_sub_slots=new_finished_subslots)
                 break
@@ -188,7 +188,7 @@ def apply_compact_proof_to_block(
             ):
                 new_proofs = sub_slot.proofs.replace(infused_challenge_chain_slot_proof=vdf_proof)
                 new_subslot = sub_slot.replace(proofs=new_proofs)
-                new_finished_subslots = block.finished_sub_slots
+                new_finished_subslots = list(block.finished_sub_slots)
                 new_finished_subslots[index] = new_subslot
                 new_block = block.replace(finished_sub_slots=new_finished_subslots)
                 break

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -64,6 +64,7 @@ from chia.full_node.mempool import MempoolRemoveInfo
 from chia.full_node.mempool_manager import MempoolManager
 from chia.full_node.remote_compact_vdf import (
     DEFAULT_REMOTE_COMPACT_VDF_BASE_URL,
+    apply_compact_vdf_entries,
     fetch_remote_compact_vdf_entries,
 )
 from chia.full_node.subscriptions import PeerSubscriptions, peers_for_spend_bundle
@@ -193,6 +194,10 @@ class FullNode:
         if url is None:
             return None
         return await fetch_remote_compact_vdf_entries(url, height)
+
+    async def block_with_remote_compact_vdfs(self, block: FullBlock) -> FullBlock:
+        entries = await self.prefetch_remote_compact_vdf_entries(block.height)
+        return await apply_compact_vdf_entries(self.constants, block, entries, self.pool)
 
     @property
     def server(self) -> ChiaServer:
@@ -1417,16 +1422,12 @@ class FullNode:
 
                     first_batch = False
 
-                    futures: list[Awaitable[PreValidationResult]] = []
-                    for block in blocks_to_validate:
-                        futures.extend(
-                            await self.prevalidate_blocks(
-                                blockchain,
-                                [block],
-                                vs,
-                                summaries,
-                            )
-                        )
+                    futures = await self.prevalidate_blocks(
+                        blockchain,
+                        blocks_to_validate,
+                        vs,
+                        summaries,
+                    )
                     start = time.monotonic()
                     await output_queue.put((peer, next_validation_state, list(futures), blocks_to_validate))
                     end = time.monotonic()
@@ -1722,19 +1723,18 @@ class FullNode:
         # call below. pre_validate_block() will update the
         # object we pass in.
         ret: list[Awaitable[PreValidationResult]] = []
-        for block in blocks_to_validate:
-            remote_compact_vdf_entries = await self.prefetch_remote_compact_vdf_entries(block.height)
+        for i, block in enumerate(blocks_to_validate):
+            blocks_to_validate[i] = await self.block_with_remote_compact_vdfs(block)
             ret.append(
                 await pre_validate_block(
                     self.constants,
                     blockchain,
-                    block,
+                    blocks_to_validate[i],
                     self.pool,
                     None,
                     vs,
                     wp_summaries=wp_summaries,
                     nice=(20,),
-                    remote_compact_vdf_entries=remote_compact_vdf_entries,
                 )
             )
         return ret
@@ -2254,7 +2254,7 @@ class FullNode:
                 return await self.add_block(new_block, peer, bls_cache)
         state_change_summary: StateChangeSummary | None = None
         ppp_result: PeakPostProcessingResult | None = None
-        remote_compact_vdf_entries = await self.prefetch_remote_compact_vdf_entries(block.height)
+        block = await self.block_with_remote_compact_vdfs(block)
         async with (
             self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high),
             enable_profiler(self.profile_block_validation) as pr,
@@ -2291,7 +2291,6 @@ class FullNode:
                 self.pool,
                 conds,
                 ValidationState(ssi, diff, prev_ses_block),
-                remote_compact_vdf_entries=remote_compact_vdf_entries,
             )
             pre_validation_result = await future
             added: AddBlockResult | None = None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -53,6 +53,7 @@ from chia.consensus.multiprocess_validation import PreValidationResult, pre_vali
 from chia.consensus.pot_iterations import calculate_sp_iters
 from chia.consensus.signage_point import SignagePoint
 from chia.full_node.block_store import BlockStore
+from chia.full_node.compact_vdf_file import CompactVdfEntry
 from chia.full_node.check_fork_next_block import check_fork_next_block
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.full_node_api import FullNodeAPI
@@ -61,7 +62,10 @@ from chia.full_node.hint_management import get_hints_and_subscription_coin_ids
 from chia.full_node.hint_store import HintStore
 from chia.full_node.mempool import MempoolRemoveInfo
 from chia.full_node.mempool_manager import MempoolManager
-from chia.full_node.remote_compact_vdf import DEFAULT_REMOTE_COMPACT_VDF_BASE_URL
+from chia.full_node.remote_compact_vdf import (
+    DEFAULT_REMOTE_COMPACT_VDF_BASE_URL,
+    fetch_remote_compact_vdf_entries,
+)
 from chia.full_node.subscriptions import PeerSubscriptions, peers_for_spend_bundle
 from chia.full_node.sync_store import Peak, SyncStore
 from chia.full_node.tx_processing_queue import PeerWithTx, TransactionQueue, TransactionQueueEntry
@@ -183,6 +187,12 @@ class FullNode:
         if url is None or url == "":
             return None
         return str(url)
+
+    async def prefetch_remote_compact_vdf_entries(self, height: uint32) -> list[CompactVdfEntry] | None:
+        url = self.remote_compact_vdf_base_url()
+        if url is None:
+            return None
+        return await fetch_remote_compact_vdf_entries(url, height)
 
     @property
     def server(self) -> ChiaServer:
@@ -1713,6 +1723,7 @@ class FullNode:
         # object we pass in.
         ret: list[Awaitable[PreValidationResult]] = []
         for block in blocks_to_validate:
+            remote_compact_vdf_entries = await self.prefetch_remote_compact_vdf_entries(block.height)
             ret.append(
                 await pre_validate_block(
                     self.constants,
@@ -1723,7 +1734,7 @@ class FullNode:
                     vs,
                     wp_summaries=wp_summaries,
                     nice=(20,),
-                    remote_compact_vdf_base_url=self.remote_compact_vdf_base_url(),
+                    remote_compact_vdf_entries=remote_compact_vdf_entries,
                 )
             )
         return ret
@@ -2243,6 +2254,7 @@ class FullNode:
                 return await self.add_block(new_block, peer, bls_cache)
         state_change_summary: StateChangeSummary | None = None
         ppp_result: PeakPostProcessingResult | None = None
+        remote_compact_vdf_entries = await self.prefetch_remote_compact_vdf_entries(block.height)
         async with (
             self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high),
             enable_profiler(self.profile_block_validation) as pr,
@@ -2279,7 +2291,7 @@ class FullNode:
                 self.pool,
                 conds,
                 ValidationState(ssi, diff, prev_ses_block),
-                remote_compact_vdf_base_url=self.remote_compact_vdf_base_url(),
+                remote_compact_vdf_entries=remote_compact_vdf_entries,
             )
             pre_validation_result = await future
             added: AddBlockResult | None = None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -53,7 +53,7 @@ from chia.consensus.multiprocess_validation import PreValidationResult, pre_vali
 from chia.consensus.pot_iterations import calculate_sp_iters
 from chia.consensus.signage_point import SignagePoint
 from chia.full_node.block_store import BlockStore
-from chia.full_node.compact_vdf_file import CompactVdfEntry
+from chia.full_node.compact_vdf_file import CompactVdfEntry, apply_compact_proof_to_block
 from chia.full_node.check_fork_next_block import check_fork_next_block
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.full_node_api import FullNodeAPI
@@ -3267,36 +3267,7 @@ class FullNode:
         if block is None:
             return False
 
-        new_block = None
-
-        if field_vdf == CompressibleVDFField.CC_EOS_VDF:
-            for index, sub_slot in enumerate(block.finished_sub_slots):
-                if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
-                    new_proofs = sub_slot.proofs.replace(challenge_chain_slot_proof=vdf_proof)
-                    new_subslot = sub_slot.replace(proofs=new_proofs)
-                    new_finished_subslots = block.finished_sub_slots
-                    new_finished_subslots[index] = new_subslot
-                    new_block = block.replace(finished_sub_slots=new_finished_subslots)
-                    break
-        if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
-            for index, sub_slot in enumerate(block.finished_sub_slots):
-                if (
-                    sub_slot.infused_challenge_chain is not None
-                    and sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf == vdf_info
-                ):
-                    new_proofs = sub_slot.proofs.replace(infused_challenge_chain_slot_proof=vdf_proof)
-                    new_subslot = sub_slot.replace(proofs=new_proofs)
-                    new_finished_subslots = block.finished_sub_slots
-                    new_finished_subslots[index] = new_subslot
-                    new_block = block.replace(finished_sub_slots=new_finished_subslots)
-                    break
-        if field_vdf == CompressibleVDFField.CC_SP_VDF:
-            if block.reward_chain_block.challenge_chain_sp_vdf == vdf_info:
-                assert block.challenge_chain_sp_proof is not None
-                new_block = block.replace(challenge_chain_sp_proof=vdf_proof)
-        if field_vdf == CompressibleVDFField.CC_IP_VDF:
-            if block.reward_chain_block.challenge_chain_ip_vdf == vdf_info:
-                new_block = block.replace(challenge_chain_ip_proof=vdf_proof)
+        new_block = apply_compact_proof_to_block(block, vdf_info, vdf_proof, field_vdf)
         if new_block is None:
             return False
         async with self.db_wrapper.writer():

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -53,15 +53,6 @@ from chia.consensus.multiprocess_validation import PreValidationResult, pre_vali
 from chia.consensus.pot_iterations import calculate_sp_iters
 from chia.consensus.signage_point import SignagePoint
 from chia.full_node.block_store import BlockStore
-from chia.full_node.compact_vdf_file import (
-    CompactVdfEntry,
-    append_entry,
-    apply_compact_proof_to_block,
-    compact_vdf_filename,
-    needs_compact_proof,
-    process_compact_vdf_file,
-)
-from chia.full_node.remote_compact_vdf import DEFAULT_REMOTE_COMPACT_VDF_BASE_URL
 from chia.full_node.check_fork_next_block import check_fork_next_block
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.full_node_api import FullNodeAPI
@@ -70,6 +61,7 @@ from chia.full_node.hint_management import get_hints_and_subscription_coin_ids
 from chia.full_node.hint_store import HintStore
 from chia.full_node.mempool import MempoolRemoveInfo
 from chia.full_node.mempool_manager import MempoolManager
+from chia.full_node.remote_compact_vdf import DEFAULT_REMOTE_COMPACT_VDF_BASE_URL
 from chia.full_node.subscriptions import PeerSubscriptions, peers_for_spend_bundle
 from chia.full_node.sync_store import Peak, SyncStore
 from chia.full_node.tx_processing_queue import PeerWithTx, TransactionQueue, TransactionQueueEntry
@@ -168,7 +160,6 @@ class FullNode:
     _transaction_queue: TransactionQueue | None = None
     _tx_task_list: list[asyncio.Task[None]] = dataclasses.field(default_factory=list)
     _compact_vdf_sem: LimitedSemaphore | None = None
-    _compact_vdf_file_lock: asyncio.Lock | None = None
     _new_peak_sem: LimitedSemaphore | None = None
     _sp_catchup_sem: LimitedSemaphore | None = None
     _add_transaction_semaphore: asyncio.Semaphore | None = None
@@ -230,7 +221,6 @@ class FullNode:
     async def manage(self) -> AsyncIterator[None]:
         self._timelord_lock = asyncio.Lock()
         self._compact_vdf_sem = LimitedSemaphore.create(active_limit=4, waiting_limit=20)
-        self._compact_vdf_file_lock = asyncio.Lock()
 
         # We don't want to run too many concurrent new_peak instances, because it would fetch the same block from
         # multiple peers and re-validate.
@@ -310,12 +300,6 @@ class FullNode:
                 self.log.info(f"Started {num_workers} threads for validation ({dedicated} dedicated)")
             selected_network = self.config.get("selected_network")
             height_map = await BlockHeightMap.create(self.db_path.parent, self._db_wrapper, selected_network)
-            await process_compact_vdf_file(
-                compact_vdf_filename(self.db_path.parent, selected_network),
-                self.block_store,
-                self.constants,
-                self.pool,
-            )
             self._blockchain = await Blockchain.create(
                 coin_store=self.coin_store,
                 block_store=self.block_store,
@@ -3179,7 +3163,48 @@ class FullNode:
     async def _needs_compact_proof(
         self, vdf_info: VDFInfo, header_block: HeaderBlock, field_vdf: CompressibleVDFField
     ) -> bool:
-        return needs_compact_proof(vdf_info, header_block, field_vdf)
+        if field_vdf == CompressibleVDFField.CC_EOS_VDF:
+            for sub_slot in header_block.finished_sub_slots:
+                if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
+                    if (
+                        sub_slot.proofs.challenge_chain_slot_proof.witness_type == 0
+                        and sub_slot.proofs.challenge_chain_slot_proof.normalized_to_identity
+                    ):
+                        return False
+                    return True
+        if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
+            for sub_slot in header_block.finished_sub_slots:
+                if (
+                    sub_slot.infused_challenge_chain is not None
+                    and sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf == vdf_info
+                ):
+                    assert sub_slot.proofs.infused_challenge_chain_slot_proof is not None
+                    if (
+                        sub_slot.proofs.infused_challenge_chain_slot_proof.witness_type == 0
+                        and sub_slot.proofs.infused_challenge_chain_slot_proof.normalized_to_identity
+                    ):
+                        return False
+                    return True
+        if field_vdf == CompressibleVDFField.CC_SP_VDF:
+            if header_block.reward_chain_block.challenge_chain_sp_vdf is None:
+                return False
+            if vdf_info == header_block.reward_chain_block.challenge_chain_sp_vdf:
+                assert header_block.challenge_chain_sp_proof is not None
+                if (
+                    header_block.challenge_chain_sp_proof.witness_type == 0
+                    and header_block.challenge_chain_sp_proof.normalized_to_identity
+                ):
+                    return False
+                return True
+        if field_vdf == CompressibleVDFField.CC_IP_VDF:
+            if vdf_info == header_block.reward_chain_block.challenge_chain_ip_vdf:
+                if (
+                    header_block.challenge_chain_ip_proof.witness_type == 0
+                    and header_block.challenge_chain_ip_proof.normalized_to_identity
+                ):
+                    return False
+                return True
+        return False
 
     async def _can_accept_compact_proof(
         self,
@@ -3195,7 +3220,7 @@ class FullNode:
         - Checks if the provided vdf_info is correct, assuming it refers to the start of sub-slot.
         - Checks if the existing proof was non-compact. Ignore this proof if we already have a compact proof.
         """
-        is_fully_compactified = await self.block_store.is_fully_compactified_effective(header_hash)
+        is_fully_compactified = await self.block_store.is_fully_compactified(header_hash)
         if is_fully_compactified is None or is_fully_compactified:
             self.log.info(f"Already compactified block: {header_hash}. Ignoring.")
             return False
@@ -3219,7 +3244,7 @@ class FullNode:
         return is_new_proof
 
     # returns True if we ended up replacing the proof, and False otherwise
-    async def _merge_compact_proof_to_cache(
+    async def _replace_proof(
         self,
         vdf_info: VDFInfo,
         vdf_proof: VDFProof,
@@ -3230,18 +3255,48 @@ class FullNode:
         if block is None:
             return False
 
-        new_block = apply_compact_proof_to_block(block, vdf_info, vdf_proof, field_vdf)
+        new_block = None
+
+        if field_vdf == CompressibleVDFField.CC_EOS_VDF:
+            for index, sub_slot in enumerate(block.finished_sub_slots):
+                if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
+                    new_proofs = sub_slot.proofs.replace(challenge_chain_slot_proof=vdf_proof)
+                    new_subslot = sub_slot.replace(proofs=new_proofs)
+                    new_finished_subslots = block.finished_sub_slots
+                    new_finished_subslots[index] = new_subslot
+                    new_block = block.replace(finished_sub_slots=new_finished_subslots)
+                    break
+        if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
+            for index, sub_slot in enumerate(block.finished_sub_slots):
+                if (
+                    sub_slot.infused_challenge_chain is not None
+                    and sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf == vdf_info
+                ):
+                    new_proofs = sub_slot.proofs.replace(infused_challenge_chain_slot_proof=vdf_proof)
+                    new_subslot = sub_slot.replace(proofs=new_proofs)
+                    new_finished_subslots = block.finished_sub_slots
+                    new_finished_subslots[index] = new_subslot
+                    new_block = block.replace(finished_sub_slots=new_finished_subslots)
+                    break
+        if field_vdf == CompressibleVDFField.CC_SP_VDF:
+            if block.reward_chain_block.challenge_chain_sp_vdf == vdf_info:
+                assert block.challenge_chain_sp_proof is not None
+                new_block = block.replace(challenge_chain_sp_proof=vdf_proof)
+        if field_vdf == CompressibleVDFField.CC_IP_VDF:
+            if block.reward_chain_block.challenge_chain_ip_vdf == vdf_info:
+                new_block = block.replace(challenge_chain_ip_proof=vdf_proof)
         if new_block is None:
             return False
-
-        self.block_store.put_block_in_cache(header_hash, new_block)
-        assert self._compact_vdf_file_lock is not None
-        await append_entry(
-            compact_vdf_filename(self.db_path.parent, self.config.get("selected_network")),
-            CompactVdfEntry(header_hash, uint8(field_vdf), vdf_proof.witness),
-            self._compact_vdf_file_lock,
-        )
-        return True
+        async with self.db_wrapper.writer():
+            try:
+                await self.block_store.replace_proof(header_hash, new_block)
+                return True
+            except BaseException as e:
+                self.log.error(
+                    f"_replace_proof error while adding block {block.header_hash} height {block.height},"
+                    f" rolling back: {e} {traceback.format_exc()}"
+                )
+                raise
 
     async def add_compact_proof_of_time(self, request: timelord_protocol.RespondCompactProofOfTime) -> None:
         peak = self.blockchain.get_peak()
@@ -3255,9 +3310,7 @@ class FullNode:
         ):
             return None
         async with self.blockchain.compact_proof_lock:
-            replaced = await self._merge_compact_proof_to_cache(
-                request.vdf_info, request.vdf_proof, request.header_hash, field_vdf
-            )
+            replaced = await self._replace_proof(request.vdf_info, request.vdf_proof, request.header_hash, field_vdf)
         if not replaced:
             self.log.error(f"Could not replace compact proof: {request.height}")
             return None
@@ -3274,7 +3327,7 @@ class FullNode:
         if peak is None or peak.height - request.height < 5:
             self.log.info(f"Ignoring new_compact_vdf, height {request.height} too recent.")
             return None
-        is_fully_compactified = await self.block_store.is_fully_compactified_effective(request.header_hash)
+        is_fully_compactified = await self.block_store.is_fully_compactified(request.header_hash)
         if is_fully_compactified is None or is_fully_compactified:
             return None
         header_block = await self.blockchain.get_header_block_by_height(
@@ -3344,9 +3397,7 @@ class FullNode:
         async with self.blockchain.compact_proof_lock:
             if self.blockchain.seen_compact_proofs(request.vdf_info, request.height):
                 return None
-            replaced = await self._merge_compact_proof_to_cache(
-                request.vdf_info, request.vdf_proof, request.header_hash, field_vdf
-            )
+            replaced = await self._replace_proof(request.vdf_info, request.vdf_proof, request.header_hash, field_vdf)
         if not replaced:
             self.log.error(f"Could not replace compact proof: {request.height}")
             return None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1422,12 +1422,19 @@ class FullNode:
 
                     first_batch = False
 
-                    futures = await self.prevalidate_blocks(
-                        blockchain,
-                        blocks_to_validate,
-                        vs,
-                        summaries,
-                    )
+                    for i in range(len(blocks_to_validate)):
+                        blocks_to_validate[i] = await self.block_with_remote_compact_vdfs(blocks_to_validate[i])
+
+                    futures: list[Awaitable[PreValidationResult]] = []
+                    for block in blocks_to_validate:
+                        futures.extend(
+                            await self.prevalidate_blocks(
+                                blockchain,
+                                [block],
+                                vs,
+                                summaries,
+                            )
+                        )
                     start = time.monotonic()
                     await output_queue.put((peer, next_validation_state, list(futures), blocks_to_validate))
                     end = time.monotonic()
@@ -1723,13 +1730,12 @@ class FullNode:
         # call below. pre_validate_block() will update the
         # object we pass in.
         ret: list[Awaitable[PreValidationResult]] = []
-        for i, block in enumerate(blocks_to_validate):
-            blocks_to_validate[i] = await self.block_with_remote_compact_vdfs(block)
+        for block in blocks_to_validate:
             ret.append(
                 await pre_validate_block(
                     self.constants,
                     blockchain,
-                    blocks_to_validate[i],
+                    block,
                     self.pool,
                     None,
                     vs,

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -53,6 +53,15 @@ from chia.consensus.multiprocess_validation import PreValidationResult, pre_vali
 from chia.consensus.pot_iterations import calculate_sp_iters
 from chia.consensus.signage_point import SignagePoint
 from chia.full_node.block_store import BlockStore
+from chia.full_node.compact_vdf_file import (
+    CompactVdfEntry,
+    append_entry,
+    apply_compact_proof_to_block,
+    compact_vdf_filename,
+    needs_compact_proof,
+    process_compact_vdf_file,
+)
+from chia.full_node.remote_compact_vdf import DEFAULT_REMOTE_COMPACT_VDF_BASE_URL
 from chia.full_node.check_fork_next_block import check_fork_next_block
 from chia.full_node.coin_store import CoinStore
 from chia.full_node.full_node_api import FullNodeAPI
@@ -159,6 +168,7 @@ class FullNode:
     _transaction_queue: TransactionQueue | None = None
     _tx_task_list: list[asyncio.Task[None]] = dataclasses.field(default_factory=list)
     _compact_vdf_sem: LimitedSemaphore | None = None
+    _compact_vdf_file_lock: asyncio.Lock | None = None
     _new_peak_sem: LimitedSemaphore | None = None
     _sp_catchup_sem: LimitedSemaphore | None = None
     _add_transaction_semaphore: asyncio.Semaphore | None = None
@@ -176,6 +186,12 @@ class FullNode:
     bad_peak_cache: dict[bytes32, uint32] = dataclasses.field(default_factory=dict)
     wallet_sync_task: asyncio.Task[None] | None = None
     _bls_cache: BLSCache = dataclasses.field(default_factory=lambda: BLSCache(50000))
+
+    def remote_compact_vdf_base_url(self) -> str | None:
+        url = self.config.get("remote_compact_vdf_base_url", DEFAULT_REMOTE_COMPACT_VDF_BASE_URL)
+        if url is None or url == "":
+            return None
+        return str(url)
 
     @property
     def server(self) -> ChiaServer:
@@ -214,6 +230,7 @@ class FullNode:
     async def manage(self) -> AsyncIterator[None]:
         self._timelord_lock = asyncio.Lock()
         self._compact_vdf_sem = LimitedSemaphore.create(active_limit=4, waiting_limit=20)
+        self._compact_vdf_file_lock = asyncio.Lock()
 
         # We don't want to run too many concurrent new_peak instances, because it would fetch the same block from
         # multiple peers and re-validate.
@@ -293,6 +310,12 @@ class FullNode:
                 self.log.info(f"Started {num_workers} threads for validation ({dedicated} dedicated)")
             selected_network = self.config.get("selected_network")
             height_map = await BlockHeightMap.create(self.db_path.parent, self._db_wrapper, selected_network)
+            await process_compact_vdf_file(
+                compact_vdf_filename(self.db_path.parent, selected_network),
+                self.block_store,
+                self.constants,
+                self.pool,
+            )
             self._blockchain = await Blockchain.create(
                 coin_store=self.coin_store,
                 block_store=self.block_store,
@@ -1716,6 +1739,7 @@ class FullNode:
                     vs,
                     wp_summaries=wp_summaries,
                     nice=(20,),
+                    remote_compact_vdf_base_url=self.remote_compact_vdf_base_url(),
                 )
             )
         return ret
@@ -2271,6 +2295,7 @@ class FullNode:
                 self.pool,
                 conds,
                 ValidationState(ssi, diff, prev_ses_block),
+                remote_compact_vdf_base_url=self.remote_compact_vdf_base_url(),
             )
             pre_validation_result = await future
             added: AddBlockResult | None = None
@@ -3154,48 +3179,7 @@ class FullNode:
     async def _needs_compact_proof(
         self, vdf_info: VDFInfo, header_block: HeaderBlock, field_vdf: CompressibleVDFField
     ) -> bool:
-        if field_vdf == CompressibleVDFField.CC_EOS_VDF:
-            for sub_slot in header_block.finished_sub_slots:
-                if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
-                    if (
-                        sub_slot.proofs.challenge_chain_slot_proof.witness_type == 0
-                        and sub_slot.proofs.challenge_chain_slot_proof.normalized_to_identity
-                    ):
-                        return False
-                    return True
-        if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
-            for sub_slot in header_block.finished_sub_slots:
-                if (
-                    sub_slot.infused_challenge_chain is not None
-                    and sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf == vdf_info
-                ):
-                    assert sub_slot.proofs.infused_challenge_chain_slot_proof is not None
-                    if (
-                        sub_slot.proofs.infused_challenge_chain_slot_proof.witness_type == 0
-                        and sub_slot.proofs.infused_challenge_chain_slot_proof.normalized_to_identity
-                    ):
-                        return False
-                    return True
-        if field_vdf == CompressibleVDFField.CC_SP_VDF:
-            if header_block.reward_chain_block.challenge_chain_sp_vdf is None:
-                return False
-            if vdf_info == header_block.reward_chain_block.challenge_chain_sp_vdf:
-                assert header_block.challenge_chain_sp_proof is not None
-                if (
-                    header_block.challenge_chain_sp_proof.witness_type == 0
-                    and header_block.challenge_chain_sp_proof.normalized_to_identity
-                ):
-                    return False
-                return True
-        if field_vdf == CompressibleVDFField.CC_IP_VDF:
-            if vdf_info == header_block.reward_chain_block.challenge_chain_ip_vdf:
-                if (
-                    header_block.challenge_chain_ip_proof.witness_type == 0
-                    and header_block.challenge_chain_ip_proof.normalized_to_identity
-                ):
-                    return False
-                return True
-        return False
+        return needs_compact_proof(vdf_info, header_block, field_vdf)
 
     async def _can_accept_compact_proof(
         self,
@@ -3211,7 +3195,7 @@ class FullNode:
         - Checks if the provided vdf_info is correct, assuming it refers to the start of sub-slot.
         - Checks if the existing proof was non-compact. Ignore this proof if we already have a compact proof.
         """
-        is_fully_compactified = await self.block_store.is_fully_compactified(header_hash)
+        is_fully_compactified = await self.block_store.is_fully_compactified_effective(header_hash)
         if is_fully_compactified is None or is_fully_compactified:
             self.log.info(f"Already compactified block: {header_hash}. Ignoring.")
             return False
@@ -3235,7 +3219,7 @@ class FullNode:
         return is_new_proof
 
     # returns True if we ended up replacing the proof, and False otherwise
-    async def _replace_proof(
+    async def _merge_compact_proof_to_cache(
         self,
         vdf_info: VDFInfo,
         vdf_proof: VDFProof,
@@ -3246,48 +3230,18 @@ class FullNode:
         if block is None:
             return False
 
-        new_block = None
-
-        if field_vdf == CompressibleVDFField.CC_EOS_VDF:
-            for index, sub_slot in enumerate(block.finished_sub_slots):
-                if sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == vdf_info:
-                    new_proofs = sub_slot.proofs.replace(challenge_chain_slot_proof=vdf_proof)
-                    new_subslot = sub_slot.replace(proofs=new_proofs)
-                    new_finished_subslots = block.finished_sub_slots
-                    new_finished_subslots[index] = new_subslot
-                    new_block = block.replace(finished_sub_slots=new_finished_subslots)
-                    break
-        if field_vdf == CompressibleVDFField.ICC_EOS_VDF:
-            for index, sub_slot in enumerate(block.finished_sub_slots):
-                if (
-                    sub_slot.infused_challenge_chain is not None
-                    and sub_slot.infused_challenge_chain.infused_challenge_chain_end_of_slot_vdf == vdf_info
-                ):
-                    new_proofs = sub_slot.proofs.replace(infused_challenge_chain_slot_proof=vdf_proof)
-                    new_subslot = sub_slot.replace(proofs=new_proofs)
-                    new_finished_subslots = block.finished_sub_slots
-                    new_finished_subslots[index] = new_subslot
-                    new_block = block.replace(finished_sub_slots=new_finished_subslots)
-                    break
-        if field_vdf == CompressibleVDFField.CC_SP_VDF:
-            if block.reward_chain_block.challenge_chain_sp_vdf == vdf_info:
-                assert block.challenge_chain_sp_proof is not None
-                new_block = block.replace(challenge_chain_sp_proof=vdf_proof)
-        if field_vdf == CompressibleVDFField.CC_IP_VDF:
-            if block.reward_chain_block.challenge_chain_ip_vdf == vdf_info:
-                new_block = block.replace(challenge_chain_ip_proof=vdf_proof)
+        new_block = apply_compact_proof_to_block(block, vdf_info, vdf_proof, field_vdf)
         if new_block is None:
             return False
-        async with self.db_wrapper.writer():
-            try:
-                await self.block_store.replace_proof(header_hash, new_block)
-                return True
-            except BaseException as e:
-                self.log.error(
-                    f"_replace_proof error while adding block {block.header_hash} height {block.height},"
-                    f" rolling back: {e} {traceback.format_exc()}"
-                )
-                raise
+
+        self.block_store.put_block_in_cache(header_hash, new_block)
+        assert self._compact_vdf_file_lock is not None
+        await append_entry(
+            compact_vdf_filename(self.db_path.parent, self.config.get("selected_network")),
+            CompactVdfEntry(header_hash, uint8(field_vdf), vdf_proof.witness),
+            self._compact_vdf_file_lock,
+        )
+        return True
 
     async def add_compact_proof_of_time(self, request: timelord_protocol.RespondCompactProofOfTime) -> None:
         peak = self.blockchain.get_peak()
@@ -3301,7 +3255,9 @@ class FullNode:
         ):
             return None
         async with self.blockchain.compact_proof_lock:
-            replaced = await self._replace_proof(request.vdf_info, request.vdf_proof, request.header_hash, field_vdf)
+            replaced = await self._merge_compact_proof_to_cache(
+                request.vdf_info, request.vdf_proof, request.header_hash, field_vdf
+            )
         if not replaced:
             self.log.error(f"Could not replace compact proof: {request.height}")
             return None
@@ -3318,7 +3274,7 @@ class FullNode:
         if peak is None or peak.height - request.height < 5:
             self.log.info(f"Ignoring new_compact_vdf, height {request.height} too recent.")
             return None
-        is_fully_compactified = await self.block_store.is_fully_compactified(request.header_hash)
+        is_fully_compactified = await self.block_store.is_fully_compactified_effective(request.header_hash)
         if is_fully_compactified is None or is_fully_compactified:
             return None
         header_block = await self.blockchain.get_header_block_by_height(
@@ -3388,7 +3344,9 @@ class FullNode:
         async with self.blockchain.compact_proof_lock:
             if self.blockchain.seen_compact_proofs(request.vdf_info, request.height):
                 return None
-            replaced = await self._replace_proof(request.vdf_info, request.vdf_proof, request.header_hash, field_vdf)
+            replaced = await self._merge_compact_proof_to_cache(
+                request.vdf_info, request.vdf_proof, request.header_hash, field_vdf
+            )
         if not replaced:
             self.log.error(f"Could not replace compact proof: {request.height}")
             return None

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -1756,65 +1756,16 @@ class FullNodeAPI:
     async def new_compact_vdf(
         self, request: full_node_protocol.NewCompactVDF, peer: WSChiaConnection, request_bytes: bytes = b""
     ) -> None:
-        if self.full_node.sync_store.get_sync_mode():
-            return None
-
-        name = std_hash(request_bytes)
-        if name in self.full_node.compact_vdf_requests:
-            self.log.debug("Ignoring NewCompactVDF, already requested: %s %s", peer.get_peer_logging(), request)
-            return None
-        self.full_node.compact_vdf_requests.add(name)
-
-        # this semaphore will only allow a limited number of tasks call
-        # new_compact_vdf() at a time, since it can be expensive
-        try:
-            async with self.full_node.compact_vdf_sem.acquire():
-                try:
-                    await self.full_node.new_compact_vdf(request, peer)
-                finally:
-                    self.full_node.compact_vdf_requests.remove(name)
-        except LimitedSemaphoreFullError:
-            self.full_node.compact_vdf_requests.discard(name)
-            self.log.debug("Ignoring NewCompactVDF, limited semaphore full: %s %s", peer.get_peer_logging(), request)
-            return None
-
         return None
 
     @metadata.request(peer_required=True, reply_types=[ProtocolMessageTypes.respond_compact_vdf])
     async def request_compact_vdf(
         self, request: full_node_protocol.RequestCompactVDF, peer: WSChiaConnection
     ) -> Message | None:
-        if self.full_node.sync_store.get_sync_mode():
-            return None
-        vdf_proof = await self.full_node.request_compact_vdf(request, peer.peer_node_id)
-        if vdf_proof is None:
-            return None
-        return make_msg(
-            ProtocolMessageTypes.respond_compact_vdf,
-            full_node_protocol.RespondCompactVDF(
-                height=request.height,
-                header_hash=request.header_hash,
-                field_vdf=request.field_vdf,
-                vdf_info=request.vdf_info,
-                vdf_proof=vdf_proof,
-            ),
-        )
+        return None
 
     @metadata.request(peer_required=True)
     async def respond_compact_vdf(self, request: full_node_protocol.RespondCompactVDF, peer: WSChiaConnection) -> None:
-        request_key = full_node_protocol.RequestCompactVDF(
-            request.height, request.header_hash, request.field_vdf, request.vdf_info
-        ).get_hash()
-        if request_key not in peer.pending_compact_vdfs:
-            if not self.is_trusted(peer):
-                await peer.ban_peer_bad_protocol("Received unsolicited RespondCompactVDF")
-                return None
-        else:
-            peer.pending_compact_vdfs.remove(request_key)
-
-        if self.full_node.sync_store.get_sync_mode():
-            return None
-        await self.full_node.add_compact_vdf(request, peer)
         return None
 
     @metadata.request(

--- a/chia/full_node/remote_compact_vdf.py
+++ b/chia/full_node/remote_compact_vdf.py
@@ -38,7 +38,7 @@ def chunk_height_range(height: uint32) -> tuple[int, int]:
 
 def remote_compact_vdf_url(base_url: str, height: uint32) -> str:
     start, end = chunk_height_range(height)
-    return f"{base_url.rstrip('/')}-{start}to{end}"
+    return f"{base_url.rstrip('/')}/compactvdf-{start}to{end}"
 
 
 async def _get_chunk_lock(key: tuple[int, int]) -> asyncio.Lock:
@@ -149,7 +149,7 @@ async def apply_compact_vdf_entries(
             continue
         block = new_block
 
-    if is_fully_compactified_header_block(block):
+    if False: # is_fully_compactified_header_block(block):
         log.info(
             "Block %s height %s is fully compactified after applying remote compact VDF proofs",
             header_hash,

--- a/chia/full_node/remote_compact_vdf.py
+++ b/chia/full_node/remote_compact_vdf.py
@@ -23,7 +23,7 @@ from chia.util.priority_thread_pool_executor import Executor
 
 log = logging.getLogger(__name__)
 
-DEFAULT_REMOTE_COMPACT_VDF_BASE_URL: Final = "https://www.xchos.com/compactvdf"
+DEFAULT_REMOTE_COMPACT_VDF_BASE_URL: Final = "https://www.xchos.com/vdfs"
 
 _chunk_cache: dict[tuple[int, int], list[CompactVdfEntry]] = {}
 _chunk_locks: dict[tuple[int, int], asyncio.Lock] = {}
@@ -38,7 +38,7 @@ def chunk_height_range(height: uint32) -> tuple[int, int]:
 
 def remote_compact_vdf_url(base_url: str, height: uint32) -> str:
     start, end = chunk_height_range(height)
-    return f"{base_url}-{start}to{end}"
+    return f"{base_url.rstrip('/')}-{start}to{end}"
 
 
 async def _get_chunk_lock(key: tuple[int, int]) -> asyncio.Lock:

--- a/chia/full_node/remote_compact_vdf.py
+++ b/chia/full_node/remote_compact_vdf.py
@@ -114,7 +114,6 @@ async def apply_compact_vdf_entries(
     if len(block_entries) == 0:
         return block
 
-    applied = 0
     for entry in block_entries:
         field_vdf = CompressibleVDFField(int(entry.field_vdf))
         vdf_proof = compact_vdf_proof(entry.witness)
@@ -142,15 +141,7 @@ async def apply_compact_vdf_entries(
             )
             continue
         block = new_block
-        applied += 1
 
-    if applied > 0:
-        log.info(
-            "Applied %s remote compact VDF proof(s) to block %s height %s before validation",
-            applied,
-            header_hash,
-            block.height,
-        )
     return block
 
 

--- a/chia/full_node/remote_compact_vdf.py
+++ b/chia/full_node/remote_compact_vdf.py
@@ -93,7 +93,13 @@ async def fetch_remote_compact_vdf_entries(base_url: str, height: uint32) -> lis
                 else:
                     text = await response.text()
                     entries = parse_compact_vdf_entries(text)
-                    log.debug("Loaded %s remote compactvdf entries from %s", len(entries), url)
+                    log.info(
+                        "Downloaded remote compactvdf file %s with %s entries (heights %s to %s)",
+                        url,
+                        len(entries),
+                        start,
+                        end,
+                    )
         except Exception:
             log.warning("Failed to fetch remote compactvdf file %s", url, exc_info=True)
 

--- a/chia/full_node/remote_compact_vdf.py
+++ b/chia/full_node/remote_compact_vdf.py
@@ -87,9 +87,9 @@ async def fetch_remote_compact_vdf_entries(base_url: str, height: uint32) -> lis
             timeout = aiohttp.ClientTimeout(total=30)
             async with aiohttp.ClientSession(timeout=timeout) as session, session.get(url) as response:
                 if response.status == 404:
-                    log.debug("Remote compactvdf file not found: %s", url)
+                    log.info("Failed to download remote compactvdf file %s: not found (HTTP 404)", url)
                 elif response.status != 200:
-                    log.warning("Failed to fetch remote compactvdf file %s: HTTP %s", url, response.status)
+                    log.info("Failed to download remote compactvdf file %s: HTTP %s", url, response.status)
                 else:
                     text = await response.text()
                     entries = parse_compact_vdf_entries(text)
@@ -100,8 +100,8 @@ async def fetch_remote_compact_vdf_entries(base_url: str, height: uint32) -> lis
                         start,
                         end,
                     )
-        except Exception:
-            log.warning("Failed to fetch remote compactvdf file %s", url, exc_info=True)
+        except Exception as e:
+            log.info("Failed to download remote compactvdf file %s: %s", url, e, exc_info=True)
 
         _chunk_cache[key] = entries
         return entries

--- a/chia/full_node/remote_compact_vdf.py
+++ b/chia/full_node/remote_compact_vdf.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Final
+
+import aiohttp
+from chia_rs import ConsensusConstants, FullBlock
+from chia_rs.sized_ints import uint32
+
+from chia.full_node.compact_vdf_file import (
+    COMPACT_VDF_HEIGHT_CHUNK_SIZE,
+    CompactVdfEntry,
+    apply_compact_proof_to_block,
+    compact_vdf_proof,
+    find_vdf_info_for_proof,
+    needs_compact_proof,
+    parse_compact_vdf_entries,
+)
+from chia.types.blockchain_format.vdf import CompressibleVDFField
+from chia.util.priority_thread_pool_executor import Executor
+
+log = logging.getLogger(__name__)
+
+DEFAULT_REMOTE_COMPACT_VDF_BASE_URL: Final = "https://www.xchos.com/compactvdf"
+
+_chunk_cache: dict[tuple[int, int], list[CompactVdfEntry]] = {}
+_chunk_locks: dict[tuple[int, int], asyncio.Lock] = {}
+_cache_guard = asyncio.Lock()
+
+
+def chunk_height_range(height: uint32) -> tuple[int, int]:
+    start = (int(height) // COMPACT_VDF_HEIGHT_CHUNK_SIZE) * COMPACT_VDF_HEIGHT_CHUNK_SIZE
+    end = start + COMPACT_VDF_HEIGHT_CHUNK_SIZE - 1
+    return start, end
+
+
+def remote_compact_vdf_url(base_url: str, height: uint32) -> str:
+    start, end = chunk_height_range(height)
+    return f"{base_url}-{start}to{end}"
+
+
+async def _get_chunk_lock(key: tuple[int, int]) -> asyncio.Lock:
+    async with _cache_guard:
+        lock = _chunk_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _chunk_locks[key] = lock
+        return lock
+
+
+async def _evict_chunks_outside_height(height: uint32) -> None:
+    current = chunk_height_range(height)
+    async with _cache_guard:
+        stale_keys = [key for key in _chunk_cache if key != current]
+        for key in stale_keys:
+            del _chunk_cache[key]
+            _chunk_locks.pop(key, None)
+        if len(stale_keys) > 0:
+            log.debug(
+                "Evicted %s remote compactvdf chunk(s) outside height %s range %sto%s",
+                len(stale_keys),
+                height,
+                current[0],
+                current[1],
+            )
+
+
+async def fetch_remote_compact_vdf_entries(base_url: str, height: uint32) -> list[CompactVdfEntry]:
+    await _evict_chunks_outside_height(height)
+    start, end = chunk_height_range(height)
+    key = (start, end)
+    cached = _chunk_cache.get(key)
+    if cached is not None:
+        return cached
+
+    lock = await _get_chunk_lock(key)
+    async with lock:
+        cached = _chunk_cache.get(key)
+        if cached is not None:
+            return cached
+
+        url = remote_compact_vdf_url(base_url, height)
+        entries: list[CompactVdfEntry] = []
+        try:
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with aiohttp.ClientSession(timeout=timeout) as session, session.get(url) as response:
+                if response.status == 404:
+                    log.debug("Remote compactvdf file not found: %s", url)
+                elif response.status != 200:
+                    log.warning("Failed to fetch remote compactvdf file %s: HTTP %s", url, response.status)
+                else:
+                    text = await response.text()
+                    entries = parse_compact_vdf_entries(text)
+                    log.debug("Loaded %s remote compactvdf entries from %s", len(entries), url)
+        except Exception:
+            log.warning("Failed to fetch remote compactvdf file %s", url, exc_info=True)
+
+        _chunk_cache[key] = entries
+        return entries
+
+
+async def apply_remote_compact_vdfs(
+    constants: ConsensusConstants,
+    block: FullBlock,
+    base_url: str | None,
+    pool: Executor | None = None,
+) -> FullBlock:
+    if base_url is None or base_url == "":
+        return block
+
+    header_hash = block.header_hash
+    entries = await fetch_remote_compact_vdf_entries(base_url, block.height)
+    block_entries = [entry for entry in entries if entry.header_hash == header_hash]
+    if len(block_entries) == 0:
+        return block
+
+    applied = 0
+    for entry in block_entries:
+        field_vdf = CompressibleVDFField(int(entry.field_vdf))
+        vdf_proof = compact_vdf_proof(entry.witness)
+        if pool is not None:
+            vdf_info = await pool.run_in_loop(find_vdf_info_for_proof, block, field_vdf, vdf_proof, constants)
+        else:
+            vdf_info = find_vdf_info_for_proof(block, field_vdf, vdf_proof, constants)
+        if vdf_info is None:
+            log.debug(
+                "Remote compact VDF proof did not validate for block %s height %s field_vdf %s",
+                header_hash,
+                block.height,
+                field_vdf,
+            )
+            continue
+        if not needs_compact_proof(vdf_info, block, field_vdf):
+            continue
+        new_block = apply_compact_proof_to_block(block, vdf_info, vdf_proof, field_vdf)
+        if new_block is None:
+            log.warning(
+                "Could not apply remote compact VDF proof for block %s height %s field_vdf %s",
+                header_hash,
+                block.height,
+                field_vdf,
+            )
+            continue
+        block = new_block
+        applied += 1
+
+    if applied > 0:
+        log.info(
+            "Applied %s remote compact VDF proof(s) to block %s height %s before validation",
+            applied,
+            header_hash,
+            block.height,
+        )
+    return block

--- a/chia/full_node/remote_compact_vdf.py
+++ b/chia/full_node/remote_compact_vdf.py
@@ -13,7 +13,7 @@ from chia.full_node.compact_vdf_file import (
     CompactVdfEntry,
     apply_compact_proof_to_block,
     compact_vdf_proof,
-    find_vdf_info_for_proof,
+    find_vdf_info_for_entry,
     is_fully_compactified_header_block,
     needs_compact_proof,
     parse_compact_vdf_entries,
@@ -125,9 +125,11 @@ async def apply_compact_vdf_entries(
         field_vdf = CompressibleVDFField(int(entry.field_vdf))
         vdf_proof = compact_vdf_proof(entry.witness)
         if pool is not None:
-            vdf_info = await pool.run_in_loop(find_vdf_info_for_proof, block, field_vdf, vdf_proof, constants)
+            vdf_info = await pool.run_in_loop(
+                find_vdf_info_for_entry, block, field_vdf, vdf_proof, constants, entry.sub_slot_index
+            )
         else:
-            vdf_info = find_vdf_info_for_proof(block, field_vdf, vdf_proof, constants)
+            vdf_info = find_vdf_info_for_entry(block, field_vdf, vdf_proof, constants, entry.sub_slot_index)
         if vdf_info is None:
             log.debug(
                 "Remote compact VDF proof did not validate for block %s height %s field_vdf %s",

--- a/chia/full_node/remote_compact_vdf.py
+++ b/chia/full_node/remote_compact_vdf.py
@@ -14,6 +14,7 @@ from chia.full_node.compact_vdf_file import (
     apply_compact_proof_to_block,
     compact_vdf_proof,
     find_vdf_info_for_proof,
+    is_fully_compactified_header_block,
     needs_compact_proof,
     parse_compact_vdf_entries,
 )
@@ -142,6 +143,12 @@ async def apply_compact_vdf_entries(
             continue
         block = new_block
 
+    if is_fully_compactified_header_block(block):
+        log.info(
+            "Block %s height %s is fully compactified after applying remote compact VDF proofs",
+            header_hash,
+            block.height,
+        )
     return block
 
 

--- a/chia/full_node/remote_compact_vdf.py
+++ b/chia/full_node/remote_compact_vdf.py
@@ -100,17 +100,16 @@ async def fetch_remote_compact_vdf_entries(base_url: str, height: uint32) -> lis
         return entries
 
 
-async def apply_remote_compact_vdfs(
+async def apply_compact_vdf_entries(
     constants: ConsensusConstants,
     block: FullBlock,
-    base_url: str | None,
+    entries: list[CompactVdfEntry] | None,
     pool: Executor | None = None,
 ) -> FullBlock:
-    if base_url is None or base_url == "":
+    if entries is None or len(entries) == 0:
         return block
 
     header_hash = block.header_hash
-    entries = await fetch_remote_compact_vdf_entries(base_url, block.height)
     block_entries = [entry for entry in entries if entry.header_hash == header_hash]
     if len(block_entries) == 0:
         return block
@@ -153,3 +152,16 @@ async def apply_remote_compact_vdfs(
             block.height,
         )
     return block
+
+
+async def apply_remote_compact_vdfs(
+    constants: ConsensusConstants,
+    block: FullBlock,
+    base_url: str | None,
+    pool: Executor | None = None,
+) -> FullBlock:
+    if base_url is None or base_url == "":
+        return block
+
+    entries = await fetch_remote_compact_vdf_entries(base_url, block.height)
+    return await apply_compact_vdf_entries(constants, block, entries, pool)

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -407,7 +407,7 @@ full_node:
   # Before validating a block, fetch compact VDF proofs from this URL prefix.
   # Files are named {url}-{height_start}to{height_end} in 10000-block ranges.
   # Set to empty string to disable.
-  remote_compact_vdf_base_url: https://www.xchos.com/compactvdf
+  remote_compact_vdf_base_url: https://www.xchos.com/vdfs
   # Setting this flag as True, blueboxes will sanitize only data needed in weight proof calculation, as opposed to whole blocks.
   # Default is set to False, as the network needs only one or two blueboxes like this.
   sanitize_weight_proof_only: False

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -404,6 +404,10 @@ full_node:
   send_uncompact_interval: 0
   # At every 'send_uncompact_interval' seconds, send blueboxes 'target_uncompact_proofs' proofs to be normalized.
   target_uncompact_proofs: 100
+  # Before validating a block, fetch compact VDF proofs from this URL prefix.
+  # Files are named {url}-{height_start}to{height_end} in 10000-block ranges.
+  # Set to empty string to disable.
+  remote_compact_vdf_base_url: https://www.xchos.com/compactvdf
   # Setting this flag as True, blueboxes will sanitize only data needed in weight proof calculation, as opposed to whole blocks.
   # Default is set to False, as the network needs only one or two blueboxes like this.
   sanitize_weight_proof_only: False

--- a/tools/process_compact_vdf/CMakeLists.txt
+++ b/tools/process_compact_vdf/CMakeLists.txt
@@ -13,6 +13,7 @@ if(NOT EXISTS "${CHIAVDF_SRC}/verifier.h")
 endif()
 
 find_package(SQLite3 REQUIRED)
+find_package(CURL REQUIRED)
 find_package(Threads REQUIRED)
 
 if(APPLE)
@@ -43,6 +44,7 @@ add_executable(process_compact_vdf
   src/mini_json.cpp
   src/process_compact_vdf.cpp
   src/export_compact_vdf.cpp
+  src/http_fetch.cpp
   "${CHIAVDF_SRC}/refcode/lzcnt.c"
 )
 
@@ -58,6 +60,7 @@ target_compile_definitions(process_compact_vdf PRIVATE
 
 target_link_libraries(process_compact_vdf PRIVATE
   SQLite::SQLite3
+  CURL::libcurl
   Threads::Threads
   ${GMP_LIBRARIES}
 )

--- a/tools/process_compact_vdf/CMakeLists.txt
+++ b/tools/process_compact_vdf/CMakeLists.txt
@@ -1,0 +1,74 @@
+cmake_minimum_required(VERSION 3.18)
+project(process_compact_vdf CXX C)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT DEFINED CHIAVDF_SRC)
+  set(CHIAVDF_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../../../chiavdf/src")
+endif()
+
+if(NOT EXISTS "${CHIAVDF_SRC}/verifier.h")
+  message(FATAL_ERROR "chiavdf sources not found at ${CHIAVDF_SRC}. Pass -DCHIAVDF_SRC=/path/to/chiavdf/src")
+endif()
+
+find_package(SQLite3 REQUIRED)
+find_package(Threads REQUIRED)
+
+if(APPLE)
+  find_library(GMP_LIBRARY gmp REQUIRED)
+  find_library(GMPXX_LIBRARY gmpxx REQUIRED)
+  find_library(ZSTD_LIBRARY zstd REQUIRED)
+  set(GMP_LIBRARIES ${GMP_LIBRARY} ${GMPXX_LIBRARY})
+  find_path(GMP_INCLUDE_DIR gmp.h)
+  find_path(GMPXX_INCLUDE_DIR gmpxx.h)
+  find_path(ZSTD_INCLUDE_DIR zstd.h)
+  include_directories(${GMP_INCLUDE_DIR} ${GMPXX_INCLUDE_DIR} ${ZSTD_INCLUDE_DIR})
+else()
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(GMP REQUIRED gmp)
+  pkg_check_modules(GMPXX REQUIRED gmpxx)
+  pkg_check_modules(ZSTD REQUIRED libzstd)
+  set(GMP_LIBRARIES ${GMP_LIBRARIES} ${GMPXX_LIBRARIES})
+  include_directories(${GMP_INCLUDE_DIRS} ${GMPXX_INCLUDE_DIRS} ${ZSTD_INCLUDE_DIRS})
+endif()
+
+add_executable(process_compact_vdf
+  src/main.cpp
+  src/chia_protocol.cpp
+  src/clvm_length.cpp
+  src/vdf_validate.cpp
+  src/db_v2.cpp
+  src/zstd_util.cpp
+  src/mini_json.cpp
+  src/process_compact_vdf.cpp
+  src/export_compact_vdf.cpp
+  "${CHIAVDF_SRC}/refcode/lzcnt.c"
+)
+
+target_include_directories(process_compact_vdf PRIVATE
+  src
+  "${CHIAVDF_SRC}"
+)
+
+target_compile_definitions(process_compact_vdf PRIVATE
+  VDF_MODE=0
+  FAST_MACHINE=1
+)
+
+target_link_libraries(process_compact_vdf PRIVATE
+  SQLite::SQLite3
+  Threads::Threads
+  ${GMP_LIBRARIES}
+)
+
+if(APPLE)
+  target_link_libraries(process_compact_vdf PRIVATE ${ZSTD_LIBRARY})
+  target_compile_definitions(process_compact_vdf PRIVATE CHIAOSX)
+else()
+  target_link_libraries(process_compact_vdf PRIVATE ${ZSTD_LIBRARIES})
+endif()
+
+if(UNIX AND NOT APPLE)
+  target_link_libraries(process_compact_vdf PRIVATE -pthread)
+endif()

--- a/tools/process_compact_vdf/README.md
+++ b/tools/process_compact_vdf/README.md
@@ -37,7 +37,7 @@ cmake --build build/process_compact_vdf -j
 The tool:
 
 1. Verifies the database has `database_version = 2`.
-2. Reads JSON lines from the compactvdf file (`header_hash`, `field_vdf`, `witness`).
+2. Reads JSON lines from the compactvdf file (`header_hash`, `field_vdf`, `witness`, optional `sub_slot_index`).
 3. Loads affected blocks from `full_blocks` (binary `header_hash`, zstd-compressed `block` blob).
 4. Validates witnesses with chiavdf and applies compact proofs to the in-memory blocks.
 5. Writes zstd-compressed blocks back and updates `full_blocks.is_fully_compactified`.
@@ -61,7 +61,8 @@ already use `witness_type` 0:
 
 This writes files like `compactvdf-0to9999`, `compactvdf-10000to19999`, etc.
 into the output directory (current directory by default). Each line matches the
-runtime compactvdf format: `header_hash`, `field_vdf`, `witness`.
+runtime compactvdf format: `header_hash`, `field_vdf`, `witness`, and `sub_slot_index`
+(for CC_EOS / ICC_EOS entries; omitted for CC_SP / CC_IP).
 
 ## v2 database schema
 

--- a/tools/process_compact_vdf/README.md
+++ b/tools/process_compact_vdf/README.md
@@ -118,7 +118,7 @@ through the current peak.
 
 Export includes one line per compressible proof on the block where:
 
-- `witness_type == 0`, and
+- `witness_type == 0` and `normalized_to_identity == true` (compact form), and
 - `witness` is non-empty.
 
 Only these fields are exported (matching `CompressibleVDFField`):

--- a/tools/process_compact_vdf/README.md
+++ b/tools/process_compact_vdf/README.md
@@ -1,0 +1,79 @@
+# process_compact_vdf
+
+Standalone C++ utility that applies pending compact VDF proofs from a `compactvdf`
+JSON-lines file to a **v2** chia blockchain SQLite database.
+
+This mirrors `chia.full_node.compact_vdf_file.process_compact_vdf_file()` but runs
+outside the Python full node. VDF validation uses the **chiavdf** C++ library only.
+
+## Requirements
+
+- CMake 3.18+
+- C++17 compiler
+- SQLite3 development headers
+- GMP / GMPXX
+- libzstd
+- chiavdf sources (sibling checkout at `../../../chiavdf` by default)
+
+## Build
+
+```bash
+cmake -S tools/process_compact_vdf -B build/process_compact_vdf \
+  -DCHIAVDF_SRC=/path/to/chiavdf/src
+cmake --build build/process_compact_vdf -j
+```
+
+## Usage
+
+```bash
+./build/process_compact_vdf/process_compact_vdf \
+  --db /path/to/blockchain_v2.sqlite \
+  --compactvdf /path/to/db/compactvdf \
+  [--batch-size 1000] \
+  [--threads 8] \
+  [--dryrun]
+```
+
+The tool:
+
+1. Verifies the database has `database_version = 2`.
+2. Reads JSON lines from the compactvdf file (`header_hash`, `field_vdf`, `witness`).
+3. Loads affected blocks from `full_blocks` (binary `header_hash`, zstd-compressed `block` blob).
+4. Validates witnesses with chiavdf and applies compact proofs to the in-memory blocks.
+5. Writes zstd-compressed blocks back and updates `full_blocks.is_fully_compactified`.
+6. Runs `PRAGMA wal_checkpoint(TRUNCATE)` and deletes the compactvdf file.
+
+With `--dryrun`, steps 5–6 are skipped and `PRAGMA query_only=ON` prevents any SQL
+writes. The database file is still opened read-write so WAL sidecar files work.
+
+## Export compactvdf files from database
+
+Scan the main chain and write compactvdf JSON-lines files containing proofs that
+already use `witness_type` 0:
+
+```bash
+./build/process_compact_vdf/process_compact_vdf \
+  --db /path/to/blockchain_v2_mainnet.sqlite \
+  --export-compactvdf \
+  [--export-chunk-size 10000] \
+  [--output-dir .]
+```
+
+This writes files like `compactvdf-0to9999`, `compactvdf-10000to19999`, etc.
+into the output directory (current directory by default). Each line matches the
+runtime compactvdf format: `header_hash`, `field_vdf`, `witness`.
+
+## v2 database schema
+
+Expected tables/columns:
+
+- `database_version(version)` with value `2`
+- `full_blocks(header_hash BLOB, block BLOB, is_fully_compactified TINYINT, ...)`
+
+Blocks are stored as zstd-compressed chia streamable `FullBlock` bytes (v0 or v1 wire format).
+
+## Notes
+
+- Only v2 databases are supported.
+- Stop the full node before running this tool against its database.
+- Network constants use mainnet discriminant size (1024 bits).

--- a/tools/process_compact_vdf/README.md
+++ b/tools/process_compact_vdf/README.md
@@ -1,10 +1,15 @@
 # process_compact_vdf
 
-Standalone C++ utility that applies pending compact VDF proofs from a `compactvdf`
-JSON-lines file to a **v2** chia blockchain SQLite database.
+Standalone C++ utility for working with compact challenge-chain VDF witnesses on a **v2**
+chia blockchain SQLite database. It supports two modes:
 
-This mirrors `chia.full_node.compact_vdf_file.process_compact_vdf_file()` but runs
-outside the Python full node. VDF validation uses the **chiavdf** C++ library only.
+1. **Process** — read a `compactvdf` JSON-lines file, validate witnesses with **chiavdf**,
+   apply compact proofs to blocks in `full_blocks`, and update `is_fully_compactified`.
+2. **Export** — scan the main chain and write `compactvdf-*` JSON-lines files for blocks
+   that already store `witness_type` 0 proofs.
+
+The tool does not run a full node. It parses streamable `FullBlock` blobs from the database,
+mutates VDF proof fields in memory, and writes compressed blocks back.
 
 ## Requirements
 
@@ -23,33 +28,51 @@ cmake -S tools/process_compact_vdf -B build/process_compact_vdf \
 cmake --build build/process_compact_vdf -j
 ```
 
-## Usage
+## Process mode
+
+Apply a pending compactvdf file to the database:
 
 ```bash
 ./build/process_compact_vdf/process_compact_vdf \
   --db /path/to/blockchain_v2.sqlite \
-  --compactvdf /path/to/db/compactvdf \
+  --compactvdf /path/to/compactvdf \
   [--batch-size 1000] \
   [--threads 8] \
   [--dryrun]
 ```
 
-The tool:
+Steps:
 
-1. Verifies the database has `database_version = 2`.
-2. Reads JSON lines from the compactvdf file (`header_hash`, `field_vdf`, `witness`, optional `sub_slot_index`).
-3. Loads affected blocks from `full_blocks` (binary `header_hash`, zstd-compressed `block` blob).
-4. Validates witnesses with chiavdf and applies compact proofs to the in-memory blocks.
-5. Writes zstd-compressed blocks back and updates `full_blocks.is_fully_compactified`.
-6. Runs `PRAGMA wal_checkpoint(TRUNCATE)` and deletes the compactvdf file.
+1. Verify `database_version = 2`.
+2. Read JSON lines from the compactvdf file (see [File format](#compactvdf-file-format)).
+3. Load affected blocks from `full_blocks` (zstd-compressed `FullBlock` blobs keyed by
+   `header_hash`).
+4. Validate witnesses in parallel (`--threads`, default: hardware concurrency) using chiavdf.
+5. Apply matching compact proofs to in-memory blocks.
+6. Write blocks back and set `full_blocks.is_fully_compactified`.
+7. Run `PRAGMA wal_checkpoint(TRUNCATE)` and delete the compactvdf file.
 
-With `--dryrun`, steps 5–6 are skipped and `PRAGMA query_only=ON` prevents any SQL
-writes. The database file is still opened read-write so WAL sidecar files work.
+With `--dryrun`, steps 6–7 are skipped. The database is opened with `PRAGMA query_only=ON`
+so no rows are written; the compactvdf file is not deleted.
 
-## Export compactvdf files from database
+### Lookup and validation
 
-Scan the main chain and write compactvdf JSON-lines files containing proofs that
-already use `witness_type` 0:
+For each entry, the tool resolves which `VDFInfo` on the block the witness belongs to:
+
+| `sub_slot_index` | Behavior |
+|------------------|----------|
+| Present (CC_EOS / ICC_EOS) | O(1) lookup via index into `finished_sub_slots`, then `validate_vdf` |
+| Absent (CC_SP / CC_IP, or legacy files) | Try each candidate `VDFInfo` for the field until `validate_vdf` succeeds |
+
+Entries that fail lookup or validation are skipped with a log message. Duplicate entries
+(same `header_hash`, `field_vdf`, `witness`) are deduplicated within each batch.
+
+Application uses the same field mapping as export (see below). Blocks are updated one at a
+time per header hash; multiple entries for the same block are applied sequentially.
+
+## Export mode
+
+Scan the main chain and write compactvdf archives:
 
 ```bash
 ./build/process_compact_vdf/process_compact_vdf \
@@ -59,10 +82,56 @@ already use `witness_type` 0:
   [--output-dir .]
 ```
 
-This writes files like `compactvdf-0to9999`, `compactvdf-10000to19999`, etc.
-into the output directory (current directory by default). Each line matches the
-runtime compactvdf format: `header_hash`, `field_vdf`, `witness`, and `sub_slot_index`
-(for CC_EOS / ICC_EOS entries; omitted for CC_SP / CC_IP).
+This writes files named `compactvdf-{start}to{end}` (inclusive height range) into
+`--output-dir` (default: current directory). One file is produced per chunk from height 0
+through the current peak.
+
+Export includes one line per compressible proof on the block where:
+
+- `witness_type == 0`, and
+- `witness` is non-empty.
+
+Only these fields are exported (matching `CompressibleVDFField`):
+
+| `field_vdf` | Proof replaced | `sub_slot_index` in file |
+|-------------|----------------|--------------------------|
+| 1 | CC end-of-slot (`challenge_chain_slot_proof`) | yes — index in `finished_sub_slots` |
+| 2 | ICC end-of-slot (`infused_challenge_chain_slot_proof`) | yes |
+| 3 | CC signage point (`challenge_chain_sp_proof`) | omitted |
+| 4 | CC infusion point (`challenge_chain_ip_proof`) | omitted |
+
+Reward-chain proofs are not exported; they are not compressible under the current protocol.
+
+## compactvdf file format
+
+UTF-8 JSON Lines: one JSON object per line. Empty lines are ignored.
+
+### Required fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `header_hash` | hex string (`0x…`, 32 bytes) | Block header hash (DB key) |
+| `field_vdf` | integer | `1`–`4` (see table above) |
+| `witness` | hex string | Compact witness bytes |
+
+### Optional fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sub_slot_index` | integer | Index into `finished_sub_slots` for `field_vdf` 1 or 2 |
+
+Legacy lines may nest the witness under `vdf_proof.witness`; the parser accepts both forms.
+
+### Example
+
+```json
+{"field_vdf":1,"header_hash":"0x…","witness":"0x…","sub_slot_index":0}
+{"field_vdf":4,"header_hash":"0x…","witness":"0x…"}
+```
+
+Each witness is applied as a compact proof: `witness_type = 0`,
+`normalized_to_identity = true`. `VDFInfo` is read from the block at apply time; it is not
+stored in the file.
 
 ## v2 database schema
 
@@ -72,6 +141,9 @@ Expected tables/columns:
 - `full_blocks(header_hash BLOB, block BLOB, is_fully_compactified TINYINT, ...)`
 
 Blocks are stored as zstd-compressed chia streamable `FullBlock` bytes (v0 or v1 wire format).
+
+`is_fully_compactified` is set when all compressible CC/ICC proofs on the header block are
+compact (CC/ICC EOS, CC SP if present, CC IP).
 
 ## Notes
 

--- a/tools/process_compact_vdf/README.md
+++ b/tools/process_compact_vdf/README.md
@@ -1,11 +1,13 @@
 # process_compact_vdf
 
 Standalone C++ utility for working with compact challenge-chain VDF witnesses on a **v2**
-chia blockchain SQLite database. It supports two modes:
+chia blockchain SQLite database. It supports three modes:
 
-1. **Process** — read a `compactvdf` JSON-lines file, validate witnesses with **chiavdf**,
+1. **Process (local file)** — read a `compactvdf` JSON-lines file, validate witnesses with **chiavdf**,
    apply compact proofs to blocks in `full_blocks`, and update `is_fully_compactified`.
-2. **Export** — scan the main chain and write `compactvdf-*` JSON-lines files for blocks
+2. **Process (remote URL)** — download 10,000-block `compactvdf-*` files from a base URL starting at
+   height 0, validate and apply each chunk until HTTP 404.
+3. **Export** — scan the main chain and write `compactvdf-*` JSON-lines files for blocks
    that already store `witness_type` 0 proofs.
 
 The tool does not run a full node. It parses streamable `FullBlock` blobs from the database,
@@ -18,6 +20,7 @@ mutates VDF proof fields in memory, and writes compressed blocks back.
 - SQLite3 development headers
 - GMP / GMPXX
 - libzstd
+- libcurl
 - chiavdf sources (sibling checkout at `../../../chiavdf` by default)
 
 ## Build
@@ -28,7 +31,7 @@ cmake -S tools/process_compact_vdf -B build/process_compact_vdf \
 cmake --build build/process_compact_vdf -j
 ```
 
-## Process mode
+## Process mode (local file)
 
 Apply a pending compactvdf file to the database:
 
@@ -54,6 +57,33 @@ Steps:
 
 With `--dryrun`, steps 6–7 are skipped. The database is opened with `PRAGMA query_only=ON`
 so no rows are written; the compactvdf file is not deleted.
+
+## Process mode (remote URL)
+
+Download and apply compactvdf archives from a static HTTP server:
+
+```bash
+./build/process_compact_vdf/process_compact_vdf \
+  --db /path/to/blockchain_v2.sqlite \
+  --remote-compactvdf-url https://www.xchos.com/vdfs \
+  [--batch-size 1000] \
+  [--threads 8] \
+  [--dryrun]
+```
+
+The tool fetches files in order:
+
+```
+{base-url}/compactvdf-0to9999
+{base-url}/compactvdf-10000to19999
+...
+```
+
+Processing stops when a chunk returns HTTP 404. Each successful download is parsed, validated,
+and applied before the next chunk is fetched. A single WAL checkpoint runs after all chunks
+(unless `--dryrun`).
+
+With `--dryrun`, proofs are validated and applied in memory only; no database writes occur.
 
 ### Lookup and validation
 

--- a/tools/process_compact_vdf/src/chia_protocol.cpp
+++ b/tools/process_compact_vdf/src/chia_protocol.cpp
@@ -1,0 +1,775 @@
+#include "chia_protocol.hpp"
+
+#include "clvm_length.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+
+namespace chia {
+namespace {
+
+template <typename T>
+std::optional<T> parse_optional(streamable::Reader& r, T (*parse_fn)(streamable::Reader&)) {
+    const uint8_t prefix = r.read_u8();
+    if (prefix == 0) {
+        return std::nullopt;
+    }
+    if (prefix == 1) {
+        return parse_fn(r);
+    }
+    throw streamable::ParseError("invalid optional prefix");
+}
+
+template <typename T>
+auto stream_fn() {
+    return [](streamable::Writer& w, const T& value) { value.stream(w); };
+}
+
+template <typename T, typename F>
+void stream_optional(streamable::Writer& w, const std::optional<T>& value, F stream_fn_impl) {
+    if (!value.has_value()) {
+        w.write_u8(0);
+        return;
+    }
+    w.write_u8(1);
+    stream_fn_impl(w, *value);
+}
+
+template <typename T>
+void stream_optional(streamable::Writer& w, const std::optional<T>& value) {
+    stream_optional(w, value, stream_fn<T>());
+}
+
+void stream_optional_bytes32(streamable::Writer& w, const std::optional<Bytes32>& value) {
+    stream_optional(w, value, [](streamable::Writer& writer, const Bytes32& v) { writer.write_fixed(v); });
+}
+
+void stream_optional_u64(streamable::Writer& w, const std::optional<uint64_t>& value) {
+    stream_optional(w, value, [](streamable::Writer& writer, uint64_t v) { writer.write_u64_be(v); });
+}
+
+template <typename T, typename U>
+std::pair<std::optional<T>, std::optional<U>> parse_dual_optional(
+    streamable::Reader& r, T (*parse_t)(streamable::Reader&), U (*parse_u)(streamable::Reader&)) {
+    const uint8_t index = r.read_u8();
+    switch (index) {
+        case 0:
+            return {std::nullopt, std::nullopt};
+        case 1:
+            return {parse_t(r), std::nullopt};
+        case 2:
+            return {std::nullopt, parse_u(r)};
+        case 3:
+            return {parse_t(r), parse_u(r)};
+        default:
+            throw streamable::ParseError("invalid dual optional index");
+    }
+}
+
+template <typename T, typename U, typename FT, typename FU>
+void stream_dual_optional(streamable::Writer& w, const std::optional<T>& first, const std::optional<U>& second,
+                          FT stream_t, FU stream_u) {
+    if (!first.has_value() && !second.has_value()) {
+        w.write_u8(0);
+    } else if (first.has_value() && !second.has_value()) {
+        w.write_u8(1);
+        stream_t(w, *first);
+    } else if (!first.has_value() && second.has_value()) {
+        w.write_u8(2);
+        stream_u(w, *second);
+    } else {
+        w.write_u8(3);
+        stream_t(w, *first);
+        stream_u(w, *second);
+    }
+}
+
+template <typename T, typename U>
+void stream_dual_optional(streamable::Writer& w, const std::optional<T>& first, const std::optional<U>& second) {
+    stream_dual_optional(w, first, second, stream_fn<T>(), stream_fn<U>());
+}
+
+template <typename T>
+std::vector<T> parse_list(streamable::Reader& r, T (*parse_fn)(streamable::Reader&)) {
+    const uint32_t len = r.read_u32_be();
+    std::vector<T> out;
+    out.reserve(len);
+    for (uint32_t i = 0; i < len; ++i) {
+        out.push_back(parse_fn(r));
+    }
+    return out;
+}
+
+template <typename T, typename F>
+void stream_list(streamable::Writer& w, const std::vector<T>& values, F stream_fn_impl) {
+    if (values.size() > std::numeric_limits<uint32_t>::max()) {
+        throw streamable::ParseError("list too large");
+    }
+    w.write_u32_be(static_cast<uint32_t>(values.size()));
+    for (const auto& value : values) {
+        stream_fn_impl(w, value);
+    }
+}
+
+template <typename T>
+void stream_list(streamable::Writer& w, const std::vector<T>& values) {
+    stream_list(w, values, stream_fn<T>());
+}
+
+bool proof_is_compact(const VDFProof& proof) {
+    return proof.witness_type == 0 && proof.normalized_to_identity;
+}
+
+}  // namespace
+
+bool VDFInfo::operator==(const VDFInfo& o) const {
+    return challenge == o.challenge && number_of_iterations == o.number_of_iterations && output == o.output;
+}
+
+bool VDFInfo::operator!=(const VDFInfo& o) const { return !(*this == o); }
+
+VDFInfo VDFInfo::parse(streamable::Reader& r) {
+    VDFInfo info;
+    info.challenge = r.read_fixed<32>();
+    info.number_of_iterations = r.read_u64_be();
+    info.output = r.read_fixed<100>();
+    return info;
+}
+
+void VDFInfo::stream(streamable::Writer& w) const {
+    w.write_fixed(challenge);
+    w.write_u64_be(number_of_iterations);
+    w.write_fixed(output);
+}
+
+VDFProof VDFProof::parse(streamable::Reader& r) {
+    VDFProof proof;
+    proof.witness_type = r.read_u8();
+    proof.witness = r.read_bytes();
+    proof.normalized_to_identity = r.read_bool();
+    return proof;
+}
+
+void VDFProof::stream(streamable::Writer& w) const {
+    w.write_u8(witness_type);
+    w.write_bytes(witness);
+    w.write_bool(normalized_to_identity);
+}
+
+VDFProof VDFProof::compact(const std::vector<uint8_t>& witness_bytes) {
+    VDFProof proof;
+    proof.witness_type = 0;
+    proof.witness = witness_bytes;
+    proof.normalized_to_identity = true;
+    return proof;
+}
+
+bool VDFProof::is_compact() const { return proof_is_compact(*this); }
+
+ClassgroupElement ClassgroupElement::parse(streamable::Reader& r) {
+    ClassgroupElement el;
+    el.data = r.read_fixed<100>();
+    return el;
+}
+
+void ClassgroupElement::stream(streamable::Writer& w) const { w.write_fixed(data); }
+
+ClassgroupElement ClassgroupElement::default_element() {
+    ClassgroupElement el;
+    el.data[0] = 0x08;
+    return el;
+}
+
+Program Program::parse(streamable::Reader& r) {
+    Program p;
+    const auto& data = r.buffer();
+    const std::size_t offset = r.position();
+    if (offset >= data.size()) {
+        throw streamable::ParseError("unexpected end of buffer");
+    }
+    try {
+        const std::size_t len = clvm_length::serialized_length_trusted(data, offset);
+        if (offset + len > data.size()) {
+            throw streamable::ParseError("unexpected end of buffer");
+        }
+        p.a0.assign(data.begin() + static_cast<std::ptrdiff_t>(offset),
+                    data.begin() + static_cast<std::ptrdiff_t>(offset + len));
+        r.skip_bytes(len);
+    } catch (const std::runtime_error& e) {
+        throw streamable::ParseError(e.what());
+    }
+    return p;
+}
+
+void Program::stream(streamable::Writer& w) const { w.write_bytes_raw(a0); }
+
+G1Element G1Element::parse(streamable::Reader& r) {
+    G1Element el;
+    el.data = r.read_fixed<48>();
+    return el;
+}
+
+void G1Element::stream(streamable::Writer& w) const { w.write_fixed(data); }
+
+G2Element G2Element::parse(streamable::Reader& r) {
+    G2Element el;
+    el.data = r.read_fixed<96>();
+    return el;
+}
+
+void G2Element::stream(streamable::Writer& w) const { w.write_fixed(data); }
+
+Coin Coin::parse(streamable::Reader& r) {
+    Coin c;
+    c.parent_coin_info = r.read_fixed<32>();
+    c.puzzle_hash = r.read_fixed<32>();
+    c.amount = r.read_u64_be();
+    return c;
+}
+
+void Coin::stream(streamable::Writer& w) const {
+    w.write_fixed(parent_coin_info);
+    w.write_fixed(puzzle_hash);
+    w.write_u64_be(amount);
+}
+
+PoolTarget PoolTarget::parse(streamable::Reader& r) {
+    PoolTarget t;
+    t.puzzle_hash = r.read_fixed<32>();
+    t.max_height = r.read_u32_be();
+    return t;
+}
+
+void PoolTarget::stream(streamable::Writer& w) const {
+    w.write_fixed(puzzle_hash);
+    w.write_u32_be(max_height);
+}
+
+ProofOfSpace ProofOfSpace::parse(streamable::Reader& r) {
+    ProofOfSpace pos;
+    pos.challenge = r.read_fixed<32>();
+    pos.pool_public_key = parse_optional<G1Element>(r, G1Element::parse);
+
+    const uint8_t prefix = r.read_u8();
+    pos.version = static_cast<uint8_t>((prefix & 0b10) != 0);
+    if ((prefix & 1) != 0) {
+        pos.pool_contract_puzzle_hash = r.read_fixed<32>();
+    }
+
+    pos.plot_public_key = G1Element::parse(r);
+
+    if (pos.version == 0) {
+        pos.size = r.read_u8();
+        pos.proof = r.read_bytes();
+        return pos;
+    }
+    if (pos.version == 1) {
+        pos.plot_index = r.read_u16_be();
+        pos.meta_group = r.read_u8();
+        pos.strength = r.read_u8();
+        pos.proof = r.read_bytes();
+        if (pos.pool_public_key.has_value() == pos.pool_contract_puzzle_hash.has_value()) {
+            throw streamable::ParseError("invalid proof of space pool fields");
+        }
+        return pos;
+    }
+    throw streamable::ParseError("invalid proof of space version");
+}
+
+void ProofOfSpace::stream(streamable::Writer& w) const {
+    w.write_fixed(challenge);
+    stream_optional<G1Element>(w, pool_public_key);
+
+    if (version == 0) {
+        uint8_t prefix = 0;
+        if (pool_contract_puzzle_hash.has_value()) {
+            prefix |= 1;
+        }
+        w.write_u8(prefix);
+        if (pool_contract_puzzle_hash.has_value()) {
+            w.write_fixed(*pool_contract_puzzle_hash);
+        }
+        plot_public_key.stream(w);
+        w.write_u8(size);
+        w.write_bytes(proof);
+        return;
+    }
+
+    uint8_t prefix = 0b10;
+    if (pool_contract_puzzle_hash.has_value()) {
+        prefix = 0b11;
+        w.write_u8(prefix);
+        w.write_fixed(*pool_contract_puzzle_hash);
+    } else {
+        w.write_u8(prefix);
+    }
+    plot_public_key.stream(w);
+    w.write_u16_be(plot_index);
+    w.write_u8(meta_group);
+    w.write_u8(strength);
+    w.write_bytes(proof);
+}
+
+RewardChainBlock RewardChainBlock::parse(streamable::Reader& r) {
+    RewardChainBlock block;
+    block.weight = r.read_u128_be();
+    block.height = r.read_u32_be();
+    block.total_iters = r.read_u128_be();
+    block.signage_point_index = r.read_u8();
+    block.pos_ss_cc_challenge_hash = r.read_fixed<32>();
+    block.proof_of_space = ProofOfSpace::parse(r);
+    block.challenge_chain_sp_vdf = parse_optional<VDFInfo>(r, VDFInfo::parse);
+    block.challenge_chain_sp_signature = G2Element::parse(r);
+    block.challenge_chain_ip_vdf = VDFInfo::parse(r);
+    block.reward_chain_sp_vdf = parse_optional<VDFInfo>(r, VDFInfo::parse);
+    block.reward_chain_sp_signature = G2Element::parse(r);
+    block.reward_chain_ip_vdf = VDFInfo::parse(r);
+    std::tie(block.infused_challenge_chain_ip_vdf, block.header_mmr_root) =
+        parse_dual_optional<VDFInfo, Bytes32>(r, VDFInfo::parse, [](streamable::Reader& reader) { return reader.read_fixed<32>(); });
+    block.is_transaction_block = r.read_bool();
+    return block;
+}
+
+void RewardChainBlock::stream(streamable::Writer& w) const {
+    w.write_u128_be(weight);
+    w.write_u32_be(height);
+    w.write_u128_be(total_iters);
+    w.write_u8(signage_point_index);
+    w.write_fixed(pos_ss_cc_challenge_hash);
+    proof_of_space.stream(w);
+    stream_optional<VDFInfo>(w, challenge_chain_sp_vdf);
+    challenge_chain_sp_signature.stream(w);
+    challenge_chain_ip_vdf.stream(w);
+    stream_optional<VDFInfo>(w, reward_chain_sp_vdf);
+    reward_chain_sp_signature.stream(w);
+    reward_chain_ip_vdf.stream(w);
+    stream_dual_optional(w, infused_challenge_chain_ip_vdf, header_mmr_root, stream_fn<VDFInfo>(),
+                         [](streamable::Writer& writer, const Bytes32& value) { writer.write_fixed(value); });
+    w.write_bool(is_transaction_block);
+}
+
+ChallengeChainSubSlot ChallengeChainSubSlot::parse(streamable::Reader& r) {
+    ChallengeChainSubSlot slot;
+    slot.challenge_chain_end_of_slot_vdf = VDFInfo::parse(r);
+    slot.infused_challenge_chain_sub_slot_hash = parse_optional<Bytes32>(r, [](streamable::Reader& reader) { return reader.read_fixed<32>(); });
+    slot.subepoch_summary_hash = parse_optional<Bytes32>(r, [](streamable::Reader& reader) { return reader.read_fixed<32>(); });
+    slot.new_sub_slot_iters = parse_optional<uint64_t>(r, [](streamable::Reader& reader) { return reader.read_u64_be(); });
+    slot.new_difficulty = parse_optional<uint64_t>(r, [](streamable::Reader& reader) { return reader.read_u64_be(); });
+    return slot;
+}
+
+void ChallengeChainSubSlot::stream(streamable::Writer& w) const {
+    challenge_chain_end_of_slot_vdf.stream(w);
+    stream_optional_bytes32(w, infused_challenge_chain_sub_slot_hash);
+    stream_optional_bytes32(w, subepoch_summary_hash);
+    stream_optional_u64(w, new_sub_slot_iters);
+    stream_optional_u64(w, new_difficulty);
+}
+
+InfusedChallengeChainSubSlot InfusedChallengeChainSubSlot::parse(streamable::Reader& r) {
+    InfusedChallengeChainSubSlot slot;
+    slot.infused_challenge_chain_end_of_slot_vdf = VDFInfo::parse(r);
+    return slot;
+}
+
+void InfusedChallengeChainSubSlot::stream(streamable::Writer& w) const {
+    infused_challenge_chain_end_of_slot_vdf.stream(w);
+}
+
+RewardChainSubSlot RewardChainSubSlot::parse(streamable::Reader& r) {
+    RewardChainSubSlot slot;
+    slot.end_of_slot_vdf = VDFInfo::parse(r);
+    slot.challenge_chain_sub_slot_hash = r.read_fixed<32>();
+    slot.infused_challenge_chain_sub_slot_hash =
+        parse_optional<Bytes32>(r, [](streamable::Reader& reader) { return reader.read_fixed<32>(); });
+    slot.deficit = r.read_u8();
+    return slot;
+}
+
+void RewardChainSubSlot::stream(streamable::Writer& w) const {
+    end_of_slot_vdf.stream(w);
+    w.write_fixed(challenge_chain_sub_slot_hash);
+    stream_optional_bytes32(w, infused_challenge_chain_sub_slot_hash);
+    w.write_u8(deficit);
+}
+
+SubSlotProofs SubSlotProofs::parse(streamable::Reader& r) {
+    SubSlotProofs proofs;
+    proofs.challenge_chain_slot_proof = VDFProof::parse(r);
+    proofs.infused_challenge_chain_slot_proof = parse_optional<VDFProof>(r, VDFProof::parse);
+    proofs.reward_chain_slot_proof = VDFProof::parse(r);
+    return proofs;
+}
+
+void SubSlotProofs::stream(streamable::Writer& w) const {
+    challenge_chain_slot_proof.stream(w);
+    stream_optional<VDFProof>(w, infused_challenge_chain_slot_proof);
+    reward_chain_slot_proof.stream(w);
+}
+
+EndOfSubSlotBundle EndOfSubSlotBundle::parse(streamable::Reader& r) {
+    EndOfSubSlotBundle bundle;
+    bundle.challenge_chain = ChallengeChainSubSlot::parse(r);
+    bundle.infused_challenge_chain = parse_optional<InfusedChallengeChainSubSlot>(r, InfusedChallengeChainSubSlot::parse);
+    bundle.reward_chain = RewardChainSubSlot::parse(r);
+    bundle.proofs = SubSlotProofs::parse(r);
+    return bundle;
+}
+
+void EndOfSubSlotBundle::stream(streamable::Writer& w) const {
+    challenge_chain.stream(w);
+    stream_optional<InfusedChallengeChainSubSlot>(w, infused_challenge_chain);
+    reward_chain.stream(w);
+    proofs.stream(w);
+}
+
+FoliageBlockData FoliageBlockData::parse(streamable::Reader& r) {
+    FoliageBlockData data;
+    data.unfinished_reward_block_hash = r.read_fixed<32>();
+    data.pool_target = PoolTarget::parse(r);
+    data.pool_signature = parse_optional<G2Element>(r, G2Element::parse);
+    data.farmer_reward_puzzle_hash = r.read_fixed<32>();
+    data.extension_data = r.read_fixed<32>();
+    return data;
+}
+
+void FoliageBlockData::stream(streamable::Writer& w) const {
+    w.write_fixed(unfinished_reward_block_hash);
+    pool_target.stream(w);
+    stream_optional<G2Element>(w, pool_signature);
+    w.write_fixed(farmer_reward_puzzle_hash);
+    w.write_fixed(extension_data);
+}
+
+FoliageTransactionBlock FoliageTransactionBlock::parse(streamable::Reader& r) {
+    FoliageTransactionBlock block;
+    block.prev_transaction_block_hash = r.read_fixed<32>();
+    block.timestamp = r.read_u64_be();
+    block.filter_hash = r.read_fixed<32>();
+    block.additions_root = r.read_fixed<32>();
+    block.removals_root = r.read_fixed<32>();
+    block.transactions_info_hash = r.read_fixed<32>();
+    return block;
+}
+
+void FoliageTransactionBlock::stream(streamable::Writer& w) const {
+    w.write_fixed(prev_transaction_block_hash);
+    w.write_u64_be(timestamp);
+    w.write_fixed(filter_hash);
+    w.write_fixed(additions_root);
+    w.write_fixed(removals_root);
+    w.write_fixed(transactions_info_hash);
+}
+
+TransactionsInfo TransactionsInfo::parse(streamable::Reader& r) {
+    TransactionsInfo info;
+    info.generator_root = r.read_fixed<32>();
+    info.generator_refs_root = r.read_fixed<32>();
+    info.aggregated_signature = G2Element::parse(r);
+    info.fees = r.read_u64_be();
+    info.cost = r.read_u64_be();
+    info.reward_claims_incorporated = parse_list<Coin>(r, Coin::parse);
+    return info;
+}
+
+void TransactionsInfo::stream(streamable::Writer& w) const {
+    w.write_fixed(generator_root);
+    w.write_fixed(generator_refs_root);
+    aggregated_signature.stream(w);
+    w.write_u64_be(fees);
+    w.write_u64_be(cost);
+    stream_list<Coin>(w, reward_claims_incorporated);
+}
+
+Foliage Foliage::parse(streamable::Reader& r) {
+    Foliage foliage;
+    foliage.prev_block_hash = r.read_fixed<32>();
+    foliage.reward_block_hash = r.read_fixed<32>();
+    foliage.foliage_block_data = FoliageBlockData::parse(r);
+    foliage.foliage_block_data_signature = G2Element::parse(r);
+    foliage.foliage_transaction_block_hash =
+        parse_optional<Bytes32>(r, [](streamable::Reader& reader) { return reader.read_fixed<32>(); });
+    foliage.foliage_transaction_block_signature = parse_optional<G2Element>(r, G2Element::parse);
+    return foliage;
+}
+
+void Foliage::stream(streamable::Writer& w) const {
+    w.write_fixed(prev_block_hash);
+    w.write_fixed(reward_block_hash);
+    foliage_block_data.stream(w);
+    foliage_block_data_signature.stream(w);
+    stream_optional_bytes32(w, foliage_transaction_block_hash);
+    stream_optional<G2Element>(w, foliage_transaction_block_signature);
+}
+
+FullBlock FullBlock::from_bytes(const std::vector<uint8_t>& bytes) {
+    streamable::Reader r(bytes);
+    FullBlock block;
+    block.finished_sub_slots = parse_list<EndOfSubSlotBundle>(r, EndOfSubSlotBundle::parse);
+    block.reward_chain_block = RewardChainBlock::parse(r);
+    block.challenge_chain_sp_proof = parse_optional<VDFProof>(r, VDFProof::parse);
+    block.challenge_chain_ip_proof = VDFProof::parse(r);
+    block.reward_chain_sp_proof = parse_optional<VDFProof>(r, VDFProof::parse);
+    block.reward_chain_ip_proof = VDFProof::parse(r);
+    block.infused_challenge_chain_ip_proof = parse_optional<VDFProof>(r, VDFProof::parse);
+    block.foliage = Foliage::parse(r);
+    block.foliage_transaction_block = parse_optional<FoliageTransactionBlock>(r, FoliageTransactionBlock::parse);
+    block.transactions_info = parse_optional<TransactionsInfo>(r, TransactionsInfo::parse);
+
+    const uint8_t prefix = r.read_u8();
+    block.version = static_cast<uint8_t>((prefix & 0b10) != 0);
+    const bool has_generator = (prefix & 1) != 0;
+
+    if (block.version == 0) {
+        if (has_generator) {
+            block.transactions_generator = Program::parse(r);
+        }
+        block.transactions_generator_ref_list =
+            parse_list<uint32_t>(r, [](streamable::Reader& reader) { return reader.read_u32_be(); });
+    } else if (block.version == 1) {
+        if (has_generator) {
+            block.transactions_generator_buffer = r.read_bytes();
+        }
+    } else {
+        throw streamable::ParseError("invalid full block version");
+    }
+
+    if (r.remaining() != 0) {
+        throw streamable::ParseError("trailing bytes in full block");
+    }
+    return block;
+}
+
+std::vector<uint8_t> FullBlock::to_bytes() const {
+    streamable::Writer w;
+    stream_list<EndOfSubSlotBundle>(w, finished_sub_slots);
+    reward_chain_block.stream(w);
+    stream_optional<VDFProof>(w, challenge_chain_sp_proof);
+    challenge_chain_ip_proof.stream(w);
+    stream_optional<VDFProof>(w, reward_chain_sp_proof);
+    reward_chain_ip_proof.stream(w);
+    stream_optional<VDFProof>(w, infused_challenge_chain_ip_proof);
+    foliage.stream(w);
+    stream_optional<FoliageTransactionBlock>(w, foliage_transaction_block);
+    stream_optional<TransactionsInfo>(w, transactions_info);
+
+    if (version == 0) {
+        uint8_t prefix = 0;
+        if (transactions_generator.has_value()) {
+            prefix |= 1;
+        }
+        w.write_u8(prefix);
+        if (transactions_generator.has_value()) {
+            transactions_generator->stream(w);
+        }
+        stream_list(w, transactions_generator_ref_list, [](streamable::Writer& writer, uint32_t value) { writer.write_u32_be(value); });
+    } else if (version == 1) {
+        if (transactions_generator_buffer.has_value()) {
+            w.write_u8(0b11);
+            w.write_bytes(*transactions_generator_buffer);
+        } else {
+            w.write_u8(0b10);
+        }
+    } else {
+        throw streamable::ParseError("invalid full block version");
+    }
+    return w.take();
+}
+
+bool FullBlock::is_fully_compactified() const {
+    for (const auto& sub_slot : finished_sub_slots) {
+        if (!proof_is_compact(sub_slot.proofs.challenge_chain_slot_proof)) {
+            return false;
+        }
+        if (sub_slot.proofs.infused_challenge_chain_slot_proof.has_value() &&
+            !proof_is_compact(*sub_slot.proofs.infused_challenge_chain_slot_proof)) {
+            return false;
+        }
+    }
+    if (challenge_chain_sp_proof.has_value() && !proof_is_compact(*challenge_chain_sp_proof)) {
+        return false;
+    }
+    return proof_is_compact(challenge_chain_ip_proof);
+}
+
+Bytes32 FullBlock::header_hash() const {
+    // For DB lookup we use the foliage hash stored in the DB key; recomputing the
+    // hash requires BLS and tree hashing. Callers should use the header hash from
+    // compactvdf entries and DB keys instead of this placeholder.
+    return foliage.reward_block_hash;
+}
+
+uint32_t FullBlock::height() const { return reward_chain_block.height; }
+
+namespace {
+
+void maybe_add_witness_type_zero_entry(const chia::Bytes32& header_hash, uint8_t field_vdf, const VDFProof& proof,
+                                       std::vector<CompactVdfEntry>& out) {
+    if (proof.witness_type != 0 || proof.witness.empty()) {
+        return;
+    }
+    out.push_back(CompactVdfEntry{header_hash, field_vdf, proof.witness});
+}
+
+}  // namespace
+
+std::vector<CompactVdfEntry> extract_witness_type_zero_entries(const chia::Bytes32& header_hash,
+                                                               const FullBlock& block) {
+    std::vector<CompactVdfEntry> entries;
+    for (const auto& sub_slot : block.finished_sub_slots) {
+        maybe_add_witness_type_zero_entry(header_hash, static_cast<uint8_t>(CompressibleVDFField::CC_EOS_VDF),
+                                          sub_slot.proofs.challenge_chain_slot_proof, entries);
+        if (sub_slot.proofs.infused_challenge_chain_slot_proof.has_value()) {
+            maybe_add_witness_type_zero_entry(header_hash, static_cast<uint8_t>(CompressibleVDFField::ICC_EOS_VDF),
+                                              *sub_slot.proofs.infused_challenge_chain_slot_proof, entries);
+        }
+    }
+    if (block.challenge_chain_sp_proof.has_value()) {
+        maybe_add_witness_type_zero_entry(header_hash, static_cast<uint8_t>(CompressibleVDFField::CC_SP_VDF),
+                                          *block.challenge_chain_sp_proof, entries);
+    }
+    maybe_add_witness_type_zero_entry(header_hash, static_cast<uint8_t>(CompressibleVDFField::CC_IP_VDF),
+                                      block.challenge_chain_ip_proof, entries);
+    return entries;
+}
+
+std::vector<VDFInfo> vdf_info_candidates(const FullBlock& block, CompressibleVDFField field) {
+    std::vector<VDFInfo> out;
+    switch (field) {
+        case CompressibleVDFField::CC_EOS_VDF:
+            for (const auto& sub_slot : block.finished_sub_slots) {
+                out.push_back(sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf);
+            }
+            break;
+        case CompressibleVDFField::ICC_EOS_VDF:
+            for (const auto& sub_slot : block.finished_sub_slots) {
+                if (sub_slot.infused_challenge_chain.has_value()) {
+                    out.push_back(sub_slot.infused_challenge_chain->infused_challenge_chain_end_of_slot_vdf);
+                }
+            }
+            break;
+        case CompressibleVDFField::CC_SP_VDF:
+            if (block.reward_chain_block.challenge_chain_sp_vdf.has_value()) {
+                out.push_back(*block.reward_chain_block.challenge_chain_sp_vdf);
+            }
+            break;
+        case CompressibleVDFField::CC_IP_VDF:
+            out.push_back(block.reward_chain_block.challenge_chain_ip_vdf);
+            break;
+    }
+    return out;
+}
+
+bool needs_compact_proof(const VDFInfo& info, const FullBlock& block, CompressibleVDFField field) {
+    switch (field) {
+        case CompressibleVDFField::CC_EOS_VDF:
+            for (const auto& sub_slot : block.finished_sub_slots) {
+                if (sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == info) {
+                    return !proof_is_compact(sub_slot.proofs.challenge_chain_slot_proof);
+                }
+            }
+            return false;
+        case CompressibleVDFField::ICC_EOS_VDF:
+            for (const auto& sub_slot : block.finished_sub_slots) {
+                if (sub_slot.infused_challenge_chain.has_value() &&
+                    sub_slot.infused_challenge_chain->infused_challenge_chain_end_of_slot_vdf == info) {
+                    return sub_slot.proofs.infused_challenge_chain_slot_proof.has_value() &&
+                           !proof_is_compact(*sub_slot.proofs.infused_challenge_chain_slot_proof);
+                }
+            }
+            return false;
+        case CompressibleVDFField::CC_SP_VDF:
+            if (!block.reward_chain_block.challenge_chain_sp_vdf.has_value()) {
+                return false;
+            }
+            if (*block.reward_chain_block.challenge_chain_sp_vdf != info) {
+                return false;
+            }
+            return block.challenge_chain_sp_proof.has_value() && !proof_is_compact(*block.challenge_chain_sp_proof);
+        case CompressibleVDFField::CC_IP_VDF:
+            if (block.reward_chain_block.challenge_chain_ip_vdf != info) {
+                return false;
+            }
+            return !proof_is_compact(block.challenge_chain_ip_proof);
+    }
+    return false;
+}
+
+bool apply_compact_proof(FullBlock& block, const VDFInfo& info, const VDFProof& proof, CompressibleVDFField field) {
+    switch (field) {
+        case CompressibleVDFField::CC_EOS_VDF:
+            for (auto& sub_slot : block.finished_sub_slots) {
+                if (sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf == info) {
+                    sub_slot.proofs.challenge_chain_slot_proof = proof;
+                    return true;
+                }
+            }
+            return false;
+        case CompressibleVDFField::ICC_EOS_VDF:
+            for (auto& sub_slot : block.finished_sub_slots) {
+                if (sub_slot.infused_challenge_chain.has_value() &&
+                    sub_slot.infused_challenge_chain->infused_challenge_chain_end_of_slot_vdf == info) {
+                    sub_slot.proofs.infused_challenge_chain_slot_proof = proof;
+                    return true;
+                }
+            }
+            return false;
+        case CompressibleVDFField::CC_SP_VDF:
+            if (block.reward_chain_block.challenge_chain_sp_vdf.has_value() &&
+                *block.reward_chain_block.challenge_chain_sp_vdf == info) {
+                block.challenge_chain_sp_proof = proof;
+                return true;
+            }
+            return false;
+        case CompressibleVDFField::CC_IP_VDF:
+            if (block.reward_chain_block.challenge_chain_ip_vdf == info) {
+                block.challenge_chain_ip_proof = proof;
+                return true;
+            }
+            return false;
+    }
+    return false;
+}
+
+std::vector<uint8_t> hex_to_bytes(const std::string& hex_in) {
+    std::string hex = hex_in;
+    if (hex.rfind("0x", 0) == 0 || hex.rfind("0X", 0) == 0) {
+        hex = hex.substr(2);
+    }
+    if (hex.size() % 2 != 0) {
+        throw std::invalid_argument("hex string must have even length");
+    }
+    std::vector<uint8_t> out;
+    out.reserve(hex.size() / 2);
+    for (size_t i = 0; i < hex.size(); i += 2) {
+        const auto byte = std::stoul(hex.substr(i, 2), nullptr, 16);
+        out.push_back(static_cast<uint8_t>(byte));
+    }
+    return out;
+}
+
+std::string bytes_to_hex(const uint8_t* data, size_t len) {
+    static const char* kHex = "0123456789abcdef";
+    std::string out;
+    out.reserve(len * 2);
+    for (size_t i = 0; i < len; ++i) {
+        out.push_back(kHex[data[i] >> 4]);
+        out.push_back(kHex[data[i] & 0x0f]);
+    }
+    return out;
+}
+
+std::string bytes32_to_db_hex(const Bytes32& hash) { return bytes_to_hex(hash.data(), hash.size()); }
+
+std::size_t Bytes32Hash::operator()(const Bytes32& hash) const noexcept {
+    std::size_t h = 0;
+    for (const uint8_t byte : hash) {
+        h = h * 31 + byte;
+    }
+    return h;
+}
+
+}  // namespace chia

--- a/tools/process_compact_vdf/src/chia_protocol.cpp
+++ b/tools/process_compact_vdf/src/chia_protocol.cpp
@@ -607,11 +607,16 @@ uint32_t FullBlock::height() const { return reward_chain_block.height; }
 namespace {
 
 void maybe_add_witness_type_zero_entry(const chia::Bytes32& header_hash, uint8_t field_vdf, const VDFProof& proof,
-                                       std::vector<CompactVdfEntry>& out) {
+                                       std::optional<uint8_t> sub_slot_index, std::vector<CompactVdfEntry>& out) {
     if (proof.witness_type != 0 || proof.witness.empty()) {
         return;
     }
-    out.push_back(CompactVdfEntry{header_hash, field_vdf, proof.witness});
+    CompactVdfEntry entry;
+    entry.header_hash = header_hash;
+    entry.field_vdf = field_vdf;
+    entry.witness = proof.witness;
+    entry.sub_slot_index = sub_slot_index;
+    out.push_back(std::move(entry));
 }
 
 }  // namespace
@@ -619,20 +624,22 @@ void maybe_add_witness_type_zero_entry(const chia::Bytes32& header_hash, uint8_t
 std::vector<CompactVdfEntry> extract_witness_type_zero_entries(const chia::Bytes32& header_hash,
                                                                const FullBlock& block) {
     std::vector<CompactVdfEntry> entries;
-    for (const auto& sub_slot : block.finished_sub_slots) {
+    for (std::size_t sub_slot_index = 0; sub_slot_index < block.finished_sub_slots.size(); ++sub_slot_index) {
+        const auto& sub_slot = block.finished_sub_slots[sub_slot_index];
+        const auto index = static_cast<uint8_t>(sub_slot_index);
         maybe_add_witness_type_zero_entry(header_hash, static_cast<uint8_t>(CompressibleVDFField::CC_EOS_VDF),
-                                          sub_slot.proofs.challenge_chain_slot_proof, entries);
+                                          sub_slot.proofs.challenge_chain_slot_proof, index, entries);
         if (sub_slot.proofs.infused_challenge_chain_slot_proof.has_value()) {
             maybe_add_witness_type_zero_entry(header_hash, static_cast<uint8_t>(CompressibleVDFField::ICC_EOS_VDF),
-                                              *sub_slot.proofs.infused_challenge_chain_slot_proof, entries);
+                                              *sub_slot.proofs.infused_challenge_chain_slot_proof, index, entries);
         }
     }
     if (block.challenge_chain_sp_proof.has_value()) {
         maybe_add_witness_type_zero_entry(header_hash, static_cast<uint8_t>(CompressibleVDFField::CC_SP_VDF),
-                                          *block.challenge_chain_sp_proof, entries);
+                                          *block.challenge_chain_sp_proof, std::nullopt, entries);
     }
     maybe_add_witness_type_zero_entry(header_hash, static_cast<uint8_t>(CompressibleVDFField::CC_IP_VDF),
-                                      block.challenge_chain_ip_proof, entries);
+                                      block.challenge_chain_ip_proof, std::nullopt, entries);
     return entries;
 }
 
@@ -661,6 +668,27 @@ std::vector<VDFInfo> vdf_info_candidates(const FullBlock& block, CompressibleVDF
             break;
     }
     return out;
+}
+
+std::optional<VDFInfo> vdf_info_for_sub_slot(const FullBlock& block, CompressibleVDFField field,
+                                             uint8_t sub_slot_index) {
+    if (sub_slot_index >= block.finished_sub_slots.size()) {
+        return std::nullopt;
+    }
+    const auto& sub_slot = block.finished_sub_slots[sub_slot_index];
+    switch (field) {
+        case CompressibleVDFField::CC_EOS_VDF:
+            return sub_slot.challenge_chain.challenge_chain_end_of_slot_vdf;
+        case CompressibleVDFField::ICC_EOS_VDF:
+            if (!sub_slot.infused_challenge_chain.has_value()) {
+                return std::nullopt;
+            }
+            return sub_slot.infused_challenge_chain->infused_challenge_chain_end_of_slot_vdf;
+        case CompressibleVDFField::CC_SP_VDF:
+        case CompressibleVDFField::CC_IP_VDF:
+            return std::nullopt;
+    }
+    return std::nullopt;
 }
 
 bool needs_compact_proof(const VDFInfo& info, const FullBlock& block, CompressibleVDFField field) {

--- a/tools/process_compact_vdf/src/chia_protocol.cpp
+++ b/tools/process_compact_vdf/src/chia_protocol.cpp
@@ -608,7 +608,7 @@ namespace {
 
 void maybe_add_witness_type_zero_entry(const chia::Bytes32& header_hash, uint8_t field_vdf, const VDFProof& proof,
                                        std::optional<uint8_t> sub_slot_index, std::vector<CompactVdfEntry>& out) {
-    if (proof.witness_type != 0 || proof.witness.empty()) {
+    if (!proof_is_compact(proof) || proof.witness.empty()) {
         return;
     }
     CompactVdfEntry entry;

--- a/tools/process_compact_vdf/src/chia_protocol.cpp
+++ b/tools/process_compact_vdf/src/chia_protocol.cpp
@@ -691,6 +691,45 @@ std::optional<VDFInfo> vdf_info_for_sub_slot(const FullBlock& block, Compressibl
     return std::nullopt;
 }
 
+bool block_field_needs_compact_proof(const FullBlock& block, CompressibleVDFField field,
+                                       const std::optional<uint8_t>& sub_slot_index) {
+    switch (field) {
+        case CompressibleVDFField::CC_EOS_VDF:
+            if (sub_slot_index.has_value()) {
+                if (*sub_slot_index >= block.finished_sub_slots.size()) {
+                    return false;
+                }
+                return !block.finished_sub_slots[*sub_slot_index].proofs.challenge_chain_slot_proof.is_compact();
+            }
+            for (const auto& sub_slot : block.finished_sub_slots) {
+                if (!sub_slot.proofs.challenge_chain_slot_proof.is_compact()) {
+                    return true;
+                }
+            }
+            return false;
+        case CompressibleVDFField::ICC_EOS_VDF:
+            if (sub_slot_index.has_value()) {
+                if (*sub_slot_index >= block.finished_sub_slots.size()) {
+                    return false;
+                }
+                const auto& icc_proof = block.finished_sub_slots[*sub_slot_index].proofs.infused_challenge_chain_slot_proof;
+                return icc_proof.has_value() && !icc_proof->is_compact();
+            }
+            for (const auto& sub_slot : block.finished_sub_slots) {
+                const auto& icc_proof = sub_slot.proofs.infused_challenge_chain_slot_proof;
+                if (icc_proof.has_value() && !icc_proof->is_compact()) {
+                    return true;
+                }
+            }
+            return false;
+        case CompressibleVDFField::CC_SP_VDF:
+            return block.challenge_chain_sp_proof.has_value() && !block.challenge_chain_sp_proof->is_compact();
+        case CompressibleVDFField::CC_IP_VDF:
+            return !block.challenge_chain_ip_proof.is_compact();
+    }
+    return false;
+}
+
 bool needs_compact_proof(const VDFInfo& info, const FullBlock& block, CompressibleVDFField field) {
     switch (field) {
         case CompressibleVDFField::CC_EOS_VDF:

--- a/tools/process_compact_vdf/src/chia_protocol.hpp
+++ b/tools/process_compact_vdf/src/chia_protocol.hpp
@@ -257,6 +257,8 @@ std::vector<CompactVdfEntry> extract_witness_type_zero_entries(const chia::Bytes
 
 std::vector<VDFInfo> vdf_info_candidates(const FullBlock& block, CompressibleVDFField field);
 std::optional<VDFInfo> vdf_info_for_sub_slot(const FullBlock& block, CompressibleVDFField field, uint8_t sub_slot_index);
+bool block_field_needs_compact_proof(const FullBlock& block, CompressibleVDFField field,
+                                       const std::optional<uint8_t>& sub_slot_index);
 bool needs_compact_proof(const VDFInfo& info, const FullBlock& block, CompressibleVDFField field);
 bool apply_compact_proof(FullBlock& block, const VDFInfo& info, const VDFProof& proof, CompressibleVDFField field);
 

--- a/tools/process_compact_vdf/src/chia_protocol.hpp
+++ b/tools/process_compact_vdf/src/chia_protocol.hpp
@@ -1,0 +1,268 @@
+#pragma once
+
+#include "streamable.hpp"
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace chia {
+
+using Bytes32 = std::array<uint8_t, 32>;
+using Bytes48 = std::array<uint8_t, 48>;
+using Bytes96 = std::array<uint8_t, 96>;
+using Bytes100 = std::array<uint8_t, 100>;
+
+struct VDFInfo {
+    Bytes32 challenge{};
+    uint64_t number_of_iterations{};
+    Bytes100 output{};
+
+    static VDFInfo parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+    bool operator==(const VDFInfo& o) const;
+    bool operator!=(const VDFInfo& o) const;
+};
+
+struct VDFProof {
+    uint8_t witness_type{};
+    std::vector<uint8_t> witness;
+    bool normalized_to_identity{};
+
+    static VDFProof parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+    static VDFProof compact(const std::vector<uint8_t>& witness_bytes);
+    bool is_compact() const;
+};
+
+struct ClassgroupElement {
+    Bytes100 data{};
+
+    static ClassgroupElement parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+    static ClassgroupElement default_element();
+};
+
+struct Program {
+    std::vector<uint8_t> a0;
+
+    static Program parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct G1Element {
+    Bytes48 data{};
+
+    static G1Element parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct G2Element {
+    Bytes96 data{};
+
+    static G2Element parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct Coin {
+    Bytes32 parent_coin_info{};
+    Bytes32 puzzle_hash{};
+    uint64_t amount{};
+
+    static Coin parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct PoolTarget {
+    Bytes32 puzzle_hash{};
+    uint32_t max_height{};
+
+    static PoolTarget parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct ProofOfSpace {
+    Bytes32 challenge{};
+    std::optional<G1Element> pool_public_key;
+    std::optional<Bytes32> pool_contract_puzzle_hash;
+    G1Element plot_public_key{};
+    uint8_t version{};
+    uint16_t plot_index{};
+    uint8_t meta_group{};
+    uint8_t strength{};
+    uint8_t size{};
+    std::vector<uint8_t> proof;
+
+    static ProofOfSpace parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct RewardChainBlock {
+    streamable::u128 weight{};
+    uint32_t height{};
+    streamable::u128 total_iters{};
+    uint8_t signage_point_index{};
+    Bytes32 pos_ss_cc_challenge_hash{};
+    ProofOfSpace proof_of_space{};
+    std::optional<VDFInfo> challenge_chain_sp_vdf;
+    G2Element challenge_chain_sp_signature{};
+    VDFInfo challenge_chain_ip_vdf{};
+    std::optional<VDFInfo> reward_chain_sp_vdf;
+    G2Element reward_chain_sp_signature{};
+    VDFInfo reward_chain_ip_vdf{};
+    std::optional<VDFInfo> infused_challenge_chain_ip_vdf;
+    std::optional<Bytes32> header_mmr_root;
+    bool is_transaction_block{};
+
+    static RewardChainBlock parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct ChallengeChainSubSlot {
+    VDFInfo challenge_chain_end_of_slot_vdf{};
+    std::optional<Bytes32> infused_challenge_chain_sub_slot_hash;
+    std::optional<Bytes32> subepoch_summary_hash;
+    std::optional<uint64_t> new_sub_slot_iters;
+    std::optional<uint64_t> new_difficulty;
+
+    static ChallengeChainSubSlot parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct InfusedChallengeChainSubSlot {
+    VDFInfo infused_challenge_chain_end_of_slot_vdf{};
+
+    static InfusedChallengeChainSubSlot parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct RewardChainSubSlot {
+    VDFInfo end_of_slot_vdf{};
+    Bytes32 challenge_chain_sub_slot_hash{};
+    std::optional<Bytes32> infused_challenge_chain_sub_slot_hash;
+    uint8_t deficit{};
+
+    static RewardChainSubSlot parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct SubSlotProofs {
+    VDFProof challenge_chain_slot_proof{};
+    std::optional<VDFProof> infused_challenge_chain_slot_proof;
+    VDFProof reward_chain_slot_proof{};
+
+    static SubSlotProofs parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct EndOfSubSlotBundle {
+    ChallengeChainSubSlot challenge_chain{};
+    std::optional<InfusedChallengeChainSubSlot> infused_challenge_chain;
+    RewardChainSubSlot reward_chain{};
+    SubSlotProofs proofs{};
+
+    static EndOfSubSlotBundle parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct FoliageBlockData {
+    Bytes32 unfinished_reward_block_hash{};
+    PoolTarget pool_target{};
+    std::optional<G2Element> pool_signature;
+    Bytes32 farmer_reward_puzzle_hash{};
+    Bytes32 extension_data{};
+
+    static FoliageBlockData parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct FoliageTransactionBlock {
+    Bytes32 prev_transaction_block_hash{};
+    uint64_t timestamp{};
+    Bytes32 filter_hash{};
+    Bytes32 additions_root{};
+    Bytes32 removals_root{};
+    Bytes32 transactions_info_hash{};
+
+    static FoliageTransactionBlock parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct TransactionsInfo {
+    Bytes32 generator_root{};
+    Bytes32 generator_refs_root{};
+    G2Element aggregated_signature{};
+    uint64_t fees{};
+    uint64_t cost{};
+    std::vector<Coin> reward_claims_incorporated;
+
+    static TransactionsInfo parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct Foliage {
+    Bytes32 prev_block_hash{};
+    Bytes32 reward_block_hash{};
+    FoliageBlockData foliage_block_data{};
+    G2Element foliage_block_data_signature{};
+    std::optional<Bytes32> foliage_transaction_block_hash;
+    std::optional<G2Element> foliage_transaction_block_signature;
+
+    static Foliage parse(streamable::Reader& r);
+    void stream(streamable::Writer& w) const;
+};
+
+struct FullBlock {
+    std::vector<EndOfSubSlotBundle> finished_sub_slots;
+    RewardChainBlock reward_chain_block{};
+    std::optional<VDFProof> challenge_chain_sp_proof;
+    VDFProof challenge_chain_ip_proof{};
+    std::optional<VDFProof> reward_chain_sp_proof;
+    VDFProof reward_chain_ip_proof{};
+    std::optional<VDFProof> infused_challenge_chain_ip_proof;
+    Foliage foliage{};
+    std::optional<FoliageTransactionBlock> foliage_transaction_block;
+    std::optional<TransactionsInfo> transactions_info;
+    std::optional<Program> transactions_generator;
+    std::vector<uint32_t> transactions_generator_ref_list;
+    std::optional<std::vector<uint8_t>> transactions_generator_buffer;
+    uint8_t version{};
+
+    static FullBlock from_bytes(const std::vector<uint8_t>& bytes);
+    std::vector<uint8_t> to_bytes() const;
+    bool is_fully_compactified() const;
+    Bytes32 header_hash() const;
+    uint32_t height() const;
+};
+
+enum class CompressibleVDFField : uint8_t {
+    CC_EOS_VDF = 1,
+    ICC_EOS_VDF = 2,
+    CC_SP_VDF = 3,
+    CC_IP_VDF = 4,
+};
+
+struct CompactVdfEntry {
+    Bytes32 header_hash{};
+    uint8_t field_vdf{};
+    std::vector<uint8_t> witness;
+};
+
+std::vector<CompactVdfEntry> extract_witness_type_zero_entries(const chia::Bytes32& header_hash,
+                                                               const FullBlock& block);
+
+std::vector<VDFInfo> vdf_info_candidates(const FullBlock& block, CompressibleVDFField field);
+bool needs_compact_proof(const VDFInfo& info, const FullBlock& block, CompressibleVDFField field);
+bool apply_compact_proof(FullBlock& block, const VDFInfo& info, const VDFProof& proof, CompressibleVDFField field);
+
+std::vector<uint8_t> hex_to_bytes(const std::string& hex);
+std::string bytes_to_hex(const uint8_t* data, size_t len);
+std::string bytes32_to_db_hex(const Bytes32& hash);
+
+struct Bytes32Hash {
+    std::size_t operator()(const Bytes32& hash) const noexcept;
+};
+
+}  // namespace chia

--- a/tools/process_compact_vdf/src/chia_protocol.hpp
+++ b/tools/process_compact_vdf/src/chia_protocol.hpp
@@ -248,12 +248,15 @@ struct CompactVdfEntry {
     Bytes32 header_hash{};
     uint8_t field_vdf{};
     std::vector<uint8_t> witness;
+    // Index into finished_sub_slots for CC_EOS / ICC_EOS entries; unset for CC_SP / CC_IP.
+    std::optional<uint8_t> sub_slot_index;
 };
 
 std::vector<CompactVdfEntry> extract_witness_type_zero_entries(const chia::Bytes32& header_hash,
                                                                const FullBlock& block);
 
 std::vector<VDFInfo> vdf_info_candidates(const FullBlock& block, CompressibleVDFField field);
+std::optional<VDFInfo> vdf_info_for_sub_slot(const FullBlock& block, CompressibleVDFField field, uint8_t sub_slot_index);
 bool needs_compact_proof(const VDFInfo& info, const FullBlock& block, CompressibleVDFField field);
 bool apply_compact_proof(FullBlock& block, const VDFInfo& info, const VDFProof& proof, CompressibleVDFField field);
 

--- a/tools/process_compact_vdf/src/clvm_length.cpp
+++ b/tools/process_compact_vdf/src/clvm_length.cpp
@@ -1,0 +1,104 @@
+#include "clvm_length.hpp"
+
+#include <stdexcept>
+
+namespace clvm_length {
+namespace {
+
+constexpr uint8_t kConsBoxMarker = 0xff;
+constexpr uint8_t kBackReference = 0xfe;
+constexpr uint8_t kMaxSingleByte = 0x7f;
+
+class ParseError : public std::runtime_error {
+  public:
+    using runtime_error::runtime_error;
+};
+
+std::size_t leading_ones(uint8_t value) {
+    std::size_t count = 0;
+    for (int bit = 7; bit >= 0; --bit) {
+        if ((value & (1u << bit)) != 0) {
+            ++count;
+        } else {
+            break;
+        }
+    }
+    return count;
+}
+
+std::size_t decode_size(const std::vector<uint8_t>& data, std::size_t& pos, uint8_t initial_b) {
+    if ((initial_b & 0x80) == 0) {
+        throw ParseError("invalid CLVM atom size prefix");
+    }
+
+    const std::size_t prefix_len = leading_ones(initial_b);
+    if (prefix_len >= 8) {
+        throw ParseError("invalid CLVM atom size prefix");
+    }
+
+    const uint8_t bit_mask = static_cast<uint8_t>(0xff >> prefix_len);
+    uint64_t atom_size = initial_b & bit_mask;
+    for (std::size_t i = 1; i < prefix_len; ++i) {
+        if (pos >= data.size()) {
+            throw ParseError("unexpected end of buffer");
+        }
+        atom_size = (atom_size << 8) + data[pos++];
+    }
+    if (atom_size >= 0x400000000ULL) {
+        throw ParseError("CLVM atom too large");
+    }
+    return static_cast<std::size_t>(atom_size);
+}
+
+std::size_t serialized_length_trusted_impl(const std::vector<uint8_t>& data, std::size_t start) {
+    std::size_t pos = start;
+    std::size_t ops_counter = 1;
+
+    while (ops_counter > 0) {
+        if (pos >= data.size()) {
+            throw ParseError("unexpected end of buffer");
+        }
+        ops_counter -= 1;
+        const uint8_t marker = data[pos++];
+
+        if (marker == kConsBoxMarker) {
+            ops_counter += 2;
+            continue;
+        }
+
+        if (marker == kBackReference) {
+            if (pos >= data.size()) {
+                throw ParseError("unexpected end of buffer");
+            }
+            const uint8_t first_byte = data[pos++];
+            if (first_byte > kMaxSingleByte) {
+                const std::size_t path_size = decode_size(data, pos, first_byte);
+                pos += path_size;
+            }
+            if (pos > data.size()) {
+                throw ParseError("unexpected end of buffer");
+            }
+            continue;
+        }
+
+        if (marker == 0x80 || marker <= kMaxSingleByte) {
+            continue;
+        }
+
+        const std::size_t blob_size = decode_size(data, pos, marker);
+        pos += blob_size;
+        if (pos > data.size()) {
+            throw ParseError("unexpected end of buffer");
+        }
+    }
+
+    return pos - start;
+}
+
+}  // namespace
+
+std::size_t serialized_length_trusted(const std::vector<uint8_t>& data, std::size_t offset) {
+    return serialized_length_trusted_impl(data, offset);
+}
+
+}  // namespace clvm_length

--- a/tools/process_compact_vdf/src/clvm_length.hpp
+++ b/tools/process_compact_vdf/src/clvm_length.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace clvm_length {
+
+// Returns the byte length of a CLVM-serialized program starting at offset.
+// Matches clvmr::serialized_length_from_bytes_trusted().
+std::size_t serialized_length_trusted(const std::vector<uint8_t>& data, std::size_t offset);
+
+}  // namespace clvm_length

--- a/tools/process_compact_vdf/src/db_v2.cpp
+++ b/tools/process_compact_vdf/src/db_v2.cpp
@@ -1,0 +1,182 @@
+#include "db_v2.hpp"
+
+#include "zstd_util.hpp"
+
+#include <sqlite3.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+namespace db_v2 {
+namespace {
+
+void check_sqlite(int rc, sqlite3* db, const char* context) {
+    if (rc != SQLITE_OK && rc != SQLITE_DONE && rc != SQLITE_ROW) {
+        const char* err = db != nullptr ? sqlite3_errmsg(db) : "unknown sqlite error";
+        throw std::runtime_error(std::string(context) + ": " + err);
+    }
+}
+
+void validate_db_path(const std::string& path) {
+    const std::filesystem::path db_path(path);
+    if (!std::filesystem::exists(db_path)) {
+        throw std::runtime_error("database file not found: " + path);
+    }
+    if (!std::filesystem::is_regular_file(db_path)) {
+        throw std::runtime_error("database path is not a file: " + path);
+    }
+}
+
+}  // namespace
+
+Database::Database(const std::string& path, bool readonly) {
+    validate_db_path(path);
+
+    // Chia uses WAL journal mode. Opening SQLITE_OPEN_READONLY often fails on the
+    // first query because SQLite cannot access the -wal/-shm sidecar files correctly.
+    // Open read-write and use query_only for dry-run instead.
+    check_sqlite(sqlite3_open_v2(path.c_str(), &db_, SQLITE_OPEN_READWRITE, nullptr), db_, "open database");
+    sqlite3_busy_timeout(db_, 30'000);
+
+    if (readonly) {
+        check_sqlite(sqlite3_exec(db_, "PRAGMA query_only=ON", nullptr, nullptr, nullptr), db_, "enable query_only");
+    }
+}
+
+Database::~Database() {
+    if (db_ != nullptr) {
+        sqlite3_close(db_);
+    }
+}
+
+void Database::ensure_v2() {
+    sqlite3_stmt* stmt = nullptr;
+    check_sqlite(sqlite3_prepare_v2(db_, "SELECT version FROM database_version LIMIT 1", -1, &stmt, nullptr), db_,
+                 "prepare database_version");
+    const int rc = sqlite3_step(stmt);
+    if (rc == SQLITE_ROW) {
+        const int version = sqlite3_column_int(stmt, 0);
+        sqlite3_finalize(stmt);
+        if (version != 2) {
+            throw std::runtime_error("database is not v2 format (version=" + std::to_string(version) + ")");
+        }
+        return;
+    }
+    sqlite3_finalize(stmt);
+    throw std::runtime_error("database_version table missing; expected v2 blockchain database");
+}
+
+std::optional<std::vector<uint8_t>> Database::get_block_bytes(const chia::Bytes32& header_hash) {
+    sqlite3_stmt* stmt = nullptr;
+    check_sqlite(sqlite3_prepare_v2(db_, "SELECT block FROM full_blocks WHERE header_hash = ?", -1, &stmt, nullptr),
+                 db_, "prepare get block");
+    check_sqlite(sqlite3_bind_blob(stmt, 1, header_hash.data(), static_cast<int>(header_hash.size()), SQLITE_TRANSIENT),
+                 db_, "bind header hash");
+
+    std::optional<std::vector<uint8_t>> result;
+    const int rc = sqlite3_step(stmt);
+    if (rc == SQLITE_ROW) {
+        const void* blob = sqlite3_column_blob(stmt, 0);
+        const int len = sqlite3_column_bytes(stmt, 0);
+        if (blob != nullptr && len > 0) {
+            const auto* bytes = static_cast<const uint8_t*>(blob);
+            result = zstd_util::decompress(std::vector<uint8_t>(bytes, bytes + len));
+        } else {
+            result = std::vector<uint8_t>{};
+        }
+    } else if (rc != SQLITE_DONE) {
+        check_sqlite(rc, db_, "get block step");
+    }
+    sqlite3_finalize(stmt);
+    return result;
+}
+
+std::optional<uint32_t> Database::max_main_chain_height() {
+    sqlite3_stmt* stmt = nullptr;
+    check_sqlite(sqlite3_prepare_v2(db_, "SELECT MAX(height) FROM full_blocks WHERE in_main_chain=1", -1, &stmt,
+                                      nullptr),
+                 db_, "prepare max height");
+    std::optional<uint32_t> result;
+    const int rc = sqlite3_step(stmt);
+    if (rc == SQLITE_ROW && sqlite3_column_type(stmt, 0) != SQLITE_NULL) {
+        result = static_cast<uint32_t>(sqlite3_column_int64(stmt, 0));
+    } else if (rc != SQLITE_DONE) {
+        check_sqlite(rc, db_, "max height step");
+    }
+    sqlite3_finalize(stmt);
+    return result;
+}
+
+std::vector<MainChainBlockRow> Database::get_main_chain_blocks_in_height_range(uint32_t start_height,
+                                                                               uint32_t end_height) {
+    sqlite3_stmt* stmt = nullptr;
+    check_sqlite(
+        sqlite3_prepare_v2(db_,
+                           "SELECT header_hash, height, block FROM full_blocks "
+                           "WHERE in_main_chain=1 AND height >= ? AND height <= ? ORDER BY height ASC",
+                           -1, &stmt, nullptr),
+        db_, "prepare blocks in height range");
+    check_sqlite(sqlite3_bind_int64(stmt, 1, start_height), db_, "bind start height");
+    check_sqlite(sqlite3_bind_int64(stmt, 2, end_height), db_, "bind end height");
+
+    std::vector<MainChainBlockRow> rows;
+    while (true) {
+        const int rc = sqlite3_step(stmt);
+        if (rc == SQLITE_DONE) {
+            break;
+        }
+        if (rc != SQLITE_ROW) {
+            check_sqlite(rc, db_, "blocks in height range step");
+        }
+
+        MainChainBlockRow row;
+        if (sqlite3_column_bytes(stmt, 0) != static_cast<int>(row.header_hash.size())) {
+            throw std::runtime_error("invalid header_hash length in database");
+        }
+        std::copy_n(static_cast<const uint8_t*>(sqlite3_column_blob(stmt, 0)), row.header_hash.size(),
+                    row.header_hash.begin());
+        row.height = static_cast<uint32_t>(sqlite3_column_int64(stmt, 1));
+
+        const void* blob = sqlite3_column_blob(stmt, 2);
+        const int len = sqlite3_column_bytes(stmt, 2);
+        if (blob != nullptr && len > 0) {
+            const auto* bytes = static_cast<const uint8_t*>(blob);
+            row.block_bytes = zstd_util::decompress(std::vector<uint8_t>(bytes, bytes + len));
+        }
+        rows.push_back(std::move(row));
+    }
+    sqlite3_finalize(stmt);
+    return rows;
+}
+
+bool Database::replace_block(const chia::Bytes32& header_hash, const std::vector<uint8_t>& block_bytes,
+                             bool is_fully_compactified) {
+    const std::vector<uint8_t> compressed = zstd_util::compress(block_bytes);
+
+    sqlite3_stmt* stmt = nullptr;
+    check_sqlite(
+        sqlite3_prepare_v2(db_, "UPDATE full_blocks SET block = ?, is_fully_compactified = ? WHERE header_hash = ?", -1,
+                           &stmt, nullptr),
+        db_, "prepare replace block");
+    check_sqlite(sqlite3_bind_blob(stmt, 1, compressed.data(), static_cast<int>(compressed.size()), SQLITE_TRANSIENT),
+                 db_, "bind block blob");
+    check_sqlite(sqlite3_bind_int(stmt, 2, is_fully_compactified ? 1 : 0), db_, "bind compact flag");
+    check_sqlite(sqlite3_bind_blob(stmt, 3, header_hash.data(), static_cast<int>(header_hash.size()), SQLITE_TRANSIENT),
+                 db_, "bind header hash");
+    check_sqlite(sqlite3_step(stmt), db_, "replace block step");
+    const int changed = sqlite3_changes(db_);
+    sqlite3_finalize(stmt);
+    return changed > 0;
+}
+
+void Database::wal_checkpoint_truncate() {
+    sqlite3_stmt* stmt = nullptr;
+    check_sqlite(sqlite3_prepare_v2(db_, "PRAGMA wal_checkpoint(TRUNCATE)", -1, &stmt, nullptr), db_,
+                 "prepare wal checkpoint");
+    check_sqlite(sqlite3_step(stmt), db_, "wal checkpoint step");
+    sqlite3_finalize(stmt);
+}
+
+}  // namespace db_v2

--- a/tools/process_compact_vdf/src/db_v2.hpp
+++ b/tools/process_compact_vdf/src/db_v2.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "chia_protocol.hpp"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+struct sqlite3;
+
+namespace db_v2 {
+
+struct MainChainBlockRow {
+    chia::Bytes32 header_hash{};
+    uint32_t height{};
+    std::vector<uint8_t> block_bytes;
+};
+
+class Database {
+  public:
+    explicit Database(const std::string& path, bool readonly = false);
+    ~Database();
+
+    Database(const Database&) = delete;
+    Database& operator=(const Database&) = delete;
+
+    void ensure_v2();
+    std::optional<uint32_t> max_main_chain_height();
+    std::vector<MainChainBlockRow> get_main_chain_blocks_in_height_range(uint32_t start_height, uint32_t end_height);
+    std::optional<std::vector<uint8_t>> get_block_bytes(const chia::Bytes32& header_hash);
+    bool replace_block(const chia::Bytes32& header_hash, const std::vector<uint8_t>& block_bytes,
+                       bool is_fully_compactified);
+    void wal_checkpoint_truncate();
+
+  private:
+    sqlite3* db_{nullptr};
+};
+
+}  // namespace db_v2

--- a/tools/process_compact_vdf/src/export_compact_vdf.cpp
+++ b/tools/process_compact_vdf/src/export_compact_vdf.cpp
@@ -1,0 +1,105 @@
+#include "export_compact_vdf.hpp"
+
+#include "chia_protocol.hpp"
+#include "db_v2.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+namespace {
+
+double seconds_since(const std::chrono::steady_clock::time_point& start) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+}
+
+std::string compact_vdf_entry_to_json(const chia::CompactVdfEntry& entry) {
+    std::ostringstream out;
+    out << "{\"field_vdf\":" << static_cast<unsigned>(entry.field_vdf) << ",\"header_hash\":\"0x"
+        << chia::bytes32_to_db_hex(entry.header_hash) << "\",\"witness\":\"0x"
+        << chia::bytes_to_hex(entry.witness.data(), entry.witness.size()) << "\"}\n";
+    return out.str();
+}
+
+std::string chunk_filename(uint32_t start_height, uint32_t end_height) {
+    return "compactvdf-" + std::to_string(start_height) + "to" + std::to_string(end_height);
+}
+
+}  // namespace
+
+ExportCompactVdfResult export_compact_vdf_files(const ExportCompactVdfOptions& options) {
+    if (options.chunk_size == 0) {
+        throw std::invalid_argument("chunk size must be greater than zero");
+    }
+
+    const auto total_start = std::chrono::steady_clock::now();
+    ExportCompactVdfResult result;
+
+    const std::filesystem::path output_dir = std::filesystem::absolute(options.output_dir);
+    if (!std::filesystem::exists(output_dir)) {
+        throw std::runtime_error("output directory does not exist: " + output_dir.string());
+    }
+    if (!std::filesystem::is_directory(output_dir)) {
+        throw std::runtime_error("output path is not a directory: " + output_dir.string());
+    }
+
+    db_v2::Database db(options.db_path, true);
+    db.ensure_v2();
+
+    const auto max_height = db.max_main_chain_height();
+    if (!max_height.has_value()) {
+        result.elapsed_seconds = seconds_since(total_start);
+        std::cout << "No main-chain blocks found; nothing to export\n";
+        return result;
+    }
+
+    result.max_height = *max_height;
+    std::cout << "Exporting witness_type 0 compact VDF proofs from main chain heights 0 to " << result.max_height
+              << " in chunks of " << options.chunk_size << " to " << output_dir.string() << '\n';
+
+    for (uint32_t start_height = 0; start_height <= result.max_height; start_height += static_cast<uint32_t>(options.chunk_size)) {
+        const uint32_t end_height =
+            std::min(start_height + static_cast<uint32_t>(options.chunk_size) - 1U, result.max_height);
+        const auto rows = db.get_main_chain_blocks_in_height_range(start_height, end_height);
+
+        const std::filesystem::path output_path = output_dir / chunk_filename(start_height, end_height);
+        std::ofstream out(output_path);
+        if (!out.is_open()) {
+            throw std::runtime_error("failed to open output file: " + output_path.string());
+        }
+
+        std::size_t chunk_entries = 0;
+        for (const auto& row : rows) {
+            ++result.blocks_scanned;
+            try {
+                const auto block = chia::FullBlock::from_bytes(row.block_bytes);
+                if (block.height() != row.height) {
+                    std::cerr << "Block height mismatch at DB height " << row.height << ": parsed "
+                              << block.height() << '\n';
+                }
+                for (const auto& entry : chia::extract_witness_type_zero_entries(row.header_hash, block)) {
+                    out << compact_vdf_entry_to_json(entry);
+                    ++chunk_entries;
+                    ++result.entries_written;
+                }
+            } catch (const std::exception& e) {
+                std::cerr << "Failed to parse block at height " << row.height << " header_hash "
+                          << chia::bytes32_to_db_hex(row.header_hash) << ": " << e.what() << '\n';
+            }
+        }
+
+        out.close();
+        ++result.files_written;
+        std::cout << "Wrote " << output_path.filename().string() << ": " << chunk_entries << " entries from "
+                  << rows.size() << " blocks (heights " << start_height << " to " << end_height << ")\n"
+                  << std::flush;
+    }
+
+    result.elapsed_seconds = seconds_since(total_start);
+    std::cout << "Finished export: " << result.entries_written << " entries across " << result.blocks_scanned
+              << " blocks in " << result.files_written << " files, time taken: " << result.elapsed_seconds << "s\n";
+    return result;
+}

--- a/tools/process_compact_vdf/src/export_compact_vdf.cpp
+++ b/tools/process_compact_vdf/src/export_compact_vdf.cpp
@@ -20,7 +20,11 @@ std::string compact_vdf_entry_to_json(const chia::CompactVdfEntry& entry) {
     std::ostringstream out;
     out << "{\"field_vdf\":" << static_cast<unsigned>(entry.field_vdf) << ",\"header_hash\":\"0x"
         << chia::bytes32_to_db_hex(entry.header_hash) << "\",\"witness\":\"0x"
-        << chia::bytes_to_hex(entry.witness.data(), entry.witness.size()) << "\"}\n";
+        << chia::bytes_to_hex(entry.witness.data(), entry.witness.size()) << "\"";
+    if (entry.sub_slot_index.has_value()) {
+        out << ",\"sub_slot_index\":" << static_cast<unsigned>(*entry.sub_slot_index);
+    }
+    out << "}\n";
     return out.str();
 }
 

--- a/tools/process_compact_vdf/src/export_compact_vdf.cpp
+++ b/tools/process_compact_vdf/src/export_compact_vdf.cpp
@@ -61,7 +61,7 @@ ExportCompactVdfResult export_compact_vdf_files(const ExportCompactVdfOptions& o
     }
 
     result.max_height = *max_height;
-    std::cout << "Exporting witness_type 0 compact VDF proofs from main chain heights 0 to " << result.max_height
+    std::cout << "Exporting compact VDF proofs from main chain heights 0 to " << result.max_height
               << " in chunks of " << options.chunk_size << " to " << output_dir.string() << '\n';
 
     for (uint32_t start_height = 0; start_height <= result.max_height; start_height += static_cast<uint32_t>(options.chunk_size)) {

--- a/tools/process_compact_vdf/src/export_compact_vdf.hpp
+++ b/tools/process_compact_vdf/src/export_compact_vdf.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+struct ExportCompactVdfOptions {
+    std::string db_path;
+    std::size_t chunk_size{10000};
+    std::string output_dir{"."};
+};
+
+struct ExportCompactVdfResult {
+    uint32_t max_height{};
+    std::size_t files_written{};
+    std::size_t entries_written{};
+    std::size_t blocks_scanned{};
+    double elapsed_seconds{};
+};
+
+ExportCompactVdfResult export_compact_vdf_files(const ExportCompactVdfOptions& options);

--- a/tools/process_compact_vdf/src/http_fetch.cpp
+++ b/tools/process_compact_vdf/src/http_fetch.cpp
@@ -1,0 +1,45 @@
+#include "http_fetch.hpp"
+
+#include <curl/curl.h>
+
+namespace {
+
+size_t write_callback(char* ptr, size_t size, size_t nmemb, void* userdata) {
+    auto* out = static_cast<std::string*>(userdata);
+    const size_t total = size * nmemb;
+    out->append(ptr, total);
+    return total;
+}
+
+}  // namespace
+
+HttpFetchResult http_get(const std::string& url, long timeout_seconds) {
+    HttpFetchResult result;
+
+    CURL* curl = curl_easy_init();
+    if (curl == nullptr) {
+        result.error = "curl_easy_init failed";
+        return result;
+    }
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &result.body);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "process_compact_vdf/1.0");
+
+    const CURLcode code = curl_easy_perform(curl);
+    if (code != CURLE_OK) {
+        result.error = curl_easy_strerror(code);
+        curl_easy_cleanup(curl);
+        return result;
+    }
+
+    long status = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
+    result.status_code = status;
+
+    curl_easy_cleanup(curl);
+    return result;
+}

--- a/tools/process_compact_vdf/src/http_fetch.hpp
+++ b/tools/process_compact_vdf/src/http_fetch.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+struct HttpFetchResult {
+    long status_code{0};
+    std::string body;
+    std::string error;
+
+    bool transport_ok() const { return error.empty(); }
+};
+
+HttpFetchResult http_get(const std::string& url, long timeout_seconds);

--- a/tools/process_compact_vdf/src/main.cpp
+++ b/tools/process_compact_vdf/src/main.cpp
@@ -1,7 +1,9 @@
 #include "export_compact_vdf.hpp"
 #include "process_compact_vdf.hpp"
 
+#include <curl/curl.h>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 namespace {
@@ -11,12 +13,20 @@ void print_usage(const char* argv0) {
               << "  " << argv0
               << " --db <blockchain_v2.sqlite> --compactvdf <compactvdf-file> [--batch-size N] [--threads N] [--dryrun]\n"
               << "  " << argv0
+              << " --db <blockchain_v2.sqlite> --remote-compactvdf-url <base-url> [--batch-size N] [--threads N] "
+                 "[--dryrun]\n"
+              << "  " << argv0
               << " --db <blockchain_v2.sqlite> --export-compactvdf [--export-chunk-size N] [--output-dir DIR]\n"
               << "\n"
-              << "Process mode:\n"
+              << "Process mode (local file):\n"
               << "  Apply a compactvdf JSON-lines file to a v2 chia blockchain database.\n"
               << "  Validated compact proofs are merged into blocks and written back to full_blocks.\n"
               << "  The compactvdf file is deleted when processing completes successfully.\n"
+              << "\n"
+              << "Process mode (remote URL):\n"
+              << "  Download compactvdf files from a base URL in 10,000-block chunks starting at height 0.\n"
+              << "  Files are fetched from {base-url}/compactvdf-{start}to{end} until HTTP 404.\n"
+              << "  Each chunk is validated and applied before the next download.\n"
               << "\n"
               << "  --dryrun   Validate and apply proofs in memory only; no database or file writes.\n"
               << "             Uses PRAGMA query_only; stop the full node before running.\n"
@@ -28,59 +38,79 @@ void print_usage(const char* argv0) {
               << "  Only VDF proofs with witness_type 0 are exported.\n";
 }
 
+struct CurlGlobalInit {
+    CurlGlobalInit() {
+        if (curl_global_init(CURL_GLOBAL_DEFAULT) != 0) {
+            throw std::runtime_error("curl_global_init failed");
+        }
+    }
+    ~CurlGlobalInit() { curl_global_cleanup(); }
+};
+
 }  // namespace
 
 int main(int argc, char** argv) {
-    ProcessCompactVdfOptions process_options;
-    ExportCompactVdfOptions export_options;
-    bool export_mode = false;
+    try {
+        const CurlGlobalInit curl_init;
 
-    for (int i = 1; i < argc; ++i) {
-        const std::string arg = argv[i];
-        if (arg == "--db" && i + 1 < argc) {
-            process_options.db_path = argv[++i];
-            export_options.db_path = process_options.db_path;
-        } else if (arg == "--compactvdf" && i + 1 < argc) {
-            process_options.compact_vdf_path = argv[++i];
-        } else if (arg == "--batch-size" && i + 1 < argc) {
-            process_options.batch_size = static_cast<std::size_t>(std::stoul(argv[++i]));
-        } else if (arg == "--threads" && i + 1 < argc) {
-            process_options.thread_count = static_cast<unsigned>(std::stoul(argv[++i]));
-        } else if (arg == "--dryrun") {
-            process_options.dry_run = true;
-        } else if (arg == "--export-compactvdf") {
-            export_mode = true;
-        } else if (arg == "--export-chunk-size" && i + 1 < argc) {
-            export_options.chunk_size = static_cast<std::size_t>(std::stoul(argv[++i]));
-        } else if (arg == "--output-dir" && i + 1 < argc) {
-            export_options.output_dir = argv[++i];
-        } else if (arg == "--help" || arg == "-h") {
-            print_usage(argv[0]);
-            return 0;
-        } else {
-            std::cerr << "Unknown argument: " << arg << '\n';
+        ProcessCompactVdfOptions process_options;
+        ExportCompactVdfOptions export_options;
+        bool export_mode = false;
+
+        for (int i = 1; i < argc; ++i) {
+            const std::string arg = argv[i];
+            if (arg == "--db" && i + 1 < argc) {
+                process_options.db_path = argv[++i];
+                export_options.db_path = process_options.db_path;
+            } else if (arg == "--compactvdf" && i + 1 < argc) {
+                process_options.compact_vdf_path = argv[++i];
+            } else if (arg == "--remote-compactvdf-url" && i + 1 < argc) {
+                process_options.remote_compact_vdf_base_url = argv[++i];
+            } else if (arg == "--batch-size" && i + 1 < argc) {
+                process_options.batch_size = static_cast<std::size_t>(std::stoul(argv[++i]));
+            } else if (arg == "--threads" && i + 1 < argc) {
+                process_options.thread_count = static_cast<unsigned>(std::stoul(argv[++i]));
+            } else if (arg == "--dryrun") {
+                process_options.dry_run = true;
+            } else if (arg == "--export-compactvdf") {
+                export_mode = true;
+            } else if (arg == "--export-chunk-size" && i + 1 < argc) {
+                export_options.chunk_size = static_cast<std::size_t>(std::stoul(argv[++i]));
+            } else if (arg == "--output-dir" && i + 1 < argc) {
+                export_options.output_dir = argv[++i];
+            } else if (arg == "--help" || arg == "-h") {
+                print_usage(argv[0]);
+                return 0;
+            } else {
+                std::cerr << "Unknown argument: " << arg << '\n';
+                print_usage(argv[0]);
+                return 1;
+            }
+        }
+
+        if (export_options.db_path.empty()) {
             print_usage(argv[0]);
             return 1;
         }
-    }
 
-    if (export_options.db_path.empty()) {
-        print_usage(argv[0]);
-        return 1;
-    }
-
-    try {
         if (export_mode) {
             export_compact_vdf_files(export_options);
             return 0;
         }
 
-        if (process_options.compact_vdf_path.empty()) {
+        const bool has_local = !process_options.compact_vdf_path.empty();
+        const bool has_remote = !process_options.remote_compact_vdf_base_url.empty();
+        if (has_local == has_remote) {
+            std::cerr << "Specify exactly one of --compactvdf or --remote-compactvdf-url\n";
             print_usage(argv[0]);
             return 1;
         }
 
-        process_compact_vdf_file(process_options);
+        if (has_remote) {
+            process_compact_vdf_remote(process_options);
+        } else {
+            process_compact_vdf_file(process_options);
+        }
         return 0;
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << '\n';

--- a/tools/process_compact_vdf/src/main.cpp
+++ b/tools/process_compact_vdf/src/main.cpp
@@ -1,0 +1,89 @@
+#include "export_compact_vdf.hpp"
+#include "process_compact_vdf.hpp"
+
+#include <iostream>
+#include <string>
+
+namespace {
+
+void print_usage(const char* argv0) {
+    std::cerr << "Usage:\n"
+              << "  " << argv0
+              << " --db <blockchain_v2.sqlite> --compactvdf <compactvdf-file> [--batch-size N] [--threads N] [--dryrun]\n"
+              << "  " << argv0
+              << " --db <blockchain_v2.sqlite> --export-compactvdf [--export-chunk-size N] [--output-dir DIR]\n"
+              << "\n"
+              << "Process mode:\n"
+              << "  Apply a compactvdf JSON-lines file to a v2 chia blockchain database.\n"
+              << "  Validated compact proofs are merged into blocks and written back to full_blocks.\n"
+              << "  The compactvdf file is deleted when processing completes successfully.\n"
+              << "\n"
+              << "  --dryrun   Validate and apply proofs in memory only; no database or file writes.\n"
+              << "             Uses PRAGMA query_only; stop the full node before running.\n"
+              << "\n"
+              << "Export mode:\n"
+              << "  Scan the main chain from height 0 through the peak and write compactvdf JSON-lines\n"
+              << "  files for every --export-chunk-size blocks (default 10000) into --output-dir.\n"
+              << "  Files are named compactvdf-<n>to<m> where n and m are the inclusive height range.\n"
+              << "  Only VDF proofs with witness_type 0 are exported.\n";
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ProcessCompactVdfOptions process_options;
+    ExportCompactVdfOptions export_options;
+    bool export_mode = false;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--db" && i + 1 < argc) {
+            process_options.db_path = argv[++i];
+            export_options.db_path = process_options.db_path;
+        } else if (arg == "--compactvdf" && i + 1 < argc) {
+            process_options.compact_vdf_path = argv[++i];
+        } else if (arg == "--batch-size" && i + 1 < argc) {
+            process_options.batch_size = static_cast<std::size_t>(std::stoul(argv[++i]));
+        } else if (arg == "--threads" && i + 1 < argc) {
+            process_options.thread_count = static_cast<unsigned>(std::stoul(argv[++i]));
+        } else if (arg == "--dryrun") {
+            process_options.dry_run = true;
+        } else if (arg == "--export-compactvdf") {
+            export_mode = true;
+        } else if (arg == "--export-chunk-size" && i + 1 < argc) {
+            export_options.chunk_size = static_cast<std::size_t>(std::stoul(argv[++i]));
+        } else if (arg == "--output-dir" && i + 1 < argc) {
+            export_options.output_dir = argv[++i];
+        } else if (arg == "--help" || arg == "-h") {
+            print_usage(argv[0]);
+            return 0;
+        } else {
+            std::cerr << "Unknown argument: " << arg << '\n';
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    if (export_options.db_path.empty()) {
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    try {
+        if (export_mode) {
+            export_compact_vdf_files(export_options);
+            return 0;
+        }
+
+        if (process_options.compact_vdf_path.empty()) {
+            print_usage(argv[0]);
+            return 1;
+        }
+
+        process_compact_vdf_file(process_options);
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << '\n';
+        return 1;
+    }
+}

--- a/tools/process_compact_vdf/src/mini_json.cpp
+++ b/tools/process_compact_vdf/src/mini_json.cpp
@@ -1,0 +1,128 @@
+#include "mini_json.hpp"
+
+#include <cctype>
+#include <stdexcept>
+
+namespace mini_json {
+namespace {
+
+class Parser {
+  public:
+    explicit Parser(const std::string& text) : text_(text) {}
+
+    Object parse_object() {
+        expect('{');
+        Object obj;
+        if (peek() == '}') {
+            ++pos_;
+            return obj;
+        }
+        while (true) {
+            const std::string key = parse_string();
+            expect(':');
+            if (peek() == '"') {
+                obj.strings_[key] = parse_string();
+            } else if (peek() == '{') {
+                obj.objects_[key] = parse_object();
+            } else if (std::isdigit(static_cast<unsigned char>(peek())) || peek() == '-') {
+                obj.numbers_[key] = parse_uint64();
+            } else {
+                throw std::runtime_error("unsupported json value");
+            }
+            if (peek() == ',') {
+                ++pos_;
+                continue;
+            }
+            expect('}');
+            return obj;
+        }
+    }
+
+  private:
+    char peek() {
+        skip_ws();
+        return pos_ < text_.size() ? text_[pos_] : '\0';
+    }
+
+    void expect(char c) {
+        skip_ws();
+        if (pos_ >= text_.size() || text_[pos_] != c) {
+            throw std::runtime_error("json parse error");
+        }
+        ++pos_;
+    }
+
+    void skip_ws() {
+        while (pos_ < text_.size() && std::isspace(static_cast<unsigned char>(text_[pos_]))) {
+            ++pos_;
+        }
+    }
+
+    std::string parse_string() {
+        expect('"');
+        std::string out;
+        while (pos_ < text_.size() && text_[pos_] != '"') {
+            if (text_[pos_] == '\\') {
+                ++pos_;
+                if (pos_ >= text_.size()) {
+                    throw std::runtime_error("invalid escape");
+                }
+            }
+            out.push_back(text_[pos_++]);
+        }
+        expect('"');
+        return out;
+    }
+
+    uint64_t parse_uint64() {
+        skip_ws();
+        size_t start = pos_;
+        while (pos_ < text_.size() && std::isdigit(static_cast<unsigned char>(text_[pos_]))) {
+            ++pos_;
+        }
+        if (start == pos_) {
+            throw std::runtime_error("expected number");
+        }
+        return std::stoull(text_.substr(start, pos_ - start));
+    }
+
+    const std::string& text_;
+    size_t pos_{0};
+};
+
+}  // namespace
+
+Object Object::parse(const std::string& text) {
+    Parser parser(text);
+    return parser.parse_object();
+}
+
+bool Object::has(const std::string& key) const {
+    return strings_.count(key) > 0 || numbers_.count(key) > 0 || objects_.count(key) > 0;
+}
+
+std::optional<std::string> Object::get_string(const std::string& key) const {
+    const auto it = strings_.find(key);
+    if (it == strings_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+std::optional<uint64_t> Object::get_uint64(const std::string& key) const {
+    const auto it = numbers_.find(key);
+    if (it == numbers_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+const Object* Object::get_object(const std::string& key) const {
+    const auto it = objects_.find(key);
+    if (it == objects_.end()) {
+        return nullptr;
+    }
+    return &it->second;
+}
+
+}  // namespace mini_json

--- a/tools/process_compact_vdf/src/mini_json.hpp
+++ b/tools/process_compact_vdf/src/mini_json.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace mini_json {
+
+// Minimal JSON object parser for compactvdf lines: string keys to string or number values.
+class Object {
+  public:
+    static Object parse(const std::string& text);
+    bool has(const std::string& key) const;
+    std::optional<std::string> get_string(const std::string& key) const;
+    std::optional<uint64_t> get_uint64(const std::string& key) const;
+    const Object* get_object(const std::string& key) const;
+
+    std::unordered_map<std::string, std::string> strings_;
+    std::unordered_map<std::string, uint64_t> numbers_;
+    std::unordered_map<std::string, Object> objects_;
+};
+
+}  // namespace mini_json

--- a/tools/process_compact_vdf/src/process_compact_vdf.cpp
+++ b/tools/process_compact_vdf/src/process_compact_vdf.cpp
@@ -1,6 +1,7 @@
 #include "process_compact_vdf.hpp"
 
 #include "db_v2.hpp"
+#include "http_fetch.hpp"
 #include "mini_json.hpp"
 #include "vdf_validate.hpp"
 
@@ -9,10 +10,10 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
-#include <future>
 #include <iostream>
 #include <limits>
 #include <mutex>
+#include <sstream>
 #include <stdexcept>
 #include <thread>
 #include <unordered_map>
@@ -46,6 +47,18 @@ struct EntryKeyHash {
 
 double seconds_since(const std::chrono::steady_clock::time_point& start) {
     return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+}
+
+std::string trim_trailing_slash(std::string url) {
+    while (!url.empty() && url.back() == '/') {
+        url.pop_back();
+    }
+    return url;
+}
+
+std::string remote_compact_vdf_url(const std::string& base_url, uint32_t start_height, uint32_t end_height) {
+    return trim_trailing_slash(base_url) + "/compactvdf-" + std::to_string(start_height) + "to" +
+           std::to_string(end_height);
 }
 
 chia::CompactVdfEntry parse_entry_json(const mini_json::Object& data) {
@@ -87,15 +100,12 @@ chia::CompactVdfEntry parse_entry_json(const mini_json::Object& data) {
     return entry;
 }
 
-std::vector<chia::CompactVdfEntry> read_entries(const std::string& path) {
-    std::ifstream in(path);
-    if (!in.is_open()) {
-        return {};
-    }
+std::vector<chia::CompactVdfEntry> parse_compact_vdf_entries_from_text(const std::string& text) {
     std::vector<chia::CompactVdfEntry> entries;
+    std::istringstream stream(text);
     std::string line;
     int line_no = 0;
-    while (std::getline(in, line)) {
+    while (std::getline(stream, line)) {
         ++line_no;
         const auto start = line.find_first_not_of(" \t\r\n");
         if (start == std::string::npos) {
@@ -110,6 +120,16 @@ std::vector<chia::CompactVdfEntry> read_entries(const std::string& path) {
     return entries;
 }
 
+std::vector<chia::CompactVdfEntry> read_entries(const std::string& path) {
+    std::ifstream in(path);
+    if (!in.is_open()) {
+        return {};
+    }
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return parse_compact_vdf_entries_from_text(buffer.str());
+}
+
 std::vector<chia::Bytes32> ordered_unique_header_hashes(const std::vector<chia::CompactVdfEntry>& entries) {
     std::vector<chia::Bytes32> unique;
     std::unordered_set<chia::Bytes32, chia::Bytes32Hash> seen;
@@ -121,18 +141,22 @@ std::vector<chia::Bytes32> ordered_unique_header_hashes(const std::vector<chia::
     return unique;
 }
 
-}  // namespace
+void merge_result(ProcessCompactVdfResult& aggregate, const ProcessCompactVdfResult& chunk) {
+    aggregate.entries_total += chunk.entries_total;
+    aggregate.entries_applied += chunk.entries_applied;
+    aggregate.blocks_processed += chunk.blocks_processed;
+    aggregate.vdf_seconds += chunk.vdf_seconds;
+    aggregate.db_read_seconds += chunk.db_read_seconds;
+    aggregate.db_flush_seconds += chunk.db_flush_seconds;
+    aggregate.download_seconds += chunk.download_seconds;
+}
 
-ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions& options) {
+ProcessCompactVdfResult process_compact_vdf_entries(db_v2::Database& db, const ProcessCompactVdfOptions& options,
+                                                    std::vector<chia::CompactVdfEntry> entries,
+                                                    const std::string& source_label) {
     ProcessCompactVdfResult result;
-    const auto total_start = std::chrono::steady_clock::now();
 
-    auto entries = read_entries(options.compact_vdf_path);
     if (entries.empty()) {
-        if (!options.dry_run && std::filesystem::exists(options.compact_vdf_path)) {
-            std::filesystem::remove(options.compact_vdf_path);
-        }
-        result.elapsed_seconds = seconds_since(total_start);
         return result;
     }
 
@@ -144,15 +168,12 @@ ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions&
     result.entries_total = entries.size();
     const std::size_t blocks_total = unique_hashes.size();
 
-    std::cout << "Starting compact VDF file processing: " << entries.size() << " entries across " << blocks_total
-              << " blocks from " << options.compact_vdf_path;
+    std::cout << "Processing compact VDF entries: " << entries.size() << " entries across " << blocks_total
+              << " blocks from " << source_label;
     if (options.dry_run) {
         std::cout << " (dry run: no writes)";
     }
     std::cout << '\n';
-
-    db_v2::Database db(options.db_path, options.dry_run);
-    db.ensure_v2();
 
     const unsigned thread_count =
         options.thread_count == 0 ? std::max(1u, std::thread::hardware_concurrency()) : options.thread_count;
@@ -221,17 +242,33 @@ ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions&
             deduped_entries.push_back(entry);
         }
 
+        std::vector<chia::CompactVdfEntry> entries_needing_compaction;
+        entries_needing_compaction.reserve(deduped_entries.size());
+        std::size_t skipped_already_compact = 0;
+        for (const auto& entry : deduped_entries) {
+            const auto block_it = blocks.find(entry.header_hash);
+            if (block_it == blocks.end()) {
+                continue;
+            }
+            const auto field = static_cast<chia::CompressibleVDFField>(entry.field_vdf);
+            if (!chia::block_field_needs_compact_proof(block_it->second, field, entry.sub_slot_index)) {
+                ++skipped_already_compact;
+                continue;
+            }
+            entries_needing_compaction.push_back(entry);
+        }
+        if (skipped_already_compact > 0) {
+            std::cout << "Skipped " << skipped_already_compact << " entries with already-compact proofs on block\n";
+        }
+
         struct ValidationItem {
             chia::CompactVdfEntry entry;
             std::optional<chia::VDFInfo> vdf_info;
         };
 
         std::vector<ValidationItem> validation_items;
-        validation_items.reserve(deduped_entries.size());
-        for (const auto& entry : deduped_entries) {
-            if (blocks.find(entry.header_hash) == blocks.end()) {
-                continue;
-            }
+        validation_items.reserve(entries_needing_compaction.size());
+        for (const auto& entry : entries_needing_compaction) {
             validation_items.push_back({entry, std::nullopt});
         }
 
@@ -348,7 +385,7 @@ ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions&
             current_block_entries.clear();
         };
 
-        for (const auto& entry : deduped_entries) {
+        for (const auto& entry : entries_needing_compaction) {
             if (!current_hash.has_value()) {
                 current_hash = entry.header_hash;
             } else if (entry.header_hash != *current_hash) {
@@ -360,33 +397,127 @@ ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions&
         flush_current_block();
     }
 
-    if (blocks_processed > 0 && !options.dry_run) {
-        const auto wal_start = std::chrono::steady_clock::now();
-        db.wal_checkpoint_truncate();
-        result.wal_checkpoint_seconds = seconds_since(wal_start);
-    }
-
-    if (!options.dry_run) {
-        std::filesystem::remove(options.compact_vdf_path);
-    }
-
     result.blocks_processed = blocks_processed;
-    result.elapsed_seconds = seconds_since(total_start);
+    return result;
+}
+
+void print_process_summary(const ProcessCompactVdfResult& result, const ProcessCompactVdfOptions& options,
+                           const std::string& source_label, bool removed_source_file) {
     const double other_seconds =
         std::max(0.0, result.elapsed_seconds - result.vdf_seconds - result.db_read_seconds - result.db_flush_seconds -
-                              result.wal_checkpoint_seconds);
+                              result.wal_checkpoint_seconds - result.download_seconds);
 
-    std::cout << "Finished processing compact VDF file: " << result.entries_applied << " proofs applied across "
-              << result.blocks_processed << " blocks, time taken: " << result.elapsed_seconds << "s (vdf "
+    std::cout << "Finished processing compact VDF";
+    if (result.chunks_processed > 0) {
+        std::cout << " from " << result.chunks_processed << " remote chunk(s)";
+    }
+    std::cout << ": " << result.entries_applied << " proofs applied across " << result.blocks_processed << " blocks";
+    if (result.entries_total > 0) {
+        std::cout << " (" << result.entries_total << " entries read)";
+    }
+    std::cout << ", time taken: " << result.elapsed_seconds << "s (download " << result.download_seconds << "s, vdf "
               << result.vdf_seconds << "s, db read " << result.db_read_seconds << "s, db flush "
               << result.db_flush_seconds << "s, wal checkpoint " << result.wal_checkpoint_seconds << "s, other "
               << other_seconds << "s)";
     if (options.dry_run) {
         std::cout << ", dry run (no writes)";
-    } else {
-        std::cout << ", removed " << options.compact_vdf_path;
+    } else if (removed_source_file) {
+        std::cout << ", removed " << source_label;
+    }
+    std::cout << '\n';
+}
+
+}  // namespace
+
+ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions& options) {
+    ProcessCompactVdfResult result;
+    const auto total_start = std::chrono::steady_clock::now();
+
+    auto entries = read_entries(options.compact_vdf_path);
+    if (entries.empty()) {
+        if (!options.dry_run && std::filesystem::exists(options.compact_vdf_path)) {
+            std::filesystem::remove(options.compact_vdf_path);
+        }
+        result.elapsed_seconds = seconds_since(total_start);
+        return result;
+    }
+
+    db_v2::Database db(options.db_path, options.dry_run);
+    db.ensure_v2();
+
+    result = process_compact_vdf_entries(db, options, std::move(entries), options.compact_vdf_path);
+
+    if (result.blocks_processed > 0 && !options.dry_run) {
+        const auto wal_start = std::chrono::steady_clock::now();
+        db.wal_checkpoint_truncate();
+        result.wal_checkpoint_seconds = seconds_since(wal_start);
+    }
+
+    const bool removed_file = !options.dry_run;
+    if (removed_file) {
+        std::filesystem::remove(options.compact_vdf_path);
+    }
+
+    result.elapsed_seconds = seconds_since(total_start);
+    print_process_summary(result, options, options.compact_vdf_path, removed_file);
+    return result;
+}
+
+ProcessCompactVdfResult process_compact_vdf_remote(const ProcessCompactVdfOptions& options) {
+    ProcessCompactVdfResult result;
+    const auto total_start = std::chrono::steady_clock::now();
+
+    const std::string base_url = trim_trailing_slash(options.remote_compact_vdf_base_url);
+    if (base_url.empty()) {
+        throw std::invalid_argument("remote compactvdf base URL is empty");
+    }
+
+    std::cout << "Starting remote compact VDF processing from " << base_url;
+    if (options.dry_run) {
+        std::cout << " (dry run: no writes)";
     }
     std::cout << '\n';
 
+    db_v2::Database db(options.db_path, options.dry_run);
+    db.ensure_v2();
+
+    for (uint32_t start_height = 0;; start_height += kCompactVdfHeightChunkSize) {
+        const uint32_t end_height = start_height + kCompactVdfHeightChunkSize - 1;
+        const std::string url = remote_compact_vdf_url(base_url, start_height, end_height);
+
+        const auto download_start = std::chrono::steady_clock::now();
+        const HttpFetchResult response = http_get(url, 30);
+        result.download_seconds += seconds_since(download_start);
+
+        if (!response.transport_ok()) {
+            throw std::runtime_error("Failed to download " + url + ": " + response.error);
+        }
+        if (response.status_code == 404) {
+            std::cout << "No more compactvdf files at " << url << " (HTTP 404)\n";
+            break;
+        }
+        if (response.status_code != 200) {
+            throw std::runtime_error("Failed to download " + url + ": HTTP " + std::to_string(response.status_code));
+        }
+
+        auto entries = parse_compact_vdf_entries_from_text(response.body);
+        std::cout << "Downloaded " << url << ": " << entries.size() << " entries (heights " << start_height << " to "
+                  << end_height << ")\n";
+
+        if (!entries.empty()) {
+            const auto chunk_result = process_compact_vdf_entries(db, options, std::move(entries), url);
+            merge_result(result, chunk_result);
+        }
+        ++result.chunks_processed;
+    }
+
+    if (result.blocks_processed > 0 && !options.dry_run) {
+        const auto wal_start = std::chrono::steady_clock::now();
+        db.wal_checkpoint_truncate();
+        result.wal_checkpoint_seconds = seconds_since(wal_start);
+    }
+
+    result.elapsed_seconds = seconds_since(total_start);
+    print_process_summary(result, options, base_url, false);
     return result;
 }

--- a/tools/process_compact_vdf/src/process_compact_vdf.cpp
+++ b/tools/process_compact_vdf/src/process_compact_vdf.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <future>
 #include <iostream>
+#include <limits>
 #include <mutex>
 #include <stdexcept>
 #include <thread>
@@ -19,12 +20,6 @@
 #include <vector>
 
 namespace {
-
-struct CompactVdfEntry {
-    chia::Bytes32 header_hash{};
-    uint8_t field_vdf{};
-    std::vector<uint8_t> witness;
-};
 
 struct EntryKey {
     chia::Bytes32 header_hash{};
@@ -53,8 +48,8 @@ double seconds_since(const std::chrono::steady_clock::time_point& start) {
     return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
 }
 
-CompactVdfEntry parse_entry_json(const mini_json::Object& data) {
-    CompactVdfEntry entry;
+chia::CompactVdfEntry parse_entry_json(const mini_json::Object& data) {
+    chia::CompactVdfEntry entry;
     const auto header_hash = data.get_string("header_hash");
     if (!header_hash.has_value()) {
         throw std::runtime_error("missing header_hash");
@@ -82,15 +77,22 @@ CompactVdfEntry parse_entry_json(const mini_json::Object& data) {
     } else {
         throw std::runtime_error("missing witness");
     }
+
+    if (const auto sub_slot_index = data.get_uint64("sub_slot_index")) {
+        if (*sub_slot_index > std::numeric_limits<uint8_t>::max()) {
+            throw std::runtime_error("sub_slot_index out of range");
+        }
+        entry.sub_slot_index = static_cast<uint8_t>(*sub_slot_index);
+    }
     return entry;
 }
 
-std::vector<CompactVdfEntry> read_entries(const std::string& path) {
+std::vector<chia::CompactVdfEntry> read_entries(const std::string& path) {
     std::ifstream in(path);
     if (!in.is_open()) {
         return {};
     }
-    std::vector<CompactVdfEntry> entries;
+    std::vector<chia::CompactVdfEntry> entries;
     std::string line;
     int line_no = 0;
     while (std::getline(in, line)) {
@@ -108,7 +110,7 @@ std::vector<CompactVdfEntry> read_entries(const std::string& path) {
     return entries;
 }
 
-std::vector<chia::Bytes32> ordered_unique_header_hashes(const std::vector<CompactVdfEntry>& entries) {
+std::vector<chia::Bytes32> ordered_unique_header_hashes(const std::vector<chia::CompactVdfEntry>& entries) {
     std::vector<chia::Bytes32> unique;
     std::unordered_set<chia::Bytes32, chia::Bytes32Hash> seen;
     for (const auto& entry : entries) {
@@ -134,7 +136,7 @@ ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions&
         return result;
     }
 
-    std::sort(entries.begin(), entries.end(), [](const CompactVdfEntry& a, const CompactVdfEntry& b) {
+    std::sort(entries.begin(), entries.end(), [](const chia::CompactVdfEntry& a, const chia::CompactVdfEntry& b) {
         return a.header_hash < b.header_hash;
     });
 
@@ -165,7 +167,7 @@ ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions&
             unique_hashes.begin() + static_cast<std::ptrdiff_t>(batch_start),
             unique_hashes.begin() + static_cast<std::ptrdiff_t>(batch_end));
 
-        std::vector<CompactVdfEntry> batch_entries;
+        std::vector<chia::CompactVdfEntry> batch_entries;
         batch_entries.reserve(entries.size());
         for (const auto& entry : entries) {
             if (batch_hash_set.count(entry.header_hash) > 0) {
@@ -208,7 +210,7 @@ ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions&
         result.db_read_seconds += seconds_since(db_read_start);
         std::cout << "Loaded " << blocks.size() << "/" << batch_hashes.size() << " blocks from DB\n" << std::flush;
 
-        std::vector<CompactVdfEntry> deduped_entries;
+        std::vector<chia::CompactVdfEntry> deduped_entries;
         deduped_entries.reserve(batch_entries.size());
         std::unordered_set<EntryKey, EntryKeyHash> seen_keys;
         for (const auto& entry : batch_entries) {
@@ -220,7 +222,7 @@ ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions&
         }
 
         struct ValidationItem {
-            CompactVdfEntry entry;
+            chia::CompactVdfEntry entry;
             std::optional<chia::VDFInfo> vdf_info;
         };
 
@@ -261,7 +263,11 @@ ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions&
                                   << static_cast<unsigned>(item.entry.field_vdf) << "...\n"
                                   << std::flush;
                     }
-                    item.vdf_info = vdf::find_vdf_info_for_proof(block, field, proof);
+                    item.vdf_info = vdf::find_vdf_info_for_entry(block, field, proof, item.entry.sub_slot_index);
+                    if (item.vdf_info.has_value() && item.entry.sub_slot_index.has_value() &&
+                        !vdf::validate_vdf(proof, *item.vdf_info)) {
+                        item.vdf_info = std::nullopt;
+                    }
 
                     const auto done = validated_count.fetch_add(1) + 1;
                     const std::lock_guard<std::mutex> lock(log_mutex);
@@ -284,7 +290,7 @@ ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions&
         }
 
         std::optional<chia::Bytes32> current_hash;
-        std::vector<CompactVdfEntry> current_block_entries;
+        std::vector<chia::CompactVdfEntry> current_block_entries;
         auto flush_current_block = [&]() {
             if (!current_hash.has_value()) {
                 return;

--- a/tools/process_compact_vdf/src/process_compact_vdf.cpp
+++ b/tools/process_compact_vdf/src/process_compact_vdf.cpp
@@ -1,0 +1,386 @@
+#include "process_compact_vdf.hpp"
+
+#include "db_v2.hpp"
+#include "mini_json.hpp"
+#include "vdf_validate.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <iostream>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace {
+
+struct CompactVdfEntry {
+    chia::Bytes32 header_hash{};
+    uint8_t field_vdf{};
+    std::vector<uint8_t> witness;
+};
+
+struct EntryKey {
+    chia::Bytes32 header_hash{};
+    std::vector<uint8_t> witness;
+    uint8_t field_vdf{};
+
+    bool operator==(const EntryKey& other) const {
+        return field_vdf == other.field_vdf && header_hash == other.header_hash && witness == other.witness;
+    }
+};
+
+struct EntryKeyHash {
+    std::size_t operator()(const EntryKey& key) const {
+        std::size_t h = std::hash<uint8_t>{}(key.field_vdf);
+        for (const auto b : key.header_hash) {
+            h = h * 31 + b;
+        }
+        for (const auto b : key.witness) {
+            h = h * 31 + b;
+        }
+        return h;
+    }
+};
+
+double seconds_since(const std::chrono::steady_clock::time_point& start) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+}
+
+CompactVdfEntry parse_entry_json(const mini_json::Object& data) {
+    CompactVdfEntry entry;
+    const auto header_hash = data.get_string("header_hash");
+    if (!header_hash.has_value()) {
+        throw std::runtime_error("missing header_hash");
+    }
+    const auto hash_bytes = chia::hex_to_bytes(*header_hash);
+    if (hash_bytes.size() != 32) {
+        throw std::runtime_error("header_hash must be 32 bytes");
+    }
+    std::copy(hash_bytes.begin(), hash_bytes.end(), entry.header_hash.begin());
+
+    const auto field_vdf = data.get_uint64("field_vdf");
+    if (!field_vdf.has_value()) {
+        throw std::runtime_error("missing field_vdf");
+    }
+    entry.field_vdf = static_cast<uint8_t>(*field_vdf);
+
+    if (const auto witness = data.get_string("witness")) {
+        entry.witness = chia::hex_to_bytes(*witness);
+    } else if (const mini_json::Object* vdf_proof = data.get_object("vdf_proof")) {
+        const auto witness = vdf_proof->get_string("witness");
+        if (!witness.has_value()) {
+            throw std::runtime_error("missing witness");
+        }
+        entry.witness = chia::hex_to_bytes(*witness);
+    } else {
+        throw std::runtime_error("missing witness");
+    }
+    return entry;
+}
+
+std::vector<CompactVdfEntry> read_entries(const std::string& path) {
+    std::ifstream in(path);
+    if (!in.is_open()) {
+        return {};
+    }
+    std::vector<CompactVdfEntry> entries;
+    std::string line;
+    int line_no = 0;
+    while (std::getline(in, line)) {
+        ++line_no;
+        const auto start = line.find_first_not_of(" \t\r\n");
+        if (start == std::string::npos) {
+            continue;
+        }
+        try {
+            entries.push_back(parse_entry_json(mini_json::Object::parse(line)));
+        } catch (const std::exception& e) {
+            std::cerr << "Skipping invalid compactvdf line " << line_no << ": " << e.what() << '\n';
+        }
+    }
+    return entries;
+}
+
+std::vector<chia::Bytes32> ordered_unique_header_hashes(const std::vector<CompactVdfEntry>& entries) {
+    std::vector<chia::Bytes32> unique;
+    std::unordered_set<chia::Bytes32, chia::Bytes32Hash> seen;
+    for (const auto& entry : entries) {
+        if (seen.insert(entry.header_hash).second) {
+            unique.push_back(entry.header_hash);
+        }
+    }
+    return unique;
+}
+
+}  // namespace
+
+ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions& options) {
+    ProcessCompactVdfResult result;
+    const auto total_start = std::chrono::steady_clock::now();
+
+    auto entries = read_entries(options.compact_vdf_path);
+    if (entries.empty()) {
+        if (!options.dry_run && std::filesystem::exists(options.compact_vdf_path)) {
+            std::filesystem::remove(options.compact_vdf_path);
+        }
+        result.elapsed_seconds = seconds_since(total_start);
+        return result;
+    }
+
+    std::sort(entries.begin(), entries.end(), [](const CompactVdfEntry& a, const CompactVdfEntry& b) {
+        return a.header_hash < b.header_hash;
+    });
+
+    const auto unique_hashes = ordered_unique_header_hashes(entries);
+    result.entries_total = entries.size();
+    const std::size_t blocks_total = unique_hashes.size();
+
+    std::cout << "Starting compact VDF file processing: " << entries.size() << " entries across " << blocks_total
+              << " blocks from " << options.compact_vdf_path;
+    if (options.dry_run) {
+        std::cout << " (dry run: no writes)";
+    }
+    std::cout << '\n';
+
+    db_v2::Database db(options.db_path, options.dry_run);
+    db.ensure_v2();
+
+    const unsigned thread_count =
+        options.thread_count == 0 ? std::max(1u, std::thread::hardware_concurrency()) : options.thread_count;
+
+    std::size_t blocks_processed = 0;
+    const std::size_t num_batches = (blocks_total + options.batch_size - 1) / options.batch_size;
+
+    for (std::size_t batch_index = 0; batch_index < num_batches; ++batch_index) {
+        const std::size_t batch_start = batch_index * options.batch_size;
+        const std::size_t batch_end = std::min(batch_start + options.batch_size, blocks_total);
+        std::unordered_set<chia::Bytes32, chia::Bytes32Hash> batch_hash_set(
+            unique_hashes.begin() + static_cast<std::ptrdiff_t>(batch_start),
+            unique_hashes.begin() + static_cast<std::ptrdiff_t>(batch_end));
+
+        std::vector<CompactVdfEntry> batch_entries;
+        batch_entries.reserve(entries.size());
+        for (const auto& entry : entries) {
+            if (batch_hash_set.count(entry.header_hash) > 0) {
+                batch_entries.push_back(entry);
+            }
+        }
+
+        std::cout << "Compact VDF batch " << (batch_index + 1) << "/" << num_batches << ": " << batch_hash_set.size()
+                  << " blocks, " << batch_entries.size() << " entries\n";
+
+        std::unordered_map<chia::Bytes32, chia::FullBlock, chia::Bytes32Hash> blocks;
+        std::vector<chia::Bytes32> batch_hashes(batch_hash_set.begin(), batch_hash_set.end());
+        std::sort(batch_hashes.begin(), batch_hashes.end());
+
+        const auto db_read_start = std::chrono::steady_clock::now();
+        for (std::size_t block_index = 0; block_index < batch_hashes.size(); ++block_index) {
+            const auto& header_hash = batch_hashes[block_index];
+            std::cout << "Reading block " << (block_index + 1) << "/" << batch_hashes.size() << " header_hash "
+                      << chia::bytes32_to_db_hex(header_hash) << "...\n"
+                      << std::flush;
+
+            const auto block_bytes = db.get_block_bytes(header_hash);
+            if (!block_bytes.has_value()) {
+                std::cerr << "Can't find block for pending compact VDF. Header hash: "
+                          << chia::bytes32_to_db_hex(header_hash) << '\n';
+                continue;
+            }
+            try {
+                const auto block = chia::FullBlock::from_bytes(*block_bytes);
+                std::cout << "Read block " << (block_index + 1) << "/" << batch_hashes.size() << " height "
+                          << block.height() << " header_hash " << chia::bytes32_to_db_hex(header_hash) << " ("
+                          << block_bytes->size() << " bytes)\n"
+                          << std::flush;
+                blocks.emplace(header_hash, std::move(block));
+            } catch (const std::exception& e) {
+                std::cerr << "Failed to parse block " << chia::bytes32_to_db_hex(header_hash) << ": " << e.what()
+                          << '\n';
+            }
+        }
+        result.db_read_seconds += seconds_since(db_read_start);
+        std::cout << "Loaded " << blocks.size() << "/" << batch_hashes.size() << " blocks from DB\n" << std::flush;
+
+        std::vector<CompactVdfEntry> deduped_entries;
+        deduped_entries.reserve(batch_entries.size());
+        std::unordered_set<EntryKey, EntryKeyHash> seen_keys;
+        for (const auto& entry : batch_entries) {
+            EntryKey key{entry.header_hash, entry.witness, entry.field_vdf};
+            if (!seen_keys.insert(key).second) {
+                continue;
+            }
+            deduped_entries.push_back(entry);
+        }
+
+        struct ValidationItem {
+            CompactVdfEntry entry;
+            std::optional<chia::VDFInfo> vdf_info;
+        };
+
+        std::vector<ValidationItem> validation_items;
+        validation_items.reserve(deduped_entries.size());
+        for (const auto& entry : deduped_entries) {
+            if (blocks.find(entry.header_hash) == blocks.end()) {
+                continue;
+            }
+            validation_items.push_back({entry, std::nullopt});
+        }
+
+        const auto vdf_start = std::chrono::steady_clock::now();
+        std::cout << "Validating " << validation_items.size() << " compact proofs with " << thread_count
+                  << " threads...\n"
+                  << std::flush;
+
+        std::atomic<std::size_t> next_index{0};
+        std::atomic<std::size_t> validated_count{0};
+        std::mutex log_mutex;
+        std::vector<std::thread> workers;
+        workers.reserve(thread_count);
+        for (unsigned i = 0; i < thread_count; ++i) {
+            workers.emplace_back([&]() {
+                while (true) {
+                    const std::size_t idx = next_index.fetch_add(1);
+                    if (idx >= validation_items.size()) {
+                        break;
+                    }
+                    auto& item = validation_items[idx];
+                    const auto& block = blocks.at(item.entry.header_hash);
+                    const auto field = static_cast<chia::CompressibleVDFField>(item.entry.field_vdf);
+                    const auto proof = chia::VDFProof::compact(item.entry.witness);
+                    {
+                        const std::lock_guard<std::mutex> lock(log_mutex);
+                        std::cout << "Validating proof " << (idx + 1) << "/" << validation_items.size()
+                                  << " block height " << block.height() << " field_vdf "
+                                  << static_cast<unsigned>(item.entry.field_vdf) << "...\n"
+                                  << std::flush;
+                    }
+                    item.vdf_info = vdf::find_vdf_info_for_proof(block, field, proof);
+
+                    const auto done = validated_count.fetch_add(1) + 1;
+                    const std::lock_guard<std::mutex> lock(log_mutex);
+                    std::cout << "Validated proof " << done << "/" << validation_items.size() << " block height "
+                              << block.height() << " field_vdf " << static_cast<unsigned>(item.entry.field_vdf) << " "
+                              << (item.vdf_info.has_value() ? "ok" : "invalid") << '\n'
+                              << std::flush;
+                }
+            });
+        }
+        for (auto& worker : workers) {
+            worker.join();
+        }
+        result.vdf_seconds += seconds_since(vdf_start);
+
+        std::unordered_map<EntryKey, std::optional<chia::VDFInfo>, EntryKeyHash> validated;
+        for (const auto& item : validation_items) {
+            EntryKey key{item.entry.header_hash, item.entry.witness, item.entry.field_vdf};
+            validated.emplace(key, item.vdf_info);
+        }
+
+        std::optional<chia::Bytes32> current_hash;
+        std::vector<CompactVdfEntry> current_block_entries;
+        auto flush_current_block = [&]() {
+            if (!current_hash.has_value()) {
+                return;
+            }
+            auto block_it = blocks.find(*current_hash);
+            if (block_it == blocks.end()) {
+                current_hash = std::nullopt;
+                current_block_entries.clear();
+                return;
+            }
+
+            const std::string header_hash_hex = chia::bytes32_to_db_hex(*current_hash);
+            std::size_t applied_for_block = 0;
+            for (const auto& entry : current_block_entries) {
+                const auto field = static_cast<chia::CompressibleVDFField>(entry.field_vdf);
+                const auto proof = chia::VDFProof::compact(entry.witness);
+                EntryKey key{entry.header_hash, entry.witness, entry.field_vdf};
+                const auto validated_it = validated.find(key);
+                if (validated_it == validated.end() || !validated_it->second.has_value()) {
+                    std::cerr << "Pending compact VDF proof is not valid for block " << header_hash_hex << '\n';
+                    continue;
+                }
+                if (!chia::needs_compact_proof(*validated_it->second, block_it->second, field)) {
+                    std::cout << "Duplicate pending compact proof for block " << header_hash_hex << '\n';
+                    continue;
+                }
+                if (!chia::apply_compact_proof(block_it->second, *validated_it->second, proof, field)) {
+                    std::cerr << "Could not apply pending compact proof for block " << header_hash_hex << '\n';
+                    continue;
+                }
+                ++applied_for_block;
+                ++result.entries_applied;
+            }
+
+            ++blocks_processed;
+            std::cout << "Processed block " << blocks_processed << "/" << blocks_total << " height "
+                      << block_it->second.height() << " header_hash " << header_hash_hex << " applied "
+                      << applied_for_block << "/" << current_block_entries.size() << " proofs";
+            if (options.dry_run) {
+                std::cout << ", skipping DB write (dry run)\n" << std::flush;
+            } else {
+                std::cout << ", flushing to DB\n" << std::flush;
+            }
+
+            if (!options.dry_run) {
+                const auto db_flush_start = std::chrono::steady_clock::now();
+                const auto bytes = block_it->second.to_bytes();
+                if (!db.replace_block(*current_hash, bytes, block_it->second.is_fully_compactified())) {
+                    std::cerr << "Failed to update block in database: " << header_hash_hex << '\n';
+                }
+                result.db_flush_seconds += seconds_since(db_flush_start);
+            }
+
+            current_hash = std::nullopt;
+            current_block_entries.clear();
+        };
+
+        for (const auto& entry : deduped_entries) {
+            if (!current_hash.has_value()) {
+                current_hash = entry.header_hash;
+            } else if (entry.header_hash != *current_hash) {
+                flush_current_block();
+                current_hash = entry.header_hash;
+            }
+            current_block_entries.push_back(entry);
+        }
+        flush_current_block();
+    }
+
+    if (blocks_processed > 0 && !options.dry_run) {
+        const auto wal_start = std::chrono::steady_clock::now();
+        db.wal_checkpoint_truncate();
+        result.wal_checkpoint_seconds = seconds_since(wal_start);
+    }
+
+    if (!options.dry_run) {
+        std::filesystem::remove(options.compact_vdf_path);
+    }
+
+    result.blocks_processed = blocks_processed;
+    result.elapsed_seconds = seconds_since(total_start);
+    const double other_seconds =
+        std::max(0.0, result.elapsed_seconds - result.vdf_seconds - result.db_read_seconds - result.db_flush_seconds -
+                              result.wal_checkpoint_seconds);
+
+    std::cout << "Finished processing compact VDF file: " << result.entries_applied << " proofs applied across "
+              << result.blocks_processed << " blocks, time taken: " << result.elapsed_seconds << "s (vdf "
+              << result.vdf_seconds << "s, db read " << result.db_read_seconds << "s, db flush "
+              << result.db_flush_seconds << "s, wal checkpoint " << result.wal_checkpoint_seconds << "s, other "
+              << other_seconds << "s)";
+    if (options.dry_run) {
+        std::cout << ", dry run (no writes)";
+    } else {
+        std::cout << ", removed " << options.compact_vdf_path;
+    }
+    std::cout << '\n';
+
+    return result;
+}

--- a/tools/process_compact_vdf/src/process_compact_vdf.hpp
+++ b/tools/process_compact_vdf/src/process_compact_vdf.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+struct ProcessCompactVdfOptions {
+    std::string db_path;
+    std::string compact_vdf_path;
+    std::size_t batch_size{1000};
+    unsigned thread_count{0};
+    bool dry_run{false};
+};
+
+struct ProcessCompactVdfResult {
+    std::size_t entries_total{};
+    std::size_t entries_applied{};
+    std::size_t blocks_processed{};
+    double elapsed_seconds{};
+    double vdf_seconds{};
+    double db_read_seconds{};
+    double db_flush_seconds{};
+    double wal_checkpoint_seconds{};
+};
+
+ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions& options);

--- a/tools/process_compact_vdf/src/process_compact_vdf.hpp
+++ b/tools/process_compact_vdf/src/process_compact_vdf.hpp
@@ -3,9 +3,12 @@
 #include <cstddef>
 #include <string>
 
+constexpr uint32_t kCompactVdfHeightChunkSize = 10000;
+
 struct ProcessCompactVdfOptions {
     std::string db_path;
     std::string compact_vdf_path;
+    std::string remote_compact_vdf_base_url;
     std::size_t batch_size{1000};
     unsigned thread_count{0};
     bool dry_run{false};
@@ -15,11 +18,14 @@ struct ProcessCompactVdfResult {
     std::size_t entries_total{};
     std::size_t entries_applied{};
     std::size_t blocks_processed{};
+    std::size_t chunks_processed{};
     double elapsed_seconds{};
     double vdf_seconds{};
     double db_read_seconds{};
     double db_flush_seconds{};
     double wal_checkpoint_seconds{};
+    double download_seconds{};
 };
 
 ProcessCompactVdfResult process_compact_vdf_file(const ProcessCompactVdfOptions& options);
+ProcessCompactVdfResult process_compact_vdf_remote(const ProcessCompactVdfOptions& options);

--- a/tools/process_compact_vdf/src/process_compact_vdf.hpp
+++ b/tools/process_compact_vdf/src/process_compact_vdf.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
 constexpr uint32_t kCompactVdfHeightChunkSize = 10000;

--- a/tools/process_compact_vdf/src/streamable.hpp
+++ b/tools/process_compact_vdf/src/streamable.hpp
@@ -1,0 +1,161 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace streamable {
+
+using u128 = __uint128_t;
+
+class ParseError : public std::runtime_error {
+  public:
+    using runtime_error::runtime_error;
+};
+
+class Reader {
+  public:
+    explicit Reader(const std::vector<uint8_t>& data) : data_(data), pos_(0) {}
+
+    size_t remaining() const { return data_.size() - pos_; }
+    size_t position() const { return pos_; }
+    const std::vector<uint8_t>& buffer() const { return data_; }
+
+    void read_exact(uint8_t* out, size_t len) {
+        if (pos_ + len > data_.size()) {
+            throw ParseError("unexpected end of buffer at offset " + std::to_string(pos_));
+        }
+        std::copy(data_.begin() + static_cast<std::ptrdiff_t>(pos_),
+                  data_.begin() + static_cast<std::ptrdiff_t>(pos_ + len), out);
+        pos_ += len;
+    }
+
+    uint8_t read_u8() {
+        uint8_t v{};
+        read_exact(&v, 1);
+        return v;
+    }
+
+    uint16_t read_u16_be() {
+        uint8_t b[2]{};
+        read_exact(b, 2);
+        return static_cast<uint16_t>((static_cast<uint16_t>(b[0]) << 8) | b[1]);
+    }
+
+    uint32_t read_u32_be() {
+        uint8_t b[4]{};
+        read_exact(b, 4);
+        return (static_cast<uint32_t>(b[0]) << 24) | (static_cast<uint32_t>(b[1]) << 16) |
+               (static_cast<uint32_t>(b[2]) << 8) | static_cast<uint32_t>(b[3]);
+    }
+
+    uint64_t read_u64_be() {
+        uint8_t b[8]{};
+        read_exact(b, 8);
+        uint64_t v = 0;
+        for (int i = 0; i < 8; ++i) {
+            v = (v << 8) | b[i];
+        }
+        return v;
+    }
+
+    u128 read_u128_be() {
+        return (static_cast<u128>(read_u64_be()) << 64) | read_u64_be();
+    }
+
+    bool read_bool() {
+        const uint8_t v = read_u8();
+        if (v == 0) {
+            return false;
+        }
+        if (v == 1) {
+            return true;
+        }
+        throw ParseError("invalid bool");
+    }
+
+    std::vector<uint8_t> read_bytes() {
+        const uint32_t len = read_u32_be();
+        std::vector<uint8_t> out(len);
+        if (len > 0) {
+            read_exact(out.data(), len);
+        }
+        return out;
+    }
+
+    void skip_bytes(std::size_t len) {
+        if (pos_ + len > data_.size()) {
+            throw ParseError("unexpected end of buffer at offset " + std::to_string(pos_));
+        }
+        pos_ += len;
+    }
+
+    template <size_t N>
+    std::array<uint8_t, N> read_fixed() {
+        std::array<uint8_t, N> out{};
+        read_exact(out.data(), N);
+        return out;
+    }
+
+  private:
+    const std::vector<uint8_t>& data_;
+    size_t pos_;
+};
+
+class Writer {
+  public:
+    void write_u8(uint8_t v) { out_.push_back(v); }
+
+    void write_u16_be(uint16_t v) {
+        write_u8(static_cast<uint8_t>((v >> 8) & 0xff));
+        write_u8(static_cast<uint8_t>(v & 0xff));
+    }
+
+    void write_u32_be(uint32_t v) {
+        write_u8(static_cast<uint8_t>((v >> 24) & 0xff));
+        write_u8(static_cast<uint8_t>((v >> 16) & 0xff));
+        write_u8(static_cast<uint8_t>((v >> 8) & 0xff));
+        write_u8(static_cast<uint8_t>(v & 0xff));
+    }
+
+    void write_u64_be(uint64_t v) {
+        for (int i = 7; i >= 0; --i) {
+            write_u8(static_cast<uint8_t>((v >> (i * 8)) & 0xff));
+        }
+    }
+
+    void write_u128_be(u128 v) {
+        write_u64_be(static_cast<uint64_t>(v >> 64));
+        write_u64_be(static_cast<uint64_t>(v));
+    }
+
+    void write_bool(bool v) { write_u8(v ? 1 : 0); }
+
+    void write_bytes(const std::vector<uint8_t>& bytes) {
+        if (bytes.size() > std::numeric_limits<uint32_t>::max()) {
+            throw ParseError("bytes too large");
+        }
+        write_u32_be(static_cast<uint32_t>(bytes.size()));
+        out_.insert(out_.end(), bytes.begin(), bytes.end());
+    }
+
+    void write_bytes_raw(const std::vector<uint8_t>& bytes) { out_.insert(out_.end(), bytes.begin(), bytes.end()); }
+
+    template <size_t N>
+    void write_fixed(const std::array<uint8_t, N>& bytes) {
+        out_.insert(out_.end(), bytes.begin(), bytes.end());
+    }
+
+    const std::vector<uint8_t>& bytes() const { return out_; }
+    std::vector<uint8_t> take() { return std::move(out_); }
+
+  private:
+    std::vector<uint8_t> out_;
+};
+
+}  // namespace streamable

--- a/tools/process_compact_vdf/src/vdf_validate.cpp
+++ b/tools/process_compact_vdf/src/vdf_validate.cpp
@@ -91,4 +91,14 @@ std::optional<chia::VDFInfo> find_vdf_info_for_proof(const chia::FullBlock& bloc
     return std::nullopt;
 }
 
+std::optional<chia::VDFInfo> find_vdf_info_for_entry(const chia::FullBlock& block, chia::CompressibleVDFField field,
+                                                     const chia::VDFProof& proof,
+                                                     const std::optional<uint8_t>& sub_slot_index) {
+    (void)proof;
+    if (sub_slot_index.has_value()) {
+        return chia::vdf_info_for_sub_slot(block, field, *sub_slot_index);
+    }
+    return find_vdf_info_for_proof(block, field, proof);
+}
+
 }  // namespace vdf

--- a/tools/process_compact_vdf/src/vdf_validate.cpp
+++ b/tools/process_compact_vdf/src/vdf_validate.cpp
@@ -1,0 +1,94 @@
+#include "vdf_validate.hpp"
+
+#include "verifier.h"
+
+#include <list>
+#include <mutex>
+#include <unordered_map>
+
+namespace vdf {
+namespace {
+
+constexpr std::size_t kDiscriminantCacheSize = 200;
+
+class DiscriminantCache {
+  public:
+    integer get(const chia::Bytes32& challenge) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const auto cached = entries_.find(challenge);
+        if (cached != entries_.end()) {
+            touch(challenge);
+            return cached->second;
+        }
+
+        std::vector<uint8_t> seed(challenge.begin(), challenge.end());
+        integer disc = CreateDiscriminant(seed, kDiscriminantSizeBits);
+        insert(challenge, std::move(disc));
+        return entries_.at(challenge);
+    }
+
+  private:
+    void touch(const chia::Bytes32& challenge) {
+        const auto it = lru_iters_.find(challenge);
+        if (it != lru_iters_.end()) {
+            lru_.splice(lru_.end(), lru_, it->second);
+        }
+    }
+
+    void insert(const chia::Bytes32& challenge, integer disc) {
+        if (entries_.size() >= kDiscriminantCacheSize && !lru_.empty()) {
+            entries_.erase(lru_.front());
+            lru_iters_.erase(lru_.front());
+            lru_.pop_front();
+        }
+        entries_.emplace(challenge, std::move(disc));
+        lru_.push_back(challenge);
+        lru_iters_[challenge] = std::prev(lru_.end());
+    }
+
+    std::mutex mutex_;
+    std::unordered_map<chia::Bytes32, integer, chia::Bytes32Hash> entries_;
+    std::list<chia::Bytes32> lru_;
+    std::unordered_map<chia::Bytes32, std::list<chia::Bytes32>::iterator, chia::Bytes32Hash> lru_iters_;
+};
+
+DiscriminantCache& discriminant_cache() {
+    static DiscriminantCache cache;
+    return cache;
+}
+
+integer discriminant_from_challenge(const chia::Bytes32& challenge) {
+    return discriminant_cache().get(challenge);
+}
+
+}  // namespace
+
+bool validate_vdf(const chia::VDFProof& proof, const chia::VDFInfo& info) {
+    if (proof.witness_type > 64) {
+        return false;
+    }
+    try {
+        integer disc = discriminant_from_challenge(info.challenge);
+        std::vector<uint8_t> proof_blob;
+        proof_blob.insert(proof_blob.end(), info.output.begin(), info.output.end());
+        proof_blob.insert(proof_blob.end(), proof.witness.begin(), proof.witness.end());
+
+        const auto default_el = chia::ClassgroupElement::default_element();
+        return CheckProofOfTimeNWesolowski(disc, default_el.data.data(), proof_blob.data(), proof_blob.size(),
+                                           info.number_of_iterations, kDiscriminantSizeBits, proof.witness_type);
+    } catch (...) {
+        return false;
+    }
+}
+
+std::optional<chia::VDFInfo> find_vdf_info_for_proof(const chia::FullBlock& block, chia::CompressibleVDFField field,
+                                                     const chia::VDFProof& proof) {
+    for (const auto& candidate : chia::vdf_info_candidates(block, field)) {
+        if (validate_vdf(proof, candidate)) {
+            return candidate;
+        }
+    }
+    return std::nullopt;
+}
+
+}  // namespace vdf

--- a/tools/process_compact_vdf/src/vdf_validate.hpp
+++ b/tools/process_compact_vdf/src/vdf_validate.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "chia_protocol.hpp"
+
+#include <cstdint>
+#include <optional>
+
+namespace vdf {
+
+constexpr uint16_t kDiscriminantSizeBits = 1024;
+
+bool validate_vdf(const chia::VDFProof& proof, const chia::VDFInfo& info);
+
+std::optional<chia::VDFInfo> find_vdf_info_for_proof(const chia::FullBlock& block, chia::CompressibleVDFField field,
+                                                     const chia::VDFProof& proof);
+
+}  // namespace vdf

--- a/tools/process_compact_vdf/src/vdf_validate.hpp
+++ b/tools/process_compact_vdf/src/vdf_validate.hpp
@@ -14,4 +14,8 @@ bool validate_vdf(const chia::VDFProof& proof, const chia::VDFInfo& info);
 std::optional<chia::VDFInfo> find_vdf_info_for_proof(const chia::FullBlock& block, chia::CompressibleVDFField field,
                                                      const chia::VDFProof& proof);
 
+std::optional<chia::VDFInfo> find_vdf_info_for_entry(const chia::FullBlock& block, chia::CompressibleVDFField field,
+                                                     const chia::VDFProof& proof,
+                                                     const std::optional<uint8_t>& sub_slot_index);
+
 }  // namespace vdf

--- a/tools/process_compact_vdf/src/zstd_util.cpp
+++ b/tools/process_compact_vdf/src/zstd_util.cpp
@@ -1,0 +1,63 @@
+#include "zstd_util.hpp"
+
+#include <zstd.h>
+
+#include <stdexcept>
+
+namespace zstd_util {
+
+std::vector<uint8_t> decompress(const std::vector<uint8_t>& compressed) {
+    if (compressed.empty()) {
+        return {};
+    }
+
+    const unsigned long long frame_size = ZSTD_getFrameContentSize(compressed.data(), compressed.size());
+    if (frame_size == ZSTD_CONTENTSIZE_ERROR) {
+        throw std::runtime_error("invalid zstd frame");
+    }
+
+    std::vector<uint8_t> out;
+    if (frame_size != ZSTD_CONTENTSIZE_UNKNOWN) {
+        out.resize(static_cast<size_t>(frame_size));
+        const size_t ret = ZSTD_decompress(out.data(), out.size(), compressed.data(), compressed.size());
+        if (ZSTD_isError(ret)) {
+            throw std::runtime_error(std::string("zstd decompress failed: ") + ZSTD_getErrorName(ret));
+        }
+        out.resize(ret);
+        return out;
+    }
+
+    size_t capacity = compressed.size() * 4;
+    if (capacity < 1024 * 1024) {
+        capacity = 1024 * 1024;
+    }
+    while (capacity <= 256 * 1024 * 1024) {
+        out.resize(capacity);
+        const size_t ret = ZSTD_decompress(out.data(), out.size(), compressed.data(), compressed.size());
+        if (!ZSTD_isError(ret)) {
+            out.resize(ret);
+            return out;
+        }
+        if (ZSTD_getErrorCode(ret) != ZSTD_error_dstSize_tooSmall) {
+            throw std::runtime_error(std::string("zstd decompress failed: ") + ZSTD_getErrorName(ret));
+        }
+        capacity *= 2;
+    }
+    throw std::runtime_error("zstd decompress output too large");
+}
+
+std::vector<uint8_t> compress(const std::vector<uint8_t>& data) {
+    if (data.empty()) {
+        return {};
+    }
+    const size_t bound = ZSTD_compressBound(data.size());
+    std::vector<uint8_t> out(bound);
+    const size_t ret = ZSTD_compress(out.data(), out.size(), data.data(), data.size(), ZSTD_defaultCLevel());
+    if (ZSTD_isError(ret)) {
+        throw std::runtime_error(std::string("zstd compress failed: ") + ZSTD_getErrorName(ret));
+    }
+    out.resize(ret);
+    return out;
+}
+
+}  // namespace zstd_util

--- a/tools/process_compact_vdf/src/zstd_util.hpp
+++ b/tools/process_compact_vdf/src/zstd_util.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace zstd_util {
+
+std::vector<uint8_t> decompress(const std::vector<uint8_t>& compressed);
+std::vector<uint8_t> compress(const std::vector<uint8_t>& data);
+
+}  // namespace zstd_util


### PR DESCRIPTION
DO NOT MERGE

### Purpose:

This specifies an optional full node optimization that downloads compact VDF proof data from static HTTP files, applies the proofs to incoming blocks before header validation, and persists the compactified block bytes. The on-chain consensus rules are unchanged: compact proofs must already be valid under existing header validation, and block identity (`header_hash`) is unchanged because VDF witnesses are not part of the foliage hash.

The also defines a JSON-lines **compactvdf** file format for publishing compact witnesses in height-indexed chunks, and recommends disabling full-node handling of the legacy peer-to-peer compact VDF protocol messages when using the remote path exclusively.

### Current Behavior:

Chia blocks store large Wesolowski VDF witnesses for compressible challenge-chain fields (`CC_EOS`, `ICC_EOS`, `CC_SP`, `CC_IP`). Timelord bluebox already produces compact witnesses (`witness_type = 0`, `normalized_to_identity = true`) that are consensus-valid replacements for the full proofs.

Today, compactification of historical blocks on full nodes relies primarily on:

1. Timelord bluebox driven by `RequestCompactProofOfTime` messages from the full node, and
2. Peer-to-peer `new_compact_vdf` / `request_compact_vdf` / `respond_compact_vdf` gossip between full nodes.

Both paths are operationally heavy during long sync: many round trips, semaphore-limited handlers, and redundant work when the same compact witnesses could be served from a static archive.

### New Behavior:

A static **compactvdf** file per 10,000 main-chain heights allows a full node to:

- Prefetch one HTTP object per height range while syncing,
- Apply all matching compact witnesses to a block in memory before `pre_validate_block`,
- Store already-compact blocks in `full_blocks`, reducing database size and future validation cost.

This does not replace timelord bluebox for live chain extension; it complements it for catch-up sync and for operators who publish compact witness archives.

### Testing Notes:

- Parse compactvdf JSON lines (with and without `sub_slot_index`, legacy `vdf_proof` nesting)
- Apply entries to a block with uncompacted CC/ICC/SP/IP proofs; verify `header_hash` unchanged
- Verify compactified block passes `pre_validate_block`
- Verify invalid witness from file fails validation, block not added
- Sync pipeline applies remote proofs before prevalidation futures
- `is_fully_compactified` set correctly in `full_blocks` after apply


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches block ingestion and sync validation order and turns off all P2P compact VDF serving/gossip by default when using the shipped config URL; consensus still gates bad proofs, but operators depend on HTTPS archive availability and the default external host.
> 
> **Overview**
> Introduces an optional **remote compact VDF** path for full nodes: when `remote_compact_vdf_base_url` is set (reference default `https://www.xchos.com/vdfs`), the node downloads 10k-height `compactvdf-{start}to{end}` JSON-lines chunks, caches them, and applies matching compact witnesses to blocks **before** `pre_validate_block` on both batch sync and `add_block`. Consensus is unchanged—invalid witnesses still fail normal header validation.
> 
> Shared logic lives in new `compact_vdf_file.py` (parse entries, locate `VDFInfo`, apply proofs, `is_fully_compactified_header_block`) and `remote_compact_vdf.py` (HTTP fetch with 30s timeout, chunk eviction). `block_store` now sets `is_fully_compactified` via that helper instead of `FullBlock.is_fully_compactified()`, and timelord/P2P `_replace_proof` reuses `apply_compact_proof_to_block` (with a proper copy of `finished_sub_slots` for sub-slots).
> 
> **P2P compact VDF is fully disabled** in `full_node_api.py` (`new_compact_vdf`, `request_compact_vdf`, `respond_compact_vdf` are unconditional no-ops), while timelord compact proof-of-time handling is left as-is. A draft CHIP (`chip-remote-compact-vdf-proofs.md`) specifies config, file format, and integration points.
> 
> Also adds a standalone C++ `tools/process_compact_vdf` utility to export, validate, and apply compactvdf files against a v2 SQLite DB (local file or remote URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04c4ce5b26a6b3e1f1c72ef43178903a5fa9b522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->