### PR TITLE
long sync with rate limits v3

### DIFF
--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -15,7 +15,9 @@ from chia._tests.core.node_height import node_height_between, node_height_exactl
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.protocols import full_node_protocol
-from chia.protocols.shared_protocol import Capability
+from chia.protocols.outbound_message import NodeType
+from chia.protocols.protocol_message_types import ProtocolMessageTypes
+from chia.protocols.shared_protocol import Capability, default_capabilities
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
 from chia.simulator.block_tools import BlockTools
@@ -115,12 +117,18 @@ async def test_long_sync_from_zero(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("use_v3_rate_limits", [False, True], ids=["default", "v3"])
 async def test_sync_from_fork_point_and_weight_proof(
     three_nodes: list[FullNodeAPI],
     default_1000_blocks: list[FullBlock],
     default_400_blocks: list[FullBlock],
     self_hostname: str,
+    use_v3_rate_limits: bool,
+    consensus_mode: ConsensusMode,
 ) -> None:
+    if use_v3_rate_limits and consensus_mode >= ConsensusMode.HARD_FORK_3_0:
+        pytest.skip("v3 handshake exchange has known issues in HARD_FORK_3_0 test modes")
+
     # Must be larger than "sync_block_behind_threshold" in the config
     num_blocks_initial = len(default_1000_blocks) - 50
     blocks_950 = default_1000_blocks[:num_blocks_initial]
@@ -130,6 +138,15 @@ async def test_sync_from_fork_point_and_weight_proof(
     server_1 = full_node_1.full_node.server
     server_2 = full_node_2.full_node.server
     server_3 = full_node_3.full_node.server
+
+    if use_v3_rate_limits:
+        v3_caps = [*default_capabilities[NodeType.FULL_NODE], (uint16(Capability.RATE_LIMITS_V3.value), "1")]
+        server_1.set_capabilities(v3_caps)
+        server_2.set_capabilities(v3_caps)
+        server_3.set_capabilities(v3_caps)
+        # sync_from_fork_point selects fetch_blocks_v3() when this is >= 3
+        full_node_2.full_node.config["rate_limits"] = 3
+        full_node_3.full_node.config["rate_limits"] = 3
 
     for block in blocks_950:
         await full_node_1.full_node.add_block(block)
@@ -167,6 +184,14 @@ async def test_sync_from_fork_point_and_weight_proof(
     # same tip at height num_blocks - 1
     await time_out_assert(300, node_height_exactly, True, full_node_2, num_blocks_initial - 1)
     await time_out_assert(180, node_height_exactly, True, full_node_3, num_blocks_initial - 1)
+
+    if use_v3_rate_limits:
+        for server in [server_2, server_3]:
+            for conn in server.all_connections.values():
+                assert Capability.RATE_LIMITS_V3 in conn.peer_capabilities
+                assert Capability.RATE_LIMITS_V3 in conn.local_capabilities
+                assert len(conn.peer_rl_settings_v3) > 0, "v3 config exchange did not populate peer settings"
+                assert ProtocolMessageTypes.request_blocks in conn.peer_rl_settings_v3
 
     def fn3_is_not_syncing() -> bool:
         return not full_node_3.full_node.sync_store.get_sync_mode()
@@ -515,3 +540,51 @@ async def test_bad_peak_cache_invalidation(
     block = blocks[-1]
     full_node_1.full_node.add_to_bad_peak_cache(block.header_hash, block.height)
     assert len(full_node_1.full_node.bad_peak_cache) == 1
+
+
+@pytest.mark.anyio
+async def test_batch_sync_v3_rate_limits(
+    two_nodes: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
+    self_hostname: str,
+    consensus_mode: ConsensusMode,
+) -> None:
+    """
+    Same as test_batch_sync but with RATE_LIMITS_V3 enabled on both nodes,
+    so the sync uses the window-based fetch_blocks_v3() path.
+    """
+    if consensus_mode >= ConsensusMode.HARD_FORK_3_0:
+        pytest.skip("v3 handshake exchange has known issues in HARD_FORK_3_0 test modes")
+
+    num_blocks = 20
+    num_blocks_2 = 9
+    full_node_1, full_node_2, server_1, server_2, bt = two_nodes
+
+    # Enable RATE_LIMITS_V3 on both servers before connecting
+    v3_capabilities = [*default_capabilities[NodeType.FULL_NODE], (uint16(Capability.RATE_LIMITS_V3.value), "1")]
+    server_1.set_capabilities(v3_capabilities)
+    server_2.set_capabilities(v3_capabilities)
+
+    blocks = bt.get_consecutive_blocks(num_blocks)
+    blocks_2 = bt.get_consecutive_blocks(num_blocks_2, seed=b"123")
+
+    for block in blocks:
+        await full_node_1.full_node.add_block(block)
+
+    for block in blocks_2:
+        await full_node_2.full_node.add_block(block)
+
+    await server_2.start_client(
+        PeerInfo(self_hostname, server_1.get_port()),
+        on_connect=full_node_2.full_node.on_connect,
+    )
+
+    # Both peers should negotiate v3 during handshake and complete the
+    # ConfigureWindowSizes exchange so that v3 windows are active.
+    await time_out_assert(10, lambda: len(server_2.all_connections) > 0)
+    for conn in server_2.all_connections.values():
+        assert Capability.RATE_LIMITS_V3 in conn.peer_capabilities
+        assert Capability.RATE_LIMITS_V3 in conn.local_capabilities
+        assert len(conn.peer_rl_settings_v3) > 0, "v3 config exchange did not populate peer settings"
+        assert ProtocolMessageTypes.request_blocks in conn.peer_rl_settings_v3
+
+    await time_out_assert(60, node_height_exactly, True, full_node_2, num_blocks - 1)

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3168,6 +3168,7 @@ async def test_sync_from_fork_point_logs_fetch_stage_exception(
         def __init__(self) -> None:
             self.closed = False
             self.peer_info = PeerInfo("127.0.0.1", uint16(8444))
+            self.peer_capabilities: list[Capability] = []
 
         async def call_api(self, *args: object, **kwargs: object) -> full_node_protocol.RespondBlocks:
             raise RuntimeError("forced fetch failure")
@@ -3201,6 +3202,7 @@ async def test_sync_from_fork_point_logs_validate_stage_exception(
         def __init__(self, blocks: list[FullBlock]) -> None:
             self.closed = False
             self.peer_info = PeerInfo("127.0.0.1", uint16(8444))
+            self.peer_capabilities: list[Capability] = []
             self._blocks = blocks
 
         async def call_api(self, *args: object, **kwargs: object) -> full_node_protocol.RespondBlocks:

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1349,6 +1349,230 @@ class FullNode:
                     self.sync_store.peers_changed.clear()
                     self.log.info(f"peers with peak: {len(new_peers_with_peak)}")
 
+        async def fetch_blocks_v3() -> AsyncIterator[tuple[WSChiaConnection, list[FullBlock]]]:
+            """
+            Window-based fetcher for peers supporting RATE_LIMITS_V3. Issues
+            multiple outstanding requests per peer (up to each peer's advertised
+            window_size) and yields results in height order.
+            """
+            v3_peers = [p for p in peers_with_peak if Capability.RATE_LIMITS_V3 in p.peer_capabilities and not p.closed]
+            if not v3_peers:
+                self.log.error("fetch_blocks_v3: no v3-capable peers available")
+                return
+
+            self.log.info(f"fetch_blocks_v3: using {len(v3_peers)} v3-capable peers")
+
+            MAX_WINDOW_CAP = 10
+            MAX_TOTAL_IN_FLIGHT = 100
+            MAX_PEER_TIMEOUTS = 3
+
+            def get_window_size(peer: WSChiaConnection) -> int:
+                setting = peer.peer_rl_settings_v3.get(ProtocolMessageTypes.request_blocks)
+                if setting is None or setting.window_size is None:
+                    return MAX_WINDOW_CAP
+                return min(setting.window_size, MAX_WINDOW_CAP)
+
+            peer_in_flight: dict[bytes32, int] = {p.peer_node_id: 0 for p in v3_peers}
+            peer_by_id: dict[bytes32, WSChiaConnection] = {p.peer_node_id: p for p in v3_peers}
+            peer_timeouts: dict[bytes32, int] = {}
+
+            # Each slot represents one batch to fetch, maintained in height order
+            all_batches: list[tuple[int, int]] = []
+            for s in range(fork_point_height, target_peak_sb_height + 1, batch_size):
+                e = min(target_peak_sb_height, s + batch_size - 1)
+                all_batches.append((s, e))
+
+            # Slots tracking state for each batch
+            # None = not dispatched or needs retry, Task = in flight, tuple = completed
+            slot_tasks: list[asyncio.Task[tuple[WSChiaConnection, Any]] | None] = [None] * len(all_batches)
+            slot_results: list[tuple[WSChiaConnection, list[FullBlock]] | None] = [None] * len(all_batches)
+            slot_peer: list[bytes32 | None] = [None] * len(all_batches)
+            slot_attempts: list[int] = [0] * len(all_batches)
+            slot_failed_peers: list[set[bytes32]] = [set() for _ in range(len(all_batches))]
+
+            yield_idx = 0
+            timeout = int(30 + 30 / len(v3_peers))
+
+            def find_available_peer(exclude: set[bytes32] | None = None) -> WSChiaConnection | None:
+                """Find a peer with capacity (in_flight < window_size)."""
+                candidates = [
+                    (peer_in_flight.get(p.peer_node_id, 0), p)
+                    for p in peer_by_id.values()
+                    if not p.closed
+                    and peer_in_flight.get(p.peer_node_id, 0) < get_window_size(p)
+                    and (exclude is None or p.peer_node_id not in exclude)
+                ]
+                if not candidates:
+                    return None
+                # prefer the peer with fewest in-flight requests
+                candidates.sort(key=lambda x: x[0])
+                return candidates[0][1]
+
+            async def do_fetch(
+                peer: WSChiaConnection, start_height: int, end_height: int
+            ) -> tuple[WSChiaConnection, Any]:
+                request = RequestBlocks(uint32(start_height), uint32(end_height), True)
+                response = await peer.call_api(FullNodeAPI.request_blocks, request, timeout=timeout)
+                return (peer, response)
+
+            active_tasks: dict[asyncio.Task[tuple[WSChiaConnection, Any]], int] = {}
+
+            try:
+                while yield_idx < len(all_batches):
+                    # Drop peers that have closed (e.g. disconnected on their own)
+                    # so they don't linger in peer_by_id and skew the
+                    # "all peers failed" check below. The timeout-close path
+                    # handles its own removal, but peers can close for other
+                    # reasons without ever being selected.
+                    for dead_id in [pid for pid, p in peer_by_id.items() if p.closed]:
+                        peer_by_id.pop(dead_id, None)
+                        peer_in_flight.pop(dead_id, None)
+                    if not peer_by_id:
+                        self.log.error("fetch_blocks_v3: no peers remaining")
+                        return
+
+                    # Dispatch: fill up as many slots as we have peer capacity
+                    total_in_flight = sum(peer_in_flight.values())
+                    for i in range(yield_idx, len(all_batches)):
+                        if total_in_flight >= MAX_TOTAL_IN_FLIGHT:
+                            break
+                        if slot_results[i] is not None:
+                            continue
+                        if slot_tasks[i] is not None:
+                            continue
+                        peer = find_available_peer(exclude=slot_failed_peers[i])
+                        if peer is None:
+                            # No peer can serve *this* slot right now (its failed
+                            # set excludes the peers that have spare capacity).
+                            # Only stop the dispatch pass if no peer has capacity
+                            # at all; otherwise keep scanning later slots that
+                            # those peers can still serve, so we don't leave
+                            # window capacity idle.
+                            if find_available_peer() is None:
+                                break
+                            continue
+                        start_h, end_h = all_batches[i]
+                        task = asyncio.ensure_future(do_fetch(peer, start_h, end_h))
+                        slot_tasks[i] = task
+                        slot_peer[i] = peer.peer_node_id
+                        active_tasks[task] = i
+                        peer_in_flight[peer.peer_node_id] = peer_in_flight.get(peer.peer_node_id, 0) + 1
+                        total_in_flight += 1
+
+                    if not active_tasks:
+                        self.log.error("fetch_blocks_v3: no active tasks and not all batches done")
+                        return
+
+                    # Wait for any task to complete
+                    done, _ = await asyncio.wait(active_tasks.keys(), return_when=asyncio.FIRST_COMPLETED)
+
+                    for task in done:
+                        slot_idx = active_tasks.pop(task)
+                        peer_id = slot_peer[slot_idx]
+                        assert peer_id is not None
+                        if peer_id in peer_in_flight:
+                            peer_in_flight[peer_id] = max(0, peer_in_flight[peer_id] - 1)
+
+                        try:
+                            peer, response = task.result()
+                        except Exception:
+                            # Network error — don't retry this peer for this slot
+                            slot_tasks[slot_idx] = None
+                            slot_peer[slot_idx] = None
+                            slot_failed_peers[slot_idx].add(peer_id)
+                            slot_attempts[slot_idx] += 1
+                            continue
+
+                        start_h, end_h = all_batches[slot_idx]
+                        if response is None:
+                            # Timeout — soft-fail this slot so it can be retried
+                            self.log.info(f"peer timed out fetching {start_h}-{end_h}")
+                            slot_tasks[slot_idx] = None
+                            slot_peer[slot_idx] = None
+                            slot_failed_peers[slot_idx].add(peer.peer_node_id)
+                            slot_attempts[slot_idx] += 1
+                            peer_timeouts[peer.peer_node_id] = peer_timeouts.get(peer.peer_node_id, 0) + 1
+                            if peer_timeouts[peer.peer_node_id] >= MAX_PEER_TIMEOUTS:
+                                self.log.info(f"peer {peer.peer_node_id} exceeded timeout threshold, closing")
+                                await peer.close()
+                                closed_peer_id = peer.peer_node_id
+                                peer_in_flight.pop(closed_peer_id, None)
+                                peer_by_id.pop(closed_peer_id, None)
+                                # Cancel remaining in-flight tasks for this peer.
+                                # Only touch tasks that are still pending — tasks
+                                # already in `done` (e.g. sibling requests to the
+                                # same peer that timed out together) are left in
+                                # active_tasks so the surrounding loop pops and
+                                # processes them normally. Popping them here would
+                                # make the later active_tasks.pop(task) raise
+                                # KeyError and abort the sync, and would also
+                                # discard any sibling that returned valid blocks.
+                                stale_tasks = [
+                                    (t, idx)
+                                    for t, idx in active_tasks.items()
+                                    if slot_peer[idx] == closed_peer_id and t not in done
+                                ]
+                                for stale_task, stale_idx in stale_tasks:
+                                    stale_task.cancel()
+                                    active_tasks.pop(stale_task)
+                                    slot_tasks[stale_idx] = None
+                                    slot_peer[stale_idx] = None
+                                    slot_failed_peers[stale_idx].add(closed_peer_id)
+                                if stale_tasks:
+                                    await asyncio.gather(*[t for t, _ in stale_tasks], return_exceptions=True)
+                                if not peer_by_id:
+                                    self.log.error("fetch_blocks_v3: no peers remaining")
+                                    return
+                        elif isinstance(response, RespondBlocks):
+                            slot_results[slot_idx] = (peer, response.blocks)
+                            slot_tasks[slot_idx] = None
+                            slot_failed_peers[slot_idx].clear()
+                        else:
+                            # Reject — don't retry this peer for this slot
+                            slot_tasks[slot_idx] = None
+                            slot_peer[slot_idx] = None
+                            slot_failed_peers[slot_idx].add(peer.peer_node_id)
+                            slot_attempts[slot_idx] += 1
+
+                    # Abort if any pending slot has been rejected/errored by every known peer
+                    peer_ids = set(peer_by_id.keys())
+                    for i in range(yield_idx, len(all_batches)):
+                        if slot_results[i] is not None or slot_tasks[i] is not None:
+                            continue
+                        if slot_failed_peers[i].issuperset(peer_ids):
+                            start_h, end_h = all_batches[i]
+                            self.log.error(
+                                f"fetch_blocks_v3: all peers failed for batch {start_h}-{end_h}, aborting sync"
+                            )
+                            return
+
+                    # Yield completed slots from the front in order
+                    while yield_idx < len(all_batches) and slot_results[yield_idx] is not None:
+                        result = slot_results[yield_idx]
+                        assert result is not None
+                        yield result
+                        slot_results[yield_idx] = None
+                        yield_idx += 1
+
+                    # Refresh peer list if peers changed
+                    if self.sync_store.peers_changed.is_set():
+                        new_peers = self.get_peers_with_peak(peak_hash)
+                        new_v3 = [
+                            p for p in new_peers if Capability.RATE_LIMITS_V3 in p.peer_capabilities and not p.closed
+                        ]
+                        for p in new_v3:
+                            if p.peer_node_id not in peer_by_id:
+                                peer_by_id[p.peer_node_id] = p
+                                peer_in_flight[p.peer_node_id] = 0
+                        self.sync_store.peers_changed.clear()
+                        self.log.info(f"fetch_blocks_v3: peers updated, now {len(peer_by_id)} v3 peers")
+            finally:
+                # Cancel any remaining in-flight tasks
+                for task in active_tasks:
+                    task.cancel()
+                if active_tasks:
+                    await asyncio.gather(*active_tasks, return_exceptions=True)
+
         first_batch = True
         vs = ValidationState(ssi, diff, prev_ses_block)
 
@@ -1442,13 +1666,25 @@ class FullNode:
             # height, in that case.
             self.blockchain.clean_block_record(end_height - self.constants.BLOCKS_CACHE_SIZE)
 
+        v3_peers = [p for p in peers_with_peak if not p.closed and Capability.RATE_LIMITS_V3 in p.peer_capabilities]
+        use_v3 = self.config.get("rate_limits", 2) >= 3 and len(v3_peers) > 0
+        source: AsyncIterator[tuple[WSChiaConnection, list[FullBlock]]]
+        if use_v3:
+            self.log.info(
+                f"sync_from_fork_point: using v3 window-based fetcher "
+                f"({len(v3_peers)}/{len(peers_with_peak)} peers support v3)"
+            )
+            source = fetch_blocks_v3()
+        else:
+            source = fetch_blocks()
+
         async def drain_pending_futures(p: TaskPipeline) -> None:
             for item in p.drain(1):
                 _, _, futures, _ = item
                 await asyncio.gather(*futures)
 
         pipeline = TaskPipeline(
-            source=fetch_blocks(),
+            source=source,
             stages=[validate_batch, ingest_batch],
             queue_size=10,
             names=["fetching", "validating", "ingesting"],


### PR DESCRIPTION
support long sync using rate limits v3 protocol, making long sync CPU bound, instead of throttled by the network protocol

### Purpose:

improve long-sync performance.

### Current Behavior:

we use an unreliable estimate of the rate of blocks we can request without being rate limited (and disconnected). This is because the v2 rate limits are based on wall clock time and (unknown) 60 second windows.

### New Behavior:

v3 rate limits are window based which makes them deterministic and provides back-pressure to the requester when it's requesting at too high a rate. This maximizes throughout while still adapting to network and node conditions.

### Testing Notes:

synced from one node over local network.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core long-sync networking with complex async concurrency, peer teardown, and fallback to the legacy fetcher; mistakes could stall sync or disconnect peers, though behavior is gated on config and v3 capability.
> 
> **Overview**
> **Long sync** from `sync_from_fork_point` can now use a new **`fetch_blocks_v3()`** path when `rate_limits` config is **≥ 3** and at least one peer advertises **`RATE_LIMITS_V3`**. Instead of spacing `RequestBlocks` on a fixed wall-clock estimate (v2-style `fetch_blocks()`), v3 keeps multiple batches in flight per peer up to each peer’s advertised **`request_blocks` window**, with caps on total concurrency, retries on other peers, and peer close after repeated timeouts.
> 
> The existing validate/ingest pipeline is unchanged; only the block **source** iterator switches between `fetch_blocks()` and `fetch_blocks_v3()`.
> 
> **Tests** enable v3 capabilities and `rate_limits = 3` in fork-point sync (parametrized default vs v3, with assertions on negotiated v3 settings), add **`test_batch_sync_v3_rate_limits`**, skip v3 cases under `HARD_FORK_3_0` due to known handshake issues, and set **`peer_capabilities`** on dummy peers in full-node unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5309cffee209beca132d2761db8c395d7ab7e3d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->