### PR TITLE
Remove chia.wallet.util.new_peak_queue from mypy exclusions

### DIFF
--- a/chia/wallet/util/new_peak_queue.py
+++ b/chia/wallet/util/new_peak_queue.py
@@ -24,53 +24,53 @@ class NewPeakItem:
     item_type: NewPeakQueueTypes
     data: Any
 
-    def __lt__(self, other):
+    def __lt__(self, other: NewPeakItem) -> bool:
         if self.item_type != other.item_type:
             return self.item_type < other.item_type
         if self.item_type in {NewPeakQueueTypes.COIN_ID_SUBSCRIPTION, NewPeakQueueTypes.PUZZLE_HASH_SUBSCRIPTION}:
             return False  # All subscriptions are equal
-        return self.data[0].height < other.data[0].height
+        return bool(self.data[0].height < other.data[0].height)
 
-    def __le__(self, other):
+    def __le__(self, other: NewPeakItem) -> bool:
         if self.item_type != other.item_type:
             return self.item_type < other.item_type
         if self.item_type in {NewPeakQueueTypes.COIN_ID_SUBSCRIPTION, NewPeakQueueTypes.PUZZLE_HASH_SUBSCRIPTION}:
             return True  # All subscriptions are equal
-        return self.data[0].height <= other.data[0].height
+        return bool(self.data[0].height <= other.data[0].height)
 
-    def __gt__(self, other):
+    def __gt__(self, other: NewPeakItem) -> bool:
         if self.item_type != other.item_type:
             return self.item_type > other.item_type
         if self.item_type in {NewPeakQueueTypes.COIN_ID_SUBSCRIPTION, NewPeakQueueTypes.PUZZLE_HASH_SUBSCRIPTION}:
             return False  # All subscriptions are equal
-        return self.data[0].height > other.data[0].height
+        return bool(self.data[0].height > other.data[0].height)
 
-    def __ge__(self, other):
+    def __ge__(self, other: NewPeakItem) -> bool:
         if self.item_type != other.item_type:
             return self.item_type > other.item_type
         if self.item_type in {NewPeakQueueTypes.COIN_ID_SUBSCRIPTION, NewPeakQueueTypes.PUZZLE_HASH_SUBSCRIPTION}:
             return True  # All subscriptions are equal
-        return self.data[0].height >= other.data[0].height
+        return bool(self.data[0].height >= other.data[0].height)
 
 
 class NewPeakQueue:
-    def __init__(self, inner_queue: asyncio.PriorityQueue):
-        self._inner_queue: asyncio.PriorityQueue = inner_queue
+    def __init__(self, inner_queue: asyncio.PriorityQueue[NewPeakItem]) -> None:
+        self._inner_queue: asyncio.PriorityQueue[NewPeakItem] = inner_queue
         self._pending_data_process_items: int = 0
 
-    async def subscribe_to_coin_ids(self, coin_ids: list[bytes32]):
+    async def subscribe_to_coin_ids(self, coin_ids: list[bytes32]) -> None:
         self._pending_data_process_items += 1
         await self._inner_queue.put(NewPeakItem(NewPeakQueueTypes.COIN_ID_SUBSCRIPTION, coin_ids))
 
-    async def subscribe_to_puzzle_hashes(self, puzzle_hashes: list[bytes32]):
+    async def subscribe_to_puzzle_hashes(self, puzzle_hashes: list[bytes32]) -> None:
         self._pending_data_process_items += 1
         await self._inner_queue.put(NewPeakItem(NewPeakQueueTypes.PUZZLE_HASH_SUBSCRIPTION, puzzle_hashes))
 
-    async def full_node_state_updated(self, coin_state_update: CoinStateUpdate, peer: WSChiaConnection):
+    async def full_node_state_updated(self, coin_state_update: CoinStateUpdate, peer: WSChiaConnection) -> None:
         self._pending_data_process_items += 1
         await self._inner_queue.put(NewPeakItem(NewPeakQueueTypes.FULL_NODE_STATE_UPDATED, (coin_state_update, peer)))
 
-    async def new_peak_wallet(self, new_peak: NewPeakWallet, peer: WSChiaConnection):
+    async def new_peak_wallet(self, new_peak: NewPeakWallet, peer: WSChiaConnection) -> None:
         await self._inner_queue.put(NewPeakItem(NewPeakQueueTypes.NEW_PEAK_WALLET, (new_peak, peer)))
 
     async def get(self) -> NewPeakItem:

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -14,7 +14,6 @@ chia.ssl.create_ssl
 chia.types.blockchain_format.program
 chia.wallet.puzzles.load_clvm
 chia.wallet.util.debug_spend_bundle
-chia.wallet.util.new_peak_queue
 chia.wallet.wallet_coin_store
 chia.wallet.wallet_interested_store
 chia.wallet.wallet_puzzle_store


### PR DESCRIPTION
### Purpose:

Continue shrinking `mypy-exclusions.txt` by enabling strict mypy checking for `chia.wallet.util.new_peak_queue`.

### Current Behavior:

The module is excluded for ten annotation-only errors around comparison methods, unparameterized priority queues, and missing coroutine returns.

### New Behavior:

- Comparison operators take `NewPeakItem` and return `bool`.
- The inner queue is `asyncio.PriorityQueue[NewPeakItem]`.
- Enqueue helpers return `None`.
- The module is removed from `mypy-exclusions.txt`.

No runtime behavior changes.

### Testing Notes:

- Repository-wide mypy passes.
- Pre-commit hooks pass.
- Draft PR CI will provide the test signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing-only edits to wallet peak-queue ordering; no logic, security, or data-path changes.
> 
> **Overview**
> Brings **`chia.wallet.util.new_peak_queue`** under strict mypy by adding annotations only—no intended runtime changes.
> 
> `NewPeakItem` comparison operators now take **`NewPeakItem`** and return **`bool`**, with height-based branches wrapped in **`bool(...)`** for typing. **`NewPeakQueue`** types the inner queue as **`asyncio.PriorityQueue[NewPeakItem]`** and marks async enqueue helpers as returning **`None`**. The module is removed from **`mypy-exclusions.txt`** as part of shrinking the exclusion list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304660e7e3b8693ad2ae94a513fa19c7fccc7e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->