### PR TITLE
Remove obsolete `add_condition_to_solution`

### DIFF
--- a/chia/wallet/puzzles/tails.py
+++ b/chia/wallet/puzzles/tails.py
@@ -25,7 +25,7 @@ from chia.wallet.cat_wallet.cat_utils import (
     unsigned_spend_bundle_for_spendable_cats,
 )
 from chia.wallet.cat_wallet.lineage_store import CATLineageStore
-from chia.wallet.conditions import CreateCoin
+from chia.wallet.conditions import CreateCoin, UnknownCondition
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.wallet_action_scope import WalletActionScope
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
@@ -123,9 +123,11 @@ class GenesisById(LimitationsProgram):
             interface.side_effects.transactions = inner_action_scope.side_effects.transactions
 
         inner_tree_hash = cat_inner.get_tree_hash()
-        inner_solution = wallet.standard_wallet.add_condition_to_solution(
-            Program.to([51, 0, -113, tail, []]),
-            wallet.standard_wallet.make_solution(primaries=[CreateCoin(inner_tree_hash, amount, [inner_tree_hash])]),
+        inner_solution = wallet.standard_wallet.make_solution(
+            primaries=[CreateCoin(inner_tree_hash, amount, [inner_tree_hash])],
+            conditions=(
+                UnknownCondition(opcode=Program.to(51), args=[Program.NIL, Program.to(-113), tail, Program.NIL]),
+            ),
         )
         eve_spend = unsigned_spend_bundle_for_spendable_cats(
             CAT_MOD,

--- a/chia/wallet/wallet.py
+++ b/chia/wallet/wallet.py
@@ -181,11 +181,6 @@ class Wallet:
 
         return solution_for_conditions(condition_list)
 
-    def add_condition_to_solution(self, condition: Program, solution: Program) -> Program:
-        python_program = solution.as_python()
-        python_program[1].append(condition)
-        return Program.to(python_program)
-
     async def select_coins(
         self,
         amount: uint64,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small refactor with equivalent solution encoding for CAT eve spends; no auth or consensus logic changes beyond removing dead API surface.
> 
> **Overview**
> Removes **`Wallet.add_condition_to_solution`**, which appended a raw CLVM condition by mutating an existing solution’s Python representation.
> 
> **Genesis-by-id CAT issuance** in `tails.py` now passes the TAIL reveal as an **`UnknownCondition`** through **`make_solution`**’s `conditions` tuple (alongside the `CreateCoin` primary), instead of building a solution and patching it afterward.
> 
> This matches how other wallet/CAT code already adds non-standard opcode **51** conditions via the typed conditions API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f6720fe5b8e814fdcafaf3c321ac1b60805fdf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->