### PR TITLE
[CHIA-4331] Drop always-true metadata guard in DID CLI test helper

### DIFF
--- a/chia/_tests/wallet/did_wallet/test_did.py
+++ b/chia/_tests/wallet/did_wallet/test_did.py
@@ -101,7 +101,7 @@ async def create_did_via_cli(
             "fee": fee,
             "name": name,
             "push": True,
-            "metadata": [f"{key}:{value}" for key, value in metadata.items()] if metadata is not None else None,
+            "metadata": [f"{key}:{value}" for key, value in metadata.items()],
         }
     ).run()
     await env.change_balances({"nft": {"init": True}})


### PR DESCRIPTION
## Summary
- `create_did_via_cli()` typed `metadata` as `dict[str, str]` with an empty-dict default, so the `metadata is not None` guard was unreachable and failed mypy's `redundant-expr` check on `main`.
- Removing the guard is behavior-identical: every caller passes a dict or omits the argument, and an empty dict already produced `[]`.
- This unblocks the pre-commit mypy hook, which runs over the whole tree.

Introduced in #21114.

## Test plan
- [x] `tools/py -m mypy chia/_tests/wallet/did_wallet/test_did.py`
- [x] `tools/pytest chia/_tests/wallet/did_wallet/test_did.py::test_get_info chia/_tests/wallet/did_wallet/test_did.py::test_creation_from_backup_file` (cover the metadata and default paths)
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only helper change with identical CLI arguments; no production or wallet logic affected.
> 
> **Overview**
> Removes an unreachable **`metadata is not None`** branch in **`create_did_via_cli()`** when building the **`CreateDidWalletCMD`** kwargs. **`metadata`** is already typed as **`dict[str, str]`** with a default empty dict, so the guard only triggered mypy’s **`redundant-expr`** and did not change runtime behavior (empty dict still becomes **`[]`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 678ebc576ce13aedc343c796b1d5c8d6abc763ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->