### PR TITLE
CHIA-4286 Bring-in Arvid's flakiness fix for test_transaction_ack_duplicate_without_resend_ignored

### DIFF
--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -1458,6 +1458,17 @@ async def test_transaction_ack_duplicate_without_resend_ignored(
     await conn.incoming_queue.put(msg)
     await time_out_assert(5, check_wallet_cache_empty, True)
 
+    # The handler clears _tx_messages_in_progress *before* it awaits
+    # remove_from_queue(), so an empty cache does not yet imply the record was
+    # updated. Wait for the record itself to reflect the processed first ack
+    # before capturing the baseline, otherwise we can read a stale sent=0 while
+    # the increment is still in flight (consistently observable on Python 3.14).
+    async def first_ack_applied() -> bool:
+        rec = await wallet_node.wallet_state_manager.get_transaction(tx.name)
+        return rec is not None and rec.sent == 1
+
+    await time_out_assert(5, first_ack_applied, True)
+
     first_tx_record = await wallet_node.wallet_state_manager.get_transaction(tx.name)
     assert first_tx_record is not None
     first_sent = first_tx_record.sent


### PR DESCRIPTION
This brings-in PR #21068's flakiness fix for `test_transaction_ack_duplicate_without_resend_ignored` in commit 980f4b3c2b79c4c84b892c38c6309745180ef9ff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization change; no production wallet or protocol logic is modified.
> 
> **Overview**
> Fixes intermittent failures in **`test_transaction_ack_duplicate_without_resend_ignored`** by not treating an empty **`_tx_messages_in_progress`** as proof the first ack was fully applied.
> 
> The test now **`time_out_assert`s** until the transaction record shows **`sent == 1`** before capturing the baseline for duplicate-ack assertions. That matches wallet behavior: the ack handler drops the in-flight entry **before** **`remove_from_queue()`** finishes, so the cache can clear while **`sent`** is still updating (notably on **Python 3.14**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8025f2f9086353a5ab98538fbd976afe8efb1937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->