### PR TITLE
CHIA-4277 Annotate trade_store.py

### DIFF
--- a/chia/wallet/trading/trade_store.py
+++ b/chia/wallet/trading/trade_store.py
@@ -221,7 +221,7 @@ class TradeStore:
             )
 
     async def set_status(
-        self, trade_id: bytes32, status: TradeStatus, offer_name: bytes32 = None, index: uint32 = uint32(0)
+        self, trade_id: bytes32, status: TradeStatus, offer_name: bytes32 | None = None, index: uint32 = uint32(0)
     ) -> None:
         """
         Updates the status of the trade

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -14,7 +14,6 @@ chia.ssl.create_ssl
 chia.types.blockchain_format.program
 chia.wallet.did_wallet.did_wallet
 chia.wallet.puzzles.load_clvm
-chia.wallet.trading.trade_store
 chia.wallet.util.debug_spend_bundle
 chia.wallet.util.new_peak_queue
 chia.wallet.wallet_coin_store


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type-only annotation and mypy config change; no logic or data-path changes.
> 
> **Overview**
> Improves **mypy** coverage for `chia/wallet/trading/trade_store.py` by typing the optional `offer_name` argument on `TradeStore.set_status` as `bytes32 | None` instead of `bytes32 = None`.
> 
> **`mypy-exclusions.txt`** no longer skips this module, so `trade_store` is checked with the rest of the typed codebase. No runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2220b70c1660cb5bd0dd97a7513d21667c9ae9de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->