### PR TITLE
Accept any `Collection` in `to_batches`

### DIFF
--- a/chia/_tests/util/test_misc.py
+++ b/chia/_tests/util/test_misc.py
@@ -95,7 +95,7 @@ def test_empty_lists() -> None:
         next(to_batches(empty, 1))
 
 
-@pytest.mark.parametrize("collection_type", [list, set])
+@pytest.mark.parametrize("collection_type", [list, set, tuple, frozenset])
 def test_valid(collection_type: type) -> None:
     for k in range(1, 10):
         test_collection = collection_type([x for x in range(k)])
@@ -122,11 +122,6 @@ def test_invalid_batch_sizes() -> None:
 
     with pytest.raises(ValueError):
         next(to_batches([], -1))
-
-
-def test_invalid_input_type() -> None:
-    with pytest.raises(ValueError, match="Unsupported type"):
-        next(to_batches(dict({1: 2}), 1))
 
 
 @contextlib.contextmanager

--- a/chia/util/batches.py
+++ b/chia/util/batches.py
@@ -26,7 +26,7 @@ def to_batches(to_split: Collection[T], batch_size: int) -> Iterator[Batch[T]]:
         for batch_start in range(0, total_size, batch_size):
             batch_end = min(batch_start + batch_size, total_size)
             yield Batch(total_size - batch_end, to_split[batch_start:batch_end])
-    elif isinstance(to_split, set):
+    else:
         processed = 0
         entries = []
         for entry in to_split:
@@ -38,5 +38,3 @@ def to_batches(to_split: Collection[T], batch_size: int) -> Iterator[Batch[T]]:
         if len(entries) > 0:
             processed += len(entries)
             yield Batch(total_size - processed, entries)
-    else:
-        raise ValueError(f"to_batches: Unsupported type {type(to_split)}")


### PR DESCRIPTION
`to_batches` is typed as taking `Collection[T]` but at runtime it raised `ValueError` for anything that isn't a `list` or a `set`. The `set` branch is plain iteration and accumulation, which works for any `Collection`, so I made it the `else` branch and dropped the restriction. The `list` fast path is unchanged, and behavior for all existing callers (lists and sets) is identical.

Review tooling flagged this on #21165, where a `Collection[bytes]` parameter was passed straight through.

Made with [Cursor](https://cursor.com)