### PR TITLE
Remove chia.wallet.util.debug_spend_bundle from mypy exclusions

### DIFF
--- a/chia/wallet/util/debug_spend_bundle.py
+++ b/chia/wallet/util/debug_spend_bundle.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from chia_rs import AugSchemeMPL
+from chia_rs import AugSchemeMPL, SpendBundle
 from clvm.operators import KEYWORD_FROM_ATOM
 from clvm_tools.binutils import disassemble as bu_disassemble
 
@@ -21,13 +21,13 @@ KFA = {v: k for k, v in CONDITIONS.items()}
 # we may need also to save the `genesis_coin_mod` or its hash
 
 
-def disassemble(sexp: Program):
+def disassemble(sexp: Program) -> str:
     """
     This version of `disassemble` also disassembles condition opcodes like `ASSERT_ANNOUNCEMENT_CONSUMED`.
     """
     kfa = dict(KEYWORD_FROM_ATOM)
     kfa.update((Program.to(k).as_atom(), v) for k, v in KFA.items())
-    return bu_disassemble(sexp, kfa)
+    return str(bu_disassemble(sexp, kfa))
 
 
 def coin_as_program(coin: Coin) -> Program:
@@ -65,7 +65,10 @@ def uncurry_dump(puzzle: Program, prefix: str = "") -> None:
     recursive_uncurry_dump(puzzle, 1, prefix, UncurriedPuzzle(mod, curried_args))
 
 
-def debug_spend_bundle(spend_bundle, agg_sig_additional_data=DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA) -> None:
+def debug_spend_bundle(
+    spend_bundle: SpendBundle,
+    agg_sig_additional_data: bytes = DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA,
+) -> None:
     """
     Print a lot of useful information about a `SpendBundle` that might help with debugging
     its clvm.

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -13,7 +13,6 @@ chia.simulator.wallet_tools
 chia.ssl.create_ssl
 chia.types.blockchain_format.program
 chia.wallet.puzzles.load_clvm
-chia.wallet.util.debug_spend_bundle
 chia.wallet.util.new_peak_queue
 chia.wallet.wallet_coin_store
 chia.wallet.wallet_interested_store


### PR DESCRIPTION
### Purpose:

Continue shrinking `mypy-exclusions.txt` by bringing `chia.wallet.util.debug_spend_bundle` under strict mypy checking.

### Current Behavior:

The module has three strict-mypy errors: an unannotated disassembler return, an `Any` return from the external CLVM disassembler, and untyped parameters on `debug_spend_bundle`.

### New Behavior:

- `disassemble` is declared to return `str` and normalizes the external function's untyped result with `str(...)`.
- `debug_spend_bundle` accepts `SpendBundle` and `bytes` parameters.
- The module is removed from `mypy-exclusions.txt`.

No intended runtime behavior change.

### Testing Notes:

- Repository-wide mypy passes.
- Pre-commit hooks pass.
- Draft PR CI will provide the test signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only changes to a debug utility; behavior is unchanged aside from explicit `str()` on disassembler output.
> 
> **Overview**
> Brings **`chia.wallet.util.debug_spend_bundle`** under strict mypy by typing the public helpers and dropping the module from **`mypy-exclusions.txt`**.
> 
> **`disassemble`** now returns **`str`** and wraps the untyped CLVM **`bu_disassemble`** result with **`str(...)`**. **`debug_spend_bundle`** is annotated to take a **`SpendBundle`** and **`bytes`** for **`agg_sig_additional_data`**, with **`SpendBundle`** imported from **`chia_rs`**. No intended runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5618b67703b6b990e1c884803de2d43060e716d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->