### PR TITLE
CHIA-4339 Annotate wallet_interested_store.py

### DIFF
--- a/chia/wallet/wallet_interested_store.py
+++ b/chia/wallet/wallet_interested_store.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from chia_rs import CoinState
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32
@@ -15,7 +17,7 @@ class WalletInterestedStore:
     db_wrapper: DBWrapper2
 
     @classmethod
-    async def create(cls, wrapper: DBWrapper2):
+    async def create(cls, wrapper: DBWrapper2) -> WalletInterestedStore:
         self = cls()
         self.db_wrapper = wrapper
 
@@ -67,7 +69,7 @@ class WalletInterestedStore:
             row = await cursor.fetchone()
         if row is None:
             return None
-        return row[0]
+        return int(row[0])
 
     async def add_interested_puzzle_hash(self, puzzle_hash: bytes32, wallet_id: int) -> None:
         async with self.db_wrapper.writer_maybe_transaction() as conn:
@@ -110,7 +112,7 @@ class WalletInterestedStore:
             )
             await cursor.close()
 
-    async def get_unacknowledged_tokens(self) -> list:
+    async def get_unacknowledged_tokens(self) -> list[dict[str, Any]]:
         """
         Get a list of all unacknowledged CATs
         :return: A json style list of unacknowledged CATs

--- a/mypy-exclusions.txt
+++ b/mypy-exclusions.txt
@@ -15,7 +15,6 @@ chia.types.blockchain_format.program
 chia.wallet.puzzles.load_clvm
 chia.wallet.util.debug_spend_bundle
 chia.wallet.util.new_peak_queue
-chia.wallet.wallet_interested_store
 chia.wallet.wallet_transaction_store
 chia._tests.clvm.test_puzzles
 chia._tests.clvm.test_singletons


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type-only changes and a trivial `int()` cast on SQLite results; no wallet logic or persistence behavior is altered.
> 
> **Overview**
> Adds **mypy return types** on `WalletInterestedStore` so the module can be removed from `mypy-exclusions.txt` and checked normally.
> 
> `create` is annotated to return `WalletInterestedStore`, `get_unacknowledged_tokens` returns `list[dict[str, Any]]`, and `get_interested_puzzle_hash_wallet_id` explicitly returns `int(row[0])` instead of a raw DB row value. **No behavioral change** beyond clearer typing for static analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f3f853730aba0aeec3f0ce24f509186e261abcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->