### PR TITLE
[LABS-478] Add a comment for `check_click_parsing`

### DIFF
--- a/chia/_tests/cmds/test_cmd_framework.py
+++ b/chia/_tests/cmds/test_cmd_framework.py
@@ -33,6 +33,13 @@ from chia.wallet.util.tx_config import CoinSelectionConfig, TXConfig
 
 
 def check_click_parsing(cmd: ChiaCommand, *args: str, context: ChiaCliContext | None = None) -> None:
+    """
+    Helper function to test that the framework correctly parses a commandline string to a command object.
+
+    The first argument is the expected result of parsing, and the rest of the arguments are strings that would
+    be passed to the commandline.
+    """
+
     @click.group()
     def _cmd() -> None:
         pass


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment-only change in test code with no functional impact.
> 
> **Overview**
> Adds a **docstring** to the test helper `check_click_parsing` in `test_cmd_framework.py` so readers know it verifies Click CLI parsing against an expected command object, with the first argument as the expected result and the remaining strings as argv tokens.
> 
> No runtime or test behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a5145747baddcee0b472c1d35f095eb1585ac50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->