### PR TITLE
[CHIA-4280] better errors for wp

### DIFF
--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -63,7 +63,7 @@ from chia.full_node.mempool_manager import MempoolManager
 from chia.full_node.subscriptions import PeerSubscriptions, peers_for_spend_bundle
 from chia.full_node.sync_store import Peak, SyncStore
 from chia.full_node.tx_processing_queue import PeerWithTx, TransactionQueue, TransactionQueueEntry
-from chia.full_node.weight_proof import WeightProofHandler
+from chia.full_node.weight_proof import WeightProofHandler, _minimum_recent_chain_length
 from chia.protocols import farmer_protocol, full_node_protocol, timelord_protocol, wallet_protocol
 from chia.protocols.farmer_protocol import SignagePointSourceData, SPSubSlotSourceData, SPVDFSourceData
 from chia.protocols.full_node_protocol import RequestBlocks, RespondBlock, RespondBlocks, RespondSignagePoint
@@ -1236,6 +1236,9 @@ class FullNode:
         if response is None or not isinstance(response, full_node_protocol.RespondProofOfWeight):
             await weight_proof_peer.close(CONSENSUS_ERROR_BAN_SECONDS)
             raise RuntimeError(f"Weight proof did not arrive in time from peer: {weight_proof_peer.peer_info.host}")
+        if len(response.wp.recent_chain_data) < _minimum_recent_chain_length(self.constants):
+            await weight_proof_peer.close(CONSENSUS_ERROR_BAN_SECONDS)
+            raise RuntimeError(f"Weight proof recent chain was too short: {weight_proof_peer.peer_info.host}")
         if response.wp.recent_chain_data[-1].reward_chain_block.height != peak_height:
             await weight_proof_peer.close(CONSENSUS_ERROR_BAN_SECONDS)
             raise RuntimeError(f"Weight proof had the wrong height: {weight_proof_peer.peer_info.host}")

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -1236,7 +1236,13 @@ def validate_recent_blocks(
     recent_chain: RecentChainData = RecentChainData.from_bytes(recent_chain_bytes)
     summaries = summaries_from_bytes(summaries_bytes)
     sub_blocks = BlockCache({}, mmr_manager=StubMMRManager())
+    if len(recent_chain.recent_chain_data) <= int(constants.SUB_EPOCH_BLOCKS):
+        log.info("recent chain is too short")
+        return False, []
     first_ses_idx = _get_ses_idx(recent_chain.recent_chain_data)
+    if len(summaries) < len(first_ses_idx):
+        log.info("recent chain has more sub-epoch summaries than weight proof")
+        return False, []
     ses_idx = len(summaries) - len(first_ses_idx)
     ssi: uint64 = constants.SUB_SLOT_ITERS_STARTING
     diff: uint64 = constants.DIFFICULTY_STARTING
@@ -1338,11 +1344,11 @@ def validate_recent_blocks(
             log.info(f"cancelling block {block.header_hash} validation, shutdown requested")
             return False, []
 
-    if len(summaries) > 2 and prev_challenge is None:
+    if prev_challenge is None:
         log.info("did not find two challenges in recent chain")
         return False, []
 
-    if len(summaries) > 2 and validated_block_count < constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK:
+    if validated_block_count < constants.MIN_BLOCKS_PER_CHALLENGE_BLOCK:
         log.info("did not validate enough blocks in recent chain part")
         return False, []
 

--- a/chia/full_node/weight_proof.py
+++ b/chia/full_node/weight_proof.py
@@ -842,6 +842,10 @@ def handle_end_of_slot(
 
 
 # wp validation methods
+def _minimum_recent_chain_length(constants: ConsensusConstants) -> int:
+    return int(constants.SUB_EPOCH_BLOCKS) - int(constants.MAX_SUB_SLOT_BLOCKS) + 2
+
+
 def _validate_sub_epoch_summaries(
     constants: ConsensusConstants,
     weight_proof: WeightProof,
@@ -1236,10 +1240,13 @@ def validate_recent_blocks(
     recent_chain: RecentChainData = RecentChainData.from_bytes(recent_chain_bytes)
     summaries = summaries_from_bytes(summaries_bytes)
     sub_blocks = BlockCache({}, mmr_manager=StubMMRManager())
-    if len(recent_chain.recent_chain_data) <= int(constants.SUB_EPOCH_BLOCKS):
+    if len(recent_chain.recent_chain_data) < _minimum_recent_chain_length(constants):
         log.info("recent chain is too short")
         return False, []
     first_ses_idx = _get_ses_idx(recent_chain.recent_chain_data)
+    if len(first_ses_idx) != 2:
+        log.info("recent chain has an invalid number of sub-epoch summaries")
+        return False, []
     if len(summaries) < len(first_ses_idx):
         log.info("recent chain has more sub-epoch summaries than weight proof")
         return False, []
@@ -1261,6 +1268,14 @@ def validate_recent_blocks(
     adjusted = False
     validated_block_count = 0
     for idx, block in enumerate(recent_chain.recent_chain_data):
+        if prev_block_record is not None:
+            if int(block.height) != int(prev_block_record.height) + 1:
+                log.info("recent chain is not height-contiguous")
+                return False, []
+            if block.prev_header_hash != prev_block_record.header_hash:
+                log.info("recent chain is not hash-contiguous")
+                return False, []
+
         pos = block.reward_chain_block.proof_of_space
         if pos.version == 1 and pos.quality_string() is None:
             log.info(f"invalid proof of space in weight proof recent chain block {block.height}")


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:
better validation errors for WP 
<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus sync validation and peer banning on weight proofs; incorrect thresholds could reject valid peers or miss attacks, but scope is defensive checks on an already security-sensitive path.
> 
> **Overview**
> Hardens **weight proof (WP)** handling during long sync by rejecting malformed `recent_chain_data` earlier and with clearer validation failures.
> 
> Adds `_minimum_recent_chain_length()` from consensus constants and uses it in **`request_validate_wp`** to **ban peers** that return a WP whose recent chain is too short, before full validation runs. **`validate_recent_blocks`** now fails fast when the recent chain is too short, when sub-epoch summary indexing is wrong (expects exactly two SES positions and enough summary entries), or when blocks are not **height-** or **hash-contiguous**.
> 
> Challenge-related checks (two challenges present, enough blocks per challenge block) now run whenever those conditions fail, not only when there are more than two summaries—so short or inconsistent recent chains get explicit log messages instead of slipping past partial gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1276028a4412055db564f9457465a0d332aa65ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->