### PR TITLE
CHIA-4218 Return None when anchored wallet timestamp lookup misses the peak header

### DIFF
--- a/chia/_tests/wallet/test_wallet_node.py
+++ b/chia/_tests/wallet/test_wallet_node.py
@@ -626,6 +626,75 @@ async def test_get_timestamp_for_height_from_peer_rejects_wrong_response_height(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("peak_response", [None, []])
+async def test_get_timestamp_for_height_from_peer_rejects_missing_peak_response(
+    root_path_populated_with_config: Path, monkeypatch: pytest.MonkeyPatch, peak_response: list[object] | None
+) -> None:
+    config = load_config(root_path_populated_with_config, "config.yaml", "wallet")
+    wallet_node = WalletNode(config, root_path_populated_with_config, test_constants)
+    expected_hash = bytes32(b"\x01" * 32)
+    peer = cast(WSChiaConnection, types.SimpleNamespace(get_peer_info=lambda: "peer"))
+    add_to_blocks = Mock()
+    cache = types.SimpleNamespace(
+        get_height_timestamp=Mock(return_value=None),
+        get_block=Mock(return_value=None),
+        add_to_blocks=add_to_blocks,
+    )
+    requested_heights: list[int] = []
+
+    async def missing_response(peer: WSChiaConnection, start_height: uint32, end_height: uint32) -> list[object] | None:
+        requested_heights.append(int(start_height))
+        return peak_response
+
+    monkeypatch.setattr(wallet_node, "get_cache_for_peer", lambda peer: cache)
+    monkeypatch.setattr("chia.wallet.wallet_node.request_header_blocks", missing_response)
+
+    # An anchored lookup whose peak height returns no block (empty or timeout) must not
+    # backtrack with a stale anchor; it returns None after the single failed peak request.
+    assert await wallet_node.get_timestamp_for_height_from_peer(uint32(100), peer, expected_hash) is None
+    assert requested_heights == [100]
+    add_to_blocks.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_get_timestamp_for_height_from_peer_unanchored_backtracks_past_missing_peak(
+    root_path_populated_with_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = load_config(root_path_populated_with_config, "config.yaml", "wallet")
+    wallet_node = WalletNode(config, root_path_populated_with_config, test_constants)
+    timestamp = uint64(12_345)
+    peer = cast(WSChiaConnection, types.SimpleNamespace(get_peer_info=lambda: "peer"))
+    add_to_blocks = Mock()
+    cache = types.SimpleNamespace(
+        get_height_timestamp=Mock(return_value=None),
+        get_block=Mock(return_value=None),
+        add_to_blocks=add_to_blocks,
+    )
+    requested_heights: list[int] = []
+
+    async def response(peer: WSChiaConnection, start_height: uint32, end_height: uint32) -> list[object]:
+        requested_heights.append(int(start_height))
+        if int(start_height) == 100:
+            return []
+        return [
+            types.SimpleNamespace(
+                height=uint32(start_height),
+                header_hash=bytes32(b"\x05" * 32),
+                prev_header_hash=bytes32(b"\x06" * 32),
+                foliage_transaction_block=types.SimpleNamespace(timestamp=timestamp),
+            )
+        ]
+
+    monkeypatch.setattr(wallet_node, "get_cache_for_peer", lambda peer: cache)
+    monkeypatch.setattr("chia.wallet.wallet_node.request_header_blocks", response)
+
+    # Without an anchor an empty peak response is not fatal: the lookup keeps backtracking
+    # toward an older transaction block, so the anchored short-circuit must not apply here.
+    assert await wallet_node.get_timestamp_for_height_from_peer(uint32(100), peer) == timestamp
+    assert requested_heights == [100, 99]
+
+
+@pytest.mark.anyio
 async def test_get_timestamp_for_height_from_peer_rejects_multiple_response_blocks(
     root_path_populated_with_config: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1267,6 +1267,14 @@ class WalletNode:
                 elif request_height < height:
                     # The peer might be slightly behind but still synced, so we should allow fetching one more block
                     break
+                elif expected_hash is not None:
+                    # Anchored lookups require a block at each height to carry the hash to the
+                    # next one. With no block here there is nothing to anchor to, so treat the
+                    # peer as not synced rather than continue against a stale hash.
+                    self.log.warning(
+                        f"missing header block response for height {request_height} from Peer {peer.get_peer_info()}."
+                    )
+                    return None
             else:
                 self.log.debug(f"get_timestamp_for_height_from_peer use cached block for height {request_height}")
 

--- a/chia/wallet/wallet_node.py
+++ b/chia/wallet/wallet_node.py
@@ -1268,9 +1268,10 @@ class WalletNode:
                     # The peer might be slightly behind but still synced, so we should allow fetching one more block
                     break
                 elif expected_hash is not None:
-                    # Anchored lookups require a block at each height to carry the hash to the
-                    # next one. With no block here there is nothing to anchor to, so treat the
-                    # peer as not synced rather than continue against a stale hash.
+                    # Only reached on the starting height. In anchored mode, this block establishes
+                    # the hash chain used to validate any backtracked headers. Without it, continuing
+                    # would only compare lower headers against the original peak hash and fail later.
+                    # Treat the peer as not synced instead.
                     self.log.warning(
                         f"missing header block response for height {request_height} from Peer {peer.get_peer_info()}."
                     )


### PR DESCRIPTION
JIRA: [CHIA-4218](https://chia-network.atlassian.net/browse/CHIA-4218)

### Purpose:

Cleanup bugfix to previous work on wallet timestamp lookup. When `get_timestamp_for_height_from_peer()` is called with `expected_header_hash`, the first requested block is the anchor for validating any later headers. If the peer returns no header for that starting height, the lookup should return `None` immediately.

### Current Behavior:

An anchored lookup with no response for the starting height continues to height-1 with the original expected hash still set. That still eventually returns `None`, but only after one extra header request and a misleading `bad header block hash` warning.

Unanchored lookups do not validate against an expected hash chain, so they may still backtrack by height when the starting height has no block response.

### New Behavior:

In anchored mode (`expected_header_hash` supplied), a missing or empty response for the starting height now returns `None` immediately.

Invariants unchanged:
- Non-anchored lookups (`get_timestamp_for_height`, `expected_header_hash is None`) still backtrack past a missing starting height toward an older transaction block.
- The new branch is only reachable on the first iteration (`request_height == height`); empty responses at lower heights still hit the existing `request_height < height` branch.
- `None` return semantics for callers are unchanged.
- `None` and `[]` peer responses are handled identically; both mean no block was returned.

### Testing Notes:

- `ruff check` / `ruff format --check` / `mypy` on `chia/wallet/wallet_node.py` and `chia/_tests/wallet/test_wallet_node.py` — pass.
- `pytest chia/_tests/wallet/test_wallet_node.py -k get_timestamp_for_height_from_peer` — 11 passed, including:
  - `test_get_timestamp_for_height_from_peer_rejects_missing_peak_response[None|peak_response1]` — anchored `None` and `[]` peak responses return `None`, request only the starting height, and do not cache anything.
  - `test_get_timestamp_for_height_from_peer_unanchored_backtracks_past_missing_peak` — unanchored lookups still backtrack to height 99 after an empty response at 100.
- Diff coverage vs `origin/main` — 100% (39 lines).
- Benchmarks (`pytest -m benchmark -n 0`) — 158 passed. Pre-existing `HARD_FORK_3_0` / `HARD_FORK_3_0_AFTER_PHASE_OUT` simulator plot-generation failures in `test_node_load` / `test_performance` / `test_mmr` are unrelated to this wallet-only change.
- `pre-commit run --all-files` — pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized wallet sync helper change with explicit anchored vs unanchored behavior preserved; tests cover the new branch and existing backtrack path.
> 
> **Overview**
> Fixes **anchored** wallet timestamp lookups (`get_timestamp_for_height_from_peer` with `expected_header_hash`) when the peer returns no header for the starting height (`None` or `[]`).
> 
> Previously the loop could still backtrack to lower heights with the original peak hash, causing an extra request and a misleading **bad header block hash** warning before returning `None`. The change returns `None` immediately on that first-height miss and logs a **missing header block response** warning instead.
> 
> **Unanchored** lookups (no expected hash) are unchanged: an empty response at the starting height still allows backtracking toward an older transaction block.
> 
> Tests cover anchored `None`/`[]` peak responses (single request, no cache), and unanchored backtrack after an empty response at height 100.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 961caca36b7ddda2efff477e8718ac314f7f233e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


[CHIA-4218]: https://chia-network.atlassian.net/browse/CHIA-4218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ