### PR TITLE
bump chia-rs to 0.46.0

### DIFF
--- a/benchmarks/block_ref.py
+++ b/benchmarks/block_ref.py
@@ -10,7 +10,7 @@ from time import monotonic
 import aiosqlite
 import click
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint32
+from chia_rs.sized_ints import uint8, uint32
 
 from chia.consensus.block_height_map import BlockHeightMap
 from chia.consensus.blockchain import Blockchain
@@ -41,6 +41,8 @@ class BlockInfo:
     prev_header_hash: bytes32
     transactions_generator: SerializedProgram | None
     transactions_generator_ref_list: list[uint32]
+    transactions_generator_buffer: list[uint8] | None = None
+    version: uint8 = uint8(0)
 
 
 def random_refs() -> list[uint32]:

--- a/benchmarks/block_store.py
+++ b/benchmarks/block_store.py
@@ -196,6 +196,8 @@ async def run_add_block_benchmark(version: int) -> None:
                 transactions_info,
                 SerializedProgram.from_bytes(clvm_generator) if is_transaction else None,  # transactions_generator
                 [],  # transactions_generator_ref_list
+                None,
+                uint8(0),
             )
 
             header_hash = full_block.header_hash

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -330,6 +330,8 @@ class TestBlockHeaderValidation:
             block.transactions_info,
             block.transactions_generator,
             [],
+            None,
+            uint8(0),
         )
         conds = None
         # if this assert fires, remove it along with the pragma for the block
@@ -364,6 +366,8 @@ class TestBlockHeaderValidation:
             block.transactions_info,
             block.transactions_generator,
             [],
+            None,
+            uint8(0),
         )
         conds = None
         # if this assert fires, remove it along with the pragma for the block
@@ -459,6 +463,8 @@ class TestBlockHeaderValidation:
                     block.transactions_info,
                     block.transactions_generator,
                     [],
+                    None,
+                    uint8(0),
                 )
                 conds = None
                 # if this assert fires, remove it along with the pragma for the block

--- a/chia/_tests/blockchain/test_get_block_generator.py
+++ b/chia/_tests/blockchain/test_get_block_generator.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import pytest
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint32
+from chia_rs.sized_ints import uint8, uint32
 
 from chia.consensus.get_block_generator import get_block_generator
 from chia.types.blockchain_format.serialized_program import SerializedProgram
@@ -17,6 +17,8 @@ class BR:
     prev_header_hash: bytes32
     transactions_generator: SerializedProgram | None
     transactions_generator_ref_list: list[uint32]
+    transactions_generator_buffer: list[uint8] | None = None
+    version: uint8 = uint8(0)
 
 
 @dataclass(frozen=True)

--- a/chia/_tests/cmds/test_show.py
+++ b/chia/_tests/cmds/test_show.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from chia_rs import FoliageTransactionBlock, FullBlock
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint32, uint64
+from chia_rs.sized_ints import uint8, uint32, uint64
 
 from chia._tests.cmds.cmd_test_utils import TestFullNodeRpcClient, TestRpcClients, run_cli_command_and_assert
 from chia._tests.cmds.testing_classes import hash_to_height, height_hash
@@ -75,6 +75,8 @@ class ShowFullNodeRpcClient(TestFullNodeRpcClient):
             transactions_info=tx_info,
             transactions_generator=SerializedProgram.from_bytes(bytes.fromhex("ff01820539")),
             transactions_generator_ref_list=[],
+            transactions_generator_buffer=None,
+            version=uint8(0),
         )
         return full_block
 

--- a/chia/_tests/core/custom_types/test_proof_of_space.py
+++ b/chia/_tests/core/custom_types/test_proof_of_space.py
@@ -302,21 +302,6 @@ def test_calculate_prefix_bits_v1(height: uint32, expected: int) -> None:
     assert calculate_prefix_bits(DEFAULT_CONSTANTS, height, PlotParam.make_v1(32)) == expected
 
 
-@pytest.mark.parametrize(
-    argnames=["height", "expected"],
-    argvalues=[
-        (0, 5),
-        (0xFFFFFFFA, 5),
-        (0xFFFFFFFB, 4),
-        (0xFFFFFFFC, 3),
-        (0xFFFFFFFD, 2),
-        (0xFFFFFFFF, 2),
-    ],
-)
-def test_calculate_prefix_bits_v2(height: uint32, expected: int) -> None:
-    assert calculate_prefix_bits(DEFAULT_CONSTANTS, height, PlotParam.make_v2(0, 0, 28)) == expected
-
-
 def test_base_filter_relative_to_fork_height() -> None:
     constants = DEFAULT_CONSTANTS.replace(
         HARD_FORK2_HEIGHT=uint32(1_000_000),

--- a/chia/_tests/core/full_node/stores/test_full_node_store.py
+++ b/chia/_tests/core/full_node/stores/test_full_node_store.py
@@ -219,6 +219,8 @@ async def test_basic_store(
                 block.transactions_info,
                 block.transactions_generator,
                 [],
+                None,
+                uint8(0),
             )
         )
 

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -2072,6 +2072,8 @@ async def test_unfinished_block_with_replaced_generator(
         transactions_info,
         replaced_generator,
         generator_refs,
+        None,
+        uint8(0),
     )
 
     _, header_error = await full_node_1.full_node.blockchain.validate_unfinished_block_header(unf)
@@ -4074,6 +4076,8 @@ def unfinished_from_full_block(block: FullBlock) -> UnfinishedBlock:
         block.transactions_info,
         block.transactions_generator,
         block.transactions_generator_ref_list,
+        block.transactions_generator_buffer,
+        block.version,
     )
 
     return unfinished_block_expected

--- a/chia/_tests/core/full_node/test_performance.py
+++ b/chia/_tests/core/full_node/test_performance.py
@@ -5,7 +5,7 @@ import random
 
 import pytest
 from chia_rs import BlockRecord, UnfinishedBlock
-from chia_rs.sized_ints import uint64
+from chia_rs.sized_ints import uint8, uint64
 
 from chia._tests.connection_utils import add_dummy_connection
 from chia._tests.core.full_node.stores.test_coin_store import get_future_reward_coins
@@ -151,6 +151,8 @@ class TestPerformance:
             block.transactions_info,
             block.transactions_generator,
             [],
+            None,
+            uint8(0),
         )
 
         with benchmark_runner.assert_runtime(seconds=0.1, label="unfinished"):

--- a/chia/_tests/core/test_full_node_rpc.py
+++ b/chia/_tests/core/test_full_node_rpc.py
@@ -79,6 +79,8 @@ async def test1(
                 block.transactions_info,
                 block.transactions_generator,
                 [],
+                None,
+                uint8(0),
             )
             await full_node_api_1.full_node.add_unfinished_block(unf, None)
             await full_node_api_1.full_node.add_block(block, None)
@@ -652,6 +654,8 @@ async def test_get_blockchain_state(
                 block.transactions_info,
                 block.transactions_generator,
                 [],
+                None,
+                uint8(0),
             )
             await full_node_api_1.full_node.add_unfinished_block(unf, None)
             await full_node_api_1.full_node.add_block(block, None)
@@ -765,6 +769,8 @@ async def test_coin_name_found_in_mempool(one_node: SimulatorsAndWalletsServices
                 block.transactions_info,
                 block.transactions_generator,
                 [],
+                None,
+                uint8(0),
             )
             await full_node_api.full_node.add_unfinished_block(unf, None)
             await full_node_api.full_node.add_block(block, None)

--- a/chia/_tests/timelord/test_new_peak.py
+++ b/chia/_tests/timelord/test_new_peak.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 from chia_rs import BlockRecord, FullBlock, SubEpochSummary, UnfinishedBlock, is_overflow_block
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint64, uint128
+from chia_rs.sized_ints import uint8, uint64, uint128
 
 from chia._tests.blockchain.blockchain_test_utils import _validate_and_add_block
 from chia._tests.conftest import ConsensusMode
@@ -280,6 +280,8 @@ class TestNewPeak:
                     block_1.transactions_info,
                     block_1.transactions_generator,
                     [],
+                    None,
+                    uint8(0),
                 )
                 await full_node.add_unfinished_block(block_1_unf, None)
                 unf: UnfinishedBlock = full_node.full_node_store.get_unfinished_block(block_1_unf.partial_hash)

--- a/chia/_tests/util/benchmarks.py
+++ b/chia/_tests/util/benchmarks.py
@@ -175,6 +175,8 @@ def rand_full_block() -> FullBlock:
         transactions_info,
         SerializedProgram.from_bytes(clvm_generator),
         [],
+        None,
+        uint8(0),
     )
 
     return full_block

--- a/chia/_tests/util/network_protocol_data.py
+++ b/chia/_tests/util/network_protocol_data.py
@@ -440,6 +440,8 @@ full_block = FullBlock(
         )
     ),
     [uint32(2456207540)],
+    None,
+    uint8(0),
 )
 
 respond_blocks = full_node_protocol.RespondBlocks(uint32(1000), uint32(4201431299), [full_block, full_block])
@@ -485,6 +487,8 @@ unfinished_block = UnfinishedBlock(
         )
     ),
     [uint32(1862532955)],
+    None,
+    uint8(0),
 )
 
 respond_unfinished_block = full_node_protocol.RespondUnfinishedBlock(unfinished_block)

--- a/chia/_tests/util/protocol_messages_json.py
+++ b/chia/_tests/util/protocol_messages_json.py
@@ -610,6 +610,8 @@ respond_blocks_json: dict[str, Any] = {
             },
             "transactions_generator": "0xff01ffff33ffa0f8912302fb33b8188046662785704afc3dd945074e4b45499a7173946e044695ff8203e880ffff33ffa03eaa52e850322dbc281c6b922e9d8819c7b4120ee054c4aa79db50be516a2bcaff8207d08080",
             "transactions_generator_ref_list": [2456207540],
+            "transactions_generator_buffer": None,
+            "version": 0,
         },
         {
             "finished_sub_slots": [
@@ -791,6 +793,8 @@ respond_blocks_json: dict[str, Any] = {
             },
             "transactions_generator": "0xff01ffff33ffa0f8912302fb33b8188046662785704afc3dd945074e4b45499a7173946e044695ff8203e880ffff33ffa03eaa52e850322dbc281c6b922e9d8819c7b4120ee054c4aa79db50be516a2bcaff8207d08080",
             "transactions_generator_ref_list": [2456207540],
+            "transactions_generator_buffer": None,
+            "version": 0,
         },
     ],
 }
@@ -978,6 +982,8 @@ respond_block_json: dict[str, Any] = {
         },
         "transactions_generator": "0xff01ffff33ffa0f8912302fb33b8188046662785704afc3dd945074e4b45499a7173946e044695ff8203e880ffff33ffa03eaa52e850322dbc281c6b922e9d8819c7b4120ee054c4aa79db50be516a2bcaff8207d08080",
         "transactions_generator_ref_list": [2456207540],
+        "transactions_generator_buffer": None,
+        "version": 0,
     }
 }
 
@@ -1130,6 +1136,8 @@ respond_unfinished_block_json: dict[str, Any] = {
         },
         "transactions_generator": "0xff01ffff33ffa0f8912302fb33b8188046662785704afc3dd945074e4b45499a7173946e044695ff8203e880ffff33ffa03eaa52e850322dbc281c6b922e9d8819c7b4120ee054c4aa79db50be516a2bcaff8207d08080",
         "transactions_generator_ref_list": [1862532955],
+        "transactions_generator_buffer": None,
+        "version": 0,
     }
 }
 

--- a/chia/_tests/util/test_full_block_utils.py
+++ b/chia/_tests/util/test_full_block_utils.py
@@ -300,6 +300,8 @@ def get_full_blocks(shard: int) -> Iterator[FullBlock]:
                                                 transactions_info,
                                                 gen,  # transactions_generator
                                                 refs_list,  # transactions_generator_ref_list
+                                                None,
+                                                uint8(0),
                                             )
 
 

--- a/chia/_tests/util/test_replace_str_to_bytes.py
+++ b/chia/_tests/util/test_replace_str_to_bytes.py
@@ -69,9 +69,19 @@ test_constants = ConsensusConstants(
     PLOT_FILTER_32_HEIGHT=uint32(20643000),
     MIN_PLOT_STRENGTH=uint8(2),
     MAX_PLOT_STRENGTH=uint8(32),
-    PLOT_FILTER_V2_FIRST_ADJUSTMENT_HEIGHT=uint32(0xFFFFFFFA),
-    PLOT_FILTER_V2_SECOND_ADJUSTMENT_HEIGHT=uint32(0xFFFFFFFB),
-    PLOT_FILTER_V2_THIRD_ADJUSTMENT_HEIGHT=uint32(0xFFFFFFFC),
+    PLOT_FILTER_V2_RELATIVE_HEIGHT=[
+        uint32(50_494_000),
+        uint32(45_444_000),
+        uint32(40_394_000),
+        uint32(35_343_000),
+        uint32(30_298_000),
+        uint32(25_247_000),
+        uint32(20_197_000),
+        uint32(15_146_000),
+        uint32(10_101_000),
+    ],
+    FILTER_WINDOW_SIZE=uint8(16),
+    MAX_EFFECTIVE_PLOT_FILTER_BITS=uint8(13),
     TESTNET=True,
 )
 

--- a/chia/_tests/wallet/wallet_block_tools.py
+++ b/chia/_tests/wallet/wallet_block_tools.py
@@ -205,6 +205,8 @@ def finish_block(
         unfinished_block.transactions_info,
         unfinished_block.transactions_generator,
         [],
+        None,
+        uint8(0),
     )
 
     block_record = block_to_block_record(
@@ -340,6 +342,8 @@ def get_full_block_and_block_record(
         transactions_info,
         block_generator.program if block_generator else None,
         [],
+        None,
+        uint8(0),
     )
 
     full_block, block_record = finish_block(constants, unfinished_block, prev_block, blocks)

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -215,6 +215,17 @@ async def validate_block_body(
     prev_transaction_block_height: uint32 = uint32(0)
     prev_transaction_block_timestamp: uint64 = uint64(0)
 
+    # 0. Validate block version. Version 1 (which omits transaction_generator_ref_list
+    # and encodes the generator as a plain buffer) is only valid after the 3.0 hard fork.
+    # TODO: allow version 1 after the hard fork activates
+    #   if block.version == 1:
+    #       if height < constants.HARD_FORK2_HEIGHT:
+    #           return Err.INVALID_BLOCK_VERSION
+    #   elif block.version != 0:
+    #       return Err.INVALID_BLOCK_VERSION
+    if block.version != 0:
+        return Err.INVALID_BLOCK_VERSION
+
     # 1. For non transaction-blocs: foliage block, transaction filter, transactions info, and generator must
     # be empty. If it is a block but not a transaction block, there is no body to validate. Check that all fields are
     # None
@@ -223,6 +234,7 @@ async def validate_block_body(
             block.foliage_transaction_block is not None
             or block.transactions_info is not None
             or block.transactions_generator is not None
+            or block.transactions_generator_buffer is not None
         ):
             return Err.NOT_BLOCK_BUT_HAS_DATA
 

--- a/chia/consensus/block_creation.py
+++ b/chia/consensus/block_creation.py
@@ -405,6 +405,8 @@ def create_unfinished_block(
         transactions_info,
         new_block_gen.program if new_block_gen else None,
         new_block_gen.block_refs if new_block_gen else [],
+        None,
+        uint8(0),
     )
 
 
@@ -499,6 +501,7 @@ def unfinished_block_to_full_block(
             foliage_transaction_block_hash=new_fbh,
             foliage_transaction_block_signature=new_fbs,
         )
+    new_generator_buffer = unfinished_block.transactions_generator_buffer if is_transaction_block else None
     ret = FullBlock(
         finished_sub_slots,
         reward_chain_block,
@@ -512,6 +515,8 @@ def unfinished_block_to_full_block(
         new_tx_info,
         new_generator,
         new_generator_ref_list,
+        new_generator_buffer,
+        unfinished_block.version,
     )
     return ret
 

--- a/chia/consensus/blockchain.py
+++ b/chia/consensus/blockchain.py
@@ -725,6 +725,16 @@ class Blockchain:
         if prev_b is None and block.prev_header_hash != self.constants.GENESIS_CHALLENGE:
             return None, Err.INVALID_PREV_BLOCK_HASH
 
+        # TODO: todo_v2_plots allow version 1 after the hard fork activates
+        # block_height = uint32(0) if prev_b is None else uint32(prev_b.height + 1)
+        # if block.version == 1:
+        #     if block_height < self.constants.HARD_FORK2_HEIGHT:
+        #         return None, Err.INVALID_BLOCK_VERSION
+        # elif block.version != 0:
+        #     return None, Err.INVALID_BLOCK_VERSION
+        if block.version != 0:
+            return None, Err.INVALID_BLOCK_VERSION
+
         prev_tx_height = pre_sp_tx_block_height(
             constants=self.constants,
             blocks=self,

--- a/chia/consensus/default_constants.py
+++ b/chia/consensus/default_constants.py
@@ -94,10 +94,19 @@ DEFAULT_CONSTANTS = ConsensusConstants(
     PLOT_FILTER_32_HEIGHT=uint32(20643000),
     MIN_PLOT_STRENGTH=uint8(2),
     MAX_PLOT_STRENGTH=uint8(32),
-    # TODO: todo_v2_plots finalize plot filter schedule
-    PLOT_FILTER_V2_FIRST_ADJUSTMENT_HEIGHT=uint32(0xFFFFFFFB),
-    PLOT_FILTER_V2_SECOND_ADJUSTMENT_HEIGHT=uint32(0xFFFFFFFC),
-    PLOT_FILTER_V2_THIRD_ADJUSTMENT_HEIGHT=uint32(0xFFFFFFFD),
+    PLOT_FILTER_V2_RELATIVE_HEIGHT=[
+        uint32(50_494_000),
+        uint32(45_444_000),
+        uint32(40_394_000),
+        uint32(35_343_000),
+        uint32(30_298_000),
+        uint32(25_247_000),
+        uint32(20_197_000),
+        uint32(15_146_000),
+        uint32(10_101_000),
+    ],
+    FILTER_WINDOW_SIZE=uint8(16),
+    MAX_EFFECTIVE_PLOT_FILTER_BITS=uint8(13),
     TESTNET=False,
 )
 

--- a/chia/full_node/full_block_utils.py
+++ b/chia/full_node/full_block_utils.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from chia_rs import G1Element, G2Element, TransactionsInfo, serialized_length
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint32
+from chia_rs.sized_ints import uint8, uint32
 from chiabip158 import PyBIP158
 
 from chia.types.blockchain_format.coin import Coin
@@ -253,6 +253,8 @@ class GeneratorBlockInfo:
     prev_header_hash: bytes32
     transactions_generator: SerializedProgram | None
     transactions_generator_ref_list: list[uint32]
+    transactions_generator_buffer: list[uint8] | None = None
+    version: uint8 = uint8(0)
 
 
 def block_info_from_block(buf: memoryview) -> GeneratorBlockInfo:

--- a/chia/simulator/block_tools.py
+++ b/chia/simulator/block_tools.py
@@ -2405,4 +2405,6 @@ def make_unfinished_block(
         block.transactions_info,
         block.transactions_generator,
         block.transactions_generator_ref_list,
+        block.transactions_generator_buffer,
+        block.version,
     )

--- a/chia/types/block_protocol.py
+++ b/chia/types/block_protocol.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import uint32
+from chia_rs.sized_ints import uint8, uint32
 from typing_extensions import Protocol
 
 from chia.types.blockchain_format.serialized_program import SerializedProgram
@@ -16,3 +16,9 @@ class BlockInfo(Protocol):
 
     @property
     def transactions_generator_ref_list(self) -> list[uint32]: ...
+
+    @property
+    def transactions_generator_buffer(self) -> list[uint8] | None: ...
+
+    @property
+    def version(self) -> uint8: ...

--- a/chia/types/blockchain_format/proof_of_space.py
+++ b/chia/types/blockchain_format/proof_of_space.py
@@ -241,12 +241,6 @@ def passes_plot_filter(
 def calculate_prefix_bits(constants: ConsensusConstants, height: uint32, plot_param: PlotParam) -> int:
     if plot_param.strength_v2 is not None:
         prefix_bits = int(constants.NUMBER_ZERO_BITS_PLOT_FILTER_V2)
-        if height >= constants.PLOT_FILTER_V2_THIRD_ADJUSTMENT_HEIGHT:
-            prefix_bits -= 3
-        elif height >= constants.PLOT_FILTER_V2_SECOND_ADJUSTMENT_HEIGHT:
-            prefix_bits -= 2
-        elif height >= constants.PLOT_FILTER_V2_FIRST_ADJUSTMENT_HEIGHT:
-            prefix_bits -= 1
         return max(0, prefix_bits)
 
     prefix_bits = int(constants.NUMBER_ZERO_BITS_PLOT_FILTER_V1)

--- a/chia/util/errors.py
+++ b/chia/util/errors.py
@@ -200,6 +200,7 @@ class Err(Enum):
     # block or spendbundle had too many spends
     TOO_MANY_SPENDS = 149
     INVALID_HEADER_MMR_ROOT = 150
+    INVALID_BLOCK_VERSION = 151
 
 
 class ValidationError(Exception):

--- a/poetry.lock
+++ b/poetry.lock
@@ -1398,38 +1398,38 @@ pytest = ">=8.3.3,<9.0.0"
 
 [[package]]
 name = "chia-rs"
-version = "0.45.1"
+version = "0.46.0"
 description = ""
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "chia_rs-0.45.1-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:4d63eb55e17596ce0d9dd1d225b1daa6027b334e6ae7234f51d42d1d4afda83e"},
-    {file = "chia_rs-0.45.1-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:017502d79160707ae1dab52f80e4fa8e17b37095573327389a0b63c7b5cc02eb"},
-    {file = "chia_rs-0.45.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:dc2cea0a6d1c4a2153d404e99587b4d0cd4f4e4d416c58a0c7c83e4ea0b03bb3"},
-    {file = "chia_rs-0.45.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0223ac26676a7b3d107dc391c49be60c0ca3daf05ffd56eade36bba5516962fa"},
-    {file = "chia_rs-0.45.1-cp310-cp310-win_amd64.whl", hash = "sha256:9b6480a0302fc0489c3eaccfedbc0f222359342782dcc60e4a9c7d4d0fda6c76"},
-    {file = "chia_rs-0.45.1-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:d4cb38215355ebe567f0ea822b121bd629e1077c4586816606360baa61a4ed56"},
-    {file = "chia_rs-0.45.1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:3d163f9b3b75a2d1c2b7eb2c08afdadc2ae16567ee2dec617697d918698879f3"},
-    {file = "chia_rs-0.45.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:71396e2fca4cccd8b23c355bfc22a89e1a438b92a08c27be36bbc33108eaf618"},
-    {file = "chia_rs-0.45.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a63f6176290d34a4bba42f2dceb32fcfaf68fc48b498bb2e3ac829ceaf363344"},
-    {file = "chia_rs-0.45.1-cp311-cp311-win_amd64.whl", hash = "sha256:a11586d52d172baa1176173a092615507e3745c8148b12ebac38ff5c3f03ab9d"},
-    {file = "chia_rs-0.45.1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b96d927bea82c946ebde6592b3368af0698911067808a29b76ce7c9c3abf057a"},
-    {file = "chia_rs-0.45.1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:c65a007067899206bbb2f65c1dde685e9ed0345143899dde71c333c8f8cb1a81"},
-    {file = "chia_rs-0.45.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e426f011b142d5edf467833d409ef5c03e8546414c1735fb119b440f0893a15c"},
-    {file = "chia_rs-0.45.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:be21b496b0180b7da79860b18226a3332dc158d3cc012505b5e7d67185d88b06"},
-    {file = "chia_rs-0.45.1-cp312-cp312-win_amd64.whl", hash = "sha256:204d95460aed639734d372b6f8e1873065783c728b14904a1df207fe9a657307"},
-    {file = "chia_rs-0.45.1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:a9e28464bb5cfb8c346ebc066e1c249472110de0f53e83836e2b7576b5cb49f0"},
-    {file = "chia_rs-0.45.1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:2f7d371120627f9be92ff3e8aa0923dd27062434dd7a1ab9c4d309d32e89bbaf"},
-    {file = "chia_rs-0.45.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:05baf3427221fc39dac4e2f9a0b66ecc58a0ab686ff15fb8792f0c658bec1d22"},
-    {file = "chia_rs-0.45.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d94fcce7ddd7f8d7b16fbf8be0ccbe4ee0264dcc36e22995f5aac74680870929"},
-    {file = "chia_rs-0.45.1-cp313-cp313-win_amd64.whl", hash = "sha256:a76cc93741a8d559594ec862ce622813a5dfde1eab56bc264c708b0bfd76deaa"},
-    {file = "chia_rs-0.45.1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:b410b8c6b8e74de334501e1af1ee0d9a9380249d7eb85fef56f238cfa992e509"},
-    {file = "chia_rs-0.45.1-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:5d6000c92b6b287e6c92e6b240039f5f5ea3ab2bee2a3a3e1a6c067cef5c3de4"},
-    {file = "chia_rs-0.45.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:4967677d01752727a11edc544c5bb0e05a4df2ceb4ff305aa69a8d659b48d9fc"},
-    {file = "chia_rs-0.45.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:bb0c916fa52ffe6f390bb4891d92d1eafa061fb04889204c34604f9f46304eee"},
-    {file = "chia_rs-0.45.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2beaa2fc6f522748cafce8d4d9bb6b3fb231a8728c9154c096bccf7d354d524"},
-    {file = "chia_rs-0.45.1.tar.gz", hash = "sha256:d8385ed711839361a691942c5c24e98fabe9a1eec289caa8b1b71a4c83f4b20e"},
+    {file = "chia_rs-0.46.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:ebb2d1b3ec20e068383df1d9c15f43471002713666814e2050be73b157323537"},
+    {file = "chia_rs-0.46.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:ab9f8a37b4a36d8b4115628f1e13117ef716b7ce9883b0c2764bd1558f85f9da"},
+    {file = "chia_rs-0.46.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:189bf6accf2c4b1cd708d00e8094c0a5d0ab9506de1f7b8e150f5aa97a5187b2"},
+    {file = "chia_rs-0.46.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:dc8e2267cde2987fe11afeb4dbc94e2100248aeb1ed02c91f194ece4677f0b56"},
+    {file = "chia_rs-0.46.0-cp310-cp310-win_amd64.whl", hash = "sha256:7405482ab4236f1c28b5ae0cb303c0fe980370b81ccfd07099d1331e0784ea63"},
+    {file = "chia_rs-0.46.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:d15527633e4b843e89e7412ea68ab37857bc7fdbfa9189e4300693d2071dc73a"},
+    {file = "chia_rs-0.46.0-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:10652ecf50189b531aae162235e2e91ca18d4ca0de5bbd0c006aa37a5b8951f1"},
+    {file = "chia_rs-0.46.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c0ef7f1cdfec81ba5926433676292f56df60b745f6606a6a566b92f2648bc190"},
+    {file = "chia_rs-0.46.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:454cab5f5dee5998a70501dc5cfadb477ce8d3380590d680a9ec472a66d1d063"},
+    {file = "chia_rs-0.46.0-cp311-cp311-win_amd64.whl", hash = "sha256:be62afbeac41a1d427d736eb5494543628dbe1a2e50acb9436d54653d4a5ea1b"},
+    {file = "chia_rs-0.46.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:6e25100aff269076ead63edca918e8ab99a63dde43f0501a11a15bfc10ae5489"},
+    {file = "chia_rs-0.46.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:4204d3acc1914c87fb4042871b38edb24e19cad0222ba319e84f2daf9335b5f6"},
+    {file = "chia_rs-0.46.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9e89f372b090dd8aafc21def5071c86adef7779126c2a459f495f050106d16f6"},
+    {file = "chia_rs-0.46.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:134c0d32b69d879f40673d4ca514a785961a12f42ea448c181dfdbfe74485bfe"},
+    {file = "chia_rs-0.46.0-cp312-cp312-win_amd64.whl", hash = "sha256:bc333e003e1145f7d986f20e3c9d2ee68ec2e4991f50a24ba08142e15091156c"},
+    {file = "chia_rs-0.46.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:a5f4276749f57d5832a666fd476e69c7c4a1e7d4fd6e878b22578377d85f3663"},
+    {file = "chia_rs-0.46.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:7f3353571723e4be2f9f81c6c946238fff2a3b129014579d0bae1773d7c10564"},
+    {file = "chia_rs-0.46.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:9addcef960c01bb5bc5688bb6aa19c9ba8c88e2699c267cf8677d82fa15ff301"},
+    {file = "chia_rs-0.46.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1c26cf82e25aba8660c5e3afbd5dc5adf736b619db43eea1fa8b324024204455"},
+    {file = "chia_rs-0.46.0-cp313-cp313-win_amd64.whl", hash = "sha256:842ae53ee4e976f27368c271b937bdb74cfec1508fc06e3f2d2550d167fe7f67"},
+    {file = "chia_rs-0.46.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:0e71e2aaeccd6328188e30cb7f7450c6e4164728c240603f5e1338a1795c1db3"},
+    {file = "chia_rs-0.46.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:557c7143016b43e20f39191aeaf864f307b3a51a88901c7a2dc82291c562bea9"},
+    {file = "chia_rs-0.46.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ac0cf244fe0148a0496d99b98bc888bbc53ecff549c99ec47a7e54a3f7a04600"},
+    {file = "chia_rs-0.46.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aee40f5115b61ac4864964dfe14ecfb90d60d65e3c763d756d8fed17c20e6c32"},
+    {file = "chia_rs-0.46.0-cp314-cp314-win_amd64.whl", hash = "sha256:bc54f7acae6888e8668904dfa729b50c2199ce9cd2ea854d7122d0ebe29a1d22"},
+    {file = "chia_rs-0.46.0.tar.gz", hash = "sha256:251275035ebaf5ed638f9f34aab82bfba1628fc07fd1e1fa535c6ecb6df1fc8a"},
 ]
 
 [package.dependencies]
@@ -5243,4 +5243,4 @@ upnp = ["miniupnpc"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <4"
-content-hash = "d83fcdaa8caf6e0ddc8fa23cbc3c6e8ed80da58a2273dd6a3994af1e173a5aeb"
+content-hash = "eced213a988f3eb2dfeec4353519e42ef319e9f3872013ead2f425abf68da805"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ boto3 = ">=1.43.8"  # AWS S3 for Data Layer S3 plugin
 chiabip158 = ">=1.5.2"  # bip158-style wallet filters
 chiapos = ">=2.0.10"  # proof of space
 chia-puzzles-py = ">=0.20.1"
-chia_rs = ">=0.45.1, <0.46"
+chia_rs = ">=0.46.0, <0.47"
 chiavdf = ">=1.1.10"  # timelord and vdf verification
 click = ">=8.1.7"  # For the CLI
 clvm = ">=0.9.14"


### PR DESCRIPTION
### Purpose:

Bump chia_rs to the latest version. It has 2 significant changes:

1. The `ConsensusConstants` type has been updated for the new v2 plot filter. This also removes the existing v2 plot filter schedule.
2. `FullBlock` and `UnfinishedBlock` now supports the new representation of block generators (a plain buffer). This is not hooked up yet, to preserve the test blockchains (for now)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus validation and plot-filter constants tied to chia-rs; version-1 generator format is explicitly disabled for now, limiting live-network impact.
> 
> **Overview**
> Upgrades **chia-rs** to **0.46.0** and threads its new block and consensus-constant shapes through the node.
> 
> **Consensus constants** drop the three `PLOT_FILTER_V2_*_ADJUSTMENT_HEIGHT` fields in favor of `PLOT_FILTER_V2_RELATIVE_HEIGHT`, plus `FILTER_WINDOW_SIZE` and `MAX_EFFECTIVE_PLOT_FILTER_BITS`. V2 plot prefix-bit logic in `calculate_prefix_bits` no longer applies height-based step-downs in Python (that schedule now lives in the updated constants type).
> 
> **Blocks** gain `transactions_generator_buffer` and `version` on `FullBlock` / `UnfinishedBlock` and related helpers (`BlockInfo`, block creation, parsing). Call sites and fixtures pass `None` and `uint8(0)` for now. Validation rejects any `version != 0` via new `Err.INVALID_BLOCK_VERSION`, with commented placeholders for post–hard-fork **version 1** (buffer generator, no ref list). Non–transaction blocks must not carry a generator buffer.
> 
> Tests and protocol JSON are updated for the new fields; the old v2 prefix-bits parametrized test is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caf8ec9760c668834a8af04346e57357dd965f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->