### PR TITLE
[LABS-162] Replace `Streamable` in `ActionScope` with `copy.deepcopy`

### DIFF
--- a/chia/_tests/util/test_action_scope.py
+++ b/chia/_tests/util/test_action_scope.py
@@ -14,13 +14,6 @@ from chia.util.action_scope import ActionScope, StateInterface
 class TestSideEffects:
     buf: bytes = b""
 
-    def __bytes__(self) -> bytes:
-        return self.buf
-
-    @classmethod
-    def from_bytes(cls, blob: bytes) -> TestSideEffects:
-        return cls(blob)
-
 
 @final
 @dataclass
@@ -44,7 +37,7 @@ def test_set_callback() -> None:
 
 @pytest.fixture(name="action_scope")
 async def action_scope_fixture() -> AsyncIterator[ActionScope[TestSideEffects, TestConfig]]:
-    async with ActionScope.new_scope(TestSideEffects, TestConfig()) as scope:
+    async with ActionScope.new_scope(TestSideEffects(), TestConfig()) as scope:
         assert scope.config == TestConfig(test_foo="test_foo")
         yield scope
 
@@ -83,7 +76,7 @@ async def test_transactionality(action_scope: ActionScope[TestSideEffects, TestC
 
 @pytest.mark.anyio
 async def test_callbacks() -> None:
-    async with ActionScope.new_scope(TestSideEffects, TestConfig()) as action_scope:
+    async with ActionScope.new_scope(TestSideEffects(), TestConfig()) as action_scope:
         async with action_scope.use() as interface:
 
             async def callback(interface: StateInterface[TestSideEffects]) -> None:
@@ -100,7 +93,7 @@ async def test_callbacks() -> None:
 @pytest.mark.anyio
 async def test_callback_in_callback_error() -> None:
     with pytest.raises(RuntimeError, match="Callback"):
-        async with ActionScope.new_scope(TestSideEffects, TestConfig()) as action_scope:
+        async with ActionScope.new_scope(TestSideEffects(), TestConfig()) as action_scope:
             async with action_scope.use() as interface:
 
                 async def callback(interface: StateInterface[TestSideEffects]) -> None:
@@ -112,7 +105,7 @@ async def test_callback_in_callback_error() -> None:
 @pytest.mark.anyio
 async def test_no_callbacks_if_error() -> None:
     with pytest.raises(Exception, match="This should prevent the callbacks from being called"):
-        async with ActionScope.new_scope(TestSideEffects, TestConfig()) as action_scope:
+        async with ActionScope.new_scope(TestSideEffects(), TestConfig()) as action_scope:
             async with action_scope.use() as interface:
 
                 async def callback(interface: StateInterface[TestSideEffects]) -> None:
@@ -124,7 +117,7 @@ async def test_no_callbacks_if_error() -> None:
                 raise RuntimeError("This should prevent the callbacks from being called")
 
     with pytest.raises(Exception, match="This should prevent the callbacks from being called"):
-        async with ActionScope.new_scope(TestSideEffects, TestConfig()) as action_scope:
+        async with ActionScope.new_scope(TestSideEffects(), TestConfig()) as action_scope:
             async with action_scope.use() as interface:
 
                 async def callback2(interface: StateInterface[TestSideEffects]) -> None:

--- a/chia/_tests/wallet/test_wallet_action_scope.py
+++ b/chia/_tests/wallet/test_wallet_action_scope.py
@@ -13,24 +13,13 @@ from chia.types.blockchain_format.coin import Coin
 from chia.wallet.signer_protocol import SigningResponse
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
-from chia.wallet.wallet_action_scope import PlotNFTTargetStateInfo, WalletSideEffects
+from chia.wallet.wallet_action_scope import PlotNFTTargetStateInfo
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 from chia.wallet.wallet_state_manager import WalletStateManager
 
 MOCK_SR = SigningResponse(b"hey", bytes32.zeros)
 MOCK_SB = WalletSpendBundle([], G2Element())
 MOCK_COIN = Coin(bytes32.zeros, bytes32.zeros, uint64(0))
-
-
-def test_back_and_forth_serialization() -> None:
-    assert bytes(WalletSideEffects())
-    assert WalletSideEffects.from_bytes(bytes(WalletSideEffects())) == WalletSideEffects()
-    assert WalletSideEffects.from_bytes(
-        bytes(WalletSideEffects([STD_TX], [MOCK_SR], [MOCK_SB], [MOCK_COIN]))
-    ) == WalletSideEffects([STD_TX], [MOCK_SR], [MOCK_SB], [MOCK_COIN])
-    assert WalletSideEffects.from_bytes(
-        bytes(WalletSideEffects([STD_TX, STD_TX], [MOCK_SR, MOCK_SR], [MOCK_SB, MOCK_SB], [MOCK_COIN, MOCK_COIN]))
-    ) == WalletSideEffects([STD_TX, STD_TX], [MOCK_SR, MOCK_SR], [MOCK_SB, MOCK_SB], [MOCK_COIN, MOCK_COIN])
 
 
 @dataclass

--- a/chia/util/action_scope.py
+++ b/chia/util/action_scope.py
@@ -1,91 +1,41 @@
 from __future__ import annotations
 
 import contextlib
+import copy
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Generic, Protocol, TypeVar
+from typing import Generic, TypeVar
 
-import aiosqlite
 from typing_extensions import Self
 
-from chia.util.db_wrapper import DBWrapper2, execute_fetchone
-
-
-class ResourceManager(Protocol):
-    @classmethod
-    @contextlib.asynccontextmanager
-    async def managed(cls, initial_resource: SideEffects) -> AsyncIterator[ResourceManager]:  # pragma: no cover
-        # yield included to make this a generator as expected by @contextlib.asynccontextmanager
-        yield  # type: ignore[misc]
-
-    @contextlib.asynccontextmanager
-    async def use(self) -> AsyncIterator[None]:  # pragma: no cover
-        # yield included to make this a generator as expected by @contextlib.asynccontextmanager
-        yield
-
-    async def get_resource(self, resource_type: type[_T_SideEffects]) -> _T_SideEffects: ...
-
-    async def save_resource(self, resource: SideEffects) -> None: ...
+_T_SideEffects = TypeVar("_T_SideEffects")
+_T_Config = TypeVar("_T_Config")
 
 
 @dataclass
-class SQLiteResourceManager:
-    _db: DBWrapper2
-    _active_writer: aiosqlite.Connection | None = field(init=False, default=None)
-
-    def get_active_writer(self) -> aiosqlite.Connection:
-        if self._active_writer is None:
-            raise RuntimeError("Can only access resources while under `use()` context manager")
-
-        return self._active_writer
+class ResourceManager(Generic[_T_SideEffects]):
+    _side_effects: _T_SideEffects
+    _active_writer: bool = False
 
     @classmethod
     @contextlib.asynccontextmanager
-    async def managed(cls, initial_resource: SideEffects) -> AsyncIterator[ResourceManager]:
-        async with DBWrapper2.managed(":memory:", reader_count=0) as db:
-            self = cls(db)
-            async with self._db.writer() as conn:
-                await conn.execute("CREATE TABLE side_effects(total blob)")
-                await conn.execute(
-                    "INSERT INTO side_effects VALUES(?)",
-                    (bytes(initial_resource),),
-                )
-            yield self
+    async def managed(cls, initial_resource: _T_SideEffects) -> AsyncIterator[Self]:
+        yield cls(copy.deepcopy(initial_resource))
 
     @contextlib.asynccontextmanager
-    async def use(self) -> AsyncIterator[None]:
-        if self._active_writer is not None:
-            raise RuntimeError("SQLiteResourceManager cannot currently support nested transactions")
-        async with self._db.writer() as conn:
-            self._active_writer = conn
-            try:
-                yield
-            finally:
-                self._active_writer = None
-
-    async def get_resource(self, resource_type: type[_T_SideEffects]) -> _T_SideEffects:
-        row = await execute_fetchone(self.get_active_writer(), "SELECT total FROM side_effects")
-        assert row is not None
-        side_effects = resource_type.from_bytes(row[0])
-        return side_effects
-
-    async def save_resource(self, resource: SideEffects) -> None:
-        # This sets all rows (there's only one) to the new serialization
-        await self.get_active_writer().execute(
-            "UPDATE side_effects SET total=?",
-            (bytes(resource),),
-        )
-
-
-class SideEffects(Protocol):
-    def __bytes__(self) -> bytes: ...
-
-    @classmethod
-    def from_bytes(cls, blob: bytes) -> Self: ...
-
-
-_T_SideEffects = TypeVar("_T_SideEffects", bound=SideEffects)
-_T_Config = TypeVar("_T_Config")
+    async def use(self) -> AsyncIterator[_T_SideEffects]:
+        if self._active_writer:
+            raise RuntimeError("ResourceManager cannot currently support nested transactions")
+        self._active_writer = True
+        side_effects_copy = copy.deepcopy(self._side_effects)
+        try:
+            yield side_effects_copy
+        except:
+            raise
+        else:
+            self._side_effects = copy.deepcopy(side_effects_copy)
+        finally:
+            self._active_writer = False
 
 
 @dataclass
@@ -99,8 +49,7 @@ class ActionScope(Generic[_T_SideEffects, _T_Config]):
     from interfering with each other.
     """
 
-    _resource_manager: ResourceManager
-    _side_effects_format: type[_T_SideEffects]
+    _resource_manager: ResourceManager[_T_SideEffects]
     _config: _T_Config  # An object not intended to be mutated during the lifetime of the scope
     _callback: Callable[[StateInterface[_T_SideEffects]], Awaitable[None]] | None = None
     _final_side_effects: _T_SideEffects | None = field(init=False, default=None)
@@ -123,32 +72,35 @@ class ActionScope(Generic[_T_SideEffects, _T_Config]):
     @contextlib.asynccontextmanager
     async def new_scope(
         cls,
-        side_effects_format: type[_T_SideEffects],
+        initial_resource: _T_SideEffects,
         # I want a default here in case a use case doesn't want to take advantage of the config but no default seems to
         # satisfy the type hint _T_Config so we'll just ignore this.
         config: _T_Config = object(),  # type: ignore[assignment]
-        resource_manager_backend: type[ResourceManager] = SQLiteResourceManager,
     ) -> AsyncIterator[ActionScope[_T_SideEffects, _T_Config]]:
-        async with resource_manager_backend.managed(side_effects_format()) as resource_manager:
-            self = cls(_resource_manager=resource_manager, _side_effects_format=side_effects_format, _config=config)
+        async with ResourceManager.managed(initial_resource) as resource_manager:
+            self = cls(_resource_manager=resource_manager, _config=config)
 
-            yield self  # noqa: RUF075  # final callback runs only on successful scope exit
-
-            async with self.use(_callbacks_allowed=False) as interface:
-                if self._callback is not None:
-                    await self._callback(interface)
-                self._final_side_effects = interface.side_effects
+            try:
+                yield self
+            except:
+                raise
+            else:
+                async with self.use(_callbacks_allowed=False) as interface:
+                    if self._callback is not None:
+                        await self._callback(interface)
+                    self._final_side_effects = interface.side_effects
 
     @contextlib.asynccontextmanager
     async def use(self, _callbacks_allowed: bool = True) -> AsyncIterator[StateInterface[_T_SideEffects]]:
-        async with self._resource_manager.use():
-            side_effects = await self._resource_manager.get_resource(self._side_effects_format)
+        async with self._resource_manager.use() as side_effects:
             interface = StateInterface(side_effects, _callbacks_allowed, self._callback)
 
-            yield interface  # noqa: RUF075  # save side effects only on successful use() exit
-
-            await self._resource_manager.save_resource(interface.side_effects)
-            self._callback = interface.callback
+            try:
+                yield interface
+            except:
+                raise
+            else:
+                self._callback = interface.callback
 
 
 @dataclass

--- a/chia/wallet/wallet_action_scope.py
+++ b/chia/wallet/wallet_action_scope.py
@@ -20,7 +20,7 @@ from chia.wallet.signer_protocol import SigningResponse
 from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.tx_config import TXConfig
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
-from chia.wallet.wsm_apis import GetUnusedDerivationRecordResult, StreambleGetUnusedDerivationRecordResult
+from chia.wallet.wsm_apis import GetUnusedDerivationRecordResult
 
 if TYPE_CHECKING:
     # Avoid a circular import here
@@ -53,7 +53,6 @@ class PlotNFTTargetStateInfo(Streamable):
             or self.next_pool_memoization is None
         ):
             raise ValueError("Error initializing next PlotNFT target state, not all options for join were specified")
-        return super().__post_init__()
 
     @property
     def pool_url_and_config(self) -> tuple[str, PoolConfig] | None:
@@ -71,18 +70,6 @@ class PlotNFTTargetStateInfo(Streamable):
         )
 
 
-@streamable
-@dataclass(frozen=True)
-class _StreamableWalletSideEffects(Streamable):
-    transactions: list[TransactionRecord]
-    signing_responses: list[SigningResponse]
-    extra_spends: list[WalletSpendBundle]
-    selected_coins: list[Coin]
-    singleton_records: list[SingletonRecord]
-    plotnft_exiting_info: PlotNFTTargetStateInfo | None
-    get_unused_derivation_record_result: StreambleGetUnusedDerivationRecordResult | None
-
-
 @dataclass
 class WalletSideEffects:
     transactions: list[TransactionRecord] = field(default_factory=list)
@@ -91,14 +78,7 @@ class WalletSideEffects:
     selected_coins: list[Coin] = field(default_factory=list)
     singleton_records: list[SingletonRecord] = field(default_factory=list)
     plotnft_exiting_info: PlotNFTTargetStateInfo | None = None
-    get_unused_derivation_record_result: StreambleGetUnusedDerivationRecordResult | None = None
-
-    def __bytes__(self) -> bytes:
-        return bytes(_StreamableWalletSideEffects(**self.__dict__))
-
-    @classmethod
-    def from_bytes(cls, blob: bytes) -> WalletSideEffects:
-        return cls(**_StreamableWalletSideEffects.from_bytes(blob).__dict__)
+    get_unused_derivation_record_result: GetUnusedDerivationRecordResult | None = None
 
 
 @final
@@ -129,13 +109,11 @@ class WalletActionScope(ActionScope[WalletSideEffects, WalletActionConfig]):
         async with self.use() as interface:
             result = await wallet_state_manager._get_unused_derivation_record(
                 wallet_state_manager.main_wallet.id(),
-                previous_result=interface.side_effects.get_unused_derivation_record_result.to_standard()
+                previous_result=interface.side_effects.get_unused_derivation_record_result
                 if interface.side_effects.get_unused_derivation_record_result is not None
                 else None,
             )
-            interface.side_effects.get_unused_derivation_record_result = (
-                StreambleGetUnusedDerivationRecordResult.from_standard(result)
-            )
+            interface.side_effects.get_unused_derivation_record_result = result
         return result
 
     async def _get_new_puzzle(self, wallet_state_manager: WalletStateManager) -> Program:
@@ -216,4 +194,4 @@ async def new_wallet_action_scope(
             plotnft_exiting_info=self.side_effects.plotnft_exiting_info,
         )
     if push and self.side_effects.get_unused_derivation_record_result is not None:
-        await self.side_effects.get_unused_derivation_record_result.to_standard().commit(wallet_state_manager)
+        await self.side_effects.get_unused_derivation_record_result.commit(wallet_state_manager)

--- a/chia/wallet/wallet_action_scope.py
+++ b/chia/wallet/wallet_action_scope.py
@@ -53,6 +53,7 @@ class PlotNFTTargetStateInfo(Streamable):
             or self.next_pool_memoization is None
         ):
             raise ValueError("Error initializing next PlotNFT target state, not all options for join were specified")
+        super().__post_init__()
 
     @property
     def pool_url_and_config(self) -> tuple[str, PoolConfig] | None:

--- a/chia/wallet/wallet_action_scope.py
+++ b/chia/wallet/wallet_action_scope.py
@@ -192,7 +192,7 @@ async def new_wallet_action_scope(
         puzzle_for_pk = wallet_state_manager.main_wallet.puzzle_for_pk
     assert puzzle_for_pk is not None
     async with WalletActionScope.new_scope(
-        WalletSideEffects,
+        WalletSideEffects(),
         WalletActionConfig(
             push, merge_spends, sign, additional_signing_responses, extra_spends, tx_config, puzzle_for_pk
         ),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches wallet action scope commit paths and transactional semantics for pending txs and derivation records; behavior should match prior rollback rules but relies on deepcopy for all nested side-effect objects.
> 
> **Overview**
> **ActionScope** no longer persists side-effect state through an in-memory SQLite table and **Streamable** byte serialization. State is held in a generic **ResourceManager** that uses **`copy.deepcopy`** on checkout and commit so failed **`use()`** blocks still roll back, while nested **`use()`** remains disallowed.
> 
> **`ActionScope.new_scope`** now takes an initial side-effects **instance** (e.g. **`WalletSideEffects()`**) instead of a type plus optional backend. The **`SideEffects`** protocol and pluggable **`SQLiteResourceManager`** are removed.
> 
> **Wallet** side effects drop **`_StreamableWalletSideEffects`** and **`WalletSideEffects`’s** **`__bytes__`/`from_bytes`**. **`get_unused_derivation_record_result`** stores **`GetUnusedDerivationRecordResult`** directly—no **`StreambleGetUnusedDerivationRecordResult`** conversion on read/write/commit. Tests are updated; wallet serialization round-trip tests are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae616e6f545fc1d9f4865624c5a558a1d387653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->