### PR TITLE
[CHIA-4282] Harden RespondBlocks handling for incomplete responses

### DIFF
--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -26,6 +26,7 @@ from chia.types.condition_opcodes import ConditionOpcode
 from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.peer_info import PeerInfo
 from chia.util.casts import int_to_bytes
+from chia.util.errors import ConsensusError
 from chia.util.hash import std_hash
 from chia.util.recursive_replace import recursive_replace
 
@@ -441,7 +442,7 @@ async def test_short_sync_batch_bans_peer_answering_wrong_block_range(
             self.ban_seconds = ban_seconds
 
     peer = DummyPeer()
-    with pytest.raises(ValueError, match="incomplete/mismatched blocks"):
+    with pytest.raises(ConsensusError, match="incomplete/mismatched blocks"):
         await node.short_sync_batch(cast(WSChiaConnection, peer), start_block.height, end_block.height)
 
     assert peer.closed

--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -16,6 +16,7 @@ from chia._tests.util.time_out_assert import time_out_assert
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.full_node.sync_store import Peak
 from chia.protocols import full_node_protocol
+from chia.protocols.protocol_timing import CONSENSUS_ERROR_BAN_SECONDS
 from chia.protocols.shared_protocol import Capability
 from chia.server.server import ChiaServer
 from chia.server.ws_connection import WSChiaConnection
@@ -352,6 +353,11 @@ async def test_short_sync_batch_raises_when_no_blocks_committed(
         "reward_chain_block.proof_of_space.proof",
         bytes([0] * 32),
     )
+    # short_sync_batch requests an inclusive range of at least two heights; keep
+    # the response length honest so this exercises validation failure, not the
+    # incomplete-RespondBlocks guard.
+    blocks = bt.get_consecutive_blocks(1, block_list_input=blocks)
+    trailing_block = blocks[-1]
 
     class DummyPeer:
         peer_node_id = bytes32(b"\x03" * 32)
@@ -365,13 +371,82 @@ async def test_short_sync_batch_raises_when_no_blocks_committed(
             if isinstance(request, full_node_protocol.RequestBlock):
                 return full_node_protocol.RespondBlock(bad_block)
             assert isinstance(request, full_node_protocol.RequestBlocks)
-            return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [bad_block])
+            return full_node_protocol.RespondBlocks(
+                request.start_height, request.end_height, [bad_block, trailing_block]
+            )
 
     peer = cast(WSChiaConnection, DummyPeer())
     # target must be > start so the batch loop runs; end_height becomes start+1.
     with pytest.raises(ValueError, match=rf"failed to validate blocks {bad_block.height}-{bad_block.height + 1}$"):
         await node.short_sync_batch(peer, bad_block.height, uint32(bad_block.height + 1))
 
+    peak = node.blockchain.get_peak()
+    assert peak is not None
+    assert peak.header_hash == peak_before.header_hash
+    assert peer.peer_node_id not in node.sync_store.batch_syncing
+
+
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
+@pytest.mark.parametrize("payload", ["empty", "short", "reordered", "wrong_range"])
+@pytest.mark.anyio
+async def test_short_sync_batch_bans_peer_answering_wrong_block_range(
+    two_nodes: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
+    consensus_mode: ConsensusMode,
+    payload: str,
+) -> None:
+    # A protocol-valid RespondBlocks that does not cover the requested range cannot
+    # advance short sync, so the peer is banned rather than credited with a fetch.
+    _full_node_1, full_node_2, _server_1, _server_2, bt = two_nodes
+    node = full_node_2.full_node
+
+    blocks = bt.get_consecutive_blocks(3)
+    for block in blocks:
+        await node.add_block(block)
+    peak_before = node.blockchain.get_peak()
+    assert peak_before is not None
+
+    blocks = bt.get_consecutive_blocks(2, block_list_input=blocks)
+    start_block, end_block = blocks[-2], blocks[-1]
+
+    class DummyPeer:
+        peer_node_id = bytes32(b"\x04" * 32)
+
+        def __init__(self) -> None:
+            self.closed = False
+            self.ban_seconds: int | None = None
+            self.peer_info = PeerInfo("127.0.0.1", uint16(0))
+
+        def get_peer_logging(self) -> PeerInfo:
+            return self.peer_info
+
+        async def call_api(
+            self, api_function: Any, request: object
+        ) -> full_node_protocol.RespondBlock | full_node_protocol.RespondBlocks:
+            if isinstance(request, full_node_protocol.RequestBlock):
+                return full_node_protocol.RespondBlock(start_block)
+            assert isinstance(request, full_node_protocol.RequestBlocks)
+            if payload == "empty":
+                return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [])
+            if payload == "short":
+                return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [start_block])
+            if payload == "reordered":
+                return full_node_protocol.RespondBlocks(
+                    request.start_height, request.end_height, [end_block, start_block]
+                )
+            return full_node_protocol.RespondBlocks(
+                request.start_height, uint32(request.end_height + 1), [start_block, end_block]
+            )
+
+        async def close(self, ban_seconds: int = 0, *args: object, **kwargs: object) -> None:
+            self.closed = True
+            self.ban_seconds = ban_seconds
+
+    peer = DummyPeer()
+    with pytest.raises(ValueError, match="incomplete/mismatched blocks"):
+        await node.short_sync_batch(cast(WSChiaConnection, peer), start_block.height, end_block.height)
+
+    assert peer.closed
+    assert peer.ban_seconds == CONSENSUS_ERROR_BAN_SECONDS
     peak = node.blockchain.get_peak()
     assert peak is not None
     assert peak.header_hash == peak_before.header_hash

--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -237,8 +237,15 @@ async def test_short_sync_batch_returns_false_on_disconnected_first_block(
     # docstring promises) rather than raising.
     _full_node_1, full_node_2, _server_1, _server_2, bt = two_nodes
     node = full_node_2.full_node
-    blocks = bt.get_consecutive_blocks(2)
-    disconnected_block = blocks[-1]  # height > 0 and its parent is not in node's database
+    blocks = bt.get_consecutive_blocks(4)
+    for block in blocks[:3]:
+        await node.add_block(block)
+
+    # A fork diverging at height 2, so its height-3 block has a parent we never stored.
+    fork = bt.get_consecutive_blocks(3, block_list_input=blocks[:2], seed=b"fork")
+    assert fork[2].header_hash != blocks[2].header_hash
+    disconnected_blocks = fork[-2:]
+    assert [block.height for block in disconnected_blocks] == [3, 4]
 
     class DummyPeer:
         peer_node_id = bytes32(b"\x01" * 32)
@@ -247,13 +254,17 @@ async def test_short_sync_batch_returns_false_on_disconnected_first_block(
             return PeerInfo("127.0.0.1", uint16(0))
 
         async def call_api(
-            self, api_function: Any, request: full_node_protocol.RequestBlocks
-        ) -> full_node_protocol.RespondBlocks:
-            return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [disconnected_block])
+            self, api_function: Any, request: object
+        ) -> full_node_protocol.RespondBlock | full_node_protocol.RespondBlocks:
+            # The fork-point probe gets a connected block, so the batch loop is reached;
+            # the batch itself then arrives on a fork we cannot connect.
+            if isinstance(request, full_node_protocol.RequestBlock):
+                return full_node_protocol.RespondBlock(blocks[3])
+            assert isinstance(request, full_node_protocol.RequestBlocks)
+            return full_node_protocol.RespondBlocks(request.start_height, request.end_height, disconnected_blocks)
 
     peer = cast(WSChiaConnection, DummyPeer())
-    # start_height == 0 skips the fork-point probe, exercising the batch loop's parent check directly.
-    result = await node.short_sync_batch(peer, uint32(0), uint32(1))
+    result = await node.short_sync_batch(peer, uint32(3), uint32(4))
     assert result is False
     assert peer.peer_node_id not in node.sync_store.batch_syncing
 

--- a/chia/_tests/core/full_node/full_sync/test_full_sync.py
+++ b/chia/_tests/core/full_node/full_sync/test_full_sync.py
@@ -387,15 +387,13 @@ async def test_short_sync_batch_raises_when_no_blocks_committed(
 
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
-@pytest.mark.parametrize("payload", ["empty", "short", "reordered", "wrong_range"])
 @pytest.mark.anyio
 async def test_short_sync_batch_bans_peer_answering_wrong_block_range(
     two_nodes: tuple[FullNodeAPI, FullNodeAPI, ChiaServer, ChiaServer, BlockTools],
     consensus_mode: ConsensusMode,
-    payload: str,
 ) -> None:
-    # A protocol-valid RespondBlocks that does not cover the requested range cannot
-    # advance short sync, so the peer is banned rather than credited with a fetch.
+    # Wiring check: an incomplete RespondBlocks is banned via respond_blocks_or_ban
+    # rather than treated as a successful short-sync fetch.
     _full_node_1, full_node_2, _server_1, _server_2, bt = two_nodes
     node = full_node_2.full_node
 
@@ -425,17 +423,7 @@ async def test_short_sync_batch_bans_peer_answering_wrong_block_range(
             if isinstance(request, full_node_protocol.RequestBlock):
                 return full_node_protocol.RespondBlock(start_block)
             assert isinstance(request, full_node_protocol.RequestBlocks)
-            if payload == "empty":
-                return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [])
-            if payload == "short":
-                return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [start_block])
-            if payload == "reordered":
-                return full_node_protocol.RespondBlocks(
-                    request.start_height, request.end_height, [end_block, start_block]
-                )
-            return full_node_protocol.RespondBlocks(
-                request.start_height, uint32(request.end_height + 1), [start_block, end_block]
-            )
+            return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [])
 
         async def close(self, ban_seconds: int = 0, *args: object, **kwargs: object) -> None:
             self.closed = True

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3445,16 +3445,14 @@ async def test_sync_from_fork_point_adds_hints_for_committed_prefix(
 
 
 @pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
-@pytest.mark.parametrize("payload", ["empty", "short", "reordered", "wrong_range"])
 @pytest.mark.anyio
 async def test_sync_from_fork_point_bans_peer_answering_wrong_block_range(
     one_node: SimulatorsAndWalletsServices,
     monkeypatch: pytest.MonkeyPatch,
     consensus_mode: ConsensusMode,
-    payload: str,
 ) -> None:
-    # A protocol-valid RespondBlocks that does not cover the requested range cannot
-    # advance the sync, so the peer is banned rather than credited with a fetch.
+    # Wiring check: an incomplete RespondBlocks is banned via respond_blocks_or_ban
+    # rather than treated as a successful long-sync fetch.
     [full_node_service], _, bt = one_node
     full_node = full_node_service._node
 
@@ -3472,15 +3470,7 @@ async def test_sync_from_fork_point_bans_peer_answering_wrong_block_range(
             request = args[1]
             assert isinstance(request, full_node_protocol.RequestBlocks)
             self.requests.append((request.start_height, request.end_height))
-            if payload == "empty":
-                return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [])
-            if payload == "short":
-                return full_node_protocol.RespondBlocks(request.start_height, request.end_height, blocks[:-1])
-            if payload == "reordered":
-                return full_node_protocol.RespondBlocks(
-                    request.start_height, request.end_height, [*blocks[1:], blocks[0]]
-                )
-            return full_node_protocol.RespondBlocks(request.start_height, uint32(request.end_height + 1), blocks)
+            return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [])
 
         async def close(self, ban_seconds: int = 0, *args: object, **kwargs: object) -> None:
             self.closed = True

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -3444,6 +3444,63 @@ async def test_sync_from_fork_point_adds_hints_for_committed_prefix(
     assert peer.closed
 
 
+@pytest.mark.limit_consensus_modes(allowed=[ConsensusMode.PLAIN], reason="save time")
+@pytest.mark.parametrize("payload", ["empty", "short", "reordered", "wrong_range"])
+@pytest.mark.anyio
+async def test_sync_from_fork_point_bans_peer_answering_wrong_block_range(
+    one_node: SimulatorsAndWalletsServices,
+    monkeypatch: pytest.MonkeyPatch,
+    consensus_mode: ConsensusMode,
+    payload: str,
+) -> None:
+    # A protocol-valid RespondBlocks that does not cover the requested range cannot
+    # advance the sync, so the peer is banned rather than credited with a fetch.
+    [full_node_service], _, bt = one_node
+    full_node = full_node_service._node
+
+    blocks = bt.get_consecutive_blocks(5)
+    target = blocks[-1]
+
+    class DummyPeer:
+        def __init__(self) -> None:
+            self.closed = False
+            self.ban_seconds: int | None = None
+            self.peer_info = PeerInfo("127.0.0.1", uint16(8444))
+            self.requests: list[tuple[uint32, uint32]] = []
+
+        async def call_api(self, *args: object, **kwargs: object) -> full_node_protocol.RespondBlocks:
+            request = args[1]
+            assert isinstance(request, full_node_protocol.RequestBlocks)
+            self.requests.append((request.start_height, request.end_height))
+            if payload == "empty":
+                return full_node_protocol.RespondBlocks(request.start_height, request.end_height, [])
+            if payload == "short":
+                return full_node_protocol.RespondBlocks(request.start_height, request.end_height, blocks[:-1])
+            if payload == "reordered":
+                return full_node_protocol.RespondBlocks(
+                    request.start_height, request.end_height, [*blocks[1:], blocks[0]]
+                )
+            return full_node_protocol.RespondBlocks(request.start_height, uint32(request.end_height + 1), blocks)
+
+        async def close(self, ban_seconds: int = 0, *args: object, **kwargs: object) -> None:
+            self.closed = True
+            self.ban_seconds = ban_seconds
+
+    peer = DummyPeer()
+    monkeypatch.setattr(full_node, "get_peers_with_peak", lambda _peak_hash: [peer])
+
+    await asyncio.wait_for(
+        full_node.sync_from_fork_point(uint32(0), target.height, target.header_hash, []),
+        timeout=60,
+    )
+
+    assert peer.closed
+    assert peer.ban_seconds == CONSENSUS_ERROR_BAN_SECONDS
+    # the range is requested once from this peer, which is then dropped rather than retried
+    assert peer.requests == [(uint32(0), target.height)]
+    assert full_node.blockchain.get_peak() is None
+
+
 @pytest.mark.anyio
 async def test_wallet_sync_task_failure_before_receiving_update_logs_error(
     caplog: pytest.LogCaptureFixture,

--- a/chia/_tests/core/full_node/test_respond_blocks_or_ban.py
+++ b/chia/_tests/core/full_node/test_respond_blocks_or_ban.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+from typing import cast
+
+import pytest
+from chia_rs import FullBlock
+from chia_rs.sized_ints import uint16, uint32
+
+from chia._tests.util.network_protocol_data import full_block
+from chia.full_node.full_node import respond_blocks_or_ban
+from chia.protocols.full_node_protocol import RespondBlocks
+from chia.protocols.protocol_timing import CONSENSUS_ERROR_BAN_SECONDS
+from chia.server.ws_connection import WSChiaConnection
+from chia.types.peer_info import PeerInfo
+from chia.util.recursive_replace import recursive_replace
+
+
+def _block(height: int) -> FullBlock:
+    return cast(FullBlock, recursive_replace(full_block, "reward_chain_block.height", uint32(height)))
+
+
+class DummyPeer:
+    def __init__(self) -> None:
+        self.closed = False
+        self.ban_seconds: int | None = None
+        self.peer_info = PeerInfo("127.0.0.1", uint16(8444))
+
+    async def close(self, ban_seconds: int = 0, *args: object, **kwargs: object) -> None:
+        self.closed = True
+        self.ban_seconds = ban_seconds
+
+
+@pytest.mark.anyio
+async def test_respond_blocks_or_ban_accepts_exact_range() -> None:
+    peer = DummyPeer()
+    response = RespondBlocks(uint32(5), uint32(7), [_block(5), _block(6), _block(7)])
+
+    assert await respond_blocks_or_ban(cast(WSChiaConnection, peer), response, 5, 7, logging.getLogger(__name__))
+    assert not peer.closed
+    assert peer.ban_seconds is None
+
+
+@pytest.mark.parametrize(
+    ("start_height", "end_height", "response"),
+    [
+        (5, 7, RespondBlocks(uint32(5), uint32(7), [])),
+        (5, 7, RespondBlocks(uint32(5), uint32(7), [_block(5), _block(6)])),
+        (5, 7, RespondBlocks(uint32(5), uint32(7), [_block(7), _block(6), _block(5)])),
+        (5, 7, RespondBlocks(uint32(5), uint32(8), [_block(5), _block(6), _block(7)])),
+        (5, 7, RespondBlocks(uint32(5), uint32(7), [_block(2), _block(3), _block(4)])),
+        (5, 7, RespondBlocks(uint32(5), uint32(7), [_block(8), _block(9), _block(10)])),
+        (5, 7, RespondBlocks(uint32(5), uint32(7), [_block(5), _block(12), _block(6)])),
+        (5, 7, RespondBlocks(uint32(5), uint32(7), [_block(5), _block(6), _block(6), _block(7)])),
+    ],
+    ids=[
+        "empty",
+        "short_prefix",
+        "reordered",
+        "wrong_end_metadata",
+        "entirely_below_range",
+        "entirely_above_range",
+        "noncontiguous",
+        "duplicates",
+    ],
+)
+@pytest.mark.anyio
+async def test_respond_blocks_or_ban_rejects_mismatched_payloads(
+    start_height: int,
+    end_height: int,
+    response: RespondBlocks,
+) -> None:
+    peer = DummyPeer()
+
+    assert not await respond_blocks_or_ban(
+        cast(WSChiaConnection, peer), response, start_height, end_height, logging.getLogger(__name__)
+    )
+    assert peer.closed
+    assert peer.ban_seconds == CONSENSUS_ERROR_BAN_SECONDS

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -107,6 +107,37 @@ from chia.util.task_referencer import create_referenced_task
 SHORT_SYNC_BACKTRACK_BLOCK_REQUEST_TIMEOUT_SEC: int = 15
 
 
+async def respond_blocks_or_ban(
+    peer: WSChiaConnection,
+    response: RespondBlocks,
+    start_height: int,
+    end_height: int,
+    log: logging.Logger,
+) -> bool:
+    """
+    Return True if response covers the inclusive requested height range.
+    Otherwise ban the peer and return False.
+
+    Honest nodes return the full inclusive range or RejectBlocks. A
+    well-formed but incomplete/mismatched RespondBlocks cannot advance
+    sync, so the peer is banned rather than credited with a fetch.
+    """
+    expected_heights = list(range(start_height, end_height + 1))
+    if (
+        response.start_height == start_height
+        and response.end_height == end_height
+        and [block.height for block in response.blocks] == expected_heights
+    ):
+        return True
+    log.warning(
+        f"peer {peer.peer_info.host} responded to request_blocks "
+        f"{start_height}-{end_height} with {response.start_height}-"
+        f"{response.end_height} ({len(response.blocks)} blocks), banning"
+    )
+    await peer.close(CONSENSUS_ERROR_BAN_SECONDS)
+    return False
+
+
 # This is the result of calling peak_post_processing, which is then fed into peak_post_processing_2
 @dataclasses.dataclass
 class PeakPostProcessingResult:
@@ -616,36 +647,6 @@ class FullNode:
         if self.state_changed_callback is not None:
             self.state_changed_callback(change, change_data)
 
-    async def _respond_blocks_or_ban(
-        self,
-        peer: WSChiaConnection,
-        response: RespondBlocks,
-        start_height: int,
-        end_height: int,
-    ) -> bool:
-        """
-        Return True if response covers the inclusive requested height range.
-        Otherwise ban the peer and return False.
-
-        Honest nodes return the full inclusive range or RejectBlocks. A
-        well-formed but incomplete/mismatched RespondBlocks cannot advance
-        sync, so the peer is banned rather than credited with a fetch.
-        """
-        expected_heights = list(range(start_height, end_height + 1))
-        if (
-            response.start_height == start_height
-            and response.end_height == end_height
-            and [block.height for block in response.blocks] == expected_heights
-        ):
-            return True
-        self.log.warning(
-            f"peer {peer.peer_info.host} responded to request_blocks "
-            f"{start_height}-{end_height} with {response.start_height}-"
-            f"{response.end_height} ({len(response.blocks)} blocks), banning"
-        )
-        await peer.close(CONSENSUS_ERROR_BAN_SECONDS)
-        return False
-
     async def short_sync_batch(self, peer: WSChiaConnection, start_height: uint32, target_height: uint32) -> bool:
         """
         Tries to sync to a chain which is not too far in the future, by downloading batches of blocks. If the first
@@ -708,7 +709,7 @@ class FullNode:
                 response = await peer.call_api(FullNodeAPI.request_blocks, request)
                 if not isinstance(response, RespondBlocks):
                     raise ValueError(f"Error short batch syncing, invalid/no response for {height}-{end_height}")
-                if not await self._respond_blocks_or_ban(peer, response, height, end_height):
+                if not await respond_blocks_or_ban(peer, response, height, end_height, self.log):
                     raise ValueError(
                         f"Error short batch syncing, incomplete/mismatched blocks for {height}-{end_height}"
                     )
@@ -1397,7 +1398,7 @@ class FullNode:
                         self.log.info(f"peer timed out after {end - start:.1f} s")
                         await peer.close()
                     elif isinstance(response, RespondBlocks):
-                        if not await self._respond_blocks_or_ban(peer, response, start_height, end_height):
+                        if not await respond_blocks_or_ban(peer, response, start_height, end_height, self.log):
                             continue
                         if end - start > 5:
                             self.log.info(f"peer took {end - start:.1f} s to respond to request_blocks")

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -616,6 +616,36 @@ class FullNode:
         if self.state_changed_callback is not None:
             self.state_changed_callback(change, change_data)
 
+    async def _respond_blocks_or_ban(
+        self,
+        peer: WSChiaConnection,
+        response: RespondBlocks,
+        start_height: int,
+        end_height: int,
+    ) -> bool:
+        """
+        Return True if response covers the inclusive requested height range.
+        Otherwise ban the peer and return False.
+
+        Honest nodes return the full inclusive range or RejectBlocks. A
+        well-formed but incomplete/mismatched RespondBlocks cannot advance
+        sync, so the peer is banned rather than credited with a fetch.
+        """
+        expected_heights = list(range(start_height, end_height + 1))
+        if (
+            response.start_height == start_height
+            and response.end_height == end_height
+            and [block.height for block in response.blocks] == expected_heights
+        ):
+            return True
+        self.log.warning(
+            f"peer {peer.peer_info.host} responded to request_blocks "
+            f"{start_height}-{end_height} with {response.start_height}-"
+            f"{response.end_height} ({len(response.blocks)} blocks), banning"
+        )
+        await peer.close(CONSENSUS_ERROR_BAN_SECONDS)
+        return False
+
     async def short_sync_batch(self, peer: WSChiaConnection, start_height: uint32, target_height: uint32) -> bool:
         """
         Tries to sync to a chain which is not too far in the future, by downloading batches of blocks. If the first
@@ -678,22 +708,7 @@ class FullNode:
                 response = await peer.call_api(FullNodeAPI.request_blocks, request)
                 if not isinstance(response, RespondBlocks):
                     raise ValueError(f"Error short batch syncing, invalid/no response for {height}-{end_height}")
-                # Honest nodes return the full inclusive range or RejectBlocks.
-                # A well-formed but incomplete/mismatched RespondBlocks cannot
-                # advance this sync step, so ban the peer rather than treating
-                # the range as fetched.
-                expected_heights = list(range(height, end_height + 1))
-                if (
-                    response.start_height != height
-                    or response.end_height != end_height
-                    or [block.height for block in response.blocks] != expected_heights
-                ):
-                    self.log.warning(
-                        f"peer {peer.peer_info.host} responded to request_blocks "
-                        f"{height}-{end_height} with {response.start_height}-"
-                        f"{response.end_height} ({len(response.blocks)} blocks), banning"
-                    )
-                    await peer.close(CONSENSUS_ERROR_BAN_SECONDS)
+                if not await self._respond_blocks_or_ban(peer, response, height, end_height):
                     raise ValueError(
                         f"Error short batch syncing, incomplete/mismatched blocks for {height}-{end_height}"
                     )
@@ -1382,22 +1397,7 @@ class FullNode:
                         self.log.info(f"peer timed out after {end - start:.1f} s")
                         await peer.close()
                     elif isinstance(response, RespondBlocks):
-                        # Honest nodes return the full inclusive range or RejectBlocks.
-                        # A well-formed but incomplete/mismatched RespondBlocks cannot
-                        # advance this sync step, so ban the peer and ask another one
-                        # for the same range.
-                        expected_heights = list(range(start_height, end_height + 1))
-                        if (
-                            response.start_height != start_height
-                            or response.end_height != end_height
-                            or [block.height for block in response.blocks] != expected_heights
-                        ):
-                            self.log.warning(
-                                f"peer {peer.peer_info.host} responded to request_blocks "
-                                f"{start_height}-{end_height} with {response.start_height}-"
-                                f"{response.end_height} ({len(response.blocks)} blocks), banning"
-                            )
-                            await peer.close(CONSENSUS_ERROR_BAN_SECONDS)
+                        if not await self._respond_blocks_or_ban(peer, response, start_height, end_height):
                             continue
                         if end - start > 5:
                             self.log.info(f"peer took {end - start:.1f} s to respond to request_blocks")

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -676,8 +676,27 @@ class FullNode:
                 end_height = min(target_height, height + batch_size)
                 request = RequestBlocks(uint32(height), uint32(end_height), True)
                 response = await peer.call_api(FullNodeAPI.request_blocks, request)
-                if not response:
+                if not isinstance(response, RespondBlocks):
                     raise ValueError(f"Error short batch syncing, invalid/no response for {height}-{end_height}")
+                # Honest nodes return the full inclusive range or RejectBlocks.
+                # A well-formed but incomplete/mismatched RespondBlocks cannot
+                # advance this sync step, so ban the peer rather than treating
+                # the range as fetched.
+                expected_heights = list(range(height, end_height + 1))
+                if (
+                    response.start_height != height
+                    or response.end_height != end_height
+                    or [block.height for block in response.blocks] != expected_heights
+                ):
+                    self.log.warning(
+                        f"peer {peer.peer_info.host} responded to request_blocks "
+                        f"{height}-{end_height} with {response.start_height}-"
+                        f"{response.end_height} ({len(response.blocks)} blocks), banning"
+                    )
+                    await peer.close(CONSENSUS_ERROR_BAN_SECONDS)
+                    raise ValueError(
+                        f"Error short batch syncing, incomplete/mismatched blocks for {height}-{end_height}"
+                    )
                 async with self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
                     state_change_summary: StateChangeSummary | None
                     prev_b = None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -710,8 +710,11 @@ class FullNode:
                 if not isinstance(response, RespondBlocks):
                     raise ValueError(f"Error short batch syncing, invalid/no response for {height}-{end_height}")
                 if not await respond_blocks_or_ban(peer, response, height, end_height, self.log):
-                    raise ValueError(
-                        f"Error short batch syncing, incomplete/mismatched blocks for {height}-{end_height}"
+                    raise ConsensusError(
+                        Err.INVALID_PROTOCOL_MESSAGE,
+                        error_msg=(
+                            f"Error short batch syncing, incomplete/mismatched blocks for {height}-{end_height}"
+                        ),
                     )
                 async with self.blockchain.priority_mutex.acquire(priority=BlockchainMutexPriority.high):
                     state_change_summary: StateChangeSummary | None

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -1363,6 +1363,23 @@ class FullNode:
                         self.log.info(f"peer timed out after {end - start:.1f} s")
                         await peer.close()
                     elif isinstance(response, RespondBlocks):
+                        # Honest nodes return the full inclusive range or RejectBlocks.
+                        # A well-formed but incomplete/mismatched RespondBlocks cannot
+                        # advance this sync step, so ban the peer and ask another one
+                        # for the same range.
+                        expected_heights = list(range(start_height, end_height + 1))
+                        if (
+                            response.start_height != start_height
+                            or response.end_height != end_height
+                            or [block.height for block in response.blocks] != expected_heights
+                        ):
+                            self.log.warning(
+                                f"peer {peer.peer_info.host} responded to request_blocks "
+                                f"{start_height}-{end_height} with {response.start_height}-"
+                                f"{response.end_height} ({len(response.blocks)} blocks), banning"
+                            )
+                            await peer.close(CONSENSUS_ERROR_BAN_SECONDS)
+                            continue
                         if end - start > 5:
                             self.log.info(f"peer took {end - start:.1f} s to respond to request_blocks")
                             # this isn't a great peer, reduce its priority


### PR DESCRIPTION
## Summary
- Reject incomplete or mismatched `RespondBlocks` replies during long sync
- Disconnect and ban peers that return such replies instead of treating the range as fetched

## Test plan
- [x] `tools/pytest -q chia/_tests/core/full_node/test_full_node.py::test_sync_from_fork_point_bans_peer_answering_wrong_block_range`
- [x] Rebased onto `main` after #21215
- [x] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core block sync and peer disconnect/ban behavior; honest peers with exact ranges are unchanged, but misformatted replies now trigger consensus bans.
> 
> **Overview**
> Adds **`respond_blocks_or_ban`**, which accepts a `RespondBlocks` only when its start/end metadata and block heights exactly match the inclusive range requested; otherwise it disconnects the peer with **`CONSENSUS_ERROR_BAN_SECONDS`** instead of treating the fetch as successful.
> 
> That check is wired into **`short_sync_batch`** (raises **`ConsensusError`** after ban) and long sync’s **`request_blocks`** loop (drops the peer and tries others). Existing sync tests were updated so batches pass the new guard (fork-point probe, multi-height responses); new tests cover the helper and end-to-end banning for short and fork-point sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d235f1d92e077444a49e48ec49c6497a608b61c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->