### PR TITLE
[CHIA-4308] add a proper run-time check for spends that are eligible for fast for…

### DIFF
--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -72,6 +72,7 @@ from chia.util.default_root import DEFAULT_ROOT_PATH
 from chia.util.errors import Err, ValidationError
 from chia.util.inline_executor import InlineExecutor
 from chia.wallet.conditions import AssertCoinAnnouncement
+from chia.wallet.lineage_proof import LineageProof, LineageProofField
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
     DEFAULT_HIDDEN_PUZZLE_HASH,
     calculate_synthetic_secret_key,
@@ -2430,8 +2431,6 @@ async def test_height_added_to_mempool(optimized_path: bool, test_coins_mempool_
 # block building) verify that. We recover it from the lineage proof embedded in
 # the singleton solution rather than fabricating a placeholder.
 def singleton_lineage_info(coin_spend: CoinSpend) -> UnspentLineageInfo:
-    from chia.wallet.lineage_proof import LineageProof, LineageProofField
-
     solution = Program.from_bytes(bytes(coin_spend.solution))
     lineage_proof = LineageProof.from_program(
         solution.first(),

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -2423,30 +2423,51 @@ async def test_height_added_to_mempool(optimized_path: bool, test_coins_mempool_
     assert mempool_item.height_added_to_mempool == original_height
 
 
+# Builds the UnspentLineageInfo the coin store would report for the latest
+# unspent version of a singleton. The grandparent id (parent_parent_id) must be
+# the real one, otherwise reconstructing the parent coin id fails; both
+# can_fast_forward_singleton (at admission) and perform_the_fast_forward (at
+# block building) verify that. We recover it from the lineage proof embedded in
+# the singleton solution rather than fabricating a placeholder.
+def singleton_lineage_info(coin_spend: CoinSpend) -> UnspentLineageInfo:
+    from chia.wallet.lineage_proof import LineageProof, LineageProofField
+
+    solution = Program.from_bytes(bytes(coin_spend.solution))
+    lineage_proof = LineageProof.from_program(
+        solution.first(),
+        [LineageProofField.PARENT_NAME, LineageProofField.INNER_PUZZLE_HASH, LineageProofField.AMOUNT],
+    )
+    assert lineage_proof.parent_name is not None
+    coin = coin_spend.coin
+    return UnspentLineageInfo(coin.name(), coin.parent_coin_info, lineage_proof.parent_name)
+
+
 # This is a test utility to provide a simple view of the coin table for the
 # mempool manager.
 class TestCoins:
     coin_records: dict[bytes32, CoinRecord]
     lineage_info: dict[bytes32, UnspentLineageInfo]
 
-    def __init__(self, coins: list[Coin], lineage: dict[bytes32, Coin]) -> None:
+    def __init__(self, coins: list[Coin], lineage: dict[bytes32, CoinSpend]) -> None:
         self.coin_records = {}
         for c in coins:
             self.coin_records[c.name()] = CoinRecord(c, uint32(0), uint32(0), False, TEST_TIMESTAMP)
         self.lineage_info = {}
-        for ph, c in lineage.items():
-            self.lineage_info[ph] = UnspentLineageInfo(c.name(), c.parent_coin_info, bytes32([42] * 32))
+        for ph, coin_spend in lineage.items():
+            self.lineage_info[ph] = singleton_lineage_info(coin_spend)
 
     def spend_coin(self, coin_id: bytes32, height: uint32 = uint32(10)) -> None:
         self.coin_records[coin_id] = self.coin_records[coin_id].replace(spent_block_index=height)
 
-    def update_lineage(self, puzzle_hash: bytes32, coin: Coin | None) -> None:
-        if coin is None:
+    def update_lineage(self, puzzle_hash: bytes32, coin_spend: CoinSpend | None) -> None:
+        if coin_spend is None:
             self.lineage_info.pop(puzzle_hash)
         else:
-            assert coin.puzzle_hash == puzzle_hash
-            prev = self.lineage_info[puzzle_hash]
-            self.lineage_info[puzzle_hash] = UnspentLineageInfo(coin.name(), coin.parent_coin_info, prev.coin_id)
+            assert coin_spend.coin.puzzle_hash == puzzle_hash
+            # Derive the lineage info from the singleton spend itself, so the
+            # grandparent id (parent_parent_id) is the real one. can_fast_forward_singleton
+            # and perform_the_fast_forward reconstruct the parent coin id from it.
+            self.lineage_info[puzzle_hash] = singleton_lineage_info(coin_spend)
 
     async def get_coin_records(self, coin_ids: Collection[bytes32]) -> list[CoinRecord]:
         ret = []
@@ -2545,7 +2566,7 @@ async def test_new_peak_ff_eviction(
     )
     bundle = SpendBundle([singleton_spend, coin_spend], G2Element())
 
-    coins = TestCoins([singleton_spend.coin, TEST_COIN], {singleton_spend.coin.puzzle_hash: singleton_spend.coin})
+    coins = TestCoins([singleton_spend.coin, TEST_COIN], {singleton_spend.coin.puzzle_hash: singleton_spend})
 
     async with setup_mempool(coins) as mempool_manager:
         bundle_add_info = await mempool_manager.add_spend_bundle(
@@ -2626,7 +2647,7 @@ async def test_multiple_ff(use_optimization: bool) -> None:
     # the singleton puzzle hash resulves to the most recent singleton coin, number 2
     # pretend that coin1 is spent
     singleton_ph = singleton_spend2.coin.puzzle_hash
-    coins = TestCoins([singleton_spend1.coin, singleton_spend2.coin, TEST_COIN], {singleton_ph: singleton_spend2.coin})
+    coins = TestCoins([singleton_spend1.coin, singleton_spend2.coin, TEST_COIN], {singleton_ph: singleton_spend2})
 
     async with setup_mempool(coins) as mempool_manager:
         bundle_add_info = await mempool_manager.add_spend_bundle(
@@ -2652,7 +2673,7 @@ async def test_multiple_ff(use_optimization: bool) -> None:
         assert not item.bundle_coin_spends[coin_spend.coin.name()].supports_fast_forward
 
         # spend the singleton coin2 and make coin3 the latest version
-        coins.update_lineage(singleton_ph, singleton_spend3.coin)
+        coins.update_lineage(singleton_ph, singleton_spend3)
         coins.spend_coin(singleton_spend2.coin.name(), uint32(11))
 
         await advance_mempool(mempool_manager, [singleton_spend2.coin.name()], use_optimization=use_optimization)
@@ -2695,7 +2716,7 @@ async def test_advancing_ff(use_optimization: bool) -> None:
     # the singleton puzzle hash resulves to the most recent singleton coin, number 2
     # pretend that coin1 is spent
     singleton_ph = spend_a.coin.puzzle_hash
-    coins = TestCoins([spend_a.coin, spend_b.coin, spend_c.coin, TEST_COIN], {singleton_ph: spend_a.coin})
+    coins = TestCoins([spend_a.coin, spend_b.coin, spend_c.coin, TEST_COIN], {singleton_ph: spend_a})
 
     async with setup_mempool(coins) as mempool_manager:
         bundle_add_info = await mempool_manager.add_spend_bundle(
@@ -2714,7 +2735,7 @@ async def test_advancing_ff(use_optimization: bool) -> None:
         assert spend.latest_singleton_lineage is not None
         assert spend.latest_singleton_lineage.coin_id == spend_a.coin.name()
 
-        coins.update_lineage(singleton_ph, spend_b.coin)
+        coins.update_lineage(singleton_ph, spend_b)
         coins.spend_coin(spend_a.coin.name(), uint32(11))
 
         await advance_mempool(mempool_manager, [spend_a.coin.name()])
@@ -2726,7 +2747,7 @@ async def test_advancing_ff(use_optimization: bool) -> None:
         assert spend.latest_singleton_lineage is not None
         assert spend.latest_singleton_lineage.coin_id == spend_b.coin.name()
 
-        coins.update_lineage(singleton_ph, spend_c.coin)
+        coins.update_lineage(singleton_ph, spend_c)
         coins.spend_coin(spend_b.coin.name(), uint32(12))
 
         await advance_mempool(mempool_manager, [spend_b.coin.name()], use_optimization=use_optimization)
@@ -3009,7 +3030,7 @@ async def test_spending_singleton_to_invalidate_existing_ff_spends() -> None:
     singleton_spend2 = make_singleton_spend(LAUNCHER_ID, PARENT_PARENT, child_amount=3)
     coins = TestCoins(
         coins=[singleton_spend1.coin, singleton_spend2.coin, TEST_COIN, TEST_COIN2],
-        lineage={singleton_spend2.coin.puzzle_hash: singleton_spend2.coin},
+        lineage={singleton_spend2.coin.puzzle_hash: singleton_spend2},
     )
 
     async with setup_mempool(coins) as mempool_manager:
@@ -3048,7 +3069,7 @@ async def test_check_removals_with_block_creation(flags: int, old: bool) -> None
     PARENT_PARENT = bytes32([2] * 32)
     singleton_spend = make_singleton_spend(LAUNCHER_ID, PARENT_PARENT)
     coins = TestCoins(
-        coins=[singleton_spend.coin, TEST_COIN], lineage={singleton_spend.coin.puzzle_hash: singleton_spend.coin}
+        coins=[singleton_spend.coin, TEST_COIN], lineage={singleton_spend.coin.puzzle_hash: singleton_spend}
     )
 
     async with setup_mempool(coins) as mempool_manager:
@@ -3382,8 +3403,8 @@ async def test_new_peak_deferred_ff_items() -> None:
     coins = TestCoins(
         [singleton_spend1.coin, singleton_spend2.coin, TEST_COIN, TEST_COIN2],
         {
-            singleton_spend1.coin.puzzle_hash: singleton_spend1.coin,
-            singleton_spend2.coin.puzzle_hash: singleton_spend2.coin,
+            singleton_spend1.coin.puzzle_hash: singleton_spend1,
+            singleton_spend2.coin.puzzle_hash: singleton_spend2,
         },
     )
     async with setup_mempool(coins) as mempool_manager:
@@ -3400,10 +3421,11 @@ async def test_new_peak_deferred_ff_items() -> None:
             )
             assert mempool_manager.get_mempool_item(sb_name) is not None
             sb_names.append(sb_name)
-        # Let's advance the mempool by spending these singletons into new lineages
-        singleton1_new_latest = Coin(singleton1_id, singleton_spend1.coin.puzzle_hash, singleton_spend1.coin.amount)
+        # Let's advance the mempool by spending these singletons into new lineages.
+        # The new latest coin is a real child of the previous singleton coin.
+        singleton1_new_latest = make_singleton_spend(bytes32([1] * 32), singleton_spend1.coin.parent_coin_info)
         coins.update_lineage(singleton_spend1.coin.puzzle_hash, singleton1_new_latest)
-        singleton2_new_latest = Coin(singleton2_id, singleton_spend2.coin.puzzle_hash, singleton_spend2.coin.amount)
+        singleton2_new_latest = make_singleton_spend(bytes32([2] * 32), singleton_spend2.coin.parent_coin_info)
         coins.update_lineage(singleton_spend2.coin.puzzle_hash, singleton2_new_latest)
         await advance_mempool(mempool_manager, [singleton1_id, singleton2_id], use_optimization=True)
         # Both items should get updated with their related latest lineages
@@ -3411,12 +3433,12 @@ async def test_new_peak_deferred_ff_items() -> None:
         assert mi1 is not None
         latest_singleton_lineage1 = mi1.bundle_coin_spends[singleton1_id].latest_singleton_lineage
         assert latest_singleton_lineage1 is not None
-        assert latest_singleton_lineage1.coin_id == singleton1_new_latest.name()
+        assert latest_singleton_lineage1.coin_id == singleton1_new_latest.coin.name()
         mi2 = mempool_manager.get_mempool_item(sb_names[1])
         assert mi2 is not None
         latest_singleton_lineage2 = mi2.bundle_coin_spends[singleton2_id].latest_singleton_lineage
         assert latest_singleton_lineage2 is not None
-        assert latest_singleton_lineage2.coin_id == singleton2_new_latest.name()
+        assert latest_singleton_lineage2.coin_id == singleton2_new_latest.coin.name()
 
 
 @pytest.mark.anyio
@@ -3432,7 +3454,7 @@ async def test_different_ff_versions() -> None:
     version2_id = singleton_spend2.coin.name()
     singleton_ph = singleton_spend2.coin.puzzle_hash
     coins = TestCoins(
-        [singleton_spend1.coin, singleton_spend2.coin, TEST_COIN, TEST_COIN2], {singleton_ph: singleton_spend2.coin}
+        [singleton_spend1.coin, singleton_spend2.coin, TEST_COIN, TEST_COIN2], {singleton_ph: singleton_spend2}
     )
     async with setup_mempool(coins) as mempool_manager:
         mempool_items: list[MempoolItem] = []
@@ -3459,9 +3481,10 @@ async def test_different_ff_versions() -> None:
         latest_singleton_lineage2 = mi2.bundle_coin_spends[version2_id].latest_singleton_lineage
         assert latest_singleton_lineage2 is not None
         assert latest_singleton_lineage2.coin_id == latest_lineage_id
-        # Let's update the lineage with a new version of the singleton
-        new_latest_lineage = Coin(version2_id, singleton_ph, singleton_spend2.coin.amount)
-        new_latest_lineage_id = new_latest_lineage.name()
+        # Let's update the lineage with a new version of the singleton, a real
+        # child of version 2.
+        new_latest_lineage = make_singleton_spend(launcher_id, singleton_spend2.coin.parent_coin_info)
+        new_latest_lineage_id = new_latest_lineage.coin.name()
         coins.update_lineage(singleton_ph, new_latest_lineage)
         await advance_mempool(mempool_manager, [version1_id, version2_id], use_optimization=True)
         # Both items should get updated with the latest lineage

--- a/chia/full_node/eligible_coin_spends.py
+++ b/chia/full_node/eligible_coin_spends.py
@@ -80,9 +80,16 @@ def perform_the_fast_forward(
     singleton_amount = spend_data.coin_spend.coin.amount
     new_coin = Coin(unspent_lineage_info.parent_id, singleton_ph, singleton_amount)
     new_parent = Coin(unspent_lineage_info.parent_parent_id, singleton_ph, singleton_amount)
-    # These hold because puzzle hash is not expected to change
-    assert new_coin.name() == unspent_lineage_info.coin_id
-    assert new_parent.name() == unspent_lineage_info.parent_id
+    # The fast forward rebases the spend onto the latest unspent version by
+    # keeping the spent coin's puzzle hash and amount. That only produces a
+    # valid spend if both the latest unspent coin and its parent actually have
+    # that same amount (their coin IDs are derived from it). This is guarded at
+    # admission by can_fast_forward_singleton, but the latest unspent version
+    # can advance further between admission and block building onto a version
+    # whose (parent's) amount differs, so we reject here too rather than
+    # asserting on reachable input.
+    if new_coin.name() != unspent_lineage_info.coin_id or new_parent.name() != unspent_lineage_info.parent_id:
+        raise ValueError("Cannot fast forward singleton onto a version with a different amount")
     new_solution = SerializedProgram.from_bytes(
         fast_forward_singleton(spend=spend_data.coin_spend, new_coin=new_coin, new_parent=new_parent)
     )
@@ -104,6 +111,27 @@ def perform_the_fast_forward(
         parent_parent_id=unspent_lineage_info.parent_id,
     )
     return new_coin_spend, patched_additions
+
+
+def can_fast_forward_singleton(*, unspent_lineage_info: UnspentLineageInfo, coin: Coin) -> bool:
+    """
+    A singleton fast forward rebases a spend onto the latest unspent version of
+    the singleton, keeping the spent coin's puzzle hash and amount (see
+    perform_the_fast_forward). That's only possible if both the latest unspent
+    version and its parent actually have the same amount as the coin we're
+    spending, since their coin IDs are derived from that amount. If the
+    singleton's amount changed between the version we're spending and the latest
+    unspent one (or its parent), the fast forward can't be performed.
+
+    This is the regular (non-assert) check that must be done before admitting a
+    fast forward spend, so that the reject in perform_the_fast_forward isn't
+    reached for spends we could have rejected earlier.
+    """
+    rebased_coin = Coin(unspent_lineage_info.parent_id, coin.puzzle_hash, coin.amount)
+    rebased_parent = Coin(unspent_lineage_info.parent_parent_id, coin.puzzle_hash, coin.amount)
+    return (
+        rebased_coin.name() == unspent_lineage_info.coin_id and rebased_parent.name() == unspent_lineage_info.parent_id
+    )
 
 
 @dataclasses.dataclass
@@ -189,11 +217,14 @@ class SingletonFastForward:
 
         Returns:
             A tuple of: map of coin IDs to coin spends and metadata after fast
-            forwarding, and the the fast forward state update to commit if the
-            item end up included.
+            forwarding, and the fast forward state update to commit if the item
+            ends up included.
 
         Raises:
-            If a fast forward cannot proceed, to prevent potential double spends
+            ValueError if a fast forward cannot proceed (to prevent potential
+            double spends), or if fast forwarding changed the item's cost (see
+            below), so the item is skipped rather than included with a stale
+            cost.
         """
 
         new_coin_spends = []
@@ -269,15 +300,25 @@ class SingletonFastForward:
             # Update the list of coins spends that make the new fast forward bundle
             new_coin_spends.append(new_coin_spend)
             fast_forwarded_spends += 1
-        if fast_forwarded_spends == 0:
-            return new_bundle_coin_spends, ff_state_update
-        # Update the mempool item after validating the new spend bundle
-        new_sb = SpendBundle(coin_spends=new_coin_spends, aggregated_signature=mempool_item.aggregated_signature)
         assert mempool_item.conds is not None
+        if fast_forwarded_spends == 0:
+            # Nothing was fast forwarded, so the cost is unchanged.
+            return new_bundle_coin_spends, ff_state_update
+        # Re-run the new spend bundle to make sure it remains valid, and to
+        # check that its cost didn't change. Fast forwarding rewrites the
+        # lineage proof's parent amount to the singleton's own amount, which can
+        # have a different serialized length than the amount that was in the
+        # original spend (this happens when the singleton's amount changed in an
+        # earlier generation), and that changes the CLVM cost. We account for
+        # this item using the cost we computed at admission, so rather than
+        # tracking a changed cost through block building we simply reject the
+        # fast forward when the cost changed. Such a spend won't be included; a
+        # fresh spend against the current singleton can be submitted instead.
+        new_sb = SpendBundle(coin_spends=new_coin_spends, aggregated_signature=mempool_item.aggregated_signature)
         try:
-            # Run the new spend bundle to make sure it remains valid. What we
-            # care about here is whether this call throws or not.
-            get_conditions_from_spendbundle(new_sb, mempool_item.conds.cost, constants, prev_tx_height)
+            new_conds = get_conditions_from_spendbundle(
+                new_sb, uint64(constants.MAX_BLOCK_COST_CLVM), constants, prev_tx_height
+            )
         # get_conditions_from_spendbundle raises a ValueError with an error code
         except ValueError as e:
             # Convert that to a ValidationError
@@ -288,6 +329,11 @@ class SingletonFastForward:
                 raise ValueError(
                     "Mempool item became invalid after singleton fast forward with an unspecified error."
                 )  # pragma: no cover
+        if new_conds.cost != mempool_item.conds.cost:
+            raise ValueError(
+                "Singleton fast forward changed the spend's cost "
+                f"({mempool_item.conds.cost} -> {new_conds.cost}), rejecting the fast forward"
+            )
         return new_bundle_coin_spends, ff_state_update
 
     def update_fast_forward_spends(self, ff_state_update: dict[bytes32, UnspentLineageInfo]) -> None:

--- a/chia/full_node/eligible_coin_spends.py
+++ b/chia/full_node/eligible_coin_spends.py
@@ -300,7 +300,6 @@ class SingletonFastForward:
             # Update the list of coins spends that make the new fast forward bundle
             new_coin_spends.append(new_coin_spend)
             fast_forwarded_spends += 1
-        assert mempool_item.conds is not None
         if fast_forwarded_spends == 0:
             # Nothing was fast forwarded, so the cost is unchanged.
             return new_bundle_coin_spends, ff_state_update

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -29,6 +29,7 @@ from typing_extensions import Self
 
 from chia.consensus.block_record import BlockRecordProtocol
 from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
+from chia.full_node.eligible_coin_spends import can_fast_forward_singleton
 from chia.full_node.fee_estimation import FeeBlockInfo, MempoolInfo, MempoolItemInfo
 from chia.full_node.fee_estimator_interface import FeeEstimatorInterface
 from chia.full_node.mempool import MEMPOOL_ITEM_FEE_LIMIT, Mempool, MempoolRemoveInfo, MempoolRemoveReason
@@ -687,6 +688,14 @@ class MempoolManager:
                 # spent_index will also fail this test, and such spends will
                 # fall back to be treated as non-FF spends.
                 lineage_info = await get_unspent_lineage_info_for_puzzle_hash(spend_conds.puzzle_hash)
+                if lineage_info is not None and not can_fast_forward_singleton(
+                    unspent_lineage_info=lineage_info, coin=coin_spend.coin
+                ):
+                    # The latest unspent version of this singleton has a
+                    # different amount than the coin we're spending, so this
+                    # spend can never be fast forwarded onto it. Fall back to
+                    # treating it as a normal spend.
+                    lineage_info = None
 
             spend_additions = []
             for puzzle_hash, amount, _ in spend_conds.create_coin:


### PR DESCRIPTION
### Purpose:

Currently the mempool rejects fast forward spends made onto coins where the amount changed, but only via an `assert`. This patch adds a proper fix, making the assert indicate a logic bug.

### Current Behavior:

The spend is rejected via `assert`

### New Behavior:

The spend is rejected via `ValueError` exception.

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mempool admission and block-building paths for singleton fast-forward spends; incorrect checks could mis-classify FF spends or skip valid inclusion, but scope is limited to FF optimization logic with added test coverage.
> 
> **Overview**
> **Singleton fast-forward** now rejects incompatible lineage with explicit checks instead of relying on `assert` during block building.
> 
> Adds `can_fast_forward_singleton` and calls it at **mempool admission** so spends that cannot be rebased onto the latest unspent singleton (because amount changed on the latest coin or its parent) are treated as **normal spends** rather than FF-eligible. `perform_the_fast_forward` raises **`ValueError`** for the same amount mismatch when lineage moves forward between admission and inclusion.
> 
> After a fast forward rewrite, block building **re-validates** the bundle and **rejects** the fast forward if CLVM **cost changed** (e.g. lineage proof amount encoding length), so items are not included under a stale admission cost.
> 
> Mempool manager tests now build **`UnspentLineageInfo` from real singleton spends** (lineage proof in the solution) instead of placeholder grandparent IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c0e7256ba2e36dd416220f87b55869bd224ee45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->