### PR TITLE
[LABS-481] Remove unnecessary `server` field from WSM

### DIFF
--- a/chia/_tests/wallet/test_wallet_state_manager.py
+++ b/chia/_tests/wallet/test_wallet_state_manager.py
@@ -625,7 +625,7 @@ async def test_get_sync_status(simulator_and_wallet: OldSimulatorsAndWallets, se
 
     # DISCONNECTED (line 745) — disconnect from peer
     await wallet_server.close_all_connections()
-    await time_out_assert(5, lambda: len(wsm.server.get_connections(NodeType.FULL_NODE)), 0)
+    await time_out_assert(5, lambda: len(wsm.wallet_node.server.get_connections(NodeType.FULL_NODE)), 0)
     assert await wsm.get_sync_status() == SyncStatus.DISCONNECTED
 
 
@@ -685,7 +685,7 @@ async def test_rpc_disconnected_errors(wallet_environments: WalletTestFramework)
 
     # Disconnect from all full node peers
     await env.peer_server.close_all_connections()
-    await time_out_assert(5, lambda: len(wsm.server.get_connections(NodeType.FULL_NODE)), 0)
+    await time_out_assert(5, lambda: len(wsm.wallet_node.server.get_connections(NodeType.FULL_NODE)), 0)
 
     # tx_endpoint decorator DISCONNECTED check (line 341)
     with pytest.raises(ValueError, match="not connected"):

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -464,7 +464,6 @@ class WalletNode:
             self.config,
             path,
             self.constants,
-            self.server,
             self.root_path,
             self,
             public_key,

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -32,7 +32,6 @@ from chia.pools.pool_puzzles import get_most_recent_singleton_coin_from_coin_spe
 from chia.pools.pool_wallet import PoolWallet
 from chia.protocols.outbound_message import NodeType
 from chia.rpc.rpc_server import StateChangedProtocol
-from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.coin import Coin
 from chia.types.blockchain_format.program import Program
@@ -210,7 +209,6 @@ class WalletStateManager:
     retry_store: WalletRetryStore
     plotnft2_store: PlotNFTStore
     multiprocessing_context: multiprocessing.context.BaseContext
-    server: ChiaServer
     root_path: Path
     wallet_node: WalletNode
     pool_store: WalletPoolStore
@@ -226,7 +224,6 @@ class WalletStateManager:
         config: dict[str, Any],
         db_path: Path,
         constants: ConsensusConstants,
-        server: ChiaServer,
         root_path: Path,
         wallet_node: WalletNode,
         root_pubkey: G1Element | None = None,
@@ -236,7 +233,6 @@ class WalletStateManager:
         self.interested_coin_cache = {}
         self.config = config
         self.constants = constants
-        self.server = server
         self.root_path = root_path
         self.log = logging.getLogger(__name__)
         self.lock = asyncio.Lock()
@@ -730,7 +726,7 @@ class WalletStateManager:
     async def synced(self, block_is_current_at: int | None = None) -> bool:
         if block_is_current_at is None:
             block_is_current_at = int(time.time() - 60 * 5)
-        if len(self.server.get_connections(NodeType.FULL_NODE)) == 0:
+        if len(self.wallet_node.server.get_connections(NodeType.FULL_NODE)) == 0:
             return False
 
         latest = await self.blockchain.get_peak_block()
@@ -755,7 +751,7 @@ class WalletStateManager:
         if peak is not None and "simulator" in self.config.get("selected_network", ""):
             return SyncStatus.SYNCED
 
-        if peak is None or len(self.server.get_connections(NodeType.FULL_NODE)) == 0:
+        if peak is None or len(self.wallet_node.server.get_connections(NodeType.FULL_NODE)) == 0:
             return SyncStatus.DISCONNECTED
 
         height_gap = peak.height - await self.blockchain.get_finished_sync_up_to()

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -172,11 +172,8 @@ class SyncStatus(IntEnum):
 
 
 class WalletStateManager:
-    # Ruff thinks these are "mutable class attributes" that should be annotated with `ClassVar`
-    # When this is a dataclass, these errors should go away
-    interested_ph_cache: dict[bytes32, list[int]] = {}  # noqa: RUF012
     # interested_coin_cache is a map from coid_ids to wallet_ids that are interested in the coin
-    interested_coin_cache: dict[bytes32, list[int]] = {}  # noqa: RUF012
+    interested_coin_cache: dict[bytes32, list[int]]
     constants: ConsensusConstants
     config: dict[str, Any]
     tx_store: WalletTransactionStore
@@ -236,6 +233,7 @@ class WalletStateManager:
     ) -> WalletStateManager:
         self = WalletStateManager()
 
+        self.interested_coin_cache = {}
         self.config = config
         self.constants = constants
         self.server = server


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow refactor with equivalent peer lookups; no new auth or data paths, only wiring cleanup.
> 
> **Overview**
> **Removes the duplicate `ChiaServer` reference from `WalletStateManager`** so peer connectivity is read only through the existing `wallet_node` link.
> 
> `WalletStateManager.create` no longer takes or stores `server`; `WalletNode` stops passing `self.server` at construction. **`synced()` and `get_sync_status()`** now call `self.wallet_node.server.get_connections(NodeType.FULL_NODE)` instead of `self.server`. Wallet tests that assert zero full-node peers after disconnect use `wsm.wallet_node.server` for the same check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d9cd3e4c276ff9945cd41fde6767386b6243424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->