### PR TITLE
Fix install_gui.ps1 when passing in a git commit/branch in Windows

### DIFF
--- a/Install-gui.ps1
+++ b/Install-gui.ps1
@@ -17,18 +17,18 @@ if ($null -eq (Get-Command node -ErrorAction SilentlyContinue))
 Write-Output "Running 'git submodule update --init --recursive'."
 Write-Output ""
 git submodule update --init --recursive
-if ( $SUBMODULE_BRANCH ) {
-  git fetch --all
-  git reset --hard $SUBMODULE_BRANCH
-  Write-Output ""
-  Write-Output "Building the GUI with branch $SUBMODULE_BRANCH"
-  Write-Output ""
-}
-
 
 Push-Location
 try {
     Set-Location chia-blockchain-gui
+
+    if ( $SUBMODULE_BRANCH ) {
+      git fetch --all
+      git reset --hard $SUBMODULE_BRANCH
+      Write-Output ""
+      Write-Output "Building the GUI with branch $SUBMODULE_BRANCH"
+      Write-Output ""
+    }
 
     $ErrorActionPreference = "SilentlyContinue"
     npm ci --loglevel=error


### PR DESCRIPTION
### Purpose:
Previously install_gui.ps1 would complete the build, but npm run dev:gui would not.
This is a twin fix with [this](https://github.com/Chia-Network/chia-blockchain-gui/pull/2987) PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Windows install-script-only change; no runtime, auth, or data-path behavior beyond fixing submodule checkout order.
> 
> **Overview**
> When `Install-gui.ps1` is run with a branch or commit argument (`$SUBMODULE_BRANCH`), **`git fetch` / `git reset --hard` now run inside `chia-blockchain-gui`** instead of at the repository root after `git submodule update`.
> 
> That way the GUI submodule is checked out to the requested ref before `npm ci` and `npm run build`, matching what `npm run dev:gui` expects. Previously the parent repo was reset while the submodule stayed on the default ref, so the install could finish but dev GUI workflows would be out of sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17ed0f439425085d3ee4f8409f68b363141b54d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->