### PR TITLE
Remove chia.ssl.create_ssl from mypy exclusions

### DIFF
--- a/chia/ssl/create_ssl.py
+++ b/chia/ssl/create_ssl.py
@@ -41,7 +41,9 @@ def get_mozilla_ca_crt() -> str:
     return str(mozilla_path)
 
 
-def write_ssl_cert_and_key(cert_path: Path, cert_data: bytes, key_path: Path, key_data: bytes, overwrite: bool = True):
+def write_ssl_cert_and_key(
+    cert_path: Path, cert_data: bytes, key_path: Path, key_data: bytes, overwrite: bool = True
+) -> None:
     flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
 
     for path, data, mode in [
@@ -58,14 +60,14 @@ def write_ssl_cert_and_key(cert_path: Path, cert_data: bytes, key_path: Path, ke
             f.write(data)  # lgtm [py/clear-text-storage-sensitive-data]
 
 
-def ensure_ssl_dirs(dirs: list[Path]):
+def ensure_ssl_dirs(dirs: list[Path]) -> None:
     """Create SSL dirs with a default 755 mode if necessary"""
     for dir in dirs:
         if not dir.exists():
             dir.mkdir(mode=0o755, parents=True)
 
 
-def generate_ca_signed_cert(ca_crt: bytes, ca_key: bytes, cert_out: Path, key_out: Path):
+def generate_ca_signed_cert(ca_crt: bytes, ca_key: bytes, cert_out: Path, key_out: Path) -> None:
     one_day = datetime.timedelta(1, 0, 0)
     root_cert = x509.load_pem_x509_certificate(ca_crt, default_backend())
     root_key = load_pem_private_key(ca_key, None, default_backend())
@@ -104,7 +106,7 @@ def generate_ca_signed_cert(ca_crt: bytes, ca_key: bytes, cert_out: Path, key_ou
     write_ssl_cert_and_key(cert_out, cert_pem, key_out, key_pem)
 
 
-def make_ca_cert(cert_path: Path, key_path: Path):
+def make_ca_cert(cert_path: Path, key_path: Path) -> None:
     root_key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
     subject = issuer = x509.Name(
         [
@@ -139,11 +141,11 @@ def create_all_ssl(
     root_path: Path,
     *,
     private_ca_crt_and_key: tuple[bytes, bytes] | None = None,
-    node_certs_and_keys: dict[str, dict] | None = None,
+    node_certs_and_keys: dict[str, dict[str, dict[str, bytes]]] | None = None,
     private_node_names: list[str] = _all_private_node_names,
     public_node_names: list[str] = _all_public_node_names,
     overwrite: bool = True,
-):
+) -> None:
     # remove old key and crt
     config_dir = root_path / "config"
     old_key_path = config_dir / "trusted.key"
@@ -222,8 +224,8 @@ def generate_ssl_for_nodes(
     prefix: str,
     nodes: list[str],
     overwrite: bool = True,
-    node_certs_and_keys: dict[str, dict] | None = None,
-):
+    node_certs_and_keys: dict[str, dict[str, dict[str, bytes]]] | None = None,
+) -> None:
     for node_name in nodes:
         node_dir = ssl_dir / node_name
         ensure_ssl_dirs([node_dir])
@@ -242,7 +244,7 @@ def generate_ssl_for_nodes(
         generate_ca_signed_cert(ca_crt, ca_key, crt_path, key_path)
 
 
-def main():
+def main() -> None:
     return make_ca_cert(Path("./chia_ca.crt"), Path("./chia_ca.key"))
 
 

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -10,7 +10,6 @@ chia.rpc.rpc_client
 chia.simulator.full_node_simulator
 chia.simulator.keyring
 chia.simulator.wallet_tools
-chia.ssl.create_ssl
 chia.types.blockchain_format.program
 chia.wallet.puzzles.load_clvm
 chia.wallet.util.debug_spend_bundle


### PR DESCRIPTION
### Purpose:

Continue shrinking `mypy-exclusions.txt` by enabling strict mypy checking for `chia.ssl.create_ssl`.

### Current Behavior:

The module is excluded for ten annotation-only errors: missing return types, unparameterized certificate maps, and an untyped `main`.

### New Behavior:

Side-effect helpers return `None`, certificate maps are typed as `dict[str, dict[str, dict[str, bytes]]]`, and the module is removed from `mypy-exclusions.txt`.

No runtime behavior changes.

### Testing Notes:

- Repository-wide mypy passes.
- Pre-commit hooks pass.
- Draft PR CI will provide the test signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only changes in SSL cert generation helpers; no logic or security behavior is altered.
> 
> **Overview**
> Enables strict mypy on **`chia.ssl.create_ssl`** by adding missing annotations and removing the module from **`mypy-exclusions.txt`**.
> 
> Side-effect helpers (`write_ssl_cert_and_key`, `ensure_ssl_dirs`, `generate_ca_signed_cert`, `make_ca_cert`, `create_all_ssl`, `generate_ssl_for_nodes`, `main`) now return **`None`**. **`node_certs_and_keys`** is typed as **`dict[str, dict[str, dict[str, bytes]]]`** on **`create_all_ssl`** and **`generate_ssl_for_nodes`**, matching how node → prefix → `crt`/`key` maps are used. There are no intentional runtime or TLS behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c1081b2215ceb4520da73db3593593f8dccd135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->