### PR TITLE
Add 2.7.3 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
+## 2.7.3 Chia blockchain 2026-07-15
+
+## What's Changed
+
+### Changed
+
+- Allow `chia_getHeightInfo` and `chia_getCoinRecordsByNames` WalletConnect commands to bypass confirmation prompts for read-only queries
+
+### Fixed
+
+- Fix confirmation dialogs not appearing on Linux (especially Wayland) when the `ready-to-show` event never fires
+- Fix Plot NFTs appearing assigned to the wrong key due to `launcherId` hex normalization
+- Fix log viewing in the reference wallet GUI by restoring missing Electron main-process imports
+- Fix "Asset type is not valid" error when confirming offers to sell NFTs
+- Fix WalletConnect JSON parsing for negative mojo amounts encoded as BigInt strings
+
 ## 2.7.2 Chia blockchain 2026-07-09
 
 ## What's Changed


### PR DESCRIPTION
Add CHANGELOG.md entry for the 2.7.3 release.

## Summary
- 1 Changed entry
- 5 Fixed entries
- All changes are from the GUI repo (`chia-blockchain-gui` `release/2.7.3` branch)

Changes only touch CHANGELOG.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to CHANGELOG.md with no runtime or code changes.
> 
> **Overview**
> Adds a **2.7.3** section (dated 2026-07-15) to `CHANGELOG.md`, documenting GUI release items from `chia-blockchain-gui` `release/2.7.3`.
> 
> Under **Changed**, it notes WalletConnect read-only commands `chia_getHeightInfo` and `chia_getCoinRecordsByNames` no longer require confirmation prompts. Under **Fixed**, it lists five items: Linux/Wayland confirmation dialogs, Plot NFT key assignment (`launcherId` hex), wallet log viewing (Electron imports), NFT offer confirmation asset validation, and WalletConnect parsing of negative mojo BigInt strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e46d9ce3155e989848778b9235508d3902e6014c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->