### PR TITLE
Add `snapshot()` to `CoinStore` for consistent reads

### DIFF
--- a/chia/_tests/core/consensus/stores/test_coin_store_protocol.py
+++ b/chia/_tests/core/consensus/stores/test_coin_store_protocol.py
@@ -4,12 +4,105 @@ import pytest
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
-from chia._tests.util.db_connection import DBConnection
+from chia._tests.util.db_connection import DBConnection, PathDBConnection
 from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
+from chia.full_node.block_store import BlockStore
 from chia.full_node.coin_store import CoinStore
+from chia.util.db_wrapper import DBWrapper2
 
 # black box tests from `chia/_tests/core/full_node/stores/test_coin_store.py`
 # should be moved here
+
+
+async def add_block_to_store(
+    db_wrapper: DBWrapper2, block_store: BlockStore, coin_store: CoinStore, height: uint32, tx_removals: list[bytes32]
+) -> bytes32:
+    """
+    Advance the stores by one block: coins in the coin store, plus a minimal
+    main-chain entry and peak update in the block store. The peak physically
+    lives in the block store's tables today, so we write just enough of a
+    `full_blocks` row for `get_peak()` to resolve the height (building real
+    blocks is not needed to exercise the coin store).
+    """
+    header_hash = bytes32([height % 256] * 32)
+    genesis_challenge = bytes32(b"\0" * 32)
+    pool_coin = create_pool_coin(height, bytes32(b"\x01" * 32), uint64(1_750_000_000_000), genesis_challenge)
+    farmer_coin = create_farmer_coin(height, bytes32(b"\x02" * 32), uint64(250_000_000_000), genesis_challenge)
+    await coin_store.new_block(
+        height=height,
+        timestamp=uint64(1234567890 + height),
+        included_reward_coins=[pool_coin, farmer_coin],
+        tx_additions=[],
+        tx_removals=tx_removals,
+    )
+    async with db_wrapper.writer_maybe_transaction() as conn:
+        await conn.execute(
+            "INSERT INTO full_blocks(header_hash, height, in_main_chain) VALUES(?, ?, 1)",
+            (header_hash, height),
+        )
+    await block_store.set_peak(header_hash)
+    return header_hash
+
+
+@pytest.mark.anyio
+async def test_snapshot_empty_db() -> None:
+    async with PathDBConnection(2) as db_wrapper:
+        block_store = await BlockStore.create(db_wrapper)
+        coin_store = await CoinStore.create(db_wrapper, block_store=block_store)
+        async with coin_store.snapshot() as snapshot:
+            assert snapshot.peak() is None
+            assert await snapshot.get_coin_records([bytes32(b"\x03" * 32)]) == []
+            assert await snapshot.get_coins_added_at_height(uint32(1)) == []
+            assert await snapshot.get_coins_removed_at_height(uint32(1)) == []
+
+
+@pytest.mark.anyio
+async def test_snapshot_requires_block_store() -> None:
+    async with DBConnection(2) as db_wrapper:
+        coin_store = await CoinStore.create(db_wrapper)
+        with pytest.raises(RuntimeError, match="block_store"):
+            async with coin_store.snapshot():
+                pass  # pragma: no cover
+
+
+@pytest.mark.anyio
+async def test_snapshot_is_consistent_across_writes() -> None:
+    """
+    Writes committed after a snapshot is acquired must not become visible
+    inside it: the snapshot's peak and coin reads stay a consistent pair.
+    This is sqlite WAL snapshot isolation on the read transaction the
+    snapshot holds open (hence the file-backed database here; the in-memory
+    test database does not support WAL).
+    """
+    async with PathDBConnection(2) as db_wrapper:
+        block_store = await BlockStore.create(db_wrapper)
+        coin_store = await CoinStore.create(db_wrapper, block_store=block_store)
+
+        hash_1 = await add_block_to_store(db_wrapper, block_store, coin_store, uint32(1), [])
+        [record_1, _] = await coin_store.get_coins_added_at_height(uint32(1))
+
+        async with coin_store.snapshot() as snapshot:
+            assert snapshot.peak() == (uint32(1), hash_1)
+
+            # advance the chain while the snapshot is held: spend a height-1
+            # coin and move the peak to height 2
+            hash_2 = await add_block_to_store(db_wrapper, block_store, coin_store, uint32(2), [record_1.coin.name()])
+
+            # the snapshot still answers as of acquisition
+            assert snapshot.peak() == (uint32(1), hash_1)
+            assert await snapshot.get_coins_added_at_height(uint32(2)) == []
+            assert await snapshot.get_coins_removed_at_height(uint32(2)) == []
+            [snapshot_record] = await snapshot.get_coin_records([record_1.coin.name()])
+            assert not snapshot_record.spent
+
+        # a snapshot acquired after the writes sees them
+        async with coin_store.snapshot() as snapshot:
+            assert snapshot.peak() == (uint32(2), hash_2)
+            assert len(await snapshot.get_coins_added_at_height(uint32(2))) == 2
+            [removed_record] = await snapshot.get_coins_removed_at_height(uint32(2))
+            assert removed_record.coin.name() == record_1.coin.name()
+            [record] = await snapshot.get_coin_records([record_1.coin.name()])
+            assert record.spent
 
 
 @pytest.mark.anyio

--- a/chia/consensus/coin_store_protocol.py
+++ b/chia/consensus/coin_store_protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection
+from contextlib import AbstractAsyncContextManager
 from typing import Protocol
 
 from chia_rs import CoinRecord
@@ -8,6 +9,37 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
 from chia.types.blockchain_format.coin import Coin
+
+
+class CoinStoreSnapshot(Protocol):
+    """
+    A consistent read view of the coin store, acquired via
+    `CoinStoreProtocol.snapshot()`. All reads within one snapshot observe
+    the same peak and coin set: a concurrent block advance or rollback does
+    not change the answers mid-view.
+    """
+
+    def peak(self) -> tuple[uint32, bytes32] | None:
+        """
+        The (height, header_hash) pair the snapshot was taken at, or None
+        if the database is empty
+        """
+
+    async def get_coin_records(self, coin_ids: Collection[bytes32]) -> list[CoinRecord]:
+        """
+        Returns the coin records for the specified coin ids, as of the
+        snapshot. Missing ids are absent from the result
+        """
+
+    async def get_coins_added_at_height(self, height: uint32) -> list[CoinRecord]:
+        """
+        Returns the coins added at a specific height, as of the snapshot
+        """
+
+    async def get_coins_removed_at_height(self, height: uint32) -> list[CoinRecord]:
+        """
+        Returns the coins removed at a specific height, as of the snapshot
+        """
 
 
 class CoinStoreProtocol(Protocol):
@@ -19,6 +51,14 @@ class CoinStoreProtocol(Protocol):
     coin states, lineage lookups, etc.), but those methods serve RPCs and the
     wallet protocol, not consensus, so they are not part of this protocol.
     """
+
+    def snapshot(self) -> AbstractAsyncContextManager[CoinStoreSnapshot]:
+        """
+        Acquire a consistent read view of the current state. Reads made
+        through the returned snapshot all observe the same peak and coin
+        set, regardless of concurrent writes
+        """
+        ...
 
     async def new_block(
         self,

--- a/chia/full_node/coin_store.py
+++ b/chia/full_node/coin_store.py
@@ -4,8 +4,9 @@ import dataclasses
 import logging
 import sqlite3
 import time
-from collections.abc import Collection
-from typing import Any, ClassVar
+from collections.abc import AsyncIterator, Collection
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import typing_extensions
 from aiosqlite import Cursor
@@ -13,12 +14,43 @@ from chia_rs import CoinRecord, CoinState
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32, uint64
 
+from chia.consensus.coin_store_protocol import CoinStoreProtocol, CoinStoreSnapshot
 from chia.types.blockchain_format.coin import Coin
 from chia.types.mempool_item import UnspentLineageInfo
 from chia.util.batches import to_batches
 from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER, DBWrapper2
 
+if TYPE_CHECKING:
+    from chia.full_node.block_store import BlockStore
+
 log = logging.getLogger(__name__)
+
+
+@typing_extensions.final
+@dataclasses.dataclass
+class _CoinStoreSnapshot:
+    """
+    A read view over the read transaction held open by `CoinStore.snapshot()`.
+    Only obtainable through that context manager.
+    """
+
+    if TYPE_CHECKING:
+        _protocol_check: ClassVar[CoinStoreSnapshot] = cast("_CoinStoreSnapshot", None)
+
+    _coin_store: CoinStore
+    _peak: tuple[uint32, bytes32] | None
+
+    def peak(self) -> tuple[uint32, bytes32] | None:
+        return self._peak
+
+    async def get_coin_records(self, coin_ids: Collection[bytes32]) -> list[CoinRecord]:
+        return await self._coin_store.get_coin_records(coin_ids)
+
+    async def get_coins_added_at_height(self, height: uint32) -> list[CoinRecord]:
+        return await self._coin_store.get_coins_added_at_height(height)
+
+    async def get_coins_removed_at_height(self, height: uint32) -> list[CoinRecord]:
+        return await self._coin_store.get_coins_removed_at_height(height)
 
 
 @typing_extensions.final
@@ -28,16 +60,28 @@ class CoinStore:
     This object handles CoinRecords in DB.
     """
 
+    if TYPE_CHECKING:
+        _protocol_check: ClassVar[CoinStoreProtocol] = cast("CoinStore", None)
+
     db_wrapper: DBWrapper2
+    # Needed by snapshot() to read the peak. The peak physically lives in
+    # BlockStore's tables for now; reading it over the snapshot's read
+    # transaction (same database, same connection) keeps it consistent with
+    # the coin reads. Moving the peak into the coin store is a later step.
+    block_store: BlockStore | None = None
     # Fall back to the `coin_puzzle_hash` index if the ff unspent index
     # does not exist.
     _unspent_lineage_for_ph_idx: str = "coin_puzzle_hash"
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper2) -> CoinStore:
+    async def create(cls, db_wrapper: DBWrapper2, block_store: BlockStore | None = None) -> CoinStore:
         if db_wrapper.db_version != 2:
             raise RuntimeError(f"CoinStore does not support database schema v{db_wrapper.db_version}")
-        self = CoinStore(db_wrapper)
+        if block_store is not None:
+            # snapshot() consistency relies on both stores reading through
+            # the same database wrapper (and thus the same read transaction)
+            assert block_store.db_wrapper is db_wrapper
+        self = CoinStore(db_wrapper, block_store)
 
         async with self.db_wrapper.writer_maybe_transaction() as conn:
             log.info("DB: Creating coin store tables and indexes.")
@@ -252,6 +296,32 @@ class CoinStore:
                         coin_record = CoinRecord(coin, row[0], row[1], row[2] != 0, row[6])
                         coins.append(coin_record)
                 return coins
+
+    @asynccontextmanager
+    async def snapshot(self) -> AsyncIterator[_CoinStoreSnapshot]:
+        """
+        Acquire a consistent read view of the coin store.
+
+        This holds a read transaction open for the duration of the scope, so
+        all reads made through the snapshot observe the same database state:
+        writes committed after acquisition become visible only after the
+        scope exits. The peak is read inside the same transaction (which also
+        pins the sqlite snapshot) and cached, so `peak()` is consistent with
+        the coin reads by construction.
+
+        Reads must be made from the task that acquired the snapshot: the
+        underlying read connection is associated with the current asyncio
+        task, and reads from other tasks would use a different connection
+        outside this transaction.
+        """
+        if self.block_store is None:
+            raise RuntimeError("CoinStore.snapshot() requires a block_store reference to read the peak")
+        async with self.db_wrapper.reader():
+            peak: tuple[uint32, bytes32] | None = None
+            peak_row = await self.block_store.get_peak()
+            if peak_row is not None:
+                peak = (peak_row[1], peak_row[0])
+            yield _CoinStoreSnapshot(self, peak)
 
     # Checks DB and DiffStores for CoinRecords with puzzle_hash and returns them
     async def get_coin_records_by_puzzle_hash(

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -275,7 +275,7 @@ class FullNode:
 
             self._block_store = await BlockStore.create(self.db_wrapper)
             self._hint_store = await HintStore.create(self.db_wrapper)
-            self._coin_store = await CoinStore.create(self.db_wrapper)
+            self._coin_store = await CoinStore.create(self.db_wrapper, block_store=self._block_store)
             self.log.info("Initializing blockchain from disk")
             start_time = time.monotonic()
             single_threaded = self.config.get("single_threaded", False)


### PR DESCRIPTION
This adds `snapshot()` to `CoinStoreProtocol`, implemented on `CoinStore`: an async context manager yielding a `CoinStoreSnapshot` — a read view where `peak()`, `get_coin_records()`, `get_coins_added_at_height()` and `get_coins_removed_at_height()` all observe the same database state. For sqlite it's a read transaction held open for the scope; the peak is read inside the same transaction and cached, so the (peak, coins) pair can't tear. A different backend would implement it with whatever snapshot mechanism it has.

Today the node has transactional writes but no transactional reads — `reader()` is used exactly once in the node, everything else is `reader_no_transaction()` — so consistent reads are being *added* here, not preserved. This is the reader/writer symmetry that came up in the #19949 discussion. First intended consumers are the peer/RPC handlers that currently hand-roll reorg detection ("read, then re-check `height_to_hash(h) == expected`", ~8 sites); converting those comes in a follow-up. The peak still physically lives in `BlockStore`'s tables: the snapshot reads it through an optional `block_store` reference on `CoinStore`, over the same read transaction (same database, same connection), which keeps it consistent without moving anything. Moving the peak into the coin store for real is a later, riskier step.

Purely additive — no existing method signatures change, and nothing calls `snapshot()` yet outside the new tests (which exercise exactly what sqlite gives us: writes committed after acquisition stay invisible inside the snapshot, WAL snapshot isolation on the held read transaction). I also added the `_protocol_check` to `CoinStore` so conformance with `CoinStoreProtocol` is now checked by mypy, same as `BlockStore`.

Made with [Cursor](https://cursor.com)