### PR TITLE
Remove chia.plotting.util from mypy exclusions

### DIFF
--- a/chia/plotting/util.py
+++ b/chia/plotting/util.py
@@ -118,7 +118,7 @@ def get_plot_filenames(root_path: Path) -> dict[Path, list[Path]]:
     return all_files
 
 
-def remove_plot(path: Path):
+def remove_plot(path: Path) -> None:
     log.debug(f"remove_plot {path!s}")
     # Remove absolute and relative paths
     if path.exists():
@@ -161,7 +161,7 @@ def update_harvester_config(
     decompressor_thread_count: int | None = None,
     recursive_plot_scan: bool | None = None,
     refresh_parameter: PlotsRefreshParameter | None = None,
-):
+) -> None:
     with lock_and_load_config(root_path, "config.yaml") as config:
         if use_gpu_harvesting is not None:
             config["harvester"]["use_gpu_harvesting"] = use_gpu_harvesting
@@ -242,7 +242,7 @@ def stream_plot_info_pk(
     pool_public_key: G1Element,
     farmer_public_key: G1Element,
     local_master_sk: PrivateKey,
-):
+) -> bytes:
     # There are two ways to stream plot info: with a pool public key, or with a pool contract puzzle hash.
     # This one streams the public key, into bytes
     data = bytes(pool_public_key) + bytes(farmer_public_key) + bytes(local_master_sk)
@@ -254,7 +254,7 @@ def stream_plot_info_ph(
     pool_contract_puzzle_hash: bytes32,
     farmer_public_key: G1Element,
     local_master_sk: PrivateKey,
-):
+) -> bytes:
     # There are two ways to stream plot info: with a pool public key, or with a pool contract puzzle hash.
     # This one streams the pool contract puzzle hash, into bytes
     data = pool_contract_puzzle_hash + bytes(farmer_public_key) + bytes(local_master_sk)
@@ -262,7 +262,7 @@ def stream_plot_info_ph(
     return data
 
 
-def find_duplicate_plot_IDs(all_filenames=None) -> None:
+def find_duplicate_plot_IDs(all_filenames: list[Path] | None = None) -> None:
     if all_filenames is None:
         all_filenames = []
     plot_ids_set = set()

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -5,7 +5,6 @@ chia.plotters.madmax
 chia.plotters.plotters
 chia.plotters.plotters_util
 chia.plotting.manager
-chia.plotting.util
 chia.rpc.rpc_client
 chia.simulator.full_node_simulator
 chia.simulator.keyring


### PR DESCRIPTION
### Purpose:

Continue shrinking `mypy-exclusions.txt` by enabling strict mypy checking for `chia.plotting.util`.

### Current Behavior:

The module is excluded for five missing annotations on plotting/configuration helper functions.

### New Behavior:

- Side-effect-only helpers return `None`.
- Plot memo streaming helpers return `bytes`.
- Duplicate plot ID checking accepts `list[Path] | None`.
- The module is removed from `mypy-exclusions.txt`.

No runtime behavior changes.

### Testing Notes:

- Repository-wide mypy passes.
- Pre-commit hooks pass.
- Draft PR CI will provide the test signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only changes to plotting helpers with no runtime or security impact.
> 
> **Overview**
> Brings **`chia.plotting.util`** under strict mypy by adding missing annotations and removing it from **`mypy-exclusions.txt`**.
> 
> **`remove_plot`** and **`update_harvester_config`** are explicitly **`-> None`**. **`stream_plot_info_pk`** and **`stream_plot_info_ph`** are **`-> bytes`**. **`find_duplicate_plot_IDs`** takes **`all_filenames: list[Path] | None`**. No logic or call-site behavior changes—typing and CI coverage only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15827714ff81203a815f5aa7cd31294bbce9079f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->