### PR TITLE
Identify DL singletons in `determine_coin_type` (and save computation)

### DIFF
--- a/chia/data_layer/data_layer_wallet.py
+++ b/chia/data_layer/data_layer_wallet.py
@@ -33,6 +33,7 @@ from chia.wallet.db_wallet.db_wallet_puzzles import (
     ACS_MU,
     ACS_MU_PH,
     GRAFTROOT_DL_OFFERS,
+    MIRROR_PUZZLE_HASH,
     create_graftroot_offer_puz,
     create_host_fullpuz,
     create_host_layer_puzzle,
@@ -52,7 +53,7 @@ from chia.wallet.transaction_record import TransactionRecord
 from chia.wallet.util.compute_additions import compute_additions
 from chia.wallet.util.merkle_utils import _simplify_merkle_proof
 from chia.wallet.util.wallet_sync_utils import fetch_coin_spend, fetch_coin_spend_for_coin_state
-from chia.wallet.util.wallet_types import WalletType
+from chia.wallet.util.wallet_types import WalletIdentifier, WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_action_scope import WalletActionScope
 from chia.wallet.wallet_coin_record import WalletCoinRecord
@@ -893,6 +894,19 @@ class DataLayerWallet:
                 if i == peer_length - 1:
                     raise e  # raise the error if we've tried all peers
                 continue  # try some other peers, maybe someone has it
+
+    @classmethod
+    async def identify(cls, wallet_state_manager: WalletStateManager, coin_state: CoinState) -> WalletIdentifier | None:
+        try:
+            dl_wallet = await wallet_state_manager.get_dl_wallet()
+        except ValueError:
+            return None
+        if (
+            coin_state.coin.puzzle_hash == MIRROR_PUZZLE_HASH
+            or await dl_wallet.get_singleton_record(coin_state.coin.name()) is not None
+        ):
+            return WalletIdentifier.create(dl_wallet)
+        return None
 
     ###########
     # UTILITY #

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -55,7 +55,6 @@ from chia.wallet.conditions import (
     CreateCoin,
     parse_timelock_info,
 )
-from chia.wallet.db_wallet.db_wallet_puzzles import MIRROR_PUZZLE_HASH
 from chia.wallet.derivation_record import DerivationRecord
 from chia.wallet.derive_keys import (
     MAX_POOL_WALLETS,
@@ -921,6 +920,10 @@ class WalletStateManager:
         ):
             return None, None
 
+        dl_identification = await DataLayerWallet.identify(self, coin_state)
+        if dl_identification is not None:
+            return dl_identification, None
+
         response: list[CoinState] = await self.wallet_node.get_coin_state(
             [coin_state.coin.parent_coin_info], peer=peer, fork_height=fork_height
         )
@@ -1704,16 +1707,6 @@ class WalletStateManager:
                         wallet_identifier = WalletIdentifier(uint32(local_record.wallet_id), local_record.wallet_type)
                     elif coin_state.created_height is not None:
                         wallet_identifier, coin_data = await self.determine_coin_type(peer, coin_state, fork_height)
-                        try:
-                            dl_wallet = await self.get_dl_wallet()
-                        except ValueError:
-                            pass
-                        else:
-                            if (
-                                await dl_wallet.get_singleton_record(coin_name) is not None
-                                or coin_state.coin.puzzle_hash == MIRROR_PUZZLE_HASH
-                            ):
-                                wallet_identifier = WalletIdentifier.create(dl_wallet)
 
                     # If this coin was previously only stored as an "interest-only" record (REMOTE),
                     # but we now recognize it as belonging to a real wallet, treat it as a new coin so wallet-specific


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes coin-to-wallet classification during sync; behavior should match the removed duplicate logic, but misclassification could affect which wallet owns incoming DL or mirror coins.
> 
> **Overview**
> Data layer singletons and mirror coins are now classified inside **`determine_coin_type`** via a new **`DataLayerWallet.identify`** helper, instead of a second pass after coin-type detection during sync.
> 
> **`identify`** returns the DL wallet when the coin’s puzzle hash is **`MIRROR_PUZZLE_HASH`** or when the DL store already has a singleton record for that coin id. **`WalletStateManager`** runs this check right after pool/farmer reward filtering and **before** fetching the parent coin state and running CAT/NFT/DID parsing, so known DL coins skip that heavier work. The duplicate DL branch removed from **`_add_coin_states`** avoids doing the same mirror/singleton lookup twice on the sync path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0b9ffc0c1ae2cd179fd6a1e6472ef2bca824664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->