### PR TITLE
Remove chia.wallet.wallet_interested_store from mypy exclusions

### DIFF
--- a/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
+++ b/chia/_tests/wallet/cat_wallet/test_cat_wallet.py
@@ -1547,7 +1547,7 @@ async def test_unacknowledged_cat_table() -> None:
                 return CoinState(Coin(bytes32.zeros, bytes32.zeros, uint64(i)), None, None)
 
             await interested_store.add_unacknowledged_coin_state(asset_id(0), coin_state(0), None)
-            await interested_store.add_unacknowledged_coin_state(asset_id(1), coin_state(1), 100)
+            await interested_store.add_unacknowledged_coin_state(asset_id(1), coin_state(1), uint32(100))
             assert await interested_store.get_unacknowledged_states_for_asset_id(asset_id(0)) == [(coin_state(0), 0)]
             await interested_store.add_unacknowledged_coin_state(asset_id(0), coin_state(0), None)
             assert await interested_store.get_unacknowledged_states_for_asset_id(asset_id(0)) == [(coin_state(0), 0)]

--- a/chia/wallet/wallet_interested_store.py
+++ b/chia/wallet/wallet_interested_store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from chia_rs import CoinState
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32
@@ -15,7 +17,7 @@ class WalletInterestedStore:
     db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, wrapper: DBWrapper2):
+    async def create(cls, wrapper: DBWrapper2) -> WalletInterestedStore:
         self = cls()
         self.db_wrapper = wrapper
 
@@ -67,7 +69,7 @@ class WalletInterestedStore:
             row = await cursor.fetchone()
         if row is None:
             return None
-        return row[0]
+        return int(row[0])
 
     async def add_interested_puzzle_hash(self, puzzle_hash: bytes32, wallet_id: int) -> None:
         async with self.db_wrapper.writer_maybe_transaction() as conn:
@@ -110,7 +112,7 @@ class WalletInterestedStore:
             )
             await cursor.close()
 
-    async def get_unacknowledged_tokens(self) -> list:
+    async def get_unacknowledged_tokens(self) -> list[dict[str, Any]]:
         """
         Get a list of all unacknowledged CATs
         :return: A json style list of unacknowledged CATs

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -16,7 +16,6 @@ chia.wallet.puzzles.load_clvm
 chia.wallet.util.debug_spend_bundle
 chia.wallet.util.new_peak_queue
 chia.wallet.wallet_coin_store
-chia.wallet.wallet_interested_store
 chia.wallet.wallet_puzzle_store
 chia.wallet.wallet_transaction_store
 chia._tests.clvm.test_puzzles


### PR DESCRIPTION
### Purpose:

Continue shrinking `mypy-exclusions.txt`. This module had three mypy failures, all missing annotations.

### Current Behavior:

`chia.wallet.wallet_interested_store` is excluded from the strict mypy config: `create` is unannotated, `get_unacknowledged_tokens` returns a bare `list`, and `get_interested_puzzle_hash_wallet_id` returns `Any` from a `int | None` signature.

### New Behavior:

The module passes the strict config and is removed from `mypy-exclusions.txt`:

- `create` returns `WalletInterestedStore`.
- `get_unacknowledged_tokens` returns `list[dict[str, Any]]`, matching its only consumer (`StrayCAT.from_json_dict` in `wallet_rpc_api.py`).
- The wallet-id row read is coerced with `int(...)` instead of returning `Any`.

Typing `create` also stopped mypy inferring the store as `Any` in tests, which exposed one `int` vs `uint32` argument in `chia/_tests/wallet/cat_wallet/test_cat_wallet.py`; that call now passes `uint32(100)`.

No runtime behavior changes.

### Testing Notes:

- `mypy` passes repo-wide with the module removed from the exclusion list.
- `chia/_tests/wallet/test_wallet_interested_store.py`: 1 passed.
- `chia/_tests/wallet/cat_wallet/test_cat_wallet.py -k unacknowledged`: 1 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only changes in a wallet persistence helper with a test typing fix; no auth, consensus, or transaction logic changes.
> 
> **Overview**
> **`chia.wallet.wallet_interested_store`** is brought under strict mypy by adding return types and tightening one DB read, and the module is removed from **`mypy-exclusions.txt`**.
> 
> `WalletInterestedStore.create` is annotated to return **`WalletInterestedStore`**. **`get_unacknowledged_tokens`** now returns **`list[dict[str, Any]]`** (aligned with **`StrayCAT.from_json_dict`** in the wallet RPC). **`get_interested_puzzle_hash_wallet_id`** wraps the SQLite row with **`int(...)`** so the declared **`int | None`** is accurate.
> 
> Stricter typing on **`create`** in **`test_cat_wallet.py`** surfaces a **`uint32`** vs plain **`int`** mismatch for **`add_unacknowledged_coin_state`**; the test passes **`uint32(100)`** instead of **`100`**.
> 
> No intended runtime behavior change beyond the explicit **`int`** coercion on wallet IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8dc5121d2cb6d4e155099ea0aee6c92d488f761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->