### PR TITLE
Remove chia.simulator.full_node_simulator from mypy exclusions

### DIFF
--- a/chia/simulator/full_node_simulator.py
+++ b/chia/simulator/full_node_simulator.py
@@ -45,7 +45,7 @@ default = _Default()
 timeout_per_block = 5
 
 
-async def wait_for_coins_in_wallet(coins: set[Coin], wallet: Wallet, timeout: float | None = 5):
+async def wait_for_coins_in_wallet(coins: set[Coin], wallet: Wallet, timeout: float | None = 5) -> None:
     """Wait until all of the specified coins are simultaneously reported as spendable
     by the wallet.
 
@@ -67,7 +67,7 @@ async def wait_for_coins_in_wallet(coins: set[Coin], wallet: Wallet, timeout: fl
 
 
 class FullNodeSimulator(FullNodeAPI):
-    def __init__(self, full_node: FullNode, block_tools: BlockTools, config: dict) -> None:
+    def __init__(self, full_node: FullNode, block_tools: BlockTools, config: dict[str, Any]) -> None:
         super().__init__(full_node)
         self.bt = block_tools
         self.full_node = full_node
@@ -250,7 +250,7 @@ class FullNodeSimulator(FullNodeAPI):
         await self.full_node.add_block(more[-1])
         return more[-1]
 
-    async def farm_new_block(self, request: FarmNewBlockProtocol, force_wait_for_timestamp: bool = False):
+    async def farm_new_block(self, request: FarmNewBlockProtocol, force_wait_for_timestamp: bool = False) -> None:
         ssi = self.full_node.constants.SUB_SLOT_ITERS_STARTING
         diff = self.full_node.constants.DIFFICULTY_STARTING
         async with self.full_node.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
@@ -300,7 +300,7 @@ class FullNodeSimulator(FullNodeAPI):
             )
         await self.full_node.add_block(more[-1])
 
-    async def reorg_from_index_to_new_index(self, request: ReorgProtocol):
+    async def reorg_from_index_to_new_index(self, request: ReorgProtocol) -> None:
         new_index = request.new_index
         old_index = request.old_index
         coinbase_ph = request.puzzle_hash

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -7,7 +7,6 @@ chia.plotters.plotters_util
 chia.plotting.manager
 chia.plotting.util
 chia.rpc.rpc_client
-chia.simulator.full_node_simulator
 chia.simulator.keyring
 chia.simulator.wallet_tools
 chia.ssl.create_ssl


### PR DESCRIPTION
### Purpose:

Continue shrinking `mypy-exclusions.txt` by enabling strict mypy checking for `chia.simulator.full_node_simulator`.

### Current Behavior:

The module is excluded for four annotation-only errors: three missing coroutine return types and one unparameterized config dictionary.

### New Behavior:

The three side-effect-only coroutines return `None`, the simulator config is typed as `dict[str, Any]`, and the module is removed from `mypy-exclusions.txt`.

No runtime behavior changes.

### Testing Notes:

- Repository-wide mypy passes.
- Pre-commit hooks pass.
- Draft PR CI will provide the test signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type annotations and mypy exclusion list only; simulator test harness logic is unchanged.
> 
> **Overview**
> **Strict mypy** is now applied to `chia.simulator.full_node_simulator` by dropping it from `mypy-exclusions.txt`.
> 
> Annotation-only fixes in that module: `wait_for_coins_in_wallet`, `farm_new_block`, and `reorg_from_index_to_new_index` are typed as returning `None`, and `FullNodeSimulator.__init__` takes `config: dict[str, Any]`. No runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cbc21b9af5ff479965ed762e3dc74e489c38180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->