### PR TITLE
CHIA-4329 Annotate wallet_coin_store.py

### DIFF
--- a/chia/_tests/wallet/test_wallet_coin_store.py
+++ b/chia/_tests/wallet/test_wallet_coin_store.py
@@ -117,10 +117,10 @@ def get_dummy_record(wallet_id: int, seeded_random: random.Random) -> WalletCoin
 @dataclass
 class DummyWalletCoinRecords:
     seeded_random: random.Random
-    records_per_wallet: dict[int, list[WalletCoinRecord]] = field(default_factory=dict)
+    records_per_wallet: dict[uint32, list[WalletCoinRecord]] = field(default_factory=dict)
 
     def generate(self, wallet_id: int, count: int) -> None:
-        records = self.records_per_wallet.setdefault(wallet_id, [])
+        records = self.records_per_wallet.setdefault(uint32(wallet_id), [])
         for _ in range(count):
             records.append(get_dummy_record(wallet_id, seeded_random=self.seeded_random))
 
@@ -200,11 +200,14 @@ async def test_set_spent() -> None:
     async with DBConnection(1) as db_wrapper:
         store = await WalletCoinStore.create(db_wrapper)
         await store.add_coin_record(record_1)
-
-        assert not (await store.get_coin_record(coin_1.name())).spent
+        coin_record = await store.get_coin_record(coin_1.name())
+        assert coin_record is not None
+        assert not coin_record.spent
         await store.set_spent(coin_1.name(), uint32(12))
-        assert (await store.get_coin_record(coin_1.name())).spent
-        assert (await store.get_coin_record(coin_1.name())).spent_block_height == 12
+        coin_record = await store.get_coin_record(coin_1.name())
+        assert coin_record is not None
+        assert coin_record.spent
+        assert coin_record.spent_block_height == 12
 
 
 @pytest.mark.anyio
@@ -776,7 +779,7 @@ async def test_get_coin_records_total_count_cache() -> None:
         assert (
             await store.get_coin_records(spent_range=UInt32Range(start=uint32(10)), include_total_count=True)
         ).total_count == 2
-        await store.set_spent(record_1.name(), 10)
+        await store.set_spent(record_1.name(), uint32(10))
         assert (
             await store.get_coin_records(spent_range=UInt32Range(start=uint32(10)), include_total_count=True)
         ).total_count == 3
@@ -827,7 +830,7 @@ async def test_get_coin_records_total_count_cache_reset() -> None:
         # All the actions in here should reset the cache and lead to the same results again in `test_cache`.
         for trigger in [
             store.add_coin_record(record_4),
-            store.set_spent(coin_4.name(), 10),
+            store.set_spent(coin_4.name(), uint32(10)),
             store.delete_coin_record(record_4.name()),
             store.rollback_to_block(1000),
             store.delete_wallet(uint32(record_1.wallet_id)),
@@ -907,6 +910,7 @@ async def test_rollback_to_block() -> None:
         await store.rollback_to_block(6)
 
         new_r5 = await store.get_coin_record(coin_5.name())
+        assert new_r5 is not None
         assert not new_r5.spent
         assert new_r5.spent_block_height == 0
         assert new_r5 != r5
@@ -917,6 +921,7 @@ async def test_rollback_to_block() -> None:
 
         assert await store.get_coin_record(coin_5.name()) is None
         new_r4 = await store.get_coin_record(coin_4.name())
+        assert new_r4 is not None
         assert not new_r4.spent
         assert new_r4.spent_block_height == 0
         assert new_r4 != r4

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -61,7 +61,7 @@ class WalletCoinStore:
     total_count_cache: LRUCache[bytes32, uint32]
 
     @classmethod
-    async def create(cls, wrapper: DBWrapper2):
+    async def create(cls, wrapper: DBWrapper2) -> WalletCoinStore:
         self = cls()
 
         self.db_wrapper = wrapper

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -15,7 +15,6 @@ chia.types.blockchain_format.program
 chia.wallet.puzzles.load_clvm
 chia.wallet.util.debug_spend_bundle
 chia.wallet.util.new_peak_queue
-chia.wallet.wallet_coin_store
 chia.wallet.wallet_interested_store
 chia.wallet.wallet_puzzle_store
 chia.wallet.wallet_transaction_store


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type annotations and test-only narrowing; no runtime behavior changes in wallet coin storage.
> 
> **Overview**
> Brings **`chia/wallet/wallet_coin_store.py`** under mypy by adding a **`WalletCoinStore`** return type on **`create`** and dropping that module from **`mypy-exclusions.txt`**.
> 
> **`test_wallet_coin_store.py`** is updated for stricter typing: wallet IDs use **`uint32`** in test helpers, **`set_spent`** calls pass **`uint32`** block heights, and tests narrow **`get_coin_record`** results with **`is not None`** before accessing fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f1cd4911aa48430bd1ef59bf83f51da8716b6db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->