### PR TITLE
CHIA-4287 Bring-in Arvid's allowed warnings as some tests leak aiohttp websocket clients

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -19,6 +19,7 @@ filterwarnings =
     error
     ignore:unclosed database:ResourceWarning
     ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning
+    ignore:Exception ignored while calling deallocator:pytest.PytestUnraisableExceptionWarning
     ignore:cannot collect test class:pytest.PytestCollectionWarning
     ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
     ignore:record_property is incompatible with junit_family:pytest.PytestWarning
@@ -28,3 +29,4 @@ filterwarnings =
     ignore:'asyncio.set_event_loop_policy' is deprecated and slated for removal in Python 3.16:DeprecationWarning
     ignore:'asyncio.WindowsProactorEventLoopPolicy' is deprecated and slated for removal in Python 3.16:DeprecationWarning
     ignore:unclosed <socket.socket:ResourceWarning
+    ignore:unclosed transport:ResourceWarning


### PR DESCRIPTION
This brings-in PR #21068's allowed warnings in commit 8f81d0b4ffd7d81908d7be0cc653eac5620c3fdc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only pytest configuration; no production code or security behavior changes.
> 
> **Overview**
> Extends **`pytest.ini`** `filterwarnings` so CI does not fail on known noisy teardown warnings from tests that leave **aiohttp** websocket/transport resources open.
> 
> Adds ignores for **`pytest.PytestUnraisableExceptionWarning`** messages about exceptions during deallocator cleanup, and **`ResourceWarning`** for **unclosed transport** (alongside the existing unclosed socket/database rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3ec70d630024af92b81fb03aefbf482ce8a8946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->