### PR TITLE
Update Managed Files

### DIFF
--- a/.github/workflows/dependency-cursor-review.yml
+++ b/.github/workflows/dependency-cursor-review.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   dependency-review:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'))
+    if: github.repository_owner == 'Chia-Network' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]')))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -766,7 +766,6 @@ jobs:
           fi
 
       - name: Run Cursor analysis
-        if: github.repository_owner == 'Chia-Network'
         timeout-minutes: 10
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> GitHub Actions guardrails only; no application runtime or auth logic changes.
> 
> **Overview**
> The **Dependency Cursor Review** workflow now runs only when `github.repository_owner == 'Chia-Network'`, in addition to the existing Dependabot/Renovate and dispatch rules.
> 
> That org check moved from the **Run Cursor analysis** step to the **dependency-review** job `if`, so the whole job is skipped outside the org and the duplicate step condition was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98c6621e483e5439499e78d988e97494ee7eda0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->