### PR TITLE
Remove chia.wallet.wallet_coin_store from mypy exclusions

### DIFF
--- a/chia/_tests/wallet/test_wallet_coin_store.py
+++ b/chia/_tests/wallet/test_wallet_coin_store.py
@@ -201,10 +201,14 @@ async def test_set_spent() -> None:
         store = await WalletCoinStore.create(db_wrapper)
         await store.add_coin_record(record_1)
 
-        assert not (await store.get_coin_record(coin_1.name())).spent
+        unspent_record = await store.get_coin_record(coin_1.name())
+        assert unspent_record is not None
+        assert not unspent_record.spent
         await store.set_spent(coin_1.name(), uint32(12))
-        assert (await store.get_coin_record(coin_1.name())).spent
-        assert (await store.get_coin_record(coin_1.name())).spent_block_height == 12
+        spent_record = await store.get_coin_record(coin_1.name())
+        assert spent_record is not None
+        assert spent_record.spent
+        assert spent_record.spent_block_height == 12
 
 
 @pytest.mark.anyio
@@ -776,7 +780,7 @@ async def test_get_coin_records_total_count_cache() -> None:
         assert (
             await store.get_coin_records(spent_range=UInt32Range(start=uint32(10)), include_total_count=True)
         ).total_count == 2
-        await store.set_spent(record_1.name(), 10)
+        await store.set_spent(record_1.name(), uint32(10))
         assert (
             await store.get_coin_records(spent_range=UInt32Range(start=uint32(10)), include_total_count=True)
         ).total_count == 3
@@ -827,7 +831,7 @@ async def test_get_coin_records_total_count_cache_reset() -> None:
         # All the actions in here should reset the cache and lead to the same results again in `test_cache`.
         for trigger in [
             store.add_coin_record(record_4),
-            store.set_spent(coin_4.name(), 10),
+            store.set_spent(coin_4.name(), uint32(10)),
             store.delete_coin_record(record_4.name()),
             store.rollback_to_block(1000),
             store.delete_wallet(uint32(record_1.wallet_id)),
@@ -907,6 +911,7 @@ async def test_rollback_to_block() -> None:
         await store.rollback_to_block(6)
 
         new_r5 = await store.get_coin_record(coin_5.name())
+        assert new_r5 is not None
         assert not new_r5.spent
         assert new_r5.spent_block_height == 0
         assert new_r5 != r5
@@ -917,6 +922,7 @@ async def test_rollback_to_block() -> None:
 
         assert await store.get_coin_record(coin_5.name()) is None
         new_r4 = await store.get_coin_record(coin_4.name())
+        assert new_r4 is not None
         assert not new_r4.spent
         assert new_r4.spent_block_height == 0
         assert new_r4 != r4
@@ -991,11 +997,11 @@ async def test_delete_wallet(seeded_random: random.Random) -> None:
         for wallet_id, records in dummy_records.records_per_wallet.items():
             for coin_record in records:
                 await store.add_coin_record(coin_record)
-            assert set((await store.get_coin_records(wallet_id=wallet_id)).records) == set(records)
+            assert set((await store.get_coin_records(wallet_id=uint32(wallet_id))).records) == set(records)
         # Remove one wallet after the other and verify before and after each
         for wallet_id, records in dummy_records.records_per_wallet.items():
             # Assert the existence again here to make sure the previous removals did not affect other wallet_ids
-            assert set((await store.get_coin_records(wallet_id=wallet_id)).records) == set(records)
+            assert set((await store.get_coin_records(wallet_id=uint32(wallet_id))).records) == set(records)
             # Remove the wallet_id and make sure its removed fully
-            await store.delete_wallet(wallet_id)
-            assert (await store.get_coin_records(wallet_id=wallet_id)).records == []
+            await store.delete_wallet(uint32(wallet_id))
+            assert (await store.get_coin_records(wallet_id=uint32(wallet_id))).records == []

--- a/chia/wallet/wallet_coin_store.py
+++ b/chia/wallet/wallet_coin_store.py
@@ -61,7 +61,7 @@ class WalletCoinStore:
     total_count_cache: LRUCache[bytes32, uint32]
 
     @classmethod
-    async def create(cls, wrapper: DBWrapper2):
+    async def create(cls, wrapper: DBWrapper2) -> WalletCoinStore:
         self = cls()
 
         self.db_wrapper = wrapper

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -15,7 +15,6 @@ chia.types.blockchain_format.program
 chia.wallet.puzzles.load_clvm
 chia.wallet.util.debug_spend_bundle
 chia.wallet.util.new_peak_queue
-chia.wallet.wallet_coin_store
 chia.wallet.wallet_interested_store
 chia.wallet.wallet_puzzle_store
 chia.wallet.wallet_transaction_store


### PR DESCRIPTION
### Purpose:

Chip away at `mypy-exclusions.txt`. `chia.wallet.wallet_coin_store` had a single mypy failure, so it is cheap to bring under the strict config.

### Current Behavior:

`WalletCoinStore.create` is unannotated, so mypy reports `no-untyped-def` and the module stays in `mypy-exclusions.txt`. Because the classmethod is untyped, every `store = await WalletCoinStore.create(...)` in tests is inferred as `Any`, hiding type errors at the call sites.

### New Behavior:

`WalletCoinStore.create` returns `WalletCoinStore`, and the module is removed from `mypy-exclusions.txt`. With the store no longer `Any`, the latent errors this exposed in `chia/_tests/wallet/test_wallet_coin_store.py` are fixed:

- `set_spent` / `get_coin_records` / `delete_wallet` are passed `uint32` instead of `int` (matching the existing `uint32(wallet_id)` pattern in `chia/_tests/pools/test_wallet_pool_store.py`).
- `get_coin_record` results are narrowed with `assert ... is not None` before attribute access.

No runtime behavior changes.

### Testing Notes:

- `mypy` passes repo-wide with the module removed from the exclusion list.
- `chia/_tests/wallet/test_wallet_coin_store.py`: 103 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing and test-only adjustments with no production logic changes.
> 
> **Overview**
> Brings **`chia.wallet.wallet_coin_store`** under strict mypy by annotating **`WalletCoinStore.create`** with a **`WalletCoinStore`** return type and removing the module from **`mypy-exclusions.txt`**.
> 
> That typing surfaces latent issues in **`test_wallet_coin_store.py`**: **`set_spent`** / **`delete_wallet`** / **`get_coin_records(wallet_id=...)`** now use **`uint32`** where the API expects it, and **`get_coin_record`** results are narrowed with **`assert ... is not None`** before attribute access. **No runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eab9e8de7aae876b104e674555bfd3c0bddef4e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->