### PR TITLE
Remove chia.simulator.wallet_tools from mypy exclusions

### DIFF
--- a/chia/simulator/wallet_tools.py
+++ b/chia/simulator/wallet_tools.py
@@ -40,13 +40,11 @@ class WalletTool:
     def __init__(self, constants: ConsensusConstants, sk: PrivateKey | None = None):
         self.constants = constants
         self.current_balance = 0
-        self.my_utxos: set = set()
         if sk is not None:
             self.private_key = sk
         else:
             self.private_key = AugSchemeMPL.key_gen(DEFAULT_SEED)
-        self.generator_lookups: dict = {}
-        self.puzzle_pk_cache: dict = {}
+        self.puzzle_pk_cache = {}
         self.get_new_puzzle()
 
     def get_next_address_index(self) -> uint32:

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -9,7 +9,6 @@ chia.plotting.util
 chia.rpc.rpc_client
 chia.simulator.full_node_simulator
 chia.simulator.keyring
-chia.simulator.wallet_tools
 chia.ssl.create_ssl
 chia.types.blockchain_format.program
 chia.wallet.puzzles.load_clvm


### PR DESCRIPTION
### Purpose:

Continue shrinking `mypy-exclusions.txt` by bringing `chia.simulator.wallet_tools` under the strict mypy configuration.

### Current Behavior:

The module has three `type-arg` errors from unparameterized `set` and `dict` instance attributes.

### New Behavior:

The two attributes with no readers (`my_utxos` and `generator_lookups`) are removed. The remaining puzzle-key cache already has a typed class attribute, so its instance assignment is inferred correctly. The module is removed from `mypy-exclusions.txt`.

### Testing Notes:

- Repository pre-commit hooks passed, including repo-wide mypy.
- Draft PR CI will provide the full test signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simulator-only cleanup of unused attributes and mypy configuration; no production wallet or consensus paths change.
> 
> **Overview**
> **Enables strict mypy on `chia.simulator.wallet_tools`** by dropping it from `mypy-exclusions.txt`.
> 
> In `WalletTool.__init__`, unused instance state **`my_utxos`** and **`generator_lookups`** is removed (they had no readers and caused unparameterized `set`/`dict` errors). **`puzzle_pk_cache`** is reset with a plain `{}` assignment so mypy infers types from the existing class-level `dict[bytes32, PrivateKey]` annotation instead of redeclaring an untyped dict in the constructor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b34a4a00654ddf7d4338b3929e5416d0aed2ac52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->