### PR TITLE
[CHIA-4271] Improve error handling when adding block batches

### DIFF
--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -20,8 +20,13 @@ from chia.protocols.shared_protocol import Capability
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
 from chia.simulator.block_tools import BlockTools
+from chia.types.blockchain_format.coin import Coin
+from chia.types.condition_opcodes import ConditionOpcode
+from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.peer_info import PeerInfo
+from chia.util.casts import int_to_bytes
 from chia.util.hash import std_hash
+from chia.util.recursive_replace import recursive_replace
 
 log = logging.getLogger(__name__)
 
@@ -234,7 +239,7 @@ async def test_short_sync_batch_returns_false_on_disconnected_first_block(
     blocks = bt.get_consecutive_blocks(2)
     disconnected_block = blocks[-1]  # height > 0 and its parent is not in node's database
 
-    class _FakePeer:
+    class DummyPeer:
         peer_node_id = bytes32(b"\x01" * 32)
 
         def get_peer_logging(self) -> PeerInfo:
@@ -245,10 +250,82 @@ async def test_short_sync_batch_returns_false_on_disconnected_first_block(
         ) -> full_node_protocol.RespondBlocks:
             return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [disconnected_block])
 
-    peer = cast(WSChiaConnection, _FakePeer())
+    peer = cast(WSChiaConnection, DummyPeer())
     # start_height == 0 skips the fork-point probe, exercising the batch loop's parent check directly.
     result = await node.short_sync_batch(peer, uint32(0), uint32(1))
     assert result is False
+    assert peer.peer_node_id not in node.sync_store.batch_syncing
+
+
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
+@pytest.mark.anyio
+async def test_short_sync_batch_post_processes_committed_prefix_before_failure(
+    two_nodes: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
+    consensus_mode: ConsensusMode,
+) -> None:
+    # A RespondBlocks batch with a valid hinted TX block followed by an invalid
+    # successor must still persist hints for the committed prefix before raising.
+    _full_node_1, full_node_2, _server_1, _server_2, bt = two_nodes
+    node = full_node_2.full_node
+
+    blocks = bt.get_consecutive_blocks(
+        5,
+        guarantee_transaction_block=True,
+        farmer_reward_puzzle_hash=bt.pool_ph,
+    )
+    for block in blocks:
+        await node.add_block(block)
+
+    wt = bt.get_pool_wallet_tool()
+    puzzle_hash = bytes32(32 * b"\0")
+    hint = bytes32(32 * b"\5")
+    amount = int_to_bytes(1)
+    coin_spent = next(c for c in blocks[-1].get_included_reward_coins() if c.puzzle_hash == bt.pool_ph)
+    tx = wt.generate_signed_transaction(
+        uint64(10),
+        wt.get_new_puzzlehash(),
+        coin_spent,
+        condition_dic={
+            ConditionOpcode.CREATE_COIN: [ConditionWithArgs(ConditionOpcode.CREATE_COIN, [puzzle_hash, amount, hint])]
+        },
+    )
+    blocks = bt.get_consecutive_blocks(
+        1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
+    )
+    tx_block = blocks[-1]
+    hinted_coin_id = Coin(coin_spent.name(), puzzle_hash, uint64(1)).name()
+
+    blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
+    bad_block = recursive_replace(
+        blocks[-1],
+        "reward_chain_block.proof_of_space.proof",
+        bytes([0] * 32),
+    )
+
+    class DummyPeer:
+        peer_node_id = bytes32(b"\x02" * 32)
+
+        def get_peer_logging(self) -> PeerInfo:
+            return PeerInfo("127.0.0.1", uint16(0))
+
+        async def call_api(
+            self, api_function: Any, request: object
+        ) -> full_node_protocol.RespondBlock | full_node_protocol.RespondBlocks:
+            if isinstance(request, full_node_protocol.RequestBlock):
+                return full_node_protocol.RespondBlock(tx_block)
+            assert isinstance(request, full_node_protocol.RequestBlocks)
+            return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [tx_block, bad_block])
+
+    peer = cast(WSChiaConnection, DummyPeer())
+    assert await node.hint_store.get_coin_ids(hint) == []
+
+    with pytest.raises(ValueError, match="failed to validate blocks after height"):
+        await node.short_sync_batch(peer, tx_block.height, bad_block.height)
+
+    assert await node.hint_store.get_coin_ids(hint) == [hinted_coin_id]
+    peak = node.blockchain.get_peak()
+    assert peak is not None
+    assert peak.header_hash == tx_block.header_hash
     assert peer.peer_node_id not in node.sync_store.batch_syncing
 
 

--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -329,6 +329,55 @@ async def test_short_sync_batch_post_processes_committed_prefix_before_failure(
     assert peer.peer_node_id not in node.sync_store.batch_syncing
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
+@pytest.mark.anyio
+async def test_short_sync_batch_raises_when_no_blocks_committed(
+    two_nodes: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
+    consensus_mode: ConsensusMode,
+) -> None:
+    # A batch whose first block is invalid commits nothing. short_sync_batch must
+    # still raise (without the "after height" prefix-failure wording) and leave the peak alone.
+    _full_node_1, full_node_2, _server_1, _server_2, bt = two_nodes
+    node = full_node_2.full_node
+
+    blocks = bt.get_consecutive_blocks(3)
+    for block in blocks:
+        await node.add_block(block)
+    peak_before = node.blockchain.get_peak()
+    assert peak_before is not None
+
+    blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
+    bad_block = recursive_replace(
+        blocks[-1],
+        "reward_chain_block.proof_of_space.proof",
+        bytes([0] * 32),
+    )
+
+    class DummyPeer:
+        peer_node_id = bytes32(b"\x03" * 32)
+
+        def get_peer_logging(self) -> PeerInfo:
+            return PeerInfo("127.0.0.1", uint16(0))
+
+        async def call_api(
+            self, api_function: Any, request: object
+        ) -> full_node_protocol.RespondBlock | full_node_protocol.RespondBlocks:
+            if isinstance(request, full_node_protocol.RequestBlock):
+                return full_node_protocol.RespondBlock(bad_block)
+            assert isinstance(request, full_node_protocol.RequestBlocks)
+            return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [bad_block])
+
+    peer = cast(WSChiaConnection, DummyPeer())
+    # target must be > start so the batch loop runs; end_height becomes start+1.
+    with pytest.raises(ValueError, match=rf"failed to validate blocks {bad_block.height}-{bad_block.height + 1}$"):
+        await node.short_sync_batch(peer, bad_block.height, uint32(bad_block.height + 1))
+
+    peak = node.blockchain.get_peak()
+    assert peak is not None
+    assert peak.header_hash == peak_before.header_hash
+    assert peer.peer_node_id not in node.sync_store.batch_syncing
+
+
 @pytest.mark.anyio
 async def test_backtrack_sync_1(
     two_nodes: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools], self_hostname: str

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3375,6 +3375,81 @@ async def test_sync_from_fork_point_logs_validate_stage_exception(
     assert peer.closed
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
+@pytest.mark.anyio
+async def test_sync_from_fork_point_adds_hints_for_committed_prefix(
+    one_node: SimulatorsAndWalletsServices,
+    monkeypatch: pytest.MonkeyPatch,
+    consensus_mode: ConsensusMode,
+) -> None:
+    # A long-sync batch with a valid hinted TX block followed by an invalid successor
+    # must still persist hints for the committed prefix before aborting.
+    [full_node_service], _, bt = one_node
+    full_node = full_node_service._node
+
+    blocks = bt.get_consecutive_blocks(
+        5,
+        guarantee_transaction_block=True,
+        farmer_reward_puzzle_hash=bt.pool_ph,
+    )
+    wt = bt.get_pool_wallet_tool()
+    puzzle_hash = bytes32(32 * b"\0")
+    hint = bytes32(32 * b"\5")
+    amount = int_to_bytes(1)
+    coin_spent = find_reward_coin(blocks[-1], bt.pool_ph)
+    tx = wt.generate_signed_transaction(
+        uint64(10),
+        wt.get_new_puzzlehash(),
+        coin_spent,
+        condition_dic={
+            ConditionOpcode.CREATE_COIN: [ConditionWithArgs(ConditionOpcode.CREATE_COIN, [puzzle_hash, amount, hint])]
+        },
+    )
+    blocks = bt.get_consecutive_blocks(
+        1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
+    )
+    tx_block = blocks[-1]
+    hinted_coin_id = Coin(coin_spent.name(), puzzle_hash, uint64(1)).name()
+
+    blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
+    bad_block = recursive_replace(
+        blocks[-1],
+        "reward_chain_block.proof_of_space.proof",
+        bytes([0] * 32),
+    )
+    peer_blocks = [*blocks[:-1], bad_block]
+
+    class DummyPeer:
+        def __init__(self, chain: list[FullBlock]) -> None:
+            self.closed = False
+            self.peer_info = PeerInfo("127.0.0.1", uint16(8444))
+            self._blocks = chain
+
+        async def call_api(self, *args: object, **kwargs: object) -> full_node_protocol.RespondBlocks:
+            request = args[1]
+            assert isinstance(request, full_node_protocol.RequestBlocks)
+            batch = [b for b in self._blocks if request.start_height <= b.height <= request.end_height]
+            return full_node_protocol.RespondBlocks(request.start_height, request.end_height, batch)
+
+        async def close(self, *args: object, **kwargs: object) -> None:
+            self.closed = True
+
+    peer = DummyPeer(peer_blocks)
+    monkeypatch.setattr(full_node, "get_peers_with_peak", lambda _peak_hash: [peer])
+
+    assert await full_node.hint_store.get_coin_ids(hint) == []
+    await asyncio.wait_for(
+        full_node.sync_from_fork_point(uint32(0), bad_block.height, bad_block.header_hash, []),
+        timeout=60,
+    )
+
+    assert await full_node.hint_store.get_coin_ids(hint) == [hinted_coin_id]
+    peak = full_node.blockchain.get_peak()
+    assert peak is not None
+    assert peak.header_hash == tx_block.header_hash
+    assert peer.closed
+
+
 @pytest.mark.anyio
 async def test_wallet_sync_task_failure_before_receiving_update_logs_error(
     caplog: pytest.LogCaptureFixture,

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -694,8 +694,6 @@ class FullNode:
                     success, state_change_summary = await self.add_block_batch(
                         response.blocks, peer_info, fork_info, vs, blockchain
                     )
-                    if not success:
-                        raise ValueError(f"Error short batch syncing, failed to validate blocks {height}-{end_height}")
                     if state_change_summary is not None:
                         try:
                             peak_fb: FullBlock | None = await self.blockchain.get_full_peak()
@@ -712,10 +710,18 @@ class FullNode:
                             await self.peak_post_processing(peak_fb, state_change_summary, peer)
                             raise
                         finally:
-                            self.log.info(f"Added blocks {height}-{end_height}")
+                            # Log the committed prefix only; a failed suffix is not ingested.
+                            self.log.info(f"Added blocks {height}-{state_change_summary.peak.height}")
                 if state_change_summary is not None and peak_fb is not None:
                     # Call outside of priority_mutex to encourage concurrency
                     await self.peak_post_processing_2(peak_fb, peer, state_change_summary, ppp_result)
+                if not success:
+                    if state_change_summary is not None:
+                        raise ValueError(
+                            f"Error short batch syncing, failed to validate blocks after height "
+                            f"{state_change_summary.peak.height} (batch {height}-{end_height})"
+                        )
+                    raise ValueError(f"Error short batch syncing, failed to validate blocks {height}-{end_height}")
         finally:
             self.sync_store.batch_syncing.remove(peer.peer_node_id)
         return True
@@ -1454,8 +1460,29 @@ class FullNode:
                 peer.peer_info,
                 vs,
             )
+            peak: BlockRecord | None = self.blockchain.get_peak()
+            if state_change_summary is not None:
+                assert peak is not None
+                # Hints must be added to the DB. The other post-processing tasks are not required when syncing.
+                # A failed batch can still have committed a valid prefix, whose hints must not be dropped.
+                hints_to_add, _ = get_hints_and_subscription_coin_ids(
+                    state_change_summary,
+                    self.subscriptions.has_coin_subscription,
+                    self.subscriptions.has_puzzle_subscription,
+                )
+                await self.hint_store.add_hints(hints_to_add)
             if err is not None:
                 await peer.close(CONSENSUS_ERROR_BAN_SECONDS)
+                if state_change_summary is not None:
+                    committed_end = state_change_summary.peak.height
+                    self.log.info(
+                        f"Added blocks {start_height} to {committed_end} "
+                        f"({block_rate:.3g} blocks/s) (from: {peer.peer_info.ip})"
+                    )
+                    raise ValueError(
+                        f"Failed to validate block batch after height {committed_end} "
+                        f"(batch {start_height}-{end_height}): {err}"
+                    )
                 raise ValueError(f"Failed to validate block batch {start_height} to {end_height}: {err}")
             if end_height - block_rate_height > 100:
                 now = time.monotonic()
@@ -1463,19 +1490,11 @@ class FullNode:
                 block_rate_time = now
                 block_rate_height = end_height
 
+            committed_end = state_change_summary.peak.height if state_change_summary is not None else end_height
             self.log.info(
-                f"Added blocks {start_height} to {end_height} ({block_rate:.3g} blocks/s) (from: {peer.peer_info.ip})"
+                f"Added blocks {start_height} to {committed_end} "
+                f"({block_rate:.3g} blocks/s) (from: {peer.peer_info.ip})"
             )
-            peak: BlockRecord | None = self.blockchain.get_peak()
-            if state_change_summary is not None:
-                assert peak is not None
-                # Hints must be added to the DB. The other post-processing tasks are not required when syncing
-                hints_to_add, _ = get_hints_and_subscription_coin_ids(
-                    state_change_summary,
-                    self.subscriptions.has_coin_subscription,
-                    self.subscriptions.has_puzzle_subscription,
-                )
-                await self.hint_store.add_hints(hints_to_add)
             # Note that end_height is not necessarily the peak at this
             # point. In case of a re-org, it may even be significantly
             # higher than _peak_height, and still not be the peak.


### PR DESCRIPTION
### Purpose:

Improve handling when a block batch fails after some blocks have already been accepted.

### Current Behavior:

Batch failure can skip follow-up handling for blocks that were already accepted.

### New Behavior:

Accepted blocks in a partially failed batch receive follow-up handling before the failure is reported.

### Testing Notes:

Added coverage for short-sync and long-sync batch failure paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core sync ingestion paths for short and long batch sync, but changes are narrowly scoped to partial-failure ordering and hint persistence, with dedicated integration tests.
> 
> **Overview**
> When **short batch sync** or **long sync from a fork point** accepts some blocks in a batch but validation fails on a later block, the node no longer abandons follow-up for the committed prefix.
> 
> In **`short_sync_batch`**, peak post-processing (including hints via the existing path) runs when `add_block_batch` returns a partial `state_change_summary` before raising. Errors distinguish a failed suffix (**after height** *N*) from a batch where nothing was committed. Progress logs report only the committed height range.
> 
> In **`sync_from_fork_point`**, **`hint_store.add_hints`** is invoked as soon as there is a `state_change_summary`, **before** handling validation errors, so hinted coins from valid prefix TX blocks are not dropped when the rest of the batch is invalid. Failure logging and `ValueError` messages use the committed end height when applicable.
> 
> Tests cover short-sync partial commit (hints + peak), short-sync with zero commits, and fork-point long sync with a valid hinted block followed by an invalid one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6cfbac33a3cd9ee2ed868ff2d0719146f609d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->