### PR TITLE
Add 2.7.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
+## 2.7.3 Chia blockchain 2026-07-16
+
+## What's Changed
+
+### Changed
+
+- Allow `chia_getHeightInfo` and `chia_getCoinRecordsByNames` WalletConnect commands to bypass confirmation prompts for read-only queries
+
+### Fixed
+
+- Fix confirmation dialogs not appearing on Linux (especially Wayland) when the `ready-to-show` event never fires
+- Fix Plot NFTs appearing assigned to the wrong key due to `launcherId` hex normalization
+- Fix log viewing in the reference wallet GUI by restoring missing Electron main-process imports
+- Fix "Asset type is not valid" error when confirming offers to sell NFTs
+
 ## 2.7.2 Chia blockchain 2026-07-09
 
 ## What's Changed


### PR DESCRIPTION
Add CHANGELOG.md entry for the 2.7.3 release.

## Summary
- 1 Changed entry (WalletConnect confirmation bypass for read-only queries)
- 4 Fixed entries (dialog popup on Linux/Wayland, Plot NFT key assignment, log viewer imports, NFT offer asset type)
- GUI-only release

Note: The BigInt parsing fix (gui#2981) was reverted by gui#2983, so it is excluded from these notes.

Changes only touch CHANGELOG.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to CHANGELOG.md with no runtime or behavioral changes.
> 
> **Overview**
> Adds a **2.7.3** section to `CHANGELOG.md` dated **2026-07-16**, following the existing Keep a Changelog layout used for prior releases.
> 
> Under **Changed**, it documents that **`chia_getHeightInfo`** and **`chia_getCoinRecordsByNames`** WalletConnect commands can skip confirmation prompts for read-only queries. Under **Fixed**, it lists four GUI issues: confirmation dialogs on Linux/Wayland when **`ready-to-show`** does not fire, Plot NFT key assignment from **`launcherId`** hex normalization, log viewing via restored Electron main-process imports, and NFT offer confirmation **"Asset type is not valid"**. No application code is modified in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f077eaa5ab7bd77b33ab53155aa1fe5575b7129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->