### PR TITLE
Remove chia.wallet.wallet_puzzle_store from mypy exclusions

### DIFF
--- a/chia/_tests/wallet/test_puzzle_store.py
+++ b/chia/_tests/wallet/test_puzzle_store.py
@@ -74,7 +74,7 @@ async def test_puzzle_store(seeded_random: random.Random) -> None:
         assert len(await db.get_all_puzzle_hashes()) == 0
         assert await db.get_last_derivation_path() is None
         assert await db.get_unused_derivation_path() is None
-        assert await db.get_derivation_record(0, 2, False) is None
+        assert await db.get_derivation_record(uint32(0), uint32(2), False) is None
 
         await db.add_derivation_paths(derivation_recs)
 
@@ -89,10 +89,10 @@ async def test_puzzle_store(seeded_random: random.Random) -> None:
         assert len(await db.get_all_puzzle_hashes()) == 2000
         assert await db.get_last_derivation_path() == 999
         assert await db.get_unused_derivation_path() == 0
-        assert await db.get_derivation_record(0, 2, False) == derivation_recs[1]
+        assert await db.get_derivation_record(uint32(0), uint32(2), False) == derivation_recs[1]
 
         # Indeces up to 250
-        await db.set_used_up_to(249)
+        await db.set_used_up_to(uint32(249))
 
         assert await db.get_unused_derivation_path() == 250
 
@@ -122,7 +122,7 @@ async def test_delete_wallet(seeded_random: random.Random) -> None:
                 )
                 assert await db.get_last_derivation_path_for_wallet(wallet_id) is not None
             # Remove the wallet_id and make sure its removed fully
-            await db.delete_wallet(wallet_id)
+            await db.delete_wallet(uint32(wallet_id))
             for record in records:
                 assert await db.get_derivation_record(record.index, record.wallet_id, record.hardened) is None
                 assert await db.get_wallet_identifier_for_puzzle_hash(record.puzzle_hash) is None

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sqlite3
 
 from chia_rs import G1Element
 from chia_rs.sized_bytes import bytes32
@@ -24,13 +25,13 @@ class WalletPuzzleStore:
 
     lock: asyncio.Lock
     db_wrapper: DBWrapper2
-    wallet_identifier_cache: LRUCache
+    wallet_identifier_cache: LRUCache[bytes32, WalletIdentifier]
     # maps wallet_id -> last_derivation_index
     last_wallet_derivation_index: dict[uint32, uint32]
     last_derivation_index: uint32 | None
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper2):
+    async def create(cls, db_wrapper: DBWrapper2) -> WalletPuzzleStore:
         self = cls()
         self.db_wrapper = db_wrapper
         async with self.db_wrapper.writer_maybe_transaction() as conn:
@@ -170,7 +171,7 @@ class WalletPuzzleStore:
 
         return row is not None
 
-    def row_to_record(self, row) -> DerivationRecord:
+    def row_to_record(self, row: sqlite3.Row) -> DerivationRecord:
         return DerivationRecord(
             uint32(row[0]),
             bytes32.fromhex(row[2]),

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -17,7 +17,6 @@ chia.wallet.util.debug_spend_bundle
 chia.wallet.util.new_peak_queue
 chia.wallet.wallet_coin_store
 chia.wallet.wallet_interested_store
-chia.wallet.wallet_puzzle_store
 chia.wallet.wallet_transaction_store
 chia._tests.clvm.test_puzzles
 chia._tests.clvm.test_singletons


### PR DESCRIPTION
### Purpose:

Continue shrinking `mypy-exclusions.txt` by enabling strict mypy checking for `chia.wallet.wallet_puzzle_store`.

### Current Behavior:

The store has four strict-mypy errors: an unparameterized cache, an untyped factory, an untyped database row, and an `Any` cache return.

### New Behavior:

- The wallet-identifier cache is `LRUCache[bytes32, WalletIdentifier]`.
- `create` returns `WalletPuzzleStore`.
- `row_to_record` accepts `sqlite3.Row`.
- The module is removed from `mypy-exclusions.txt`.

Typing the factory exposed existing plain-`int` arguments in `test_puzzle_store.py`; those calls now use `uint32`, matching the store API.

No runtime behavior changes beyond explicit construction of the same sized integers in tests.

### Testing Notes:

- Repository-wide mypy passes.
- Pre-commit hooks pass.
- Draft PR CI will provide the test signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation and test-only typing adjustments; no intended runtime behavior change.
> 
> **Overview**
> **`chia.wallet.wallet_puzzle_store`** is removed from **`mypy-exclusions.txt`** so the module is checked under strict mypy.
> 
> The store gains explicit types: **`wallet_identifier_cache`** is **`LRUCache[bytes32, WalletIdentifier]`**, **`create`** returns **`WalletPuzzleStore`**, and **`row_to_record`** takes **`sqlite3.Row`**. **`test_puzzle_store.py`** passes **`uint32`** where the API expects sized integers (e.g. **`get_derivation_record`**, **`set_used_up_to`**, **`delete_wallet`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54fdfc51dea8e5125f01752bc57a6e53022f6642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->