### PR TITLE
Remove chia.simulator.keyring from mypy exclusions

### DIFF
--- a/chia/_tests/conftest.py
+++ b/chia/_tests/conftest.py
@@ -1357,13 +1357,13 @@ def database_uri_fixture() -> str:
 
 
 @pytest.fixture(name="empty_temp_file_keyring")
-def empty_temp_file_keyring_fixture() -> Iterator[TempKeyring]:
+def empty_temp_file_keyring_fixture() -> Iterator[Keychain]:
     with TempKeyring(populate=False) as keyring:
         yield keyring
 
 
 @pytest.fixture(name="populated_temp_file_keyring")
-def populated_temp_file_keyring_fixture() -> Iterator[TempKeyring]:
+def populated_temp_file_keyring_fixture() -> Iterator[Keychain]:
     """Populated with a payload containing 0 keys using the default passphrase."""
     with TempKeyring(populate=True) as keyring:
         yield keyring

--- a/chia/simulator/keyring.py
+++ b/chia/simulator/keyring.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 from chia.util.file_keyring import FileKeyring, keyring_path_from_root
@@ -11,7 +12,9 @@ from chia.util.keychain import Keychain
 from chia.util.keyring_wrapper import KeyringWrapper
 
 
-def setup_mock_file_keyring(mock_configure_backend, temp_file_keyring_dir, populate=False):
+def setup_mock_file_keyring(
+    mock_configure_backend: Any, temp_file_keyring_dir: str | Path, populate: bool = False
+) -> None:
     if populate:
         # Populate the file keyring with an empty (but encrypted) data set
         file_keyring_path = keyring_path_from_root(Path(temp_file_keyring_dir))
@@ -54,7 +57,7 @@ class TempKeyring:
             existing_keyring_path=existing_keyring_path,
             use_os_credential_store=use_os_credential_store,
         )
-        self.old_keys_root_path = None
+        self.old_keys_root_path: Path | None = None
         self.delete_on_cleanup = delete_on_cleanup
         self.cleaned_up = False
 
@@ -66,7 +69,7 @@ class TempKeyring:
         populate: bool,
         existing_keyring_path: str | None,
         use_os_credential_store: bool,
-    ):
+    ) -> Keychain:
         existing_keyring_dir = Path(existing_keyring_path).parent if existing_keyring_path else None
         temp_dir = existing_keyring_dir or tempfile.mkdtemp(prefix="test_keyring_wrapper")
 
@@ -92,7 +95,7 @@ class TempKeyring:
 
         return keychain
 
-    def __enter__(self):
+    def __enter__(self) -> Keychain:
         assert not self.cleaned_up
         if KeyringWrapper.get_shared_instance(create_if_necessary=False) is not None:
             self.old_keys_root_path = KeyringWrapper.get_shared_instance().keys_root_path
@@ -101,7 +104,7 @@ class TempKeyring:
         KeyringWrapper.set_keys_root_path(kc.keyring_wrapper.keys_root_path)
         return kc
 
-    def __exit__(self, exc_type, exc_value, exc_tb):
+    def __exit__(self, *args: object) -> None:
         self.cleanup()
 
     def get_keychain(self) -> Keychain:
@@ -114,7 +117,7 @@ class TempKeyring:
 
         if self.delete_on_cleanup:
             self.keychain.keyring_wrapper.keyring.cleanup_keyring_file_watcher()
-            shutil.rmtree(self.keychain._temp_dir)
+            shutil.rmtree(self.keychain._temp_dir)  # type: ignore[attr-defined]
 
         if self.old_keys_root_path is not None:
             if KeyringWrapper.get_shared_instance(create_if_necessary=False) is not None:

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -8,7 +8,6 @@ chia.plotting.manager
 chia.plotting.util
 chia.rpc.rpc_client
 chia.simulator.full_node_simulator
-chia.simulator.keyring
 chia.simulator.wallet_tools
 chia.ssl.create_ssl
 chia.types.blockchain_format.program


### PR DESCRIPTION
### Purpose:

Continue shrinking `mypy-exclusions.txt` by enabling strict mypy checking for `chia.simulator.keyring`.

### Current Behavior:

The module is excluded for seven annotation errors around mock setup, context-manager helpers, and an untyped `Path | None` field.

### New Behavior:

- Mock/file-keyring helpers and context-manager methods are annotated.
- `old_keys_root_path` is typed as `Path | None`.
- The empty/populated temp keyring fixtures declare `Iterator[Keychain]`, matching what `TempKeyring.__enter__` has always returned.
- The module is removed from `mypy-exclusions.txt`.

No runtime behavior changes.

### Testing Notes:

- Repository-wide mypy passes.
- Pre-commit hooks pass.
- Draft PR CI will provide the test signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation and mypy-exclusion cleanup only; test simulator keyring behavior is unchanged.
> 
> **Overview**
> Brings **`chia.simulator.keyring`** under normal mypy by adding type annotations and dropping it from **`mypy-exclusions.txt`**.
> 
> In **`chia/simulator/keyring.py`**, mock setup helpers, **`TempKeyring`** context-manager methods, **`_patch_and_create_keychain`**, and **`old_keys_root_path`** (`Path | None`) are explicitly typed; **`cleanup`** uses a **`type: ignore`** for the dynamic **`_temp_dir`** attribute on **`Keychain`**.
> 
> In **`chia/_tests/conftest.py`**, the **`empty_temp_file_keyring`** and **`populated_temp_file_keyring`** fixtures are annotated as **`Iterator[Keychain]`** instead of **`Iterator[TempKeyring]`**, matching what **`TempKeyring.__enter__`** returns.
> 
> No runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108adefbd9103f458a39360b66346fa09ca4a053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->