### PR TITLE
CHIA-4285 Bring-in Arvid's fix for test_spam_message_too_large

### DIFF
--- a/chia/_tests/core/server/test_dos.py
+++ b/chia/_tests/core/server/test_dos.py
@@ -407,6 +407,15 @@ class TestDos:
         def is_closed() -> bool:
             return ws_con.closed
 
+        # This test drives sends manually via the private ``_send_message`` while
+        # controlling the outbound rate limiter. Stop the connection's own
+        # outbound handler first so it can't concurrently send a message that an
+        # earlier rate-limited send re-queued via ``_wait_and_retry``. Two tasks
+        # calling ``ws.send_bytes`` on the same websocket corrupts the connection
+        # (observed as a spurious cancellation on Python 3.10).
+        assert ws_con.outbound_task is not None
+        ws_con.outbound_task.cancel()
+
         new_message = make_msg(
             ProtocolMessageTypes.request_mempool_transactions,
             full_node_protocol.RequestMempoolTransactions(bytes([0] * 5 * 1024 * 1024)),


### PR DESCRIPTION
This brings-in PR #21068's fix for `test_spam_message_too_large` in commit 9c1e69c7228021e862e4609203e22522e9c639a7.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production server behavior modified.
> 
> **Overview**
> Stabilizes **`test_spam_message_too_large`** by canceling the connection’s **`outbound_task`** before the test calls **`_send_message`** directly.
> 
> The test manually drives outbound sends while exercising rate limits; leaving **`outbound_handler`** running could re-queue rate-limited traffic via **`_wait_and_retry`** and race another **`ws.send_bytes`**, which was corrupting the websocket and causing flaky failures (e.g. spurious cancellation on Python 3.10). Inline comments document that rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 442242a47a64890bf49e822e92cd7d955404d2c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->