### PR TITLE
Remove chia.introducer.introducer from mypy exclusions

### DIFF
--- a/chia/introducer/introducer.py
+++ b/chia/introducer/introducer.py
@@ -65,10 +65,10 @@ class Introducer:
     def get_connections(self, request_node_type: NodeType | None) -> list[dict[str, Any]]:
         return default_get_connections(server=self.server, request_node_type=request_node_type)
 
-    def set_server(self, server: ChiaServer):
+    def set_server(self, server: ChiaServer) -> None:
         self._server = server
 
-    async def _vetting_loop(self):
+    async def _vetting_loop(self) -> None:
         while True:
             if self._shut_down:
                 return None
@@ -78,9 +78,9 @@ class Introducer:
                         return None
                     await asyncio.sleep(1)
                 self.log.info("Vetting random peers.")
-                if self._server.introducer_peers is None:
+                if self._server is None or self._server.introducer_peers is None:
                     continue
-                raw_peers = self.server.introducer_peers.get_peers(100, True, 3 * self.recent_peer_threshold)
+                raw_peers = self._server.introducer_peers.get_peers(100, True, 3 * self.recent_peer_threshold)
 
                 if len(raw_peers) == 0:
                     continue
@@ -119,7 +119,8 @@ class Introducer:
 
                         # if we have failed 6 times in a row, remove the peer
                         if peer.vetted < -6:
-                            self.server.introducer_peers.remove(peer)
+                            assert self._server.introducer_peers is not None
+                            self._server.introducer_peers.remove(peer)
                         continue
 
                     self.log.info(f"Have vetted {peer} successfully!")

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -1,5 +1,4 @@
 # File created by: python manage-mypy.py build-exclusions
-chia.introducer.introducer
 chia.plotters.bladebit
 chia.plotters.madmax
 chia.plotters.plotters


### PR DESCRIPTION
### Purpose:

Continue shrinking `mypy-exclusions.txt` by enabling strict mypy checking for `chia.introducer.introducer`.

### Current Behavior:

The module is excluded for six annotation and optional-narrowing errors around the vetting loop and server assignment.

### New Behavior:

- `set_server` and `_vetting_loop` are annotated to return `None`.
- The vetting loop checks `self._server is None` before using it, and asserts introducer peers are present before removal.
- The module is removed from `mypy-exclusions.txt`.

No intended runtime behavior change for a properly configured introducer.

### Testing Notes:

- Repository-wide mypy passes.
- Pre-commit hooks pass.
- Draft PR CI will provide the test signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing and defensive None checks only; no intended change to introducer runtime behavior when the server is set.
> 
> **Overview**
> Brings **`chia.introducer.introducer`** under normal mypy strictness by dropping it from **`mypy-exclusions.txt`**.
> 
> The vetting loop now uses **`self._server`** with an explicit **`None`** guard (and an assert before peer removal) instead of **`self.server`**, and **`set_server`** / **`_vetting_loop`** get **`-> None`** return annotations. Intended behavior for a configured introducer is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 040fd665493545d5a3d7a3d6065b54fb1a0922a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->