### PR TITLE
[CHIA-3815] add V2 predictable plot filter primitives

### DIFF
--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -228,7 +228,8 @@ def test_verify_and_get_quality_string_v2(caplog: pytest.LogCaptureFixture, case
         (PlotParam.make_v1(49), True),
         (PlotParam.make_v1(50), True),
         (PlotParam.make_v1(51), False),  # too large
-        (PlotParam.make_v2(0, 0, 1), False),  # too small
+        (PlotParam.make_v2(0, 0, 0), False),  # strength too low
+        (PlotParam.make_v2(0, 0, 1), False),  # strength too low
         (PlotParam.make_v2(0, 0, 2), True),
         (PlotParam.make_v2(0, 0, 3), True),
         (PlotParam.make_v2(0, 0, 32), True),
@@ -311,11 +312,11 @@ def test_base_filter_relative_to_fork_height() -> None:
 @pytest.mark.parametrize(
     "plot_strength,expected_bits",
     [
-        (0, 9),  # at min strength (0) -> plain base filter
-        (1, 10),
-        (2, 11),
-        (4, 13),  # reaches the 8192 cap
-        (5, 13),  # capped
+        (2, 9),  # at min strength (2) -> plain base filter
+        (3, 10),
+        (4, 11),
+        (6, 13),  # reaches the 8192 cap
+        (7, 13),  # capped
         (17, 13),  # capped
     ],
 )
@@ -323,7 +324,7 @@ def test_calculate_plot_filter_bits(plot_strength: int, expected_bits: int) -> N
     constants = DEFAULT_CONSTANTS.replace(
         HARD_FORK2_HEIGHT=uint32(1_000_000),
         NUMBER_ZERO_BITS_PLOT_FILTER_V2=uint8(9),
-        MIN_PLOT_STRENGTH=uint8(0),
+        MIN_PLOT_STRENGTH=uint8(2),
     )
     assert calculate_plot_filter_bits(uint32(1_000_000), constants, plot_strength) == expected_bits
 

--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -12,14 +12,19 @@ from chia_rs.sized_ints import uint8, uint32
 from chia._tests.util.misc import Marks, datacases
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.types.blockchain_format.proof_of_space import (
+    calculate_base_plot_filter_bits,
+    calculate_plot_filter_bits,
     calculate_prefix_bits,
     check_plot_param,
+    compute_plot_group_id,
     is_v1_phased_out,
     make_pos,
     num_phase_out_epochs,
     passes_plot_filter,
+    passes_plot_filter_v2,
     verify_and_get_quality_string,
 )
+from chia.util.hash import std_hash
 
 
 @dataclass
@@ -291,6 +296,65 @@ def test_calculate_prefix_bits_v1(height: uint32, expected: int) -> None:
 )
 def test_calculate_prefix_bits_v2(height: uint32, expected: int) -> None:
     assert calculate_prefix_bits(DEFAULT_CONSTANTS, height, PlotParam.make_v2(0, 0, 28)) == expected
+
+
+def test_base_filter_relative_to_fork_height() -> None:
+    constants = DEFAULT_CONSTANTS.replace(
+        HARD_FORK2_HEIGHT=uint32(1_000_000),
+        NUMBER_ZERO_BITS_PLOT_FILTER_V2=uint8(9),
+    )
+    assert calculate_base_plot_filter_bits(uint32(1_000_000), constants) == 9
+    assert calculate_base_plot_filter_bits(uint32(11_101_000), constants) == 8
+    assert calculate_base_plot_filter_bits(uint32(0), constants) == 9  # before fork
+
+
+@pytest.mark.parametrize(
+    "plot_strength,expected_bits",
+    [
+        (0, 9),  # at min strength (0) -> plain base filter
+        (1, 10),
+        (2, 11),
+        (4, 13),  # reaches the 8192 cap
+        (5, 13),  # capped
+        (17, 13),  # capped
+    ],
+)
+def test_calculate_plot_filter_bits(plot_strength: int, expected_bits: int) -> None:
+    constants = DEFAULT_CONSTANTS.replace(
+        HARD_FORK2_HEIGHT=uint32(1_000_000),
+        NUMBER_ZERO_BITS_PLOT_FILTER_V2=uint8(9),
+        MIN_PLOT_STRENGTH=uint8(0),
+    )
+    assert calculate_plot_filter_bits(uint32(1_000_000), constants, plot_strength) == expected_bits
+
+
+def test_effective_bits_relative_to_min_strength() -> None:
+    constants = DEFAULT_CONSTANTS.replace(
+        HARD_FORK2_HEIGHT=uint32(1_000_000),
+        NUMBER_ZERO_BITS_PLOT_FILTER_V2=uint8(9),
+        MIN_PLOT_STRENGTH=uint8(2),
+    )
+    assert calculate_plot_filter_bits(uint32(1_000_000), constants, 2) == 9
+    assert calculate_plot_filter_bits(uint32(1_000_000), constants, 3) == 10
+
+
+class TestV2PlotFilter:
+    def test_passes_plot_filter_v2_deterministic(self) -> None:
+        plot_group_id = bytes32.from_hexstr("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+        filter_challenge = bytes32.from_hexstr("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+
+        assert passes_plot_filter_v2(plot_group_id, 42, 8, filter_challenge, 5) == passes_plot_filter_v2(
+            plot_group_id, 42, 8, filter_challenge, 5
+        )
+
+    def test_compute_plot_group_id_formula(self) -> None:
+        plot_public_key = G1Element()
+        pool_ph = bytes32.from_hexstr("0x" + "cd" * 32)
+        strength = 3
+
+        assert compute_plot_group_id(strength, plot_public_key, pool_ph) == std_hash(
+            bytes([strength]) + bytes(plot_public_key) + bytes(pool_ph)
+        )
 
 
 def test_v1_phase_out() -> None:

--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -339,6 +339,12 @@ def test_effective_bits_relative_to_min_strength() -> None:
     assert calculate_plot_filter_bits(uint32(1_000_000), constants, 3) == 10
 
 
+def test_calculate_plot_filter_bits_rejects_below_min_strength() -> None:
+    constants = DEFAULT_CONSTANTS.replace(HARD_FORK2_HEIGHT=uint32(1_000_000), MIN_PLOT_STRENGTH=uint8(2))
+    with pytest.raises(ValueError, match=r"Plot strength \(1\) is lower than the minimum \(2\)"):
+        calculate_plot_filter_bits(uint32(1_000_000), constants, 1)
+
+
 class TestV2PlotFilter:
     def test_passes_plot_filter_v2_deterministic(self) -> None:
         plot_group_id = bytes32.from_hexstr("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
@@ -354,7 +360,7 @@ class TestV2PlotFilter:
         strength = 3
 
         assert compute_plot_group_id(strength, plot_public_key, pool_ph) == std_hash(
-            bytes([strength]) + bytes(plot_public_key) + bytes(pool_ph)
+            strength.to_bytes(1, "big") + bytes(plot_public_key) + bytes(pool_ph)
         )
 
 

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -119,6 +119,21 @@ def is_v1_phased_out(
     return proof_value >= epoch_counter
 
 
+def compute_plot_group_id(strength: int, plot_public_key: G1Element, pool_info: G1Element | bytes32) -> bytes32:
+    """
+    Compute plot_group_id for V2 filter.
+    Formula: sha256(strength || plot_pk || pool_info)
+    Verified to match chia_rs compute_plot_id_v2 internals.
+    """
+    return std_hash(bytes([strength]) + bytes(plot_public_key) + bytes(pool_info))
+
+
+def compute_plot_group_id_from_pos(pos: ProofOfSpace) -> bytes32:
+    pool_info = pos.pool_contract_puzzle_hash if pos.pool_contract_puzzle_hash else pos.pool_public_key
+    assert pool_info is not None
+    return compute_plot_group_id(pos.strength, pos.plot_public_key, pool_info)
+
+
 def verify_and_get_quality_string(
     pos: ProofOfSpace,
     constants: ConsensusConstants,
@@ -128,6 +143,8 @@ def verify_and_get_quality_string(
     height: uint32,
     prev_transaction_block_height: uint32,  # this is the height of the last tx block before the current block SP
     height_agnostic: bool = False,
+    filter_challenge: bytes32 | None = None,  # For V2 plot filter
+    signage_point_index: int | None = None,  # For V2 plot filter
 ) -> bytes32 | None:
     plot_param = pos.param()
 
@@ -158,7 +175,9 @@ def verify_and_get_quality_string(
         log.error(f"Calculated pos challenge doesn't match the provided one {new_challenge}")
         return None
 
-    # we use different plot filter prefix sizes depending on v1 or v2 plots
+    # PR A introduces the V2 predictable-filter helpers but intentionally keeps
+    # V2 validation on the old prefix-bits path. The activation PR switches this
+    # branch to passes_plot_filter_v2().
     prefix_bits = calculate_prefix_bits(constants, height, plot_param)
     if not passes_plot_filter(prefix_bits, plot_id, original_challenge_hash, signage_point):
         log.error(f"Did not pass the plot filter. prefix bits: {prefix_bits} {'V1' if plot_param.size_v1 else 'V2'}")
@@ -234,6 +253,68 @@ def calculate_prefix_bits(constants: ConsensusConstants, height: uint32, plot_pa
 
 def calculate_plot_filter_input(plot_id: bytes32, challenge_hash: bytes32, signage_point: bytes32) -> bytes32:
     return std_hash(plot_id + challenge_hash + signage_point)
+
+
+# V2 Plot Filter Constants
+# TODO: todo_v2_plots move FILTER_WINDOW_SIZE and _BASE_FILTER_OFFSETS to ConsensusConstants in chia_rs
+FILTER_WINDOW_SIZE: int = 16  # SPs per filter window (64 SPs / 4 windows)
+MAX_EFFECTIVE_PLOT_FILTER_BITS: int = 13  # 8192 effective plot filter cap
+
+# Base plot filter reduction schedule — offsets from HARD_FORK2_HEIGHT
+# Starts at 9 bits (512), reduces every 3-6 years until 0 bits (1)
+_BASE_FILTER_OFFSETS: list[tuple[int, int]] = [
+    (50_494_000, 0),  # +~31 years
+    (45_444_000, 1),  # +~28 years
+    (40_394_000, 2),  # +~25 years
+    (35_343_000, 3),  # +~21 years
+    (30_298_000, 4),  # +~18 years
+    (25_247_000, 5),  # +~15 years
+    (20_197_000, 6),  # +~12 years
+    (15_146_000, 7),  # +~9 years
+    (10_101_000, 8),  # +~6 years
+    (0, 9),  # at hard fork
+]
+
+
+def calculate_base_plot_filter_bits(height: uint32, constants: ConsensusConstants) -> int:
+    relative_height = int(height) - constants.HARD_FORK2_HEIGHT
+    if relative_height < 0:
+        return constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2
+    for offset, bits in _BASE_FILTER_OFFSETS:
+        if relative_height >= offset:
+            return min(bits, constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2)
+    return constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2
+
+
+def calculate_plot_filter_bits(height: uint32, constants: ConsensusConstants, plot_strength: int) -> int:
+    # TODO: todo_v2_plots MIN_PLOT_STRENGTH is fixed for now; a height-based
+    # min-strength schedule would change the zero point here.
+    strength_delta = max(0, int(plot_strength) - constants.MIN_PLOT_STRENGTH)
+    return min(calculate_base_plot_filter_bits(height, constants) + strength_delta, MAX_EFFECTIVE_PLOT_FILTER_BITS)
+
+
+def passes_plot_filter_v2(
+    plot_group_id: bytes32,
+    meta_group: int,
+    group_strength: int,
+    filter_challenge: bytes32,
+    signage_point_index: int,
+    window_size: int = FILTER_WINDOW_SIZE,
+) -> bool:
+    """
+    V2 plot filter - predictable passage.
+
+    passes = (effective_filter == target)
+    Where:
+        effective_filter = hash(plot_group_id + filter_challenge)[:4] & mask
+        target = (challenge_index ^ meta_group) & mask
+        mask = (1 << group_strength) - 1
+    """
+    challenge_index = signage_point_index % window_size
+    mask = (1 << group_strength) - 1
+    effective_filter = int.from_bytes(std_hash(plot_group_id + filter_challenge)[:4], "big") & mask
+    target = (challenge_index ^ meta_group) & mask
+    return effective_filter == target
 
 
 def calculate_pos_challenge(plot_id: bytes32, challenge_hash: bytes32, signage_point: bytes32) -> bytes32:

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -125,7 +125,7 @@ def compute_plot_group_id(strength: int, plot_public_key: G1Element, pool_info: 
     Formula: sha256(strength || plot_pk || pool_info)
     Verified to match chia_rs compute_plot_id_v2 internals.
     """
-    return std_hash(bytes([strength]) + bytes(plot_public_key) + bytes(pool_info))
+    return std_hash(int(strength).to_bytes(1, "big") + bytes(plot_public_key) + bytes(pool_info))
 
 
 def compute_plot_group_id_from_pos(pos: ProofOfSpace) -> bytes32:
@@ -260,36 +260,39 @@ def calculate_plot_filter_input(plot_id: bytes32, challenge_hash: bytes32, signa
 FILTER_WINDOW_SIZE: int = 16  # SPs per filter window (64 SPs / 4 windows)
 MAX_EFFECTIVE_PLOT_FILTER_BITS: int = 13  # 8192 effective plot filter cap
 
-# Base plot filter reduction schedule — offsets from HARD_FORK2_HEIGHT
-# Starts at 9 bits (512), reduces every 3-6 years until 0 bits (1)
-_BASE_FILTER_OFFSETS: list[tuple[int, int]] = [
-    (50_494_000, 0),  # +~31 years
-    (45_444_000, 1),  # +~28 years
-    (40_394_000, 2),  # +~25 years
-    (35_343_000, 3),  # +~21 years
-    (30_298_000, 4),  # +~18 years
-    (25_247_000, 5),  # +~15 years
-    (20_197_000, 6),  # +~12 years
-    (15_146_000, 7),  # +~9 years
-    (10_101_000, 8),  # +~6 years
-    (0, 9),  # at hard fork
+# Base plot filter reduction schedule — relative heights from HARD_FORK2_HEIGHT.
+# Starts at NUMBER_ZERO_BITS_PLOT_FILTER_V2 at the fork, then reduces over time.
+_BASE_FILTER_RELATIVE_HEIGHTS: list[uint32] = [
+    uint32(50_494_000),  # +~31 years
+    uint32(45_444_000),  # +~28 years
+    uint32(40_394_000),  # +~25 years
+    uint32(35_343_000),  # +~21 years
+    uint32(30_298_000),  # +~18 years
+    uint32(25_247_000),  # +~15 years
+    uint32(20_197_000),  # +~12 years
+    uint32(15_146_000),  # +~9 years
+    uint32(10_101_000),  # +~6 years
 ]
 
 
 def calculate_base_plot_filter_bits(height: uint32, constants: ConsensusConstants) -> int:
+    base_bits = int(constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2)
     relative_height = int(height) - constants.HARD_FORK2_HEIGHT
-    if relative_height < 0:
-        return constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2
-    for offset, bits in _BASE_FILTER_OFFSETS:
+    if relative_height <= 0:
+        return base_bits
+    for index, offset in enumerate(_BASE_FILTER_RELATIVE_HEIGHTS):
         if relative_height >= offset:
-            return min(bits, constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2)
-    return constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2
+            reductions = len(_BASE_FILTER_RELATIVE_HEIGHTS) - index
+            return max(0, base_bits - reductions)
+    return base_bits
 
 
 def calculate_plot_filter_bits(height: uint32, constants: ConsensusConstants, plot_strength: int) -> int:
     # TODO: todo_v2_plots MIN_PLOT_STRENGTH is fixed for now; a height-based
     # min-strength schedule would change the zero point here.
-    strength_delta = max(0, int(plot_strength) - constants.MIN_PLOT_STRENGTH)
+    if plot_strength < constants.MIN_PLOT_STRENGTH:
+        raise ValueError(f"Plot strength ({plot_strength}) is lower than the minimum ({constants.MIN_PLOT_STRENGTH})")
+    strength_delta = int(plot_strength) - constants.MIN_PLOT_STRENGTH
     return min(calculate_base_plot_filter_bits(height, constants) + strength_delta, MAX_EFFECTIVE_PLOT_FILTER_BITS)
 
 


### PR DESCRIPTION
  ### Purpose:
helpers for the V2 predictable plot filter (CHIP-48 / CHIA-3814), as the first step of a stacked rollout. This PR is **additive and inert**: the new functions
  land but the consensus V2 path still uses the old prefix-bits filter until the activation PR in this stack flips it.
  ### Current Behavior:
  V2 plot filter passage is decided by the V1-style prefix-bits filter (`passes_plot_filter` with `NUMBER_ZERO_BITS_PLOT_FILTER_V2`). There is no concept of plot-group identity, sub-slot `filter_challenge`, or
  strength-relative effective filter bits.
  ### New Behavior:
  Adds, in `chia/types/blockchain_format/proof_of_space.py`:
  - `compute_plot_group_id()` / `compute_plot_group_id_from_pos()` — V2 plot-group identity (`sha256(strength ‖ plot_pk ‖ pool_info)`), verified against `chia_rs` internals.
  - `passes_plot_filter_v2()` — the mask/xor formula from the ticket: `hash(plot_group_id ‖ filter_challenge)[:4] & mask == (challenge_index ^ meta_group) & mask`.
  - `FILTER_WINDOW_SIZE` (16), `MAX_EFFECTIVE_PLOT_FILTER_BITS` (13, the 8192 cap), `_BASE_FILTER_OFFSETS` (height-based base-filter reduction schedule).
  - `calculate_base_plot_filter_bits()` and `calculate_plot_filter_bits()` = `min(base + max(0, strength − MIN_PLOT_STRENGTH), 13)` — relative-strength effective filter with the 8192 cap.
  - `verify_and_get_quality_string` gains `filter_challenge` / `signage_point_index` keyword args (default `None`, **unused** in this PR).
  No consensus constants change. V2 validation behavior is unchanged — `calculate_prefix_bits` still handles V2 via the old prefix path. Generated test chains are byte-identical to `main`.
  ### Testing Notes:



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Consensus behavior is explicitly unchanged on the validation path; new code is additive with broad unit test coverage and no constant changes.
> 
> **Overview**
> Adds **CHIP-48 / predictable V2 plot filter** helpers in `proof_of_space.py` ahead of a later activation PR. Live V2 proof validation is **unchanged**: it still uses `calculate_prefix_bits` + `passes_plot_filter` on `plot_id`; comments note a follow-up will switch to `passes_plot_filter_v2()`.
> 
> New pieces include **`compute_plot_group_id`** / **`compute_plot_group_id_from_pos`** (`sha256(strength ‖ plot_pk ‖ pool_info)`), **`passes_plot_filter_v2`** (hash/mask/xor vs `filter_challenge` and signage index), **`calculate_base_plot_filter_bits`** (long-term reduction schedule from `HARD_FORK2_HEIGHT`), and **`calculate_plot_filter_bits`** (base + strength above `MIN_PLOT_STRENGTH`, capped at 13 bits). **`verify_and_get_quality_string`** gains optional `filter_challenge` and `signage_point_index` kwargs that are not used yet.
> 
> Tests cover the new math, treat V2 strength 0/1 as invalid in `check_plot_param`, and add deterministic checks for group id and `passes_plot_filter_v2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57bf116132a2089ddd6a4a453a2f1e45506b0718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->