### PR TITLE
[CHIA-4294] Fixed Electron source install not working

### DIFF
--- a/Install-gui.ps1
+++ b/Install-gui.ps1
@@ -33,6 +33,16 @@ try {
     $ErrorActionPreference = "SilentlyContinue"
     npm ci --loglevel=error
     npm audit fix
+
+    # Work around Electron's postinstall being silently skipped in the workspaces/
+    # hoisted install, which leaves node_modules/electron present but without its
+    # platform binary (no path.txt). Re-run Electron's own installer if needed.
+    # Otherwise 'npm run electron' fails with "Electron failed to install correctly".
+    if (-not (Test-Path "node_modules/electron/path.txt")) {
+        Write-Output "Electron binary is missing; running Electron's install script."
+        node node_modules/electron/install.js
+    }
+
     npm run build
     py ..\installhelper.py
 

--- a/install-gui.sh
+++ b/install-gui.sh
@@ -105,6 +105,16 @@ if [ ! "$CI" ]; then
 
   npm ci
   npm audit fix || true
+
+  # Work around Electron's postinstall being silently skipped in the workspaces/
+  # hoisted install, which leaves node_modules/electron present but without its
+  # platform binary (no path.txt). Re-run Electron's own installer if needed.
+  # Otherwise `npm run electron` fails with "Electron failed to install correctly".
+  if [ ! -f node_modules/electron/path.txt ]; then
+    echo "Electron binary is missing; running Electron's install script."
+    node node_modules/electron/install.js
+  fi
+
   npm run build
 
   # Set modified output of `chia version` to version property of GUI's package.json


### PR DESCRIPTION
## Summary

Work around recent npm / workspaces installs that skip Electron’s `postinstall`, leaving `node_modules/electron` present but without its platform binary (`path.txt` missing). Without this, source installs fail with “Electron failed to install correctly” when running `npm run electron`.

After `npm ci` in `chia-blockchain-gui`, both `install-gui.sh` and `Install-gui.ps1` now check for `node_modules/electron/path.txt` and, if missing, run `node node_modules/electron/install.js` before `npm run build`.

### Related: Node 24.16.0+ yauzl breakage

On Node 24.16.0+, Electron extraction can also fail because of a zlib / **yauzl 2.x** regression ([electron/electron#51619](https://github.com/electron/electron/issues/51619)). Re-running `install.js` alone is not enough while yauzl 2.x is still resolved — that needs the GUI override:

- [Chia-Network/chia-blockchain-gui#2970](https://github.com/Chia-Network/chia-blockchain-gui/pull/2970)

These script guards cover the separate “postinstall skipped” case and should be merged alongside that GUI fix.

## Test plan

- [x] Fresh GUI install via `./install-gui.sh` (or `Install-gui.ps1`) with a GUI submodule that includes the yauzl override
- [x] Confirm Electron binary is present and `npm run electron` starts
- [x] Optionally: simulate a missing `path.txt` and confirm the script re-runs `install.js`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect local install scripts after `npm ci`; no production runtime, auth, or data-path changes.
> 
> **Overview**
> **Adds a post-`npm ci` guard** in `install-gui.sh` and `Install-gui.ps1` so source GUI installs still get a working Electron binary when npm workspaces skip Electron’s `postinstall`.
> 
> After `npm ci` and `npm audit fix`, both scripts now check for `node_modules/electron/path.txt`. If it’s missing, they run `node node_modules/electron/install.js` before `npm run build`, avoiding the “Electron failed to install correctly” error when starting the GUI with `npm run electron`.
> 
> This targets the “postinstall skipped / hoisted install” case; Node 24.16+ **yauzl** extraction issues still need the separate GUI override noted in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3585fd36c4f1d33e411a490a37e18d7ad6be08f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->