### PR TITLE
Remove chia.plotting.manager from mypy exclusions

### DIFF
--- a/chia/_tests/plotting/test_plot_manager.py
+++ b/chia/_tests/plotting/test_plot_manager.py
@@ -19,8 +19,8 @@ from chia._tests.plotting.util import get_test_plots
 from chia._tests.util.misc import boolean_datacases
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
-from chia.plotting.cache import CURRENT_VERSION, CacheDataV1
-from chia.plotting.manager import Cache, PlotManager
+from chia.plotting.cache import CURRENT_VERSION, Cache, CacheDataV1
+from chia.plotting.manager import PlotManager
 from chia.plotting.prover import V1Prover
 from chia.plotting.util import (
     PlotInfo,

--- a/chia/plotting/manager.py
+++ b/chia/plotting/manager.py
@@ -45,7 +45,7 @@ class PlotManager:
     _lock: threading.Lock
     _refresh_thread: threading.Thread | None
     _refreshing_enabled: bool
-    _refresh_callback: Callable
+    _refresh_callback: Callable[[PlotRefreshEvents, PlotRefreshResult], None]
     _initial: bool
     max_compression_level_allowed: int
     context_count: int
@@ -54,7 +54,7 @@ class PlotManager:
     def __init__(
         self,
         root_path: Path,
-        refresh_callback: Callable,
+        refresh_callback: Callable[[PlotRefreshEvents, PlotRefreshResult], None],
         constants: ConsensusConstants,
         match_str: str | None = None,
         open_no_key_filenames: bool = False,
@@ -87,10 +87,10 @@ class PlotManager:
         self.context_count = 0
         self.constants = constants
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         self._lock.acquire()
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(self, *args: object) -> None:
         self._lock.release()
 
     def configure_decompressor(
@@ -139,10 +139,10 @@ class PlotManager:
             self.no_key_filenames.clear()
             self._initial = True
 
-    def set_refresh_callback(self, callback: Callable):
+    def set_refresh_callback(self, callback: Callable[[PlotRefreshEvents, PlotRefreshResult], None]) -> None:
         self._refresh_callback = callback
 
-    def set_public_keys(self, farmer_public_keys: list[G1Element], pool_public_keys: list[G1Element]):
+    def set_public_keys(self, farmer_public_keys: list[G1Element], pool_public_keys: list[G1Element]) -> None:
         self.farmer_public_keys = farmer_public_keys
         self.pool_public_keys = pool_public_keys
 
@@ -167,7 +167,7 @@ class PlotManager:
     def needs_refresh(self) -> bool:
         return time.time() - self.last_refresh_time > float(self.refresh_parameter.interval_seconds)
 
-    def start_refreshing(self, sleep_interval_ms: int = 1000):
+    def start_refreshing(self, sleep_interval_ms: int = 1000) -> None:
         self._refreshing_enabled = True
         if self._refresh_thread is None or not self._refresh_thread.is_alive():
             self.cache.load()
@@ -184,7 +184,7 @@ class PlotManager:
         log.debug("trigger_refresh")
         self.last_refresh_time = 0
 
-    def _refresh_task(self, sleep_interval_ms: int):
+    def _refresh_task(self, sleep_interval_ms: int) -> None:
         while self._refreshing_enabled:
             try:
                 while not self.needs_refresh() and self._refreshing_enabled:

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -4,7 +4,6 @@ chia.plotters.bladebit
 chia.plotters.madmax
 chia.plotters.plotters
 chia.plotters.plotters_util
-chia.plotting.manager
 chia.plotting.util
 chia.rpc.rpc_client
 chia.simulator.full_node_simulator


### PR DESCRIPTION
### Purpose:

Continue shrinking `mypy-exclusions.txt` by enabling strict mypy checking for `chia.plotting.manager`.

### Current Behavior:

The module is excluded for nine annotation-only errors around unparameterized refresh callbacks and missing return types on lifecycle helpers.

### New Behavior:

- Refresh callbacks are `Callable[[PlotRefreshEvents, PlotRefreshResult], None]`.
- Context-manager and refresh helpers return `None`.
- The plot-manager test imports `Cache` from `chia.plotting.cache` instead of re-exporting it through `manager`.
- The module is removed from `mypy-exclusions.txt`.

No runtime behavior changes.

### Testing Notes:

- Repository-wide mypy passes.
- Pre-commit hooks pass.
- Draft PR CI will provide the test signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only changes to plot refresh typing with no logic or security behavior changes.
> 
> **Overview**
> Brings **`chia.plotting.manager`** under strict mypy by tightening types only—no intended runtime changes.
> 
> **`PlotManager`** now types refresh hooks as `Callable[[PlotRefreshEvents, PlotRefreshResult], None]` on construction, `set_refresh_callback`, and the internal field. Context manager methods and refresh lifecycle helpers (`start_refreshing`, `_refresh_task`, `set_public_keys`, etc.) are annotated to return `None`.
> 
> Plot-manager tests import **`Cache`** from **`chia.plotting.cache`** instead of via **`manager`**. **`chia.plotting.manager`** is removed from **`mypy-exclusions.txt`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e4f141041da35106d590164b4e61c92635b985a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->