### PR TITLE
CHIA-4264: Continue Wallet Subscriptions After a Single Peer Fails

### DIFF
--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -40,8 +40,6 @@ from chia.util.config import load_config
 from chia.util.errors import Err
 from chia.util.hash import std_hash
 from chia.util.keychain import Keychain, KeyData, generate_mnemonic
-from chia.util.task_referencer import create_referenced_task
-from chia.wallet.util.new_peak_queue import NewPeakQueue
 from chia.wallet.util.peer_request_cache import PeerRequestCache
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_sync_utils import PeerRequestException
@@ -2193,54 +2191,49 @@ async def test_collect_valid_states(
     ["puzzle_hash", "coin_id"],
 )
 async def test_process_new_subscriptions_continues_after_peer_error(
-    root_path_populated_with_config: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    setup_two_nodes_and_wallet: OldSimulatorsAndWallets,
+    self_hostname: str,
     subscription_kind: str,
 ) -> None:
     """One failing peer must not skip subscription registration on later peers."""
-    import chia.wallet.wallet_node as wallet_node_module
+    [bad_fn_api, good_fn_api], [(wallet_node, wallet_server)], _ = setup_two_nodes_and_wallet
+    # Keep both peers; do not prefer a trusted peer that would disconnect the other.
+    wallet_node.config["trusted_peers"] = {}
 
-    config = load_config(root_path_populated_with_config, "config.yaml", "wallet")
-    wallet_node = WalletNode(config, root_path_populated_with_config, test_constants)
-    wallet_node._new_peak_queue = NewPeakQueue(inner_queue=asyncio.PriorityQueue())
-    wallet_node._wallet_state_manager = MagicMock()
-    wallet_node._wallet_state_manager.lock = asyncio.Lock()
+    assert await wallet_server.start_client(PeerInfo(self_hostname, bad_fn_api.server.get_port()), None)
+    assert await wallet_server.start_client(PeerInfo(self_hostname, good_fn_api.server.get_port()), None)
+    await time_out_assert(10, lambda: len(wallet_server.get_connections(NodeType.FULL_NODE)) == 2)
 
-    bad_peer = MagicMock()
-    bad_peer.peer_info.host = "bad-peer"
-    bad_peer.close = AsyncMock()
-    good_peer = MagicMock()
-    good_peer.peer_info.host = "good-peer"
-    good_peer.close = AsyncMock()
+    target = bytes32.random()
 
-    server = MagicMock()
-    server.get_connections = Mock(return_value=[bad_peer, good_peer])
-    wallet_node._server = server
+    async def register_for_ph_updates(
+        self: object, request: wallet_protocol.RegisterForPhUpdates, peer: WSChiaConnection
+    ) -> None:
+        raise RuntimeError("simulated peer failure")
 
-    subscribed_peers: list[object] = []
-    target = bytes32(b"\x11" * 32)
-
-    async def fake_subscribe(ids: list[bytes32], peer: object, min_height: int, priority: int = 0) -> list[CoinState]:
-        assert ids == [target]
-        if peer is bad_peer:
-            raise ValueError("simulated peer failure")
-        subscribed_peers.append(peer)
-        return []
+    async def register_for_coin_updates(
+        self: object, request: wallet_protocol.RegisterForCoinUpdates, peer: WSChiaConnection
+    ) -> None:
+        raise RuntimeError("simulated peer failure")
 
     if subscription_kind == "puzzle_hash":
-        monkeypatch.setattr(wallet_node_module, "subscribe_to_phs", fake_subscribe)
-        await wallet_node.new_peak_queue.subscribe_to_puzzle_hashes([target])
-    else:
-        monkeypatch.setattr(wallet_node_module, "subscribe_to_coin_updates", fake_subscribe)
-        await wallet_node.new_peak_queue.subscribe_to_coin_ids([target])
+        handler: Any = register_for_ph_updates
 
-    task = create_referenced_task(wallet_node._process_new_subscriptions())
-    try:
-        await time_out_assert(5, lambda: len(subscribed_peers) == 1)
-        assert subscribed_peers == [good_peer]
-        bad_peer.close.assert_awaited()
-        good_peer.close.assert_not_called()
-    finally:
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+        def good_peer_subscribed() -> bool:
+            return target in good_fn_api.full_node.subscriptions.puzzle_subscriptions(wallet_server.node_id)
+
+    else:
+        handler = register_for_coin_updates
+
+        def good_peer_subscribed() -> bool:
+            return target in good_fn_api.full_node.subscriptions.coin_subscriptions(wallet_server.node_id)
+
+    with patch_request_handler(api=bad_fn_api, handler=handler):
+        if subscription_kind == "puzzle_hash":
+            await wallet_node.new_peak_queue.subscribe_to_puzzle_hashes([target])
+        else:
+            await wallet_node.new_peak_queue.subscribe_to_coin_ids([target])
+        await time_out_assert(10, good_peer_subscribed)
+        await time_out_assert(10, lambda: bad_fn_api.server.node_id not in wallet_server.all_connections)
+
+    assert good_fn_api.server.node_id in wallet_server.all_connections

--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -40,6 +40,8 @@ from chia.util.config import load_config
 from chia.util.errors import Err
 from chia.util.hash import std_hash
 from chia.util.keychain import Keychain, KeyData, generate_mnemonic
+from chia.util.task_referencer import create_referenced_task
+from chia.wallet.util.new_peak_queue import NewPeakQueue
 from chia.wallet.util.peer_request_cache import PeerRequestCache
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.util.wallet_sync_utils import PeerRequestException
@@ -2183,3 +2185,62 @@ async def test_collect_valid_states(
         )
     assert [cs.coin.name() for cs in valid_states] == [good_coin_state.coin.name()]
     assert f"Failed to validate coin_state {bad_coin_state}" in caplog.text
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "subscription_kind",
+    ["puzzle_hash", "coin_id"],
+)
+async def test_process_new_subscriptions_continues_after_peer_error(
+    root_path_populated_with_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    subscription_kind: str,
+) -> None:
+    """One failing peer must not skip subscription registration on later peers."""
+    import chia.wallet.wallet_node as wallet_node_module
+
+    config = load_config(root_path_populated_with_config, "config.yaml", "wallet")
+    wallet_node = WalletNode(config, root_path_populated_with_config, test_constants)
+    wallet_node._new_peak_queue = NewPeakQueue(inner_queue=asyncio.PriorityQueue())
+    wallet_node._wallet_state_manager = MagicMock()
+    wallet_node._wallet_state_manager.lock = asyncio.Lock()
+
+    bad_peer = MagicMock()
+    bad_peer.peer_info.host = "bad-peer"
+    bad_peer.close = AsyncMock()
+    good_peer = MagicMock()
+    good_peer.peer_info.host = "good-peer"
+    good_peer.close = AsyncMock()
+
+    server = MagicMock()
+    server.get_connections = Mock(return_value=[bad_peer, good_peer])
+    wallet_node._server = server
+
+    subscribed_peers: list[object] = []
+    target = bytes32(b"\x11" * 32)
+
+    async def fake_subscribe(ids: list[bytes32], peer: object, min_height: int, priority: int = 0) -> list[CoinState]:
+        assert ids == [target]
+        if peer is bad_peer:
+            raise ValueError("simulated peer failure")
+        subscribed_peers.append(peer)
+        return []
+
+    if subscription_kind == "puzzle_hash":
+        monkeypatch.setattr(wallet_node_module, "subscribe_to_phs", fake_subscribe)
+        await wallet_node.new_peak_queue.subscribe_to_puzzle_hashes([target])
+    else:
+        monkeypatch.setattr(wallet_node_module, "subscribe_to_coin_updates", fake_subscribe)
+        await wallet_node.new_peak_queue.subscribe_to_coin_ids([target])
+
+    task = create_referenced_task(wallet_node._process_new_subscriptions())
+    try:
+        await time_out_assert(5, lambda: len(subscribed_peers) == 1)
+        assert subscribed_peers == [good_peer]
+        bad_peer.close.assert_awaited()
+        good_peer.close.assert_not_called()
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/chia/_tests/wallet/test_wallet_sync_utils.py
+++ b/chia/_tests/wallet/test_wallet_sync_utils.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import pytest
-from chia_rs import RespondToPhUpdates
-from chia_rs.sized_bytes import bytes32
-from chia_rs.sized_ints import int16, uint32
+from chia_rs.sized_ints import int16
 
 from chia.protocols.shared_protocol import Error
-from chia.protocols.wallet_protocol import RespondToCoinUpdates
 from chia.wallet.util.wallet_sync_utils import _coin_states_from_subscribe_response
 
 
@@ -25,17 +22,3 @@ from chia.wallet.util.wallet_sync_utils import _coin_states_from_subscribe_respo
 def test_coin_states_from_subscribe_response_rejects_invalid(response: object, match: str) -> None:
     with pytest.raises(ValueError, match=match):
         _coin_states_from_subscribe_response(response, "peer.example", "register_for_ph_updates")
-
-
-@pytest.mark.parametrize(
-    "response",
-    [
-        RespondToPhUpdates([bytes32.zeros], uint32(0), []),
-        RespondToCoinUpdates([bytes32.zeros], uint32(0), []),
-    ],
-    ids=["ph_updates", "coin_updates"],
-)
-def test_coin_states_from_subscribe_response_returns_coin_states(
-    response: RespondToPhUpdates | RespondToCoinUpdates,
-) -> None:
-    assert _coin_states_from_subscribe_response(response, "peer.example", "register_for_ph_updates") == []

--- a/chia/_tests/wallet/test_wallet_sync_utils.py
+++ b/chia/_tests/wallet/test_wallet_sync_utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+from chia_rs import RespondToPhUpdates
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import int16, uint32
+
+from chia.protocols.shared_protocol import Error
+from chia.protocols.wallet_protocol import RespondToCoinUpdates
+from chia.wallet.util.wallet_sync_utils import _coin_states_from_subscribe_response
+
+
+@pytest.mark.parametrize(
+    "response, match",
+    [
+        (None, "None response from peer peer.example for register_for_ph_updates"),
+        (
+            Error(int16(1), "rejected", None),
+            "Error response from peer peer.example for register_for_ph_updates",
+        ),
+        (object(), "Unexpected response from peer peer.example for register_for_ph_updates: object"),
+    ],
+    ids=["none", "protocol_error", "unexpected_type"],
+)
+def test_coin_states_from_subscribe_response_rejects_invalid(response: object, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        _coin_states_from_subscribe_response(response, "peer.example", "register_for_ph_updates")
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        RespondToPhUpdates([bytes32.zeros], uint32(0), []),
+        RespondToCoinUpdates([bytes32.zeros], uint32(0), []),
+    ],
+    ids=["ph_updates", "coin_updates"],
+)
+def test_coin_states_from_subscribe_response_returns_coin_states(
+    response: RespondToPhUpdates | RespondToCoinUpdates,
+) -> None:
+    assert _coin_states_from_subscribe_response(response, "peer.example", "register_for_ph_updates") == []

--- a/chia/wallet/util/wallet_sync_utils.py
+++ b/chia/wallet/util/wallet_sync_utils.py
@@ -18,7 +18,7 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32
 
 from chia.full_node.full_node_api import FullNodeAPI
-from chia.protocols.shared_protocol import Capability
+from chia.protocols.shared_protocol import Capability, Error
 from chia.protocols.wallet_protocol import (
     RegisterForCoinUpdates,
     RegisterForPhUpdates,
@@ -51,6 +51,21 @@ class PeerRequestException(Exception):
     pass
 
 
+def _coin_states_from_subscribe_response(
+    response: object,
+    peer_host: str,
+    request_name: str,
+) -> list[CoinState]:
+    """Normalize call_api results for subscription helpers into coin states or ValueError."""
+    if response is None:
+        raise ValueError(f"None response from peer {peer_host} for {request_name}")
+    if isinstance(response, Error):
+        raise ValueError(f"Error response from peer {peer_host} for {request_name}: {response}")
+    if isinstance(response, (RespondToPhUpdates, RespondToCoinUpdates)):
+        return response.coin_states
+    raise ValueError(f"Unexpected response from peer {peer_host} for {request_name}: {type(response).__name__}")
+
+
 async def subscribe_to_phs(
     puzzle_hashes: list[bytes32],
     peer: WSChiaConnection,
@@ -61,12 +76,10 @@ async def subscribe_to_phs(
     Tells full nodes that we are interested in puzzle hashes, and returns the response.
     """
     msg = RegisterForPhUpdates(puzzle_hashes, uint32(max(min_height, uint32(0))))
-    all_coins_state: RespondToPhUpdates | None = await peer.call_api(
+    all_coins_state: RespondToPhUpdates | Error | None = await peer.call_api(
         FullNodeAPI.register_for_ph_updates, msg, timeout=300, priority=priority
     )
-    if all_coins_state is None:
-        raise ValueError(f"None response from peer {peer.peer_info.host} for register_for_ph_updates")
-    return all_coins_state.coin_states
+    return _coin_states_from_subscribe_response(all_coins_state, peer.peer_info.host, "register_for_ph_updates")
 
 
 async def subscribe_to_coin_updates(
@@ -79,13 +92,10 @@ async def subscribe_to_coin_updates(
     Tells full nodes that we are interested in coin ids, and returns the response.
     """
     msg = RegisterForCoinUpdates(coin_names, uint32(max(0, min_height)))
-    all_coins_state: RespondToCoinUpdates | None = await peer.call_api(
+    all_coins_state: RespondToCoinUpdates | Error | None = await peer.call_api(
         FullNodeAPI.register_for_coin_updates, msg, timeout=300, priority=priority
     )
-
-    if all_coins_state is None:
-        raise ValueError(f"None response from peer {peer.peer_info.host} for register_for_coin_updates")
-    return all_coins_state.coin_states
+    return _coin_states_from_subscribe_response(all_coins_state, peer.peer_info.host, "register_for_coin_updates")
 
 
 def validate_additions(

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -683,10 +683,9 @@ class WalletNode:
                     coin_ids: list[bytes32] = item.data
                     for peer in self.server.get_connections(NodeType.FULL_NODE):
                         try:
+                            # Only catch peer/RPC failures here. Local apply errors should
+                            # surface to the outer handler so we do not ban every peer.
                             coin_states: list[CoinState] = await subscribe_to_coin_updates(coin_ids, peer, 0)
-                            if len(coin_states) > 0:
-                                async with self.wallet_state_manager.lock:
-                                    await self.add_states_from_peer(coin_states, peer)
                         except Exception as e:
                             # Keep going so one bad peer cannot drop this batch for everyone else.
                             self.log.warning(
@@ -694,16 +693,26 @@ class WalletNode:
                                 peer.peer_info.host,
                                 e,
                             )
-                            await peer.close(9999)
+                            try:
+                                await peer.close(9999)
+                            except Exception:
+                                self.log.warning(
+                                    "Failed closing peer %s after COIN_ID_SUBSCRIPTION error",
+                                    peer.peer_info.host,
+                                    exc_info=True,
+                                )
+                            continue
+                        if len(coin_states) > 0:
+                            async with self.wallet_state_manager.lock:
+                                await self.add_states_from_peer(coin_states, peer)
                 elif item.item_type == NewPeakQueueTypes.PUZZLE_HASH_SUBSCRIPTION:
                     self.log.debug("Pulled from queue: %s %s", item.item_type.name, item.data)
                     puzzle_hashes: list[bytes32] = item.data
                     for peer in self.server.get_connections(NodeType.FULL_NODE):
                         try:
+                            # Only catch peer/RPC failures here. Local apply errors should
+                            # surface to the outer handler so we do not ban every peer.
                             coin_states = await subscribe_to_phs(puzzle_hashes, peer, 0)
-                            if len(coin_states) > 0:
-                                async with self.wallet_state_manager.lock:
-                                    await self.add_states_from_peer(coin_states, peer)
                         except Exception as e:
                             # Keep going so one bad peer cannot drop this batch for everyone else.
                             self.log.warning(
@@ -711,7 +720,18 @@ class WalletNode:
                                 peer.peer_info.host,
                                 e,
                             )
-                            await peer.close(9999)
+                            try:
+                                await peer.close(9999)
+                            except Exception:
+                                self.log.warning(
+                                    "Failed closing peer %s after PUZZLE_HASH_SUBSCRIPTION error",
+                                    peer.peer_info.host,
+                                    exc_info=True,
+                                )
+                            continue
+                        if len(coin_states) > 0:
+                            async with self.wallet_state_manager.lock:
+                                await self.add_states_from_peer(coin_states, peer)
                 elif item.item_type == NewPeakQueueTypes.FULL_NODE_STATE_UPDATED:
                     # Note: this can take a while when we have a lot of transactions. We want to process these
                     # before new_peaks, since new_peak_wallet requires that we first obtain the state for that peak.

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -682,19 +682,36 @@ class WalletNode:
                     # we might not be able to process some state.
                     coin_ids: list[bytes32] = item.data
                     for peer in self.server.get_connections(NodeType.FULL_NODE):
-                        coin_states: list[CoinState] = await subscribe_to_coin_updates(coin_ids, peer, 0)
-                        if len(coin_states) > 0:
-                            async with self.wallet_state_manager.lock:
-                                await self.add_states_from_peer(coin_states, peer)
+                        try:
+                            coin_states: list[CoinState] = await subscribe_to_coin_updates(coin_ids, peer, 0)
+                            if len(coin_states) > 0:
+                                async with self.wallet_state_manager.lock:
+                                    await self.add_states_from_peer(coin_states, peer)
+                        except Exception as e:
+                            # Keep going so one bad peer cannot drop this batch for everyone else.
+                            self.log.warning(
+                                "COIN_ID_SUBSCRIPTION failed for peer %s: %s",
+                                peer.peer_info.host,
+                                e,
+                            )
+                            await peer.close(9999)
                 elif item.item_type == NewPeakQueueTypes.PUZZLE_HASH_SUBSCRIPTION:
                     self.log.debug("Pulled from queue: %s %s", item.item_type.name, item.data)
                     puzzle_hashes: list[bytes32] = item.data
                     for peer in self.server.get_connections(NodeType.FULL_NODE):
-                        # Puzzle hash subscription
-                        coin_states = await subscribe_to_phs(puzzle_hashes, peer, 0)
-                        if len(coin_states) > 0:
-                            async with self.wallet_state_manager.lock:
-                                await self.add_states_from_peer(coin_states, peer)
+                        try:
+                            coin_states = await subscribe_to_phs(puzzle_hashes, peer, 0)
+                            if len(coin_states) > 0:
+                                async with self.wallet_state_manager.lock:
+                                    await self.add_states_from_peer(coin_states, peer)
+                        except Exception as e:
+                            # Keep going so one bad peer cannot drop this batch for everyone else.
+                            self.log.warning(
+                                "PUZZLE_HASH_SUBSCRIPTION failed for peer %s: %s",
+                                peer.peer_info.host,
+                                e,
+                            )
+                            await peer.close(9999)
                 elif item.item_type == NewPeakQueueTypes.FULL_NODE_STATE_UPDATED:
                     # Note: this can take a while when we have a lot of transactions. We want to process these
                     # before new_peaks, since new_peak_wallet requires that we first obtain the state for that peak.

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -49,9 +49,17 @@ from chia.types.weight_proof import WeightProof
 from chia.util.batches import to_batches
 from chia.util.config import lock_and_load_config, process_config_start_method, save_config
 from chia.util.db_wrapper import SQLITE_MAX_VARIABLE_NUMBER, manage_connection
-from chia.util.errors import Err, KeychainIsEmpty, KeychainIsLocked, KeychainKeyNotFound, KeychainProxyConnectionFailure
+from chia.util.errors import (
+    Err,
+    KeychainIsEmpty,
+    KeychainIsLocked,
+    KeychainKeyNotFound,
+    KeychainProxyConnectionFailure,
+    ProtocolError,
+)
 from chia.util.hash import std_hash
 from chia.util.keychain import Keychain
+from chia.util.log_exceptions import log_exceptions
 from chia.util.path import path_from_root
 from chia.util.profiler import mem_profile_task, profile_task
 from chia.util.streamable import Streamable, streamable
@@ -683,24 +691,24 @@ class WalletNode:
                     coin_ids: list[bytes32] = item.data
                     for peer in self.server.get_connections(NodeType.FULL_NODE):
                         try:
-                            # Only catch peer/RPC failures here. Local apply errors should
-                            # surface to the outer handler so we do not ban every peer.
+                            # Peer/RPC failures only: subscribe_to_* raises ValueError on None
+                            # responses; call_api may raise ProtocolError; transport may raise OSError.
+                            # Local apply errors should surface to the outer handler.
                             coin_states: list[CoinState] = await subscribe_to_coin_updates(coin_ids, peer, 0)
-                        except Exception as e:
+                        except (ValueError, ProtocolError, OSError) as e:
                             # Keep going so one bad peer cannot drop this batch for everyone else.
                             self.log.warning(
                                 "COIN_ID_SUBSCRIPTION failed for peer %s: %s",
                                 peer.peer_info.host,
                                 e,
                             )
-                            try:
+                            with log_exceptions(
+                                self.log,
+                                consume=True,
+                                message=f"Failed closing peer {peer.peer_info.host} after COIN_ID_SUBSCRIPTION error",
+                                level=logging.WARNING,
+                            ):
                                 await peer.close(9999)
-                            except Exception:
-                                self.log.warning(
-                                    "Failed closing peer %s after COIN_ID_SUBSCRIPTION error",
-                                    peer.peer_info.host,
-                                    exc_info=True,
-                                )
                             continue
                         if len(coin_states) > 0:
                             async with self.wallet_state_manager.lock:
@@ -710,24 +718,26 @@ class WalletNode:
                     puzzle_hashes: list[bytes32] = item.data
                     for peer in self.server.get_connections(NodeType.FULL_NODE):
                         try:
-                            # Only catch peer/RPC failures here. Local apply errors should
-                            # surface to the outer handler so we do not ban every peer.
+                            # Peer/RPC failures only: subscribe_to_* raises ValueError on None
+                            # responses; call_api may raise ProtocolError; transport may raise OSError.
+                            # Local apply errors should surface to the outer handler.
                             coin_states = await subscribe_to_phs(puzzle_hashes, peer, 0)
-                        except Exception as e:
+                        except (ValueError, ProtocolError, OSError) as e:
                             # Keep going so one bad peer cannot drop this batch for everyone else.
                             self.log.warning(
                                 "PUZZLE_HASH_SUBSCRIPTION failed for peer %s: %s",
                                 peer.peer_info.host,
                                 e,
                             )
-                            try:
+                            with log_exceptions(
+                                self.log,
+                                consume=True,
+                                message=(
+                                    f"Failed closing peer {peer.peer_info.host} after PUZZLE_HASH_SUBSCRIPTION error"
+                                ),
+                                level=logging.WARNING,
+                            ):
                                 await peer.close(9999)
-                            except Exception:
-                                self.log.warning(
-                                    "Failed closing peer %s after PUZZLE_HASH_SUBSCRIPTION error",
-                                    peer.peer_info.host,
-                                    exc_info=True,
-                                )
                             continue
                         if len(coin_states) > 0:
                             async with self.wallet_state_manager.lock:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -62,7 +62,7 @@ from chia.util.keychain import Keychain
 from chia.util.log_exceptions import log_exceptions
 from chia.util.path import path_from_root
 from chia.util.profiler import mem_profile_task, profile_task
-from chia.util.streamable import Streamable, streamable
+from chia.util.streamable import Streamable, StreamableError, streamable
 from chia.util.task_referencer import create_referenced_task
 from chia.wallet.puzzles.clawback.metadata import AutoClaimSettings
 from chia.wallet.transaction_record import TransactionRecord
@@ -691,11 +691,11 @@ class WalletNode:
                     coin_ids: list[bytes32] = item.data
                     for peer in self.server.get_connections(NodeType.FULL_NODE):
                         try:
-                            # Peer/RPC failures only: subscribe_to_* raises ValueError on None
-                            # responses; call_api may raise ProtocolError; transport may raise OSError.
-                            # Local apply errors should surface to the outer handler.
+                            # Peer/RPC failures only. subscribe_to_* raises ValueError on None/Error
+                            # responses; call_api may raise ProtocolError/StreamableError; transport
+                            # may raise OSError. Local apply errors should surface to the outer handler.
                             coin_states: list[CoinState] = await subscribe_to_coin_updates(coin_ids, peer, 0)
-                        except (ValueError, ProtocolError, OSError) as e:
+                        except (ValueError, ProtocolError, OSError, StreamableError) as e:
                             # Keep going so one bad peer cannot drop this batch for everyone else.
                             self.log.warning(
                                 "COIN_ID_SUBSCRIPTION failed for peer %s: %s",
@@ -718,11 +718,11 @@ class WalletNode:
                     puzzle_hashes: list[bytes32] = item.data
                     for peer in self.server.get_connections(NodeType.FULL_NODE):
                         try:
-                            # Peer/RPC failures only: subscribe_to_* raises ValueError on None
-                            # responses; call_api may raise ProtocolError; transport may raise OSError.
-                            # Local apply errors should surface to the outer handler.
+                            # Peer/RPC failures only. subscribe_to_* raises ValueError on None/Error
+                            # responses; call_api may raise ProtocolError/StreamableError; transport
+                            # may raise OSError. Local apply errors should surface to the outer handler.
                             coin_states = await subscribe_to_phs(puzzle_hashes, peer, 0)
-                        except (ValueError, ProtocolError, OSError) as e:
+                        except (ValueError, ProtocolError, OSError, StreamableError) as e:
                             # Keep going so one bad peer cannot drop this batch for everyone else.
                             self.log.warning(
                                 "PUZZLE_HASH_SUBSCRIPTION failed for peer %s: %s",


### PR DESCRIPTION
## Summary
- Catch per-peer failures when registering coin-id / puzzle-hash subscriptions so one bad peer cannot drop the batch for remaining full-node peers
- Add a focused unit test covering both subscription kinds with limited mocks

## Test plan
- [x] `pytest chia/_tests/wallet/test_wallet_node.py::test_process_new_subscriptions_continues_after_peer_error`


Made with [Cursor](https://cursor.com)