### PR TITLE
Fix spelling typos in wallet conditions, solver API, and config

### DIFF
--- a/chia/_tests/clvm/test_message_conditions.py
+++ b/chia/_tests/clvm/test_message_conditions.py
@@ -100,7 +100,7 @@ async def test_basic_message_send_receive(mode: int, cost_logger: CostLogger) ->
 
 
 def test_message_error_conditions() -> None:
-    with pytest.raises(ValueError, match="Must specify at least one committment"):
+    with pytest.raises(ValueError, match="Must specify at least one commitment"):
         MessageParticipant()
 
     test_coin = Coin(bytes32.zeros, bytes32.zeros, uint64(0))
@@ -124,7 +124,7 @@ def test_message_error_conditions() -> None:
                 amount_committed=test_coin.amount if (not mode & 0b001) or (mode == 0b111) else None,
             )
 
-    with pytest.raises(ValueError, match="without committment information"):
+    with pytest.raises(ValueError, match="without commitment information"):
         MessageParticipant(
             mode_integer=uint8(0b111),
         ).necessary_args

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1807,7 +1807,7 @@ async def test_new_unfinished_block2_forward_limit(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "committment,expected",
+    "commitment,expected",
     [
         (0, Err.INVALID_TRANSACTIONS_GENERATOR_HASH),
         (1, Err.INVALID_TRANSACTIONS_INFO_HASH),
@@ -1824,7 +1824,7 @@ async def test_unfinished_block_with_replaced_generator(
         FullNodeSimulator, FullNodeSimulator, ChiaServer, ChiaServer, WalletTool, WalletTool, BlockTools
     ],
     self_hostname: str,
-    committment: int,
+    commitment: int,
     expected: Err,
 ) -> None:
     full_node_1, _full_node_2, server_1, server_2, _wallet_a, _wallet_receiver, bt = wallet_nodes
@@ -1838,7 +1838,7 @@ async def test_unfinished_block_with_replaced_generator(
 
     replaced_generator = SerializedProgram.from_bytes(b"\x80")
 
-    if committment > 0:
+    if commitment > 0:
         tr = block.transactions_info
         assert tr is not None
         transactions_info = TransactionsInfo(
@@ -1853,7 +1853,7 @@ async def test_unfinished_block_with_replaced_generator(
         assert block.transactions_info is not None
         transactions_info = block.transactions_info
 
-    if committment > 1:
+    if commitment > 1:
         tb = block.foliage_transaction_block
         assert tb is not None
         transaction_block = FoliageTransactionBlock(
@@ -1868,7 +1868,7 @@ async def test_unfinished_block_with_replaced_generator(
         assert block.foliage_transaction_block is not None
         transaction_block = block.foliage_transaction_block
 
-    if committment > 2:
+    if commitment > 2:
         fl = block.foliage
         foliage = Foliage(
             fl.prev_block_hash,
@@ -1881,7 +1881,7 @@ async def test_unfinished_block_with_replaced_generator(
     else:
         foliage = block.foliage
 
-    if committment > 3:
+    if commitment > 3:
         fl = block.foliage
 
         secret_key: PrivateKey = AugSchemeMPL.key_gen(bytes([2] * 32))
@@ -1897,10 +1897,10 @@ async def test_unfinished_block_with_replaced_generator(
             signature,
         )
 
-        if committment > 4:
+        if commitment > 4:
             pos = block.reward_chain_block.proof_of_space
 
-            if committment > 5:
+            if commitment > 5:
                 if pos.pool_public_key is None:
                     assert pos.pool_contract_puzzle_hash is not None
                     plot_id = calculate_plot_id_ph(pos.pool_contract_puzzle_hash, public_key)
@@ -1949,7 +1949,7 @@ async def test_unfinished_block_with_replaced_generator(
         reward_chain_block = block.reward_chain_block.get_unfinished()
 
     generator_refs: list[uint32] = []
-    if committment > 6:
+    if commitment > 6:
         generator_refs = [uint32(n) for n in range(600)]
 
     unf = UnfinishedBlock(

--- a/chia/solver/solver_api.py
+++ b/chia/solver/solver_api.py
@@ -36,7 +36,7 @@ class SolverAPI:
     ) -> Message | None:
         """
         Solve a V2 plot partial proof to get the full proof of space.
-        This is called by the farmer when it receives V2 parital proofs from harvester.
+        This is called by the farmer when it receives V2 partial proofs from harvester.
         """
         if not self.solver.started:
             self.log.error("Solver is not started")
@@ -47,7 +47,7 @@ class SolverAPI:
         try:
             proof = self.solver.solve(request.partial_proof, request.plot_id, request.strength, request.size)
             if proof is None:
-                self.log.warning(f"Solver returned no proof for parital {request.partial_proof.fragments[:5]}")
+                self.log.warning(f"Solver returned no proof for partial {request.partial_proof.fragments[:5]}")
                 return None
 
             self.log.debug(f"Successfully solved partial proof, returning {len(proof)} byte proof")
@@ -57,5 +57,5 @@ class SolverAPI:
             )
 
         except Exception as e:
-            self.log.error(f"Error solving parital {request.partial_proof.fragments[:5]}: {e}")
+            self.log.error(f"Error solving partial {request.partial_proof.fragments[:5]}: {e}")
             return None

--- a/chia/wallet/conditions.py
+++ b/chia/wallet/conditions.py
@@ -442,7 +442,7 @@ class MessageParticipant(Streamable):
             and self.coin_id_committed is None
             and self.mode_integer is None
         ):
-            raise ValueError("Must specify at least one committment. Anyone-can-send/recieve is not allowed.")
+            raise ValueError("Must specify at least one commitment. Anyone-can-send/receive is not allowed.")
         if self.coin_id_committed is not None:
             if self.parent_id_committed is None or self.puzzle_hash_committed is None or self.amount_committed is None:
                 if not (
@@ -465,7 +465,7 @@ class MessageParticipant(Streamable):
                 ), "The value for coin_id_committed must be equal to the implied ID of the other three arguments"
         if self.mode_integer is not None:
             assert self.mode == self.mode_integer, (
-                "If mode_integer is manually specified, you must specify committments that match with the mode"
+                "If mode_integer is manually specified, you must specify commitments that match with the mode"
             )
 
     @property
@@ -497,7 +497,7 @@ class MessageParticipant(Streamable):
     @property
     def necessary_args(self) -> list[Program]:
         if self._nothing_committed:
-            raise ValueError("Cannot generate necessary_args for a participant without committment information")
+            raise ValueError("Cannot generate necessary_args for a participant without commitment information")
 
         if self.coin_id_committed:
             return [Program.to(self.coin_id_committed)]

--- a/ruff.toml
+++ b/ruff.toml
@@ -47,7 +47,7 @@ ignore = [
     # Ruff Specific
 
     # This code is problematic because using instantiated types as defaults is so common across the codebase.
-    # Its purpose is to prevent accidenatally assigning mutable defaults. However, this is a bit overkill for that.
+    # Its purpose is to prevent accidentally assigning mutable defaults. However, this is a bit overkill for that.
     # That being said, it would be nice to add some way to actually guard against that specific mutable default behavior.
     "RUF009", # function-call-in-dataclass-default-argument
     "RUF056", # falsy-dict-get-fallback


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Purpose:

Combine straightforward spelling corrections from community PRs #20672 and #20655 into a single change. No behavior changes.

Thanks to [@Pleorqy](https://github.com/Pleorqy) for the original fixes in #20672 and [@bknox83](https://github.com/bknox83) for the original fixes in #20655.

### Current Behavior:

- `MessageParticipant` error messages and related tests use "committment", "committments", and "recieve"
- `SolverAPI.solve` docstring and log messages use "parital"
- A comment in `ruff.toml` uses "accidenatally"
- `test_full_node.py` uses a `committment` parameter name

### New Behavior:

- Correct spelling: "commitment", "commitments", "receive", "partial", and "accidentally"
- Test parameter renamed from `committment` to `commitment`

### Testing Notes:

- Ran `pytest chia/_tests/clvm/test_message_conditions.py::test_message_error_conditions` — passed
- No logic changes; only strings, comments, and test identifiers updated

### Files changed

From #20672 ([@Pleorqy](https://github.com/Pleorqy)):
- `chia/wallet/conditions.py`
- `chia/_tests/clvm/test_message_conditions.py`
- `chia/_tests/core/full_node/test_full_node.py`

From #20655 ([@bknox83](https://github.com/bknox83)):
- `chia/solver/solver_api.py`
- `ruff.toml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1995-653d-7765-aa98-9c3c5c5d2f42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1995-653d-7765-aa98-9c3c5c5d2f42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

