### PR TITLE
Add optional transaction-block foliage to create_block_generator RPC

### DIFF
--- a/chia/_tests/core/test_full_node_rpc.py
+++ b/chia/_tests/core/test_full_node_rpc.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from chia_rs import AugSchemeMPL, BlockRecord, FullBlock, UnfinishedBlock
+from chia_rs import AugSchemeMPL, BlockRecord, FullBlock, TransactionsInfo, UnfinishedBlock
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint8, uint32, uint64
 
@@ -560,6 +560,111 @@ async def test_signage_points(
         assert "signage_point" not in res
         assert res["eos"] == selected_eos
         assert res["reverted"]
+
+
+@pytest.mark.anyio
+async def test_create_block_generator(
+    two_nodes_sim_and_wallets_services: SimulatorsAndWalletsServices, empty_blockchain: Blockchain
+) -> None:
+    # Covers the create_block_generator RPC: the legacy no-arg response, the opt-in "farmer template"
+    # mode that returns the transaction-block foliage for a signage point, and the error path.
+    nodes, _, bt = two_nodes_sim_and_wallets_services
+    full_node_service_1, full_node_service_2 = nodes
+    full_node_api_1 = full_node_service_1._api
+    full_node_api_2 = full_node_service_2._api
+    server_1 = full_node_api_1.full_node.server
+    server_2 = full_node_api_2.full_node.server
+    self_hostname = bt.config["self_hostname"]
+
+    peer = await connect_and_get_peer(server_1, server_2, self_hostname)
+    assert full_node_service_1.rpc_server is not None
+    async with FullNodeRpcClient.create_as_context(
+        self_hostname,
+        full_node_service_1.rpc_server.listen_port,
+        full_node_service_1.root_path,
+        full_node_service_1.config,
+    ) as client:
+        # Build a short chain and register a live signage point (mirrors test_signage_points)
+        blocks = bt.get_consecutive_blocks(5)
+        for block in blocks:
+            await full_node_api_1.full_node.add_block(block)
+
+        blocks = bt.get_consecutive_blocks(1, block_list_input=blocks, skip_slots=1, force_overflow=True)
+        for block in blocks:
+            await _validate_and_add_block(empty_blockchain, block)
+
+        peak_2 = empty_blockchain.get_peak()
+        assert peak_2 is not None
+        sp_index = uint8(4)
+        sp: SignagePoint = get_signage_point(
+            bt.constants,
+            full_node_api_1.full_node.blockchain,
+            peak_2,
+            peak_2.ip_sub_slot_total_iters(bt.constants),
+            sp_index,
+            [],
+            peak_2.sub_slot_iters,
+        )
+        assert sp.cc_vdf is not None and sp.cc_proof is not None
+        assert sp.rc_vdf is not None and sp.rc_proof is not None
+
+        await full_node_api_1.full_node.add_block(blocks[-1])
+        await full_node_api_1.respond_signage_point(
+            full_node_protocol.RespondSignagePoint(sp_index, sp.cc_vdf, sp.cc_proof, sp.rc_vdf, sp.rc_proof), peer
+        )
+        assert full_node_api_1.full_node.full_node_store.get_signage_point(sp.cc_vdf.output.get_hash()) is not None
+
+        # 1) Legacy no-arg call is unchanged and exposes no farmer-template fields
+        legacy = await client.create_block_generator()
+        assert legacy is not None
+        for key in ("generator", "refs", "additions", "removals", "sig", "cost"):
+            assert key in legacy
+        assert "tx_block_info" not in legacy
+        assert "prev_block_header_hash" not in legacy
+        assert "peak_height" not in legacy
+
+        # 2) Farmer template mode returns the transaction-block foliage for the signage point
+        result = await client.create_block_generator(
+            signage_point_index=int(sp_index),
+            challenge_hash=sp.cc_vdf.challenge,
+            challenge_chain_sp=sp.cc_vdf.output.get_hash(),
+            reward_chain_sp=sp.rc_vdf.output.get_hash(),
+        )
+        assert result is not None
+        for key in ("generator", "refs", "additions", "removals", "sig", "cost"):
+            assert key in result
+        peak = full_node_api_1.full_node.blockchain.get_peak()
+        assert peak is not None
+        assert result["peak_height"] == peak.height
+        assert result["prev_block_header_hash"] is not None
+
+        tx_block_info = result["tx_block_info"]
+        assert tx_block_info is not None
+        assert tx_block_info["is_transaction_block"] is True
+        for key in (
+            "prev_transaction_block_hash",
+            "prev_transaction_block_timestamp",
+            "filter_hash",
+            "additions_root",
+            "removals_root",
+            "transactions_info",
+            "transactions_info_hash",
+            "fees",
+            "reward_claims_incorporated",
+        ):
+            assert key in tx_block_info
+        # transactions_info_hash must be consistent with the returned transactions_info
+        ti = TransactionsInfo.from_json_dict(tx_block_info["transactions_info"])
+        assert bytes32.from_hexstr(tx_block_info["transactions_info_hash"]) == ti.get_hash()
+
+        # 3) An unknown signage point is rejected
+        with pytest.raises(ValueError):
+            await client.create_block_generator(
+                signage_point_index=int(sp_index),
+                challenge_hash=std_hash(b"unknown-challenge"),
+                challenge_chain_sp=std_hash(b"unknown-cc-sp"),
+                reward_chain_sp=std_hash(b"unknown-rc-sp"),
+            )
 
 
 @pytest.mark.anyio

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -51,6 +51,159 @@ def compute_block_fee(additions: Sequence[Coin], removals: Sequence[Coin]) -> ui
     return uint64(removal_amount - addition_amount)
 
 
+def create_transaction_block_info(
+    constants: ConsensusConstants,
+    new_block_gen: NewBlockGenerator | None,
+    prev_block: BlockRecord | None,
+    blocks: BlockRecordsProtocol,
+    total_iters_sp: uint128,
+    timestamp: uint64,
+    compute_fees: Callable[[Sequence[Coin], Sequence[Coin]], uint64] = compute_block_fee,
+) -> tuple[FoliageTransactionBlock, TransactionsInfo] | None:
+    """
+    Computes the farmer-independent transaction-block foliage and transactions info for the block that
+    would extend ``prev_block`` at signage-point total iters ``total_iters_sp``. Returns ``None`` if that
+    block is not a transaction block.
+
+    This is factored out of ``create_foliage`` so that block creation and the ``create_block_generator``
+    RPC (used by lightweight farmer gateways) share a single implementation, rather than duplicating the
+    filter/merkle-root/reward-claim logic. Nothing here depends on the proof of space or farmer identity.
+    """
+    if prev_block is None:
+        is_transaction_block = True
+        prev_transaction_block: BlockRecord | None = None
+    else:
+        is_transaction_block, prev_transaction_block = get_prev_transaction_block(prev_block, blocks, total_iters_sp)
+    if not is_transaction_block:
+        return None
+
+    height: uint32 = uint32(0) if prev_block is None else uint32(prev_block.height + 1)
+
+    byte_array_tx: list[bytearray] = []
+    tx_additions: list[Coin] = []
+    tx_removals: list[bytes32] = []
+    generator_block_heights_list: list[uint32] = []
+
+    # Calculate the cost of transactions
+    if new_block_gen is not None:
+        cost: uint64 = new_block_gen.cost
+        spend_bundle_fees: uint64 = compute_fees(new_block_gen.additions, new_block_gen.removals)
+    else:
+        spend_bundle_fees = uint64(0)
+        cost = uint64(0)
+
+    reward_claims_incorporated: list[Coin] = []
+    if height > 0:
+        assert prev_transaction_block is not None
+        assert prev_block is not None
+        curr: BlockRecord = prev_block
+        while not curr.is_transaction_block:
+            curr = blocks.block_record(curr.prev_hash)
+
+        assert curr.fees is not None
+        pool_coin = create_pool_coin(
+            curr.height, curr.pool_puzzle_hash, calculate_pool_reward(curr.height), constants.GENESIS_CHALLENGE
+        )
+
+        farmer_coin = create_farmer_coin(
+            curr.height,
+            curr.farmer_puzzle_hash,
+            uint64(calculate_base_farmer_reward(curr.height) + curr.fees),
+            constants.GENESIS_CHALLENGE,
+        )
+        assert curr.header_hash == prev_transaction_block.header_hash
+        reward_claims_incorporated += [pool_coin, farmer_coin]
+
+        if curr.height > 0:
+            curr = blocks.block_record(curr.prev_hash)
+            # Prev block is not genesis
+            while not curr.is_transaction_block:
+                pool_coin = create_pool_coin(
+                    curr.height,
+                    curr.pool_puzzle_hash,
+                    calculate_pool_reward(curr.height),
+                    constants.GENESIS_CHALLENGE,
+                )
+                farmer_coin = create_farmer_coin(
+                    curr.height,
+                    curr.farmer_puzzle_hash,
+                    calculate_base_farmer_reward(curr.height),
+                    constants.GENESIS_CHALLENGE,
+                )
+                reward_claims_incorporated += [pool_coin, farmer_coin]
+                curr = blocks.block_record(curr.prev_hash)
+
+    for coin in reward_claims_incorporated:
+        tx_additions.append(coin)
+        byte_array_tx.append(bytearray(coin.puzzle_hash))
+
+    if new_block_gen is not None:
+        generator_block_heights_list = new_block_gen.block_refs
+        for coin in new_block_gen.additions:
+            tx_additions.append(coin)
+            byte_array_tx.append(bytearray(coin.puzzle_hash))
+        for coin in new_block_gen.removals:
+            cname = coin.name()
+            tx_removals.append(cname)
+            byte_array_tx.append(bytearray(cname))
+
+    bip158: PyBIP158 = PyBIP158(byte_array_tx)
+    encoded = bytes(bip158.GetEncoded())
+
+    additions_merkle_items: list[bytes32] = []
+
+    # Create addition Merkle set
+    puzzlehash_coin_map: dict[bytes32, list[bytes32]] = {}
+
+    for coin in tx_additions:
+        if coin.puzzle_hash in puzzlehash_coin_map:
+            puzzlehash_coin_map[coin.puzzle_hash].append(coin.name())
+        else:
+            puzzlehash_coin_map[coin.puzzle_hash] = [coin.name()]
+
+    # Addition Merkle set contains puzzlehash and hash of all coins with that puzzlehash
+    for puzzle, coin_ids in puzzlehash_coin_map.items():
+        additions_merkle_items.append(puzzle)
+        additions_merkle_items.append(hash_coin_ids(coin_ids))
+
+    additions_root = bytes32(compute_merkle_set_root(additions_merkle_items))
+    removals_root = bytes32(compute_merkle_set_root(tx_removals))
+
+    generator_hash = bytes32.zeros
+    if new_block_gen is not None:
+        generator_hash = std_hash(new_block_gen.program)
+
+    generator_refs_hash = bytes32([1] * 32)
+    if generator_block_heights_list not in (None, []):
+        generator_ref_list_bytes = b"".join([i.stream_to_bytes() for i in generator_block_heights_list])
+        generator_refs_hash = std_hash(generator_ref_list_bytes)
+
+    filter_hash: bytes32 = std_hash(encoded)
+
+    transactions_info = TransactionsInfo(
+        generator_hash,
+        generator_refs_hash,
+        new_block_gen.signature if new_block_gen else G2Element(),
+        spend_bundle_fees,
+        cost,
+        reward_claims_incorporated,
+    )
+    if prev_transaction_block is None:
+        prev_transaction_block_hash: bytes32 = constants.GENESIS_CHALLENGE
+    else:
+        prev_transaction_block_hash = prev_transaction_block.header_hash
+
+    foliage_transaction_block = FoliageTransactionBlock(
+        prev_transaction_block_hash,
+        timestamp,
+        filter_hash,
+        additions_root,
+        removals_root,
+        transactions_info.get_hash(),
+    )
+    return foliage_transaction_block, transactions_info
+
+
 def create_foliage(
     constants: ConsensusConstants,
     reward_block_unfinished: RewardChainBlockUnfinished,
@@ -87,15 +240,6 @@ def create_foliage(
 
     """
 
-    if prev_block is not None:
-        res = get_prev_transaction_block(prev_block, blocks, total_iters_sp)
-        is_transaction_block: bool = res[0]
-        prev_transaction_block: BlockRecord | None = res[1]
-    else:
-        # Genesis is a transaction block
-        prev_transaction_block = None
-        is_transaction_block = True
-
     rng = random.Random()
     rng.seed(seed)
     # Use the extension data to create different blocks based on header hash
@@ -104,11 +248,6 @@ def create_foliage(
         height: uint32 = uint32(0)
     else:
         height = uint32(prev_block.height + 1)
-
-    # Create filter
-    byte_array_tx: list[bytearray] = []
-    tx_additions: list[Coin] = []
-    tx_removals: list[bytes32] = []
 
     pool_target_signature: G2Element | None = get_pool_signature(
         pool_target, reward_block_unfinished.proof_of_space.pool_public_key
@@ -132,144 +271,27 @@ def create_foliage(
         assert prev_block is not None
         prev_block_hash = prev_block.header_hash
 
-    generator_block_heights_list: list[uint32] = []
-
+    tx_info = create_transaction_block_info(
+        constants,
+        new_block_gen,
+        prev_block,
+        blocks,
+        total_iters_sp,
+        timestamp,
+        compute_fees,
+    )
     foliage_transaction_block_hash: bytes32 | None
-
-    if is_transaction_block:
-        cost: uint64
-        spend_bundle_fees: uint64
-
-        # Calculate the cost of transactions
-        if new_block_gen is not None:
-            cost = new_block_gen.cost
-            spend_bundle_fees = compute_fees(new_block_gen.additions, new_block_gen.removals)
-        else:
-            spend_bundle_fees = uint64(0)
-            cost = uint64(0)
-
-        reward_claims_incorporated = []
-        if height > 0:
-            assert prev_transaction_block is not None
-            assert prev_block is not None
-            curr: BlockRecord = prev_block
-            while not curr.is_transaction_block:
-                curr = blocks.block_record(curr.prev_hash)
-
-            assert curr.fees is not None
-            pool_coin = create_pool_coin(
-                curr.height, curr.pool_puzzle_hash, calculate_pool_reward(curr.height), constants.GENESIS_CHALLENGE
-            )
-
-            farmer_coin = create_farmer_coin(
-                curr.height,
-                curr.farmer_puzzle_hash,
-                uint64(calculate_base_farmer_reward(curr.height) + curr.fees),
-                constants.GENESIS_CHALLENGE,
-            )
-            assert curr.header_hash == prev_transaction_block.header_hash
-            reward_claims_incorporated += [pool_coin, farmer_coin]
-
-            if curr.height > 0:
-                curr = blocks.block_record(curr.prev_hash)
-                # Prev block is not genesis
-                while not curr.is_transaction_block:
-                    pool_coin = create_pool_coin(
-                        curr.height,
-                        curr.pool_puzzle_hash,
-                        calculate_pool_reward(curr.height),
-                        constants.GENESIS_CHALLENGE,
-                    )
-                    farmer_coin = create_farmer_coin(
-                        curr.height,
-                        curr.farmer_puzzle_hash,
-                        calculate_base_farmer_reward(curr.height),
-                        constants.GENESIS_CHALLENGE,
-                    )
-                    reward_claims_incorporated += [pool_coin, farmer_coin]
-                    curr = blocks.block_record(curr.prev_hash)
-
-        for coin in reward_claims_incorporated:
-            tx_additions.append(coin)
-            byte_array_tx.append(bytearray(coin.puzzle_hash))
-
-        if new_block_gen is not None:
-            generator_block_heights_list = new_block_gen.block_refs
-            for coin in new_block_gen.additions:
-                tx_additions.append(coin)
-                byte_array_tx.append(bytearray(coin.puzzle_hash))
-            for coin in new_block_gen.removals:
-                cname = coin.name()
-                tx_removals.append(cname)
-                byte_array_tx.append(bytearray(cname))
-
-        bip158: PyBIP158 = PyBIP158(byte_array_tx)
-        encoded = bytes(bip158.GetEncoded())
-
-        additions_merkle_items: list[bytes32] = []
-
-        # Create addition Merkle set
-        puzzlehash_coin_map: dict[bytes32, list[bytes32]] = {}
-
-        for coin in tx_additions:
-            if coin.puzzle_hash in puzzlehash_coin_map:
-                puzzlehash_coin_map[coin.puzzle_hash].append(coin.name())
-            else:
-                puzzlehash_coin_map[coin.puzzle_hash] = [coin.name()]
-
-        # Addition Merkle set contains puzzlehash and hash of all coins with that puzzlehash
-        for puzzle, coin_ids in puzzlehash_coin_map.items():
-            additions_merkle_items.append(puzzle)
-            additions_merkle_items.append(hash_coin_ids(coin_ids))
-
-        additions_root = bytes32(compute_merkle_set_root(additions_merkle_items))
-        removals_root = bytes32(compute_merkle_set_root(tx_removals))
-
-        generator_hash = bytes32.zeros
-        if new_block_gen is not None:
-            generator_hash = std_hash(new_block_gen.program)
-
-        generator_refs_hash = bytes32([1] * 32)
-        if generator_block_heights_list not in (None, []):
-            generator_ref_list_bytes = b"".join([i.stream_to_bytes() for i in generator_block_heights_list])
-            generator_refs_hash = std_hash(generator_ref_list_bytes)
-
-        filter_hash: bytes32 = std_hash(encoded)
-
-        transactions_info: TransactionsInfo | None = TransactionsInfo(
-            generator_hash,
-            generator_refs_hash,
-            new_block_gen.signature if new_block_gen else G2Element(),
-            spend_bundle_fees,
-            cost,
-            reward_claims_incorporated,
-        )
-        if prev_transaction_block is None:
-            prev_transaction_block_hash: bytes32 = constants.GENESIS_CHALLENGE
-        else:
-            prev_transaction_block_hash = prev_transaction_block.header_hash
-
-        assert transactions_info is not None
-        foliage_transaction_block: FoliageTransactionBlock | None = FoliageTransactionBlock(
-            prev_transaction_block_hash,
-            timestamp,
-            filter_hash,
-            additions_root,
-            removals_root,
-            transactions_info.get_hash(),
-        )
-        assert foliage_transaction_block is not None
-
+    if tx_info is not None:
+        foliage_transaction_block, transactions_info = tx_info
         foliage_transaction_block_hash = foliage_transaction_block.get_hash()
         foliage_transaction_block_signature: G2Element | None = get_plot_signature(
             foliage_transaction_block_hash, reward_block_unfinished.proof_of_space.plot_public_key
         )
-        assert foliage_transaction_block_signature is not None
     else:
-        foliage_transaction_block_hash = None
-        foliage_transaction_block_signature = None
         foliage_transaction_block = None
         transactions_info = None
+        foliage_transaction_block_hash = None
+        foliage_transaction_block_signature = None
     assert (foliage_transaction_block_hash is None) == (foliage_transaction_block_signature is None)
 
     foliage = Foliage(

--- a/chia/full_node/full_node_rpc_api.py
+++ b/chia/full_node/full_node_rpc_api.py
@@ -19,11 +19,14 @@ from chia_rs import (
 )
 from chia_rs import get_puzzle_and_solution_for_coin2 as get_puzzle_and_solution_for_coin
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint32, uint64, uint128
+from chia_rs.sized_ints import uint8, uint32, uint64, uint128
 
+from chia.consensus.block_creation import create_transaction_block_info
 from chia.consensus.blockchain import Blockchain, BlockchainMutexPriority
 from chia.consensus.get_block_generator import get_block_generator
 from chia.consensus.pos_quality import UI_ACTUAL_SPACE_CONSTANT_FACTOR
+from chia.consensus.pot_iterations import calculate_sp_iters
+from chia.consensus.prev_transaction_block import get_prev_transaction_block
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
 from chia.full_node.full_node import FullNode
 from chia.full_node.hard_fork_utils import get_flags
@@ -964,15 +967,123 @@ class FullNodeRpcApi:
 
         return {"mempool_items": [item.to_json_dict() for item in items]}
 
-    async def create_block_generator(self, _: dict[str, Any]) -> EndpointResult:
+    def _resolve_signage_point_context(
+        self,
+        peak: BlockRecord,
+        signage_point_index: uint8,
+        challenge_hash: bytes32,
+        challenge_chain_sp: bytes32,
+        reward_chain_sp: bytes32,
+    ) -> tuple[BlockRecord | None, uint128, str | None]:
+        """
+        Resolves the block that would be farmed at the given signage point, returning
+        ``(prev_block, total_iters_sp, error)``. On success ``error`` is None.
+
+        This mirrors the signage-point / previous-block resolution in
+        ``FullNodeAPI.declare_proof_of_space`` so that the resulting ``prev_block`` and
+        ``total_iters_sp`` (and therefore the transaction-block foliage computed from them) match what
+        the node itself would build for this signage point, including overflow blocks. It reuses the
+        existing ``full_node_store`` helpers rather than duplicating any consensus math.
+        """
+        store = self.service.full_node_store
+        constants = self.service.constants
+
+        sp_vdfs = store.get_signage_point_by_index_and_cc_output(
+            challenge_chain_sp, challenge_hash, signage_point_index
+        )
+        if sp_vdfs is None:
+            return None, uint128(0), f"unknown signage point {challenge_chain_sp.hex()}"
+        if signage_point_index > 0:
+            if sp_vdfs.rc_vdf is None or sp_vdfs.rc_vdf.output.get_hash() != reward_chain_sp:
+                return None, uint128(0), "reward chain signage point mismatch (stale signage point)"
+
+        if signage_point_index == 0:
+            cc_challenge_hash = challenge_chain_sp
+        else:
+            assert sp_vdfs.cc_vdf is not None
+            cc_challenge_hash = sp_vdfs.cc_vdf.challenge
+
+        pos_sub_slot = None
+        if challenge_hash != constants.GENESIS_CHALLENGE:
+            pos_sub_slot = store.get_sub_slot(cc_challenge_hash)
+            if pos_sub_slot is None:
+                return None, uint128(0), "unknown sub slot for signage point"
+            total_iters_pos_slot: uint128 = pos_sub_slot[2]
+        else:
+            total_iters_pos_slot = uint128(0)
+        if cc_challenge_hash != challenge_hash:
+            return None, uint128(0), "signage point challenge hash mismatch"
+
+        # Find the previous block from the signage point, ensuring the reward chain VDF is correct
+        prev_b: BlockRecord | None = peak
+        if signage_point_index == 0:
+            assert pos_sub_slot is not None
+            rc_challenge = pos_sub_slot[0].reward_chain.end_of_slot_vdf.challenge
+        else:
+            assert sp_vdfs.rc_vdf is not None
+            rc_challenge = sp_vdfs.rc_vdf.challenge
+
+        # Backtrack through empty sub-slots
+        for eos, _, _ in reversed(store.finished_sub_slots):
+            if eos is not None and eos.reward_chain.get_hash() == rc_challenge:
+                rc_challenge = eos.reward_chain.end_of_slot_vdf.challenge
+
+        found = False
+        attempts = 0
+        while prev_b is not None and attempts < 10:
+            if prev_b.reward_infusion_new_challenge == rc_challenge:
+                found = True
+                break
+            if prev_b.finished_reward_slot_hashes is not None and len(prev_b.finished_reward_slot_hashes) > 0:
+                if prev_b.finished_reward_slot_hashes[-1] == rc_challenge:
+                    prev_b = self.service.blockchain.try_block_record(prev_b.prev_hash)
+                    found = True
+                    break
+            prev_b = self.service.blockchain.try_block_record(prev_b.prev_hash)
+            attempts += 1
+        if not found:
+            return None, uint128(0), "did not find a previous block with the correct reward chain hash"
+
+        try:
+            finished_sub_slots = store.get_finished_sub_slots(self.service.blockchain, prev_b, cc_challenge_hash)
+        except ValueError as e:
+            return None, uint128(0), f"value error resolving finished sub slots: {e}"
+        if finished_sub_slots is None:
+            return None, uint128(0), "could not resolve finished sub slots"
+        if len(finished_sub_slots) > 0 and pos_sub_slot is not None and finished_sub_slots[-1] != pos_sub_slot[0]:
+            return None, uint128(0), "have different sub-slots than required to farm this block"
+
+        if peak.height <= constants.MAX_SUB_SLOT_BLOCKS:
+            sub_slot_iters = constants.SUB_SLOT_ITERS_STARTING
+        else:
+            sub_slot_iters = peak.sub_slot_iters
+            for sub_slot in finished_sub_slots:
+                if sub_slot.challenge_chain.new_sub_slot_iters is not None:
+                    sub_slot_iters = sub_slot.challenge_chain.new_sub_slot_iters
+
+        sp_iters = calculate_sp_iters(constants, sub_slot_iters, signage_point_index)
+        total_iters_sp = uint128(total_iters_pos_slot + sp_iters)
+        return prev_b, total_iters_sp, None
+
+    async def create_block_generator(self, request: dict[str, Any]) -> EndpointResult:
+        # When a signage point is supplied ("farmer template" mode), additionally resolve the block that
+        # would be farmed at that signage point and return the farmer-independent transaction-block foliage
+        # (filter hash, additions/removals roots, transactions info). With no signage point this behaves
+        # exactly as before and is byte-for-byte backwards compatible.
+        sp_index_req = request.get("signage_point_index")
+        farmer_template_mode = sp_index_req is not None
+
         gen = NewBlockGenerator()
+        maybe_gen: NewBlockGenerator | None = None
+        prev_b: BlockRecord | None = None
+        total_iters_sp: uint128 = uint128(0)
 
         # Grab best transactions from Mempool for given tip target
         async with self.service.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.low):
             peak: BlockRecord | None = self.service.blockchain.get_peak()
 
             if peak is None:
-                return {
+                result: EndpointResult = {
                     "generator": gen.program,
                     "refs": gen.block_refs,
                     "additions": gen.additions,
@@ -980,17 +1091,41 @@ class FullNodeRpcApi:
                     "sig": gen.signature,
                     "cost": gen.cost,
                 }
+                if farmer_template_mode:
+                    result["prev_block_header_hash"] = None
+                    result["peak_height"] = None
+                    result["tx_block_info"] = None
+                return result
 
-            # Finds the last transaction block before this one
-            curr_l_tb: BlockRecord = peak
-            while not curr_l_tb.is_transaction_block:
-                curr_l_tb = self.service.blockchain.block_record(curr_l_tb.prev_hash)
+            if farmer_template_mode:
+                assert sp_index_req is not None
+                prev_b, total_iters_sp, resolve_err = self._resolve_signage_point_context(
+                    peak,
+                    uint8(sp_index_req),
+                    bytes32.from_hexstr(request["challenge_hash"]),
+                    bytes32.from_hexstr(request["challenge_chain_sp"]),
+                    bytes32.from_hexstr(request["reward_chain_sp"]),
+                )
+                if resolve_err is not None:
+                    raise ValueError(resolve_err)
+            else:
+                prev_b = peak
+
+            # Target for the transaction generator is the latest transaction block
+            tx_peak = self.service.blockchain.get_tx_peak()
+            if tx_peak is not None:
+                tx_base = tx_peak.header_hash
+            else:
+                curr_l_tb: BlockRecord = peak
+                while not curr_l_tb.is_transaction_block:
+                    curr_l_tb = self.service.blockchain.block_record(curr_l_tb.prev_hash)
+                tx_base = curr_l_tb.header_hash
 
             self.service.log.info("Beginning simulated block construction from mempool")
             start_time = time.monotonic()
 
             try:
-                maybe_gen = self.service.mempool_manager.create_block_generator2(curr_l_tb.header_hash, 2.0)
+                maybe_gen = self.service.mempool_manager.create_block_generator2(tx_base, 2.0)
                 if maybe_gen is None:
                     self.service.log.error(f"failed to create block generator, peak: {peak}")
                 else:
@@ -999,7 +1134,9 @@ class FullNodeRpcApi:
                 self.service.log.exception(f"Error creating block generator, peak: {peak}")
             self.service.log.info(f"Simulated block constructed in {time.monotonic() - start_time:0.2f} seconds")
 
-            if maybe_gen is not None:
+            # The run_block_generator2 self-check re-executes the generator (expensive CLVM run) and only
+            # logs; skip it in farmer template mode so per-signage-point fetches stay cheap.
+            if not farmer_template_mode and maybe_gen is not None:
                 # this also validates the signature
                 err, err_msg, conds = await self.service.pool.run_in_loop(
                     run_block_generator2,
@@ -1025,14 +1162,51 @@ class FullNodeRpcApi:
                         )
                     # TODO: maybe validate additions and removals too
 
-        return {
-            "generator": gen.program,
-            "refs": gen.block_refs,
-            "additions": gen.additions,
-            "removals": gen.removals,
-            "sig": gen.signature,
-            "cost": gen.cost,
-        }
+            result = {
+                "generator": gen.program,
+                "refs": gen.block_refs,
+                "additions": gen.additions,
+                "removals": gen.removals,
+                "sig": gen.signature,
+                "cost": gen.cost,
+            }
+
+            if farmer_template_mode:
+                result["prev_block_header_hash"] = None if prev_b is None else prev_b.header_hash
+                result["peak_height"] = peak.height
+                tx_info = create_transaction_block_info(
+                    self.service.constants,
+                    maybe_gen,
+                    prev_b,
+                    self.service.blockchain,
+                    total_iters_sp,
+                    uint64(0),
+                )
+                if tx_info is None:
+                    result["tx_block_info"] = {"is_transaction_block": False}
+                else:
+                    foliage_tx_block, transactions_info = tx_info
+                    prev_tx_block = None
+                    if prev_b is not None:
+                        _is_tb, prev_tx_block = get_prev_transaction_block(
+                            prev_b, self.service.blockchain, total_iters_sp
+                        )
+                    result["tx_block_info"] = {
+                        "is_transaction_block": True,
+                        "prev_transaction_block_hash": foliage_tx_block.prev_transaction_block_hash,
+                        "prev_transaction_block_timestamp": (
+                            None if prev_tx_block is None else prev_tx_block.timestamp
+                        ),
+                        "filter_hash": foliage_tx_block.filter_hash,
+                        "additions_root": foliage_tx_block.additions_root,
+                        "removals_root": foliage_tx_block.removals_root,
+                        "transactions_info": transactions_info,
+                        "transactions_info_hash": foliage_tx_block.transactions_info_hash,
+                        "fees": transactions_info.fees,
+                        "reward_claims_incorporated": transactions_info.reward_claims_incorporated,
+                    }
+
+        return result
 
     def _get_spendbundle_type_cost(self, name: str) -> uint64:
         """

--- a/chia/full_node/full_node_rpc_client.py
+++ b/chia/full_node/full_node_rpc_client.py
@@ -250,8 +250,28 @@ class FullNodeRpcClient(RpcClient):
         response = await self.fetch("get_mempool_items_by_coin_name", {"coin_name": coin_name.hex()})
         return response
 
-    async def create_block_generator(self) -> dict[str, Any] | None:
-        response = await self.fetch("create_block_generator", {})
+    async def create_block_generator(
+        self,
+        signage_point_index: int | None = None,
+        challenge_hash: bytes32 | None = None,
+        challenge_chain_sp: bytes32 | None = None,
+        reward_chain_sp: bytes32 | None = None,
+    ) -> dict[str, Any] | None:
+        # With no signage point, returns the transaction generator template for the current peak (legacy
+        # behavior). When a signage point is supplied, the response additionally includes the
+        # farmer-independent transaction-block foliage under "tx_block_info".
+        request: dict[str, Any] = {}
+        if signage_point_index is not None:
+            assert challenge_hash is not None
+            assert challenge_chain_sp is not None
+            assert reward_chain_sp is not None
+            request = {
+                "signage_point_index": signage_point_index,
+                "challenge_hash": challenge_hash.hex(),
+                "challenge_chain_sp": challenge_chain_sp.hex(),
+                "reward_chain_sp": reward_chain_sp.hex(),
+            }
+        response = await self.fetch("create_block_generator", request)
         return response
 
     async def get_recent_signage_point_or_eos(


### PR DESCRIPTION
### Purpose:

Expose the full node's own transaction-block construction output through the
existing `create_block_generator` RPC, so external tooling — in particular a
lightweight "farmer gateway" that speaks the native farmer protocol to many
farmers — can assemble a winning block without re-implementing mempool
selection, singleton fast-forward, or the filter/merkle-root logic.

This is purely additive and **not a breaking change**: with no new parameters
the endpoint behaves exactly as before.

### Current Behavior:

- `create_block_generator` (no arguments) returns only
  `{generator, refs, additions, removals, sig, cost}` and always runs the
  `run_block_generator2` self-check.
- The transaction-block foliage (filter hash, additions/removals roots,
  transactions info, reward claims) is computed inline inside `create_foliage`
  and is not exposed anywhere.

### New Behavior:

- Factor the farmer-independent transaction-block foliage computation out of
  `create_foliage` into a new reusable helper `create_transaction_block_info`
  (`chia/consensus/block_creation.py`). `create_foliage` now calls it; this is a
  behavior-preserving move (`git diff --color-moved` shows it as a move rather
  than a rewrite).
- Extend `create_block_generator` with optional signage-point parameters:
  `signage_point_index`, `challenge_hash`, `challenge_chain_sp`,
  `reward_chain_sp`.
  - Omitted → the endpoint behaves exactly as before (byte-for-byte compatible
    response).
  - Supplied ("farmer template mode") → the endpoint resolves the block that
    would be farmed at that signage point, mirroring `declare_proof_of_space`
    (including overflow blocks), and returns the transaction-block foliage under
    a new `tx_block_info` object plus `prev_block_header_hash` and `peak_height`.
- The `run_block_generator2` self-check (which only logs and re-executes the
  generator) is skipped in farmer template mode, keeping per-signage-point
  fetches cheap.
- `FullNodeRpcClient.create_block_generator` gains matching optional parameters.

Response additions in farmer template mode:

- Top level: `prev_block_header_hash`, `peak_height`
- `tx_block_info`: `is_transaction_block`, `prev_transaction_block_hash`,
  `prev_transaction_block_timestamp`, `filter_hash`, `additions_root`,
  `removals_root`, `transactions_info`, `transactions_info_hash`, `fees`,
  `reward_claims_incorporated` — or `{"is_transaction_block": false}` when the
  resolved block is not a transaction block.

### Testing Notes:

- New `test_create_block_generator` in `chia/_tests/core/test_full_node_rpc.py`
  covers the legacy no-arg response (asserting the farmer-template fields are
  absent), the farmer-template response for a registered signage point
  (asserting `tx_block_info` fields, `peak_height`/`prev_block_header_hash`, and
  that `transactions_info_hash` matches `hash(transactions_info)`), and the
  error path for an unknown signage point. Passes across all consensus-mode
  variants.
- The `create_foliage` refactor is a behavior-preserving extraction, also
  covered by the existing block-creation tests, since `block_tools` builds every
  simulated block via `create_unfinished_block` → `create_foliage`. Verified
  with `pytest chia/_tests/core/mempool/test_mempool_manager.py -k "create_block_generator or fill_rate_block_validation or check_removals_with_block_creation"`
  (138 passed).
- `ruff format --check`, `ruff check`, and `mypy` pass on all changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus block-creation paths and signage-point resolution used to assemble winning blocks; legacy no-arg RPC is unchanged, but incorrect foliage in farmer-template mode could mislead external farmers.
> 
> **Overview**
> Adds an opt-in **farmer template** mode to `create_block_generator` so external gateways can fetch the same transaction-block foliage the full node would build at a given signage point, without reimplementing mempool or merkle/filter logic.
> 
> Transaction-block foliage computation is **extracted** from `create_foliage` into `create_transaction_block_info` in `block_creation.py`; `create_foliage` now calls that helper (intended as behavior-preserving). The RPC gains optional `signage_point_index`, `challenge_hash`, `challenge_chain_sp`, and `reward_chain_sp`. When omitted, the response stays the legacy shape; when set, it resolves `prev_block` / `total_iters_sp` via new `_resolve_signage_point_context` (aligned with `declare_proof_of_space`, including overflow), returns `prev_block_header_hash`, `peak_height`, and `tx_block_info`, and **skips** the expensive `run_block_generator2` self-check. Mempool block construction now anchors on `get_tx_peak()` instead of walking from chain peak to the latest transaction block.
> 
> `FullNodeRpcClient.create_block_generator` accepts the same optional parameters. `test_create_block_generator` covers legacy response, farmer-template fields (including `transactions_info_hash` consistency), and unknown signage-point errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b761b5e36276dc402233868d1714f805d8fb2416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->