### PR TITLE
[CHIA-4276] Block validation fast fail

### DIFF
--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -2616,6 +2616,65 @@ class TestBodyValidation:
         await _validate_and_add_block(b, block_2, expected_error=Err.INVALID_TRANSACTIONS_GENERATOR_HASH)
 
     @pytest.mark.anyio
+    async def test_prevalidation_fast_fail_mutated_generator(
+        self, empty_blockchain: Blockchain, bt: BlockTools, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Adversarial fast-fail: a peer can take a valid block, keep all
+        # farmed/signed header fields and commitments intact, and swap only
+        # transactions_generator for malicious CLVM. Prevalidation must reject
+        # this with the cheap generator_root hash check
+        # (INVALID_TRANSACTIONS_GENERATOR_HASH) BEFORE executing the generator,
+        # so the expensive CLVM run is never performed for the bad block. This
+        # mirrors the unfinished-block path, which already gates CLVM on these
+        # commitments.
+        b = empty_blockchain
+        blocks = bt.get_consecutive_blocks(2, guarantee_transaction_block=True)
+        await _validate_and_add_block(b, blocks[0])
+        await _validate_and_add_block(b, blocks[1])
+        blocks = bt.get_consecutive_blocks(
+            2,
+            block_list_input=blocks,
+            guarantee_transaction_block=True,
+            farmer_reward_puzzle_hash=bt.pool_ph,
+        )
+        await _validate_and_add_block(b, blocks[2])
+        await _validate_and_add_block(b, blocks[3])
+
+        wt: WalletTool = bt.get_pool_wallet_tool()
+        coin = find_reward_coin(blocks[-1], bt.pool_ph)
+        tx = wt.generate_signed_transaction(uint64(10), wt.get_new_puzzlehash(), coin)
+        blocks = bt.get_consecutive_blocks(
+            1, block_list_input=blocks, guarantee_transaction_block=True, transaction_data=tx
+        )
+        block: FullBlock = blocks[-1]
+        assert block.transactions_generator is not None
+
+        # Swap only the generator bytes; leave transactions_info.generator_root
+        # and all foliage/signatures pointing at the original generator. This
+        # is the attack: commitments unchanged, generator replaced (the peer
+        # cannot re-sign without the plot key).
+        malicious_generator = SerializedProgram.fromhex("80")
+        mutated = recursive_replace(block, "transactions_generator", malicious_generator)
+        # Sanity: the swap actually breaks the commitment.
+        assert std_hash(bytes(mutated.transactions_generator)) != mutated.transactions_info.generator_root
+
+        # Trap _run_block: if the generator is executed, raise. _pre_validate_block's
+        # outer try/except would convert that into UNKNOWN, so observing
+        # INVALID_TRANSACTIONS_GENERATOR_HASH instead proves CLVM did not run.
+        clvm_calls = 0
+
+        def _trap_run_block(*args: object, **kwargs: object) -> None:
+            nonlocal clvm_calls
+            clvm_calls += 1
+            raise AssertionError("CLVM generator execution must not run for a mutated generator")
+
+        monkeypatch.setattr("chia.consensus.multiprocess_validation._run_block", _trap_run_block)
+
+        await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_TRANSACTIONS_GENERATOR_HASH)
+
+        assert clvm_calls == 0
+
+    @pytest.mark.anyio
     async def test_invalid_transactions_ref_list(
         self, empty_blockchain: Blockchain, bt: BlockTools, consensus_mode: ConsensusMode
     ) -> None:

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -2674,6 +2674,18 @@ class TestBodyValidation:
 
         assert clvm_calls == 0
 
+        # Removing the foliage transaction block must not bypass the
+        # transactions-info commitment. Make the replacement generator and its
+        # direct root self-consistent; the missing signed link must still reject
+        # the block before CLVM execution.
+        mutated = recursive_replace(block, "transactions_generator", malicious_generator)
+        mutated = recursive_replace(mutated, "transactions_info.generator_root", std_hash(bytes(malicious_generator)))
+        mutated = recursive_replace(mutated, "foliage_transaction_block", None)
+
+        await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_TRANSACTIONS_INFO_HASH)
+
+        assert clvm_calls == 0
+
     @pytest.mark.anyio
     async def test_invalid_transactions_ref_list(
         self, empty_blockchain: Blockchain, bt: BlockTools, consensus_mode: ConsensusMode

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -2674,6 +2674,14 @@ class TestBodyValidation:
 
         assert clvm_calls == 0
 
+        # Missing transactions_info must be reported as an invalid block rather
+        # than escaping prevalidation as an AssertionError.
+        mutated = recursive_replace(block, "transactions_info", None)
+
+        await _validate_and_add_block(b, mutated, expected_error=Err.IS_TRANSACTION_BLOCK_BUT_NO_DATA)
+
+        assert clvm_calls == 0
+
         # Removing the foliage transaction block must not bypass the
         # transactions-info commitment. Make the replacement generator and its
         # direct root self-consistent; the missing signed link must still reject
@@ -2747,7 +2755,7 @@ class TestBodyValidation:
             # after the hard fork activation, we no longer allow block references
             expected_error = Err.TOO_MANY_GENERATOR_REFS
 
-        await _validate_and_add_block(b, block_2, expected_error=expected_error, skip_prevalidation=True)
+        await _validate_and_add_block(b, block_2, expected_error=expected_error)
 
         # Hash should be correct when there is a ref list
         await _validate_and_add_block(b, blocks[-1])

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -2617,7 +2617,11 @@ class TestBodyValidation:
 
     @pytest.mark.anyio
     async def test_prevalidation_fast_fail_mutated_generator(
-        self, empty_blockchain: Blockchain, bt: BlockTools, monkeypatch: pytest.MonkeyPatch
+        self,
+        empty_blockchain: Blockchain,
+        bt: BlockTools,
+        monkeypatch: pytest.MonkeyPatch,
+        consensus_mode: ConsensusMode,
     ) -> None:
         # Adversarial fast-fail: a peer can take a valid block, keep all
         # farmed/signed header fields and commitments intact, and swap only
@@ -2674,6 +2678,16 @@ class TestBodyValidation:
 
         assert clvm_calls == 0
 
+        mutated = recursive_replace(
+            block, "foliage_transaction_block.transactions_info_hash", std_hash(b"invalid transactions info")
+        )
+        await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_TRANSACTIONS_INFO_HASH)
+
+        mutated = recursive_replace(
+            block, "foliage.foliage_transaction_block_hash", std_hash(b"invalid foliage transaction block")
+        )
+        await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_FOLIAGE_BLOCK_HASH)
+
         # Removing the foliage transaction block must not bypass the
         # transactions-info commitment. Make the replacement generator and its
         # direct root self-consistent; the missing signed link must still reject
@@ -2684,6 +2698,58 @@ class TestBodyValidation:
 
         await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_TRANSACTIONS_INFO_HASH)
 
+        assert clvm_calls == 0
+
+        mutated = recursive_replace(block, "transactions_info.generator_refs_root", bytes([0] * 32))
+        await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT)
+
+        future_ref = block.height
+        mutated = recursive_replace(block, "transactions_generator_ref_list", [future_ref])
+        mutated = recursive_replace(
+            mutated, "transactions_info.generator_refs_root", std_hash(future_ref.stream_to_bytes())
+        )
+        expected_ref_error = (
+            Err.FUTURE_GENERATOR_REFS if consensus_mode < ConsensusMode.SOFT_FORK_2_7 else Err.TOO_MANY_GENERATOR_REFS
+        )
+        await _validate_and_add_block(b, mutated, expected_error=expected_ref_error)
+
+        if consensus_mode >= ConsensusMode.SOFT_FORK_2_7:
+            noncanonical_generator = SerializedProgram.fromhex("c00101")
+            mutated = recursive_replace(block, "transactions_generator", noncanonical_generator)
+            mutated = recursive_replace(
+                mutated, "transactions_info.generator_root", std_hash(bytes(noncanonical_generator))
+            )
+            mutated = recursive_replace(
+                mutated,
+                "foliage_transaction_block.transactions_info_hash",
+                std_hash(bytes(mutated.transactions_info)),
+            )
+            mutated = recursive_replace(
+                mutated,
+                "foliage.foliage_transaction_block_hash",
+                std_hash(bytes(mutated.foliage_transaction_block)),
+            )
+            await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_TRANSACTIONS_GENERATOR_ENCODING)
+
+        # Reject structurally invalid reference lists before attempting any
+        # generator lookup.
+        generator_lookups = 0
+
+        async def _trap_generator_lookup(*args: object, **kwargs: object) -> None:
+            nonlocal generator_lookups
+            generator_lookups += 1
+            raise AssertionError("generator lookup must not run for too many references")
+
+        monkeypatch.setattr(AugmentedBlockchain, "lookup_block_generators", _trap_generator_lookup)
+        mutated = recursive_replace(
+            block,
+            "transactions_generator_ref_list",
+            [uint32(0)] * (b.constants.MAX_GENERATOR_REF_LIST_SIZE + 1),
+        )
+
+        await _validate_and_add_block(b, mutated, expected_error=Err.TOO_MANY_GENERATOR_REFS)
+
+        assert generator_lookups == 0
         assert clvm_calls == 0
 
     @pytest.mark.anyio

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -2616,7 +2616,7 @@ class TestBodyValidation:
         await _validate_and_add_block(b, block_2, expected_error=Err.INVALID_TRANSACTIONS_GENERATOR_HASH)
 
     @pytest.mark.anyio
-    async def test_prevalidation_fast_fail_mutated_generator(
+    async def test_prevalidation_fast_fail(
         self, empty_blockchain: Blockchain, bt: BlockTools, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Adversarial fast-fail: a peer can take a valid block, keep all
@@ -2661,26 +2661,18 @@ class TestBodyValidation:
         # Trap _run_block: if the generator is executed, raise. _pre_validate_block's
         # outer try/except would convert that into UNKNOWN, so observing
         # INVALID_TRANSACTIONS_GENERATOR_HASH instead proves CLVM did not run.
-        clvm_calls = 0
-
         def _trap_run_block(*args: object, **kwargs: object) -> None:
-            nonlocal clvm_calls
-            clvm_calls += 1
             raise AssertionError("CLVM generator execution must not run for a mutated generator")
 
         monkeypatch.setattr("chia.consensus.multiprocess_validation._run_block", _trap_run_block)
 
         await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_TRANSACTIONS_GENERATOR_HASH)
 
-        assert clvm_calls == 0
-
         # Missing transactions_info must be reported as an invalid block rather
         # than escaping prevalidation as an AssertionError.
         mutated = recursive_replace(block, "transactions_info", None)
 
         await _validate_and_add_block(b, mutated, expected_error=Err.IS_TRANSACTION_BLOCK_BUT_NO_DATA)
-
-        assert clvm_calls == 0
 
         # Removing the foliage transaction block must not bypass the
         # transactions-info commitment. Make the replacement generator and its
@@ -2692,15 +2684,9 @@ class TestBodyValidation:
 
         await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_TRANSACTIONS_INFO_HASH)
 
-        assert clvm_calls == 0
-
         # Reject structurally invalid reference lists before attempting any
         # generator lookup.
-        generator_lookups = 0
-
         async def _trap_generator_lookup(*args: object, **kwargs: object) -> None:
-            nonlocal generator_lookups
-            generator_lookups += 1
             raise AssertionError("generator lookup must not run for too many references")
 
         monkeypatch.setattr(AugmentedBlockchain, "lookup_block_generators", _trap_generator_lookup)
@@ -2712,8 +2698,24 @@ class TestBodyValidation:
 
         await _validate_and_add_block(b, mutated, expected_error=Err.TOO_MANY_GENERATOR_REFS)
 
-        assert generator_lookups == 0
-        assert clvm_calls == 0
+        # A failed generator resolution must not leave the candidate block in
+        # the speculative chain.
+        augmented_blockchain = AugmentedBlockchain(b)
+
+        async def _fail_generator_resolution(*args: object, **kwargs: object) -> None:
+            assert augmented_blockchain.try_block_record(block.header_hash) is None
+            raise ValueError("generator reference is unavailable")
+
+        monkeypatch.setattr("chia.consensus.multiprocess_validation.get_block_generator", _fail_generator_resolution)
+
+        await _validate_and_add_block(
+            b,
+            block,
+            expected_error=Err.FAILED_GETTING_GENERATOR_MULTIPROCESSING,
+            augmented_blockchain=augmented_blockchain,
+        )
+
+        assert augmented_blockchain.try_block_record(block.header_hash) is None
 
     @pytest.mark.anyio
     async def test_invalid_transactions_ref_list(

--- a/chia/_tests/blockchain/test_blockchain.py
+++ b/chia/_tests/blockchain/test_blockchain.py
@@ -2617,11 +2617,7 @@ class TestBodyValidation:
 
     @pytest.mark.anyio
     async def test_prevalidation_fast_fail_mutated_generator(
-        self,
-        empty_blockchain: Blockchain,
-        bt: BlockTools,
-        monkeypatch: pytest.MonkeyPatch,
-        consensus_mode: ConsensusMode,
+        self, empty_blockchain: Blockchain, bt: BlockTools, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Adversarial fast-fail: a peer can take a valid block, keep all
         # farmed/signed header fields and commitments intact, and swap only
@@ -2678,16 +2674,6 @@ class TestBodyValidation:
 
         assert clvm_calls == 0
 
-        mutated = recursive_replace(
-            block, "foliage_transaction_block.transactions_info_hash", std_hash(b"invalid transactions info")
-        )
-        await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_TRANSACTIONS_INFO_HASH)
-
-        mutated = recursive_replace(
-            block, "foliage.foliage_transaction_block_hash", std_hash(b"invalid foliage transaction block")
-        )
-        await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_FOLIAGE_BLOCK_HASH)
-
         # Removing the foliage transaction block must not bypass the
         # transactions-info commitment. Make the replacement generator and its
         # direct root self-consistent; the missing signed link must still reject
@@ -2699,37 +2685,6 @@ class TestBodyValidation:
         await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_TRANSACTIONS_INFO_HASH)
 
         assert clvm_calls == 0
-
-        mutated = recursive_replace(block, "transactions_info.generator_refs_root", bytes([0] * 32))
-        await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT)
-
-        future_ref = block.height
-        mutated = recursive_replace(block, "transactions_generator_ref_list", [future_ref])
-        mutated = recursive_replace(
-            mutated, "transactions_info.generator_refs_root", std_hash(future_ref.stream_to_bytes())
-        )
-        expected_ref_error = (
-            Err.FUTURE_GENERATOR_REFS if consensus_mode < ConsensusMode.SOFT_FORK_2_7 else Err.TOO_MANY_GENERATOR_REFS
-        )
-        await _validate_and_add_block(b, mutated, expected_error=expected_ref_error)
-
-        if consensus_mode >= ConsensusMode.SOFT_FORK_2_7:
-            noncanonical_generator = SerializedProgram.fromhex("c00101")
-            mutated = recursive_replace(block, "transactions_generator", noncanonical_generator)
-            mutated = recursive_replace(
-                mutated, "transactions_info.generator_root", std_hash(bytes(noncanonical_generator))
-            )
-            mutated = recursive_replace(
-                mutated,
-                "foliage_transaction_block.transactions_info_hash",
-                std_hash(bytes(mutated.transactions_info)),
-            )
-            mutated = recursive_replace(
-                mutated,
-                "foliage.foliage_transaction_block_hash",
-                std_hash(bytes(mutated.foliage_transaction_block)),
-            )
-            await _validate_and_add_block(b, mutated, expected_error=Err.INVALID_TRANSACTIONS_GENERATOR_ENCODING)
 
         # Reject structurally invalid reference lists before attempting any
         # generator lookup.

--- a/chia/_tests/wallet/conftest.py
+++ b/chia/_tests/wallet/conftest.py
@@ -25,6 +25,7 @@ from chia._tests.wallet.wallet_block_tools import WalletBlockTools
 from chia.full_node.full_node import FullNode
 from chia.full_node.full_node_rpc_client import FullNodeRpcClient
 from chia.types.peer_info import PeerInfo
+from chia.util.errors import Err
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG, TXConfig
 from chia.wallet.wallet_node import Balance
 from chia.wallet.wallet_rpc_client import WalletRpcClient
@@ -84,7 +85,7 @@ async def ignore_block_validation(
 
     def run_block(
         block: FullBlock, prev_generators: list[bytes], prev_tx_height: uint32, constants: ConsensusConstants
-    ) -> tuple[int | None, str | None, SpendBundleConditions | None]:
+    ) -> tuple[Err | None, str | None, SpendBundleConditions | None]:
         assert block.transactions_generator is not None
         assert block.transactions_info is not None
         flags = get_flags_for_height_and_constants(prev_tx_height, constants) | DONT_VALIDATE_SIGNATURE
@@ -104,7 +105,7 @@ async def ignore_block_validation(
         # pretend that the signatures are OK
         if conds is not None:
             conds = conds.replace(validated_signature=True)
-        return err, err_msg, conds
+        return None if err is None else Err(err), err_msg, conds
 
     monkeypatch.setattr("chia.simulator.block_tools.BlockTools", WalletBlockTools)
     monkeypatch.setattr(FullNode, "create", create_wrapper(FullNode.create))

--- a/chia/_tests/wallet/conftest.py
+++ b/chia/_tests/wallet/conftest.py
@@ -109,6 +109,7 @@ async def ignore_block_validation(
     monkeypatch.setattr("chia.simulator.block_tools.BlockTools", WalletBlockTools)
     monkeypatch.setattr(FullNode, "create", create_wrapper(FullNode.create))
     monkeypatch.setattr("chia.consensus.blockchain.validate_block_body", validate_block_body)
+    monkeypatch.setattr("chia.consensus.multiprocess_validation.validate_generator_ref_list", lambda *_, **__: None)
     monkeypatch.setattr("chia.consensus.multiprocess_validation._run_block", run_block)
     monkeypatch.setattr(
         "chia.consensus.block_header_validation.validate_unfinished_header_block", lambda *_, **__: (uint64(1), None)

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -29,6 +29,35 @@ from chia.util.hash import std_hash
 
 log = logging.getLogger(__name__)
 
+
+def validate_generator_ref_list(
+    constants: ConsensusConstants,
+    block: FullBlock | UnfinishedBlock,
+    height: uint32,
+    prev_transaction_block_height: uint32,
+) -> Err | None:
+    assert block.transactions_info is not None
+
+    if block.transactions_generator_ref_list == []:
+        if block.transactions_info.generator_refs_root != bytes([1] * 32):
+            return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
+        return None
+
+    if prev_transaction_block_height >= constants.SOFT_FORK9_HEIGHT:
+        return Err.TOO_MANY_GENERATOR_REFS
+    if block.transactions_generator is None:
+        return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
+    if len(block.transactions_generator_ref_list) > constants.MAX_GENERATOR_REF_LIST_SIZE:
+        return Err.TOO_MANY_GENERATOR_REFS
+    generator_refs_hash = std_hash(b"".join(i.stream_to_bytes() for i in block.transactions_generator_ref_list))
+    if block.transactions_info.generator_refs_root != generator_refs_hash:
+        return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
+    if any(index >= height for index in block.transactions_generator_ref_list):
+        return Err.FUTURE_GENERATOR_REFS
+
+    return None
+
+
 #  peak->  o
 #  main    |
 #  chain   o  o <- peak_height  \ additions and removals
@@ -352,26 +381,9 @@ async def validate_block_body(
     #     the generator ref list for this block (or 'one' bytes [0x01] if no generator)
     # 8b. The generator ref list length must be less than or equal to MAX_GENERATOR_REF_LIST_SIZE entries
     # 8c. The generator ref list must not point to a height >= this block's height
-    if block.transactions_generator_ref_list == []:
-        if block.transactions_info.generator_refs_root != bytes([1] * 32):
-            return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
-    else:
-        # With hard fork 2 we ban transactions_generator_ref_list.
-        if prev_transaction_block_height >= constants.SOFT_FORK9_HEIGHT:
-            return Err.TOO_MANY_GENERATOR_REFS
-
-        # If we have a generator reference list, we must have a generator
-        if block.transactions_generator is None:
-            return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
-
-        # The generator_refs_root must be the hash of the concatenation of the list[uint32]
-        generator_refs_hash = std_hash(b"".join([i.stream_to_bytes() for i in block.transactions_generator_ref_list]))
-        if block.transactions_info.generator_refs_root != generator_refs_hash:
-            return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
-        if len(block.transactions_generator_ref_list) > constants.MAX_GENERATOR_REF_LIST_SIZE:
-            return Err.TOO_MANY_GENERATOR_REFS
-        if any([index >= height for index in block.transactions_generator_ref_list]):
-            return Err.FUTURE_GENERATOR_REFS
+    generator_ref_error = validate_generator_ref_list(constants, block, height, prev_transaction_block_height)
+    if generator_ref_error is not None:
+        return generator_ref_error
 
     if block.transactions_generator is not None:
         # Get List of names removed, puzzles hashes for removed coins and conditions created

--- a/chia/consensus/block_body_validation.py
+++ b/chia/consensus/block_body_validation.py
@@ -23,41 +23,12 @@ from chiabip158 import PyBIP158
 from chia.consensus.block_rewards import calculate_base_farmer_reward, calculate_pool_reward
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.coinbase import create_farmer_coin, create_pool_coin
+from chia.consensus.generator_validation import validate_generator_ref_list
 from chia.types.blockchain_format.coin import Coin, hash_coin_ids
 from chia.util.errors import Err
 from chia.util.hash import std_hash
 
 log = logging.getLogger(__name__)
-
-
-def validate_generator_ref_list(
-    constants: ConsensusConstants,
-    block: FullBlock | UnfinishedBlock,
-    height: uint32,
-    prev_transaction_block_height: uint32,
-) -> Err | None:
-    assert block.transactions_info is not None
-
-    if block.transactions_generator_ref_list == []:
-        if block.transactions_info.generator_refs_root != bytes([1] * 32):
-            return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
-        return None
-
-    if prev_transaction_block_height >= constants.SOFT_FORK9_HEIGHT:
-        return Err.TOO_MANY_GENERATOR_REFS
-    if block.transactions_generator is None:
-        return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
-    if len(block.transactions_generator_ref_list) > constants.MAX_GENERATOR_REF_LIST_SIZE:
-        return Err.TOO_MANY_GENERATOR_REFS
-    generator_refs_hash = std_hash(b"".join(i.stream_to_bytes() for i in block.transactions_generator_ref_list))
-    if block.transactions_info.generator_refs_root != generator_refs_hash:
-        return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
-    if any(index >= height for index in block.transactions_generator_ref_list):
-        return Err.FUTURE_GENERATOR_REFS
-
-    return None
-
-
 #  peak->  o
 #  main    |
 #  chain   o  o <- peak_height  \ additions and removals

--- a/chia/consensus/generator_validation.py
+++ b/chia/consensus/generator_validation.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from chia_rs import ConsensusConstants, FullBlock, UnfinishedBlock
+from chia_rs.sized_ints import uint32
+
+from chia.util.errors import Err
+from chia.util.hash import std_hash
+
+
+def validate_generator_ref_list(
+    constants: ConsensusConstants,
+    block: FullBlock | UnfinishedBlock,
+    height: uint32,
+    prev_transaction_block_height: uint32,
+) -> Err | None:
+    assert block.transactions_info is not None
+
+    if block.transactions_generator_ref_list == []:
+        if block.transactions_info.generator_refs_root != bytes([1] * 32):
+            return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
+        return None
+
+    if prev_transaction_block_height >= constants.SOFT_FORK9_HEIGHT:
+        return Err.TOO_MANY_GENERATOR_REFS
+    if block.transactions_generator is None:
+        return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
+    if len(block.transactions_generator_ref_list) > constants.MAX_GENERATOR_REF_LIST_SIZE:
+        return Err.TOO_MANY_GENERATOR_REFS
+    generator_refs_hash = std_hash(b"".join(i.stream_to_bytes() for i in block.transactions_generator_ref_list))
+    if block.transactions_info.generator_refs_root != generator_refs_hash:
+        return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
+    if any(index >= height for index in block.transactions_generator_ref_list):
+        return Err.FUTURE_GENERATOR_REFS
+
+    return None

--- a/chia/consensus/generator_validation.py
+++ b/chia/consensus/generator_validation.py
@@ -15,7 +15,8 @@ def validate_generator_ref_list(
 ) -> Err | None:
     assert block.transactions_info is not None
 
-    if block.transactions_generator_ref_list == []:
+    generator_refs = block.transactions_generator_ref_list
+    if not generator_refs:
         if block.transactions_info.generator_refs_root != bytes([1] * 32):
             return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
         return None
@@ -24,12 +25,12 @@ def validate_generator_ref_list(
         return Err.TOO_MANY_GENERATOR_REFS
     if block.transactions_generator is None:
         return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
-    if len(block.transactions_generator_ref_list) > constants.MAX_GENERATOR_REF_LIST_SIZE:
+    if len(generator_refs) > constants.MAX_GENERATOR_REF_LIST_SIZE:
         return Err.TOO_MANY_GENERATOR_REFS
-    generator_refs_hash = std_hash(b"".join(i.stream_to_bytes() for i in block.transactions_generator_ref_list))
+    generator_refs_hash = std_hash(b"".join(i.stream_to_bytes() for i in generator_refs))
     if block.transactions_info.generator_refs_root != generator_refs_hash:
         return Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT
-    if any(index >= height for index in block.transactions_generator_ref_list):
+    if any(index >= height for index in generator_refs):
         return Err.FUTURE_GENERATOR_REFS
 
     return None

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -282,8 +282,15 @@ async def pre_validate_block(
     if required_iters is None:
         return return_error(Err.INVALID_POSPACE)
 
-    if block.transactions_generator is not None:
-        assert block.transactions_info is not None
+    if block.transactions_info is None:
+        if block.transactions_generator is not None or block.transactions_generator_ref_list:
+            error = (
+                Err.IS_TRANSACTION_BLOCK_BUT_NO_DATA
+                if block.foliage.foliage_transaction_block_hash is not None
+                else Err.NOT_BLOCK_BUT_HAS_DATA
+            )
+            return return_error(error)
+    else:
         generator_ref_error = validate_generator_ref_list(constants, block, block.height, prev_tx_height)
         if generator_ref_error is not None:
             return return_error(generator_ref_error)
@@ -308,7 +315,6 @@ async def pre_validate_block(
             return return_error(Err.INVALID_SUB_EPOCH_SUMMARY)
 
     blockchain.add_extra_block(block, block_rec)  # Temporarily add block to chain
-    prev_b = block_rec
 
     previous_generators: list[bytes] | None = None
 

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -138,21 +138,29 @@ def _pre_validate_block(
                     None,
                     uint32(validation_time * 1000),
                 )
-            if block.foliage_transaction_block is not None:
-                if block.foliage_transaction_block.transactions_info_hash != std_hash(block.transactions_info):
-                    validation_time = time.monotonic() - validation_start
-                    return PreValidationResult(
-                        uint16(Err.INVALID_TRANSACTIONS_INFO_HASH.value),
-                        None,
-                        None,
-                        None,
-                        uint32(validation_time * 1000),
-                    )
-                if block.foliage.foliage_transaction_block_hash != std_hash(block.foliage_transaction_block):
-                    validation_time = time.monotonic() - validation_start
-                    return PreValidationResult(
-                        uint16(Err.INVALID_FOLIAGE_BLOCK_HASH.value), None, None, None, uint32(validation_time * 1000)
-                    )
+            if block.foliage_transaction_block is None:
+                validation_time = time.monotonic() - validation_start
+                return PreValidationResult(
+                    uint16(Err.INVALID_TRANSACTIONS_INFO_HASH.value),
+                    None,
+                    None,
+                    None,
+                    uint32(validation_time * 1000),
+                )
+            if block.foliage_transaction_block.transactions_info_hash != std_hash(block.transactions_info):
+                validation_time = time.monotonic() - validation_start
+                return PreValidationResult(
+                    uint16(Err.INVALID_TRANSACTIONS_INFO_HASH.value),
+                    None,
+                    None,
+                    None,
+                    uint32(validation_time * 1000),
+                )
+            if block.foliage.foliage_transaction_block_hash != std_hash(block.foliage_transaction_block):
+                validation_time = time.monotonic() - validation_start
+                return PreValidationResult(
+                    uint16(Err.INVALID_FOLIAGE_BLOCK_HASH.value), None, None, None, uint32(validation_time * 1000)
+                )
 
             prev_tx_height = pre_sp_tx_block_height(
                 constants=constants,

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -13,6 +13,7 @@ from chia_rs import (
     SpendBundleConditions,
     SubEpochSummary,
     get_flags_for_height_and_constants,
+    is_canonical_serialization,
     run_block_generator,
     run_block_generator2,
 )
@@ -39,6 +40,7 @@ from chia.types.blockchain_format.coin import Coin
 from chia.types.generator_types import BlockGenerator
 from chia.types.validation_state import ValidationState
 from chia.util.errors import Err
+from chia.util.hash import std_hash
 from chia.util.priority_thread_pool_executor import Executor, _SupportsLessThan
 from chia.util.streamable import Streamable, streamable
 
@@ -123,6 +125,35 @@ def _pre_validate_block(
                     uint16(Err.BLOCK_COST_EXCEEDS_MAX.value), None, None, None, uint32(validation_time * 1000)
                 )
 
+            # Fast-fail: prove the generator is the committed one before
+            # executing it. A peer can keep all farmed/signed header fields
+            # intact and swap only transactions_generator; these cheap hash
+            # checks reject that before the expensive CLVM run.
+            if std_hash(bytes(block.transactions_generator)) != block.transactions_info.generator_root:
+                validation_time = time.monotonic() - validation_start
+                return PreValidationResult(
+                    uint16(Err.INVALID_TRANSACTIONS_GENERATOR_HASH.value),
+                    None,
+                    None,
+                    None,
+                    uint32(validation_time * 1000),
+                )
+            if block.foliage_transaction_block is not None:
+                if block.foliage_transaction_block.transactions_info_hash != std_hash(block.transactions_info):
+                    validation_time = time.monotonic() - validation_start
+                    return PreValidationResult(
+                        uint16(Err.INVALID_TRANSACTIONS_INFO_HASH.value),
+                        None,
+                        None,
+                        None,
+                        uint32(validation_time * 1000),
+                    )
+                if block.foliage.foliage_transaction_block_hash != std_hash(block.foliage_transaction_block):
+                    validation_time = time.monotonic() - validation_start
+                    return PreValidationResult(
+                        uint16(Err.INVALID_FOLIAGE_BLOCK_HASH.value), None, None, None, uint32(validation_time * 1000)
+                    )
+
             prev_tx_height = pre_sp_tx_block_height(
                 constants=constants,
                 blocks=blockchain,
@@ -130,6 +161,73 @@ def _pre_validate_block(
                 sp_index=block.reward_chain_block.signage_point_index,
                 finished_sub_slots=len(block.finished_sub_slots),
             )
+
+            # More CLVM-independent gates (see validate_block_body). These need
+            # only prev_tx_height and the block itself, so they can run before
+            # the generator is executed.
+            if block.transactions_generator_ref_list == []:
+                if block.transactions_info.generator_refs_root != bytes([1] * 32):
+                    validation_time = time.monotonic() - validation_start
+                    return PreValidationResult(
+                        uint16(Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT.value),
+                        None,
+                        None,
+                        None,
+                        uint32(validation_time * 1000),
+                    )
+            else:
+                # With hard fork 2 we ban transactions_generator_ref_list.
+                if prev_tx_height >= constants.SOFT_FORK9_HEIGHT:
+                    validation_time = time.monotonic() - validation_start
+                    return PreValidationResult(
+                        uint16(Err.TOO_MANY_GENERATOR_REFS.value),
+                        None,
+                        None,
+                        None,
+                        uint32(validation_time * 1000),
+                    )
+                generator_refs_hash = std_hash(
+                    b"".join([i.stream_to_bytes() for i in block.transactions_generator_ref_list])
+                )
+                if block.transactions_info.generator_refs_root != generator_refs_hash:
+                    validation_time = time.monotonic() - validation_start
+                    return PreValidationResult(
+                        uint16(Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT.value),
+                        None,
+                        None,
+                        None,
+                        uint32(validation_time * 1000),
+                    )
+                if len(block.transactions_generator_ref_list) > constants.MAX_GENERATOR_REF_LIST_SIZE:
+                    validation_time = time.monotonic() - validation_start
+                    return PreValidationResult(
+                        uint16(Err.TOO_MANY_GENERATOR_REFS.value),
+                        None,
+                        None,
+                        None,
+                        uint32(validation_time * 1000),
+                    )
+                if any([index >= block.height for index in block.transactions_generator_ref_list]):
+                    validation_time = time.monotonic() - validation_start
+                    return PreValidationResult(
+                        uint16(Err.FUTURE_GENERATOR_REFS.value),
+                        None,
+                        None,
+                        None,
+                        uint32(validation_time * 1000),
+                    )
+
+            if prev_tx_height >= constants.SOFT_FORK9_HEIGHT:
+                if not is_canonical_serialization(bytes(block.transactions_generator)):
+                    validation_time = time.monotonic() - validation_start
+                    return PreValidationResult(
+                        uint16(Err.INVALID_TRANSACTIONS_GENERATOR_ENCODING.value),
+                        None,
+                        None,
+                        None,
+                        uint32(validation_time * 1000),
+                    )
+
             err, err_msg, conds = _run_block(block, prev_generators, prev_tx_height, constants)
 
             assert (err is None) != (conds is None)

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -21,6 +21,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint16, uint32, uint64
 
 from chia.consensus.augmented_chain import AugmentedBlockchain
+from chia.consensus.block_body_validation import validate_generator_ref_list
 from chia.consensus.block_header_validation import validate_finished_header_block
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
@@ -170,61 +171,6 @@ def _pre_validate_block(
                 finished_sub_slots=len(block.finished_sub_slots),
             )
 
-            # More CLVM-independent gates (see validate_block_body). These need
-            # only prev_tx_height and the block itself, so they can run before
-            # the generator is executed.
-            if block.transactions_generator_ref_list == []:
-                if block.transactions_info.generator_refs_root != bytes([1] * 32):
-                    validation_time = time.monotonic() - validation_start
-                    return PreValidationResult(
-                        uint16(Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT.value),
-                        None,
-                        None,
-                        None,
-                        uint32(validation_time * 1000),
-                    )
-            else:
-                # With hard fork 2 we ban transactions_generator_ref_list.
-                if prev_tx_height >= constants.SOFT_FORK9_HEIGHT:
-                    validation_time = time.monotonic() - validation_start
-                    return PreValidationResult(
-                        uint16(Err.TOO_MANY_GENERATOR_REFS.value),
-                        None,
-                        None,
-                        None,
-                        uint32(validation_time * 1000),
-                    )
-                generator_refs_hash = std_hash(
-                    b"".join([i.stream_to_bytes() for i in block.transactions_generator_ref_list])
-                )
-                if block.transactions_info.generator_refs_root != generator_refs_hash:
-                    validation_time = time.monotonic() - validation_start
-                    return PreValidationResult(
-                        uint16(Err.INVALID_TRANSACTIONS_GENERATOR_REFS_ROOT.value),
-                        None,
-                        None,
-                        None,
-                        uint32(validation_time * 1000),
-                    )
-                if len(block.transactions_generator_ref_list) > constants.MAX_GENERATOR_REF_LIST_SIZE:
-                    validation_time = time.monotonic() - validation_start
-                    return PreValidationResult(
-                        uint16(Err.TOO_MANY_GENERATOR_REFS.value),
-                        None,
-                        None,
-                        None,
-                        uint32(validation_time * 1000),
-                    )
-                if any([index >= block.height for index in block.transactions_generator_ref_list]):
-                    validation_time = time.monotonic() - validation_start
-                    return PreValidationResult(
-                        uint16(Err.FUTURE_GENERATOR_REFS.value),
-                        None,
-                        None,
-                        None,
-                        uint32(validation_time * 1000),
-                    )
-
             if prev_tx_height >= constants.SOFT_FORK9_HEIGHT:
                 if not is_canonical_serialization(bytes(block.transactions_generator)):
                     validation_time = time.monotonic() - validation_start
@@ -354,6 +300,13 @@ async def pre_validate_block(
             block.reward_chain_block.signage_point_index,
         )
 
+    prev_tx_height = pre_sp_tx_block_height(
+        constants=constants,
+        blocks=blockchain,
+        prev_b_hash=block.prev_header_hash,
+        sp_index=block.reward_chain_block.signage_point_index,
+        finished_sub_slots=len(block.finished_sub_slots),
+    )
     required_iters = validate_pospace_and_get_required_iters(
         constants,
         block.reward_chain_block.proof_of_space,
@@ -361,18 +314,18 @@ async def pre_validate_block(
         cc_sp_hash,
         block.height,
         expected_vs.difficulty,
-        pre_sp_tx_block_height(
-            constants=constants,
-            blocks=blockchain,
-            prev_b_hash=block.prev_header_hash,
-            sp_index=block.reward_chain_block.signage_point_index,
-            finished_sub_slots=len(block.finished_sub_slots),
-        ),
+        prev_tx_height,
         filter_challenge=filter_challenge,
         signage_point_index=block.reward_chain_block.signage_point_index,
     )
     if required_iters is None:
         return return_error(Err.INVALID_POSPACE)
+
+    if block.transactions_generator is not None:
+        assert block.transactions_info is not None
+        generator_ref_error = validate_generator_ref_list(constants, block, block.height, prev_tx_height)
+        if generator_ref_error is not None:
+            return return_error(generator_ref_error)
 
     try:
         block_rec = block_to_block_record(

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -92,6 +92,7 @@ def _pre_validate_block(
     block: FullBlock,
     prev_generators: list[bytes] | None,
     conds: SpendBundleConditions | None,
+    prev_tx_height: uint32,
     expected_vs: ValidationState,
     *,
     skip_commitment_validation: bool = False,
@@ -103,14 +104,20 @@ def _pre_validate_block(
         block:
         prev_generators:
         conds:
+        prev_tx_height:
         expected_vs: The validation state that we calculate for the next block
             if it's validated.
         skip_commitment_validation: If True, skips validation of MMR roots (for weight proofs without full history).
             Challenge merkle tree validation is gated by HARD_FORK2_HEIGHT, not this flag.
     """
 
+    validation_start = time.monotonic()
+
+    def error_result(error_code: int, error_msg: str | None = None) -> PreValidationResult:
+        validation_time = time.monotonic() - validation_start
+        return PreValidationResult(uint16(error_code), error_msg, None, None, uint32(validation_time * 1000))
+
     try:
-        validation_start = time.monotonic()
         removals_and_additions: tuple[Collection[bytes32], Collection[Coin]] | None = None
         if conds is not None:
             assert conds.validated_signature is True
@@ -121,73 +128,30 @@ def _pre_validate_block(
             assert block.transactions_info is not None
 
             if block.transactions_info.cost > constants.MAX_BLOCK_COST_CLVM:
-                validation_time = time.monotonic() - validation_start
-                return PreValidationResult(
-                    uint16(Err.BLOCK_COST_EXCEEDS_MAX.value), None, None, None, uint32(validation_time * 1000)
-                )
+                return error_result(Err.BLOCK_COST_EXCEEDS_MAX.value)
 
             # Fast-fail: prove the generator is the committed one before
             # executing it. A peer can keep all farmed/signed header fields
             # intact and swap only transactions_generator; these cheap hash
             # checks reject that before the expensive CLVM run.
             if std_hash(bytes(block.transactions_generator)) != block.transactions_info.generator_root:
-                validation_time = time.monotonic() - validation_start
-                return PreValidationResult(
-                    uint16(Err.INVALID_TRANSACTIONS_GENERATOR_HASH.value),
-                    None,
-                    None,
-                    None,
-                    uint32(validation_time * 1000),
-                )
+                return error_result(Err.INVALID_TRANSACTIONS_GENERATOR_HASH.value)
             if block.foliage_transaction_block is None:
-                validation_time = time.monotonic() - validation_start
-                return PreValidationResult(
-                    uint16(Err.INVALID_TRANSACTIONS_INFO_HASH.value),
-                    None,
-                    None,
-                    None,
-                    uint32(validation_time * 1000),
-                )
+                return error_result(Err.INVALID_TRANSACTIONS_INFO_HASH.value)
             if block.foliage_transaction_block.transactions_info_hash != std_hash(block.transactions_info):
-                validation_time = time.monotonic() - validation_start
-                return PreValidationResult(
-                    uint16(Err.INVALID_TRANSACTIONS_INFO_HASH.value),
-                    None,
-                    None,
-                    None,
-                    uint32(validation_time * 1000),
-                )
+                return error_result(Err.INVALID_TRANSACTIONS_INFO_HASH.value)
             if block.foliage.foliage_transaction_block_hash != std_hash(block.foliage_transaction_block):
-                validation_time = time.monotonic() - validation_start
-                return PreValidationResult(
-                    uint16(Err.INVALID_FOLIAGE_BLOCK_HASH.value), None, None, None, uint32(validation_time * 1000)
-                )
-
-            prev_tx_height = pre_sp_tx_block_height(
-                constants=constants,
-                blocks=blockchain,
-                prev_b_hash=block.prev_header_hash,
-                sp_index=block.reward_chain_block.signage_point_index,
-                finished_sub_slots=len(block.finished_sub_slots),
-            )
+                return error_result(Err.INVALID_FOLIAGE_BLOCK_HASH.value)
 
             if prev_tx_height >= constants.SOFT_FORK9_HEIGHT:
                 if not is_canonical_serialization(bytes(block.transactions_generator)):
-                    validation_time = time.monotonic() - validation_start
-                    return PreValidationResult(
-                        uint16(Err.INVALID_TRANSACTIONS_GENERATOR_ENCODING.value),
-                        None,
-                        None,
-                        None,
-                        uint32(validation_time * 1000),
-                    )
+                    return error_result(Err.INVALID_TRANSACTIONS_GENERATOR_ENCODING.value)
 
             err, err_msg, conds = _run_block(block, prev_generators, prev_tx_height, constants)
 
             assert (err is None) != (conds is None)
             if err is not None:
-                validation_time = time.monotonic() - validation_start
-                return PreValidationResult(uint16(err), err_msg, None, None, uint32(validation_time * 1000))
+                return error_result(err, err_msg)
             assert conds is not None
             assert conds.validated_signature is True
             removals_and_additions = tx_removals_and_additions(conds)
@@ -204,9 +168,7 @@ def _pre_validate_block(
             expected_vs,
             skip_commitment_validation=skip_commitment_validation,
         )
-        error_int: uint16 | None = None
-        if error is not None:
-            error_int = uint16(error.code.value)
+        error_int = None if error is None else uint16(error.code.value)
 
         validation_time = time.monotonic() - validation_start
         return PreValidationResult(
@@ -219,8 +181,7 @@ def _pre_validate_block(
     except Exception:
         error_stack = traceback.format_exc()
         log.error(f"Exception: {error_stack}")
-        validation_time = time.monotonic() - validation_start
-        return PreValidationResult(uint16(Err.UNKNOWN.value), None, None, None, uint32(validation_time * 1000))
+        return error_result(Err.UNKNOWN.value)
 
 
 async def pre_validate_block(
@@ -367,6 +328,7 @@ async def pre_validate_block(
         block,
         previous_generators,
         conds,
+        prev_tx_height,
         expected_vs,
         skip_commitment_validation=skip_commitment_validation,
         nice=nice,

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -21,12 +21,12 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint16, uint32, uint64
 
 from chia.consensus.augmented_chain import AugmentedBlockchain
-from chia.consensus.block_body_validation import validate_generator_ref_list
 from chia.consensus.block_header_validation import validate_finished_header_block
 from chia.consensus.blockchain_interface import BlockRecordsProtocol
 from chia.consensus.difficulty_adjustment import get_next_sub_slot_iters_and_difficulty
 from chia.consensus.full_block_to_block_record import block_to_block_record
 from chia.consensus.generator_tools import get_block_header, tx_removals_and_additions
+from chia.consensus.generator_validation import validate_generator_ref_list
 from chia.consensus.get_block_challenge import (
     get_block_challenge,
     get_filter_challenge_from_chain,

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -130,14 +130,15 @@ def _pre_validate_block(
             if block.transactions_info.cost > constants.MAX_BLOCK_COST_CLVM:
                 return error_result(Err.BLOCK_COST_EXCEEDS_MAX.value)
 
+            if block.foliage_transaction_block is None:
+                return error_result(Err.INVALID_TRANSACTIONS_INFO_HASH.value)
+
             # Fast-fail: prove the generator is the committed one before
             # executing it. A peer can keep all farmed/signed header fields
             # intact and swap only transactions_generator; these cheap hash
             # checks reject that before the expensive CLVM run.
             if std_hash(bytes(block.transactions_generator)) != block.transactions_info.generator_root:
                 return error_result(Err.INVALID_TRANSACTIONS_GENERATOR_HASH.value)
-            if block.foliage_transaction_block is None:
-                return error_result(Err.INVALID_TRANSACTIONS_INFO_HASH.value)
             if block.foliage_transaction_block.transactions_info_hash != std_hash(block.transactions_info):
                 return error_result(Err.INVALID_TRANSACTIONS_INFO_HASH.value)
             if block.foliage.foliage_transaction_block_hash != std_hash(block.foliage_transaction_block):
@@ -314,8 +315,6 @@ async def pre_validate_block(
             log.error("sub_epoch_summary does not match wp sub_epoch_summary list")
             return return_error(Err.INVALID_SUB_EPOCH_SUMMARY)
 
-    blockchain.add_extra_block(block, block_rec)  # Temporarily add block to chain
-
     previous_generators: list[bytes] | None = None
 
     try:
@@ -325,6 +324,7 @@ async def pre_validate_block(
     except ValueError:
         return return_error(Err.FAILED_GETTING_GENERATOR_MULTIPROCESSING)
 
+    blockchain.add_extra_block(block, block_rec)  # Temporarily add block to chain
     readonly_blockchain = blockchain.read_only_snapshot()
 
     future = pool.run_in_loop(

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -67,7 +67,7 @@ class PreValidationResult(Streamable):
 # this layer of abstraction is here to let wallet tests monkeypatch it
 def _run_block(
     block: FullBlock, prev_generators: list[bytes], prev_tx_height: uint32, constants: ConsensusConstants
-) -> tuple[int | None, str | None, SpendBundleConditions | None]:
+) -> tuple[Err | None, str | None, SpendBundleConditions | None]:
     assert block.transactions_generator is not None
     assert block.transactions_info is not None
     flags = get_flags_for_height_and_constants(prev_tx_height, constants)
@@ -75,7 +75,7 @@ def _run_block(
         run_block = run_block_generator2
     else:
         run_block = run_block_generator
-    return run_block(
+    error, error_msg, conds = run_block(
         bytes(block.transactions_generator),
         prev_generators,
         block.transactions_info.cost,
@@ -84,6 +84,7 @@ def _run_block(
         None,
         constants,
     )
+    return None if error is None else Err(error), error_msg, conds
 
 
 def _pre_validate_block(
@@ -113,9 +114,9 @@ def _pre_validate_block(
 
     validation_start = time.monotonic()
 
-    def error_result(error_code: int, error_msg: str | None = None) -> PreValidationResult:
+    def error_result(error: Err, error_msg: str | None = None) -> PreValidationResult:
         validation_time = time.monotonic() - validation_start
-        return PreValidationResult(uint16(error_code), error_msg, None, None, uint32(validation_time * 1000))
+        return PreValidationResult(uint16(error.value), error_msg, None, None, uint32(validation_time * 1000))
 
     try:
         removals_and_additions: tuple[Collection[bytes32], Collection[Coin]] | None = None
@@ -128,25 +129,25 @@ def _pre_validate_block(
             assert block.transactions_info is not None
 
             if block.transactions_info.cost > constants.MAX_BLOCK_COST_CLVM:
-                return error_result(Err.BLOCK_COST_EXCEEDS_MAX.value)
+                return error_result(Err.BLOCK_COST_EXCEEDS_MAX)
 
             if block.foliage_transaction_block is None:
-                return error_result(Err.INVALID_TRANSACTIONS_INFO_HASH.value)
+                return error_result(Err.INVALID_TRANSACTIONS_INFO_HASH)
 
             # Fast-fail: prove the generator is the committed one before
             # executing it. A peer can keep all farmed/signed header fields
             # intact and swap only transactions_generator; these cheap hash
             # checks reject that before the expensive CLVM run.
             if std_hash(bytes(block.transactions_generator)) != block.transactions_info.generator_root:
-                return error_result(Err.INVALID_TRANSACTIONS_GENERATOR_HASH.value)
+                return error_result(Err.INVALID_TRANSACTIONS_GENERATOR_HASH)
             if block.foliage_transaction_block.transactions_info_hash != std_hash(block.transactions_info):
-                return error_result(Err.INVALID_TRANSACTIONS_INFO_HASH.value)
+                return error_result(Err.INVALID_TRANSACTIONS_INFO_HASH)
             if block.foliage.foliage_transaction_block_hash != std_hash(block.foliage_transaction_block):
-                return error_result(Err.INVALID_FOLIAGE_BLOCK_HASH.value)
+                return error_result(Err.INVALID_FOLIAGE_BLOCK_HASH)
 
             if prev_tx_height >= constants.SOFT_FORK9_HEIGHT:
                 if not is_canonical_serialization(bytes(block.transactions_generator)):
-                    return error_result(Err.INVALID_TRANSACTIONS_GENERATOR_ENCODING.value)
+                    return error_result(Err.INVALID_TRANSACTIONS_GENERATOR_ENCODING)
 
             err, err_msg, conds = _run_block(block, prev_generators, prev_tx_height, constants)
 
@@ -182,7 +183,7 @@ def _pre_validate_block(
     except Exception:
         error_stack = traceback.format_exc()
         log.error(f"Exception: {error_stack}")
-        return error_result(Err.UNKNOWN.value)
+        return error_result(Err.UNKNOWN)
 
 
 async def pre_validate_block(

--- a/chia/consensus/multiprocess_validation.py
+++ b/chia/consensus/multiprocess_validation.py
@@ -140,9 +140,9 @@ def _pre_validate_block(
             # checks reject that before the expensive CLVM run.
             if std_hash(bytes(block.transactions_generator)) != block.transactions_info.generator_root:
                 return error_result(Err.INVALID_TRANSACTIONS_GENERATOR_HASH)
-            if block.foliage_transaction_block.transactions_info_hash != std_hash(block.transactions_info):
+            if block.foliage_transaction_block.transactions_info_hash != block.transactions_info.get_hash():
                 return error_result(Err.INVALID_TRANSACTIONS_INFO_HASH)
-            if block.foliage.foliage_transaction_block_hash != std_hash(block.foliage_transaction_block):
+            if block.foliage.foliage_transaction_block_hash != block.foliage_transaction_block.get_hash():
                 return error_result(Err.INVALID_FOLIAGE_BLOCK_HASH)
 
             if prev_tx_height >= constants.SOFT_FORK9_HEIGHT:


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

Reject malformed transaction generators and generator references during prevalidation, before expensive CLVM execution or speculative-chain mutation. This reduces resource consumption from adversarial blocks during long sync and ensures malformed peer input returns normal validation errors so the peer can be handled appropriately.

<!-- Does this PR introduce a breaking change? -->

No.

### Current Behavior:

Long-sync prevalidation can execute a transaction generator before confirming that it matches the block's commitments. Generator-reference validation occurs later during body validation, malformed generator shapes can escape through assertions, and failed generator resolution can leave the candidate block in the speculative validation overlay.

### New Behavior:

Prevalidation now:

- verifies generator, transaction-info, and foliage commitments before CLVM execution;
- validates generator-reference roots, limits, heights, and hard-fork restrictions before generator lookup;
- returns structured validation errors for malformed generator fields;
- reuses the pre-signage-point transaction-block height across validation stages; and
- resolves referenced generators before adding the candidate to the speculative chain.

Generator-reference checks are shared with block-body validation to avoid rule drift. Wallet tests retain their intentional simplified-block validation bypass.

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

Added regression coverage confirming that malformed generators fail before CLVM execution, malformed reference lists fail before generator lookup, missing transaction data returns validation errors, and failed generator resolution does not mutate the speculative chain.

Locally verified with:

- `tools/pytest -q chia/_tests/blockchain/test_blockchain.py::TestBodyValidation::test_prevalidation_fast_fail`
- `tools/pytest -q chia/_tests/blockchain/test_blockchain.py::TestBodyValidation::test_invalid_transactions_ref_list`
- `tools/pytest -q 'chia/_tests/cmds/test_cmd_framework.py::test_wallet_rpc_helper[ConsensusMode.PLAIN-True-False-wallet_environments0]'`

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus validation order and shared generator-ref rules on the sync hot path; intended behavior matches existing body checks but mis-ordering could reject valid blocks or miss attacks.
> 
> **Overview**
> **Prevalidation now rejects bad transaction blocks before expensive CLVM work**, by checking generator roots, transaction-info hashes, foliage links, and canonical generator encoding ahead of `_run_block`. Generator reference rules are centralized in `validate_generator_ref_list` and applied in both prevalidation and body validation so peers cannot force lookup or execution on obviously invalid blocks.
> 
> **Ordering and error handling tighten the sync path**: `prev_tx_height` is computed once and reused; missing `transactions_info` vs stray generator data returns structured `Err` values instead of assertions; referenced generators are resolved **before** the candidate is added to the speculative `AugmentedBlockchain` overlay. `_run_block` now surfaces `Err` consistently for wallet test mocks.
> 
> **Tests** add `test_prevalidation_fast_fail` (monkeypatched traps proving CLVM and generator lookup do not run on malformed input) and drop `skip_prevalidation=True` from a generator-ref-list case so prevalidation is exercised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77df95c9dec985fac55076f4b15eb22f7118f38d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->