### PR TITLE
fix flaky DoS test

### DIFF
--- a/chia/_tests/core/server/test_dos.py
+++ b/chia/_tests/core/server/test_dos.py
@@ -151,8 +151,13 @@ class TestDos:
                 await time_out_assert(10, lambda: self_hostname in server_1.banned_peers)
 
             print(response)
-            assert response.type == WSMsgType.CLOSE
-            assert response.data == WSCloseCode.MESSAGE_TOO_BIG
+            # aiohttp rejects the oversized frame from its header before reading the payload, so the
+            # server tears down the socket while the ~60MB message is still in flight. The resulting
+            # TCP reset can discard the server's close frame, leaving the client with an abrupt CLOSED
+            # instead of a clean CLOSE carrying the MESSAGE_TOO_BIG code.
+            assert response.type in {WSMsgType.CLOSE, WSMsgType.CLOSED}
+            if response.type == WSMsgType.CLOSE:
+                assert response.data == WSCloseCode.MESSAGE_TOO_BIG
 
     @pytest.mark.anyio
     async def test_bad_handshake_and_ban(


### PR DESCRIPTION
### Purpose:

When we deliver a `WSMsgType.CLOSE` message because we're receiving a too large message, it's not certain that the other end will receive the message. In case it keeps sending after the socket is closed, it will receive a TCP reset message, and will only be notified of the socket closing, not our specific message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths affected.
> 
> **Overview**
> Fixes flakiness in **`test_large_message_disconnect_and_ban`** by aligning expectations with how aiohttp and TCP behave when the server rejects an oversized frame.
> 
> The test still sends a ~60MB message, expects the peer to be **banned**, and documents that the server can drop the connection while the payload is still sending. The client may see **`WSMsgType.CLOSED`** (abrupt teardown / TCP reset) instead of a clean **`WSMsgType.CLOSE`** with **`MESSAGE_TOO_BIG`**. Assertions now allow either close type and only check the close code when the message is a proper **`CLOSE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e41a307ca73c0e3ac300c412a38e5bddb14ddb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->