### PR TITLE
Update Managed Files

### DIFF
--- a/.github/workflows/dependency-cursor-review.yml
+++ b/.github/workflows/dependency-cursor-review.yml
@@ -766,6 +766,7 @@ jobs:
           fi
 
       - name: Run Cursor analysis
+        if: github.repository_owner == 'Chia-Network'
         timeout-minutes: 10
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single workflow guard; malware scan and commenting remain; only external Cursor API usage is restricted.
> 
> **Overview**
> The **Dependency Cursor Review** workflow still runs malware scanning and posts PR comments on forks, but the **Run Cursor analysis** step now runs only when `github.repository_owner == 'Chia-Network'`.
> 
> This matches other org-gated workflows and avoids spending `CURSOR_API_KEY` / Cursor CLI time on non-org copies of the repo. When the step is skipped, downstream comment logic should still see the existing fallback when `cursor_output.json` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac824d98e0bd66ccea6143b0f373dce403620c94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->