### PR TITLE
Move raw hints query from FullNodeAPI into HintStore

### DIFF
--- a/chia/_tests/core/full_node/stores/test_hint_store.py
+++ b/chia/_tests/core/full_node/stores/test_hint_store.py
@@ -260,6 +260,42 @@ async def test_multi_batch_limit(db_version: int, monkeypatch: pytest.MonkeyPatc
 
 
 @pytest.mark.anyio
+async def test_get_coin_ids_by_hints(db_version: int, monkeypatch: pytest.MonkeyPatch) -> None:
+    # small batch size, so the query below spans multiple batches
+    monkeypatch.setattr("chia.full_node.hint_store.SQLITE_MAX_VARIABLE_NUMBER", 5)
+
+    async with DBConnection(db_version) as db_wrapper:
+        hint_store = await HintStore.create(db_wrapper)
+
+        # empty input returns an empty set without opening a transaction
+        assert await hint_store.get_coin_ids_by_hints(set()) == set()
+
+        num_hints = 20
+        all_hints = [h.to_bytes(1, "big") + (31 * b"\x00") for h in range(num_hints)]
+        coin_ids = [bytes32(h.to_bytes(2, "big") + (30 * b"\x00")) for h in range(num_hints)]
+        # every hint also maps to a shared coin id, to exercise set dedup
+        shared_coin_id = bytes32(32 * b"\x42")
+        hints_list = [(coin_id, hint) for coin_id, hint in zip(coin_ids, all_hints)]
+        hints_list.extend((shared_coin_id, hint) for hint in all_hints)
+
+        await hint_store.add_hints(hints_list)
+
+        # all hints at once spans multiple batches; the shared coin id shows up once
+        result = await hint_store.get_coin_ids_by_hints(all_hints)
+        assert result == {*coin_ids, shared_coin_id}
+
+        # any Collection is accepted, e.g. a tuple
+        assert await hint_store.get_coin_ids_by_hints(tuple(all_hints[:2])) == {
+            coin_ids[0],
+            coin_ids[1],
+            shared_coin_id,
+        }
+
+        # unknown hint yields nothing
+        assert await hint_store.get_coin_ids_by_hints([32 * b"\xff"]) == set()
+
+
+@pytest.mark.anyio
 async def test_unsupported_version() -> None:
     with pytest.raises(RuntimeError, match="HintStore does not support database schema v1"):
         async with DBConnection(1) as db_wrapper:

--- a/chia/full_node/full_node_api.py
+++ b/chia/full_node/full_node_api.py
@@ -71,8 +71,6 @@ from chia.types.clvm_cost import QUOTE_BYTES, QUOTE_EXECUTION_COST
 from chia.types.generator_types import BlockGenerator, NewBlockGenerator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.peer_info import PeerInfo
-from chia.util.batches import to_batches
-from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER
 from chia.util.errors import ConsensusError, Err
 from chia.util.hash import std_hash
 from chia.util.limited_semaphore import LimitedSemaphore, LimitedSemaphoreFullError
@@ -2192,25 +2190,13 @@ class FullNodeAPI:
 
         start_time = time.monotonic()
 
-        async with self.full_node.db_wrapper.reader() as conn:
-            transaction_ids = set(
-                self.full_node.mempool_manager.mempool.items_with_puzzle_hashes(puzzle_hashes, include_hints)
-            )
+        transaction_ids = set(
+            self.full_node.mempool_manager.mempool.items_with_puzzle_hashes(puzzle_hashes, include_hints)
+        )
 
-            hinted_coin_ids: set[bytes32] = set()
+        hinted_coin_ids = await self.full_node.hint_store.get_coin_ids_by_hints(puzzle_hashes)
 
-            for batch in to_batches(puzzle_hashes, SQLITE_MAX_VARIABLE_NUMBER):
-                hints_db: tuple[bytes, ...] = tuple(batch.entries)
-                cursor = await conn.execute(
-                    f"SELECT coin_id from hints INDEXED BY hint_index "
-                    f"WHERE hint IN ({'?,' * (len(batch.entries) - 1)}?)",
-                    hints_db,
-                )
-                for row in await cursor.fetchall():
-                    hinted_coin_ids.add(bytes32(row[0]))
-                await cursor.close()
-
-            transaction_ids |= set(self.full_node.mempool_manager.mempool.items_with_coin_ids(hinted_coin_ids))
+        transaction_ids |= set(self.full_node.mempool_manager.mempool.items_with_coin_ids(hinted_coin_ids))
 
         if len(transaction_ids) > 0:
             message = wallet_protocol.MempoolItemsAdded(list(transaction_ids))

--- a/chia/full_node/hint_store.py
+++ b/chia/full_node/hint_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+from collections.abc import Collection
 
 import typing_extensions
 from chia_rs.sized_bytes import bytes32
@@ -54,6 +55,24 @@ class HintStore:
                 await cursor.close()
                 if len(coin_ids) >= max_items:
                     break
+
+        return coin_ids
+
+    async def get_coin_ids_by_hints(self, hints: Collection[bytes]) -> set[bytes32]:
+        coin_ids: set[bytes32] = set()
+
+        # use a single read transaction so all batches see a consistent view
+        async with self.db_wrapper.reader() as conn:
+            for batch in to_batches(hints, SQLITE_MAX_VARIABLE_NUMBER):
+                hints_db: tuple[bytes, ...] = tuple(batch.entries)
+                cursor = await conn.execute(
+                    f"SELECT coin_id from hints INDEXED BY hint_index "
+                    f"WHERE hint IN ({'?,' * (len(batch.entries) - 1)}?)",
+                    hints_db,
+                )
+                for row in await cursor.fetchall():
+                    coin_ids.add(bytes32(row[0]))
+                await cursor.close()
 
         return coin_ids
 

--- a/chia/full_node/hint_store.py
+++ b/chia/full_node/hint_store.py
@@ -60,10 +60,13 @@ class HintStore:
 
     async def get_coin_ids_by_hints(self, hints: Collection[bytes]) -> set[bytes32]:
         coin_ids: set[bytes32] = set()
+        if len(hints) == 0:
+            return coin_ids
 
         # use a single read transaction so all batches see a consistent view
         async with self.db_wrapper.reader() as conn:
-            for batch in to_batches(hints, SQLITE_MAX_VARIABLE_NUMBER):
+            # to_batches only supports list and set at runtime; hints may be any Collection
+            for batch in to_batches(list(hints), SQLITE_MAX_VARIABLE_NUMBER):
                 hints_db: tuple[bytes, ...] = tuple(batch.entries)
                 cursor = await conn.execute(
                     f"SELECT coin_id from hints INDEXED BY hint_index "


### PR DESCRIPTION
### Purpose:

`FullNodeAPI.mempool_updates_for_puzzle_hashes` runs raw SQL against the `hints` table — the only raw table read above the store layer in the node. This moves the query into `HintStore.get_coin_ids_by_hints` so the store owns all access to its table.

### Current Behavior:

FullNodeAPI opens `db_wrapper.reader()` and queries the `hints` table directly, batching over `SQLITE_MAX_VARIABLE_NUMBER`.

### New Behavior:

Same query, same batching, now inside HintStore. The single read transaction wrapping the batches (consistent view) is preserved inside the method. No behavior change.

### Testing Notes:

ruff, mypy, tach and `check_sql_statements` all pass. Ran `test_hint_store.py` and `test_new_wallet_protocol.py -k mempool_update` (covers the hint-based mempool update path); all pass except pre-existing local-environment failures in the HARD_FORK_3_0 consensus modes that also fail on main.

Made with [Cursor](https://cursor.com)