### PR TITLE
CHIA-4330 Annotate wallet_puzzle_store.py

### DIFF
--- a/chia/_tests/wallet/test_puzzle_store.py
+++ b/chia/_tests/wallet/test_puzzle_store.py
@@ -74,7 +74,7 @@ async def test_puzzle_store(seeded_random: random.Random) -> None:
         assert len(await db.get_all_puzzle_hashes()) == 0
         assert await db.get_last_derivation_path() is None
         assert await db.get_unused_derivation_path() is None
-        assert await db.get_derivation_record(0, 2, False) is None
+        assert await db.get_derivation_record(uint32(0), uint32(2), False) is None
 
         await db.add_derivation_paths(derivation_recs)
 
@@ -89,10 +89,10 @@ async def test_puzzle_store(seeded_random: random.Random) -> None:
         assert len(await db.get_all_puzzle_hashes()) == 2000
         assert await db.get_last_derivation_path() == 999
         assert await db.get_unused_derivation_path() == 0
-        assert await db.get_derivation_record(0, 2, False) == derivation_recs[1]
+        assert await db.get_derivation_record(uint32(0), uint32(2), False) == derivation_recs[1]
 
-        # Indeces up to 250
-        await db.set_used_up_to(249)
+        # Indices up to 250
+        await db.set_used_up_to(uint32(249))
 
         assert await db.get_unused_derivation_path() == 250
 
@@ -122,7 +122,7 @@ async def test_delete_wallet(seeded_random: random.Random) -> None:
                 )
                 assert await db.get_last_derivation_path_for_wallet(wallet_id) is not None
             # Remove the wallet_id and make sure its removed fully
-            await db.delete_wallet(wallet_id)
+            await db.delete_wallet(uint32(wallet_id))
             for record in records:
                 assert await db.get_derivation_record(record.index, record.wallet_id, record.hardened) is None
                 assert await db.get_wallet_identifier_for_puzzle_hash(record.puzzle_hash) is None

--- a/chia/wallet/wallet_puzzle_store.py
+++ b/chia/wallet/wallet_puzzle_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from sqlite3 import Row
 
 from chia_rs import G1Element
 from chia_rs.sized_bytes import bytes32
@@ -24,13 +25,13 @@ class WalletPuzzleStore:
 
     lock: asyncio.Lock
     db_wrapper: DBWrapper2
-    wallet_identifier_cache: LRUCache
+    wallet_identifier_cache: LRUCache[bytes32, WalletIdentifier]
     # maps wallet_id -> last_derivation_index
     last_wallet_derivation_index: dict[uint32, uint32]
     last_derivation_index: uint32 | None
 
     @classmethod
-    async def create(cls, db_wrapper: DBWrapper2):
+    async def create(cls, db_wrapper: DBWrapper2) -> WalletPuzzleStore:
         self = cls()
         self.db_wrapper = db_wrapper
         async with self.db_wrapper.writer_maybe_transaction() as conn:
@@ -170,7 +171,7 @@ class WalletPuzzleStore:
 
         return row is not None
 
-    def row_to_record(self, row) -> DerivationRecord:
+    def row_to_record(self, row: Row) -> DerivationRecord:
         return DerivationRecord(
             uint32(row[0]),
             bytes32.fromhex(row[2]),

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -16,7 +16,6 @@ chia.wallet.puzzles.load_clvm
 chia.wallet.util.debug_spend_bundle
 chia.wallet.util.new_peak_queue
 chia.wallet.wallet_interested_store
-chia.wallet.wallet_puzzle_store
 chia.wallet.wallet_transaction_store
 chia._tests.clvm.test_puzzles
 chia._tests.clvm.test_singletons


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Annotation and test-call updates only; no intended runtime behavior change in wallet puzzle persistence.
> 
> **Overview**
> Adds static typing to **`WalletPuzzleStore`** so mypy can check it: generic **`LRUCache[bytes32, WalletIdentifier]`**, **`create` → WalletPuzzleStore**, and **`row_to_record(row: Row)`** (with **`sqlite3.Row`** import).
> 
> **`chia.wallet.wallet_puzzle_store`** is removed from **`mypy-exclusions.txt`**.
> 
> Wallet puzzle store tests now pass **`uint32(...)`** where the store API expects **`uint32`** (e.g. **`get_derivation_record`**, **`set_used_up_to`**, **`delete_wallet`**), and a comment typo is fixed (**Indices**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2997800674eb79a2b6b08556502709302c8fdcd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->