### PR TITLE
CHIA-4350 Make sure coins aren't being spent by any other spends in the spend bundle immediately after fast forward

### DIFF
--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -78,6 +78,7 @@ from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
     DEFAULT_HIDDEN_PUZZLE_HASH,
     calculate_synthetic_secret_key,
 )
+from chia.wallet.puzzles.singleton_top_layer_v1_1 import MELT_CONDITION, puzzle_for_singleton, solution_for_singleton
 from chia.wallet.util.tx_config import DEFAULT_TX_CONFIG
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_coin_record import WalletCoinRecord
@@ -2498,11 +2499,8 @@ class TestCoins:
 
 # creates a CoinSpend of a made up
 def make_singleton_spend(
-    launcher_id: bytes32, parent_parent_id: bytes32 = bytes32([3] * 32), child_amount: int = 1
+    launcher_id: bytes32, parent_parent_id: bytes32 = bytes32([3] * 32), child_amount: int = 1, *, melt: bool = False
 ) -> CoinSpend:
-    from chia.wallet.lineage_proof import LineageProof
-    from chia.wallet.puzzles.singleton_top_layer_v1_1 import puzzle_for_singleton, solution_for_singleton
-
     singleton_puzzle = puzzle_for_singleton(launcher_id, Program.to(1)).to_serialized()
 
     PARENT_COIN = Coin(parent_parent_id, singleton_puzzle.get_tree_hash(), uint64(1))
@@ -2510,7 +2508,9 @@ def make_singleton_spend(
 
     lineage_proof = LineageProof(parent_parent_id, IDENTITY_PUZZLE_HASH, uint64(1))
 
-    inner_solution = Program.to([[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, uint64(child_amount)]])
+    inner_solution = Program.to(
+        [MELT_CONDITION] if melt else [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, uint64(child_amount)]]
+    )
     singleton_solution = solution_for_singleton(lineage_proof, uint64(1), inner_solution).to_serialized()
 
     ret = CoinSpend(COIN, singleton_puzzle, singleton_solution)
@@ -3573,3 +3573,28 @@ async def test_mempool_item_to_spend_bundle() -> None:
         result = mi.to_spend_bundle()
         assert result == sb
         assert result.name() == sb_name
+
+
+@pytest.mark.anyio
+async def test_bundle_with_old_ff_spend_plus_melt_ff_spend() -> None:
+    """
+    Covers the scenario where a spend bundle has a coin that gets spent by
+    another spend immediately after fast forward, to make sure we reject that
+    spend bundle.
+    """
+    launcher_id = bytes32([1] * 32)
+    version_1_spend = make_singleton_spend(launcher_id, bytes32([2] * 32))
+    version_2_spend = make_singleton_spend(launcher_id, bytes32([3] * 32))
+    version_3_spend = make_singleton_spend(launcher_id, bytes32([4] * 32), melt=True)
+    coins = TestCoins(
+        [version_1_spend.coin, version_2_spend.coin, version_3_spend.coin],
+        {version_3_spend.coin.puzzle_hash: version_3_spend},
+    )
+    coins.spend_coin(version_1_spend.coin.name())
+    coins.spend_coin(version_2_spend.coin.name())
+    sb = SpendBundle([version_1_spend, version_3_spend], G2Element())
+    async with setup_mempool(coins) as mempool_manager:
+        _, status, error = await add_spendbundle(mempool_manager, sb, sb.name())
+        assert status == MempoolInclusionStatus.FAILED
+        assert error == Err.DOUBLE_SPEND
+        assert_sb_not_in_pool(mempool_manager, sb)

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -712,11 +712,23 @@ class MempoolManager:
                 latest_singleton_lineage=lineage_info,
             )
 
-        # fast forward spends are only allowed when bundled with other, non-FF, spends
-        # in order to evict an FF spend, it must be associated with a normal
-        # spend that can be included in a block or invalidated some other way
-        if all([s.supports_fast_forward for s in bundle_coin_spends.values()]):
+        non_ff_spend_ids = set()
+        ff_latest_ids = set()
+        for coin_id, spend_data in bundle_coin_spends.items():
+            if spend_data.latest_singleton_lineage is None:
+                non_ff_spend_ids.add(coin_id)
+            else:
+                ff_latest_ids.add(spend_data.latest_singleton_lineage.coin_id)
+        # Fast forward spends are only allowed when bundled with other, non-FF
+        # spends in order to evict an FF spend, it must be associated with a
+        # normal spend that can be included in a block or invalidated some
+        # other way.
+        if len(non_ff_spend_ids) == 0:
             return Err.INVALID_SPEND_BUNDLE, None, []
+        # Fast forward spends rebase onto latest unspent coin IDs so a non-FF
+        # spend of the same coin is a double spend after rebase.
+        if len(ff_latest_ids.intersection(non_ff_spend_ids)) > 0:
+            return Err.DOUBLE_SPEND, None, []
 
         removal_record_dict: dict[bytes32, CoinRecord] = {}
         removal_amount: int = 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core mempool validation for fast-forward singleton bundles; incorrect logic could wrongly reject valid transactions or miss invalid double spends.
> 
> **Overview**
> **Mempool admission** now rejects spend bundles where a fast-forward singleton spend would rebase onto the latest unspent coin while another spend in the **same bundle** removes that coin (e.g. melt). That overlap is treated as **`Err.DOUBLE_SPEND`** instead of only checking that FF spends are not bundled alone.
> 
> The FF-only-bundle rule is rewritten using explicit sets of non-FF removal coin IDs versus FF **latest lineage** coin IDs, rather than iterating `supports_fast_forward` on every spend.
> 
> **Tests:** `make_singleton_spend` supports a **`melt`** flag via `MELT_CONDITION`, and **`test_bundle_with_old_ff_spend_plus_melt_ff_spend`** covers an old FF spend bundled with a melt on the current singleton head.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5c8b0c17e9036c75a8c1a1703cdb0bdcc04d0f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->