### PR TITLE
[LABS-480] Remove interested_ph_cache and initialize coin cache in init

### DIFF
--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -172,11 +172,8 @@ class SyncStatus(IntEnum):
 
 
 class WalletStateManager:
-    # Ruff thinks these are "mutable class attributes" that should be annotated with `ClassVar`
-    # When this is a dataclass, these errors should go away
-    interested_ph_cache: dict[bytes32, list[int]] = {}  # noqa: RUF012
     # interested_coin_cache is a map from coid_ids to wallet_ids that are interested in the coin
-    interested_coin_cache: dict[bytes32, list[int]] = {}  # noqa: RUF012
+    interested_coin_cache: dict[bytes32, list[int]]
     constants: ConsensusConstants
     config: dict[str, Any]
     tx_store: WalletTransactionStore
@@ -236,6 +233,7 @@ class WalletStateManager:
     ) -> WalletStateManager:
         self = WalletStateManager()
 
+        self.interested_coin_cache = {}
         self.config = config
         self.constants = constants
         self.server = server


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small lifecycle/cleanup change in wallet state manager; no auth or persistence logic changes beyond avoiding shared mutable class state.
> 
> **Overview**
> Removes the unused **`interested_ph_cache`** field from `WalletStateManager` and stops using a shared class-level `{}` for **`interested_coin_cache`**.
> 
> `interested_coin_cache` is now only a type annotation on the class and is set to a fresh `{}` in **`WalletStateManager.create()`**, so each manager instance gets its own cache instead of inheriting a mutable default on the class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7110f4407a325ad2a8ff717488f0173db34e310f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->