### PR TITLE
[CHIA-4344] improve mempool's atom- and pair-count awareness

### DIFF
--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -4,7 +4,6 @@ import dataclasses
 import logging
 import random
 from collections.abc import Callable
-from typing import Any
 
 import pytest
 from chia_rs import (
@@ -46,7 +45,7 @@ from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
-from chia.full_node.eligible_coin_spends import IdenticalSpendDedup
+from chia.full_node.eligible_coin_spends import DedupCoinSpend, IdenticalSpendDedup
 from chia.full_node.fee_estimation import EmptyMempoolInfo, MempoolInfo
 from chia.full_node.full_node_api import FullNodeAPI
 from chia.full_node.mempool import MAX_BLOCK_ATOMS, MAX_BLOCK_PAIRS, MAX_SKIPPED_ITEMS, MAX_SPENDS_PER_BLOCK, Mempool
@@ -73,7 +72,7 @@ from chia.types.condition_with_args import ConditionWithArgs
 from chia.types.fee_rate import FeeRate
 from chia.types.generator_types import BlockGenerator
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
-from chia.types.mempool_item import MempoolItem, UnspentLineageInfo
+from chia.types.mempool_item import BundleCoinSpend, MempoolItem, UnspentLineageInfo
 from chia.util.casts import int_to_bytes
 from chia.util.errors import Err, ValidationError
 from chia.util.hash import std_hash
@@ -3532,10 +3531,12 @@ def test_block_atom_saturation_stops_scanning(monkeypatch: pytest.MonkeyPatch) -
     dedup_calls = 0
     original_get_deduplication_info = IdenticalSpendDedup.get_deduplication_info
 
-    def counting_get_deduplication_info(self: IdenticalSpendDedup, **kwargs: Any) -> Any:
+    def counting_get_deduplication_info(
+        self: IdenticalSpendDedup, *, bundle_coin_spends: dict[bytes32, BundleCoinSpend]
+    ) -> tuple[list[CoinSpend], uint64, list[Coin], dict[bytes32, DedupCoinSpend]]:
         nonlocal dedup_calls
         dedup_calls += 1
-        return original_get_deduplication_info(self, **kwargs)
+        return original_get_deduplication_info(self, bundle_coin_spends=bundle_coin_spends)
 
     monkeypatch.setattr(IdenticalSpendDedup, "get_deduplication_info", counting_get_deduplication_info)
 

--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -4,6 +4,7 @@ import dataclasses
 import logging
 import random
 from collections.abc import Callable
+from typing import Any
 
 import pytest
 from chia_rs import (
@@ -45,9 +46,10 @@ from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.condition_costs import ConditionCost
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
 from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
+from chia.full_node.eligible_coin_spends import IdenticalSpendDedup
 from chia.full_node.fee_estimation import EmptyMempoolInfo, MempoolInfo
 from chia.full_node.full_node_api import FullNodeAPI
-from chia.full_node.mempool import MAX_SPENDS_PER_BLOCK, Mempool
+from chia.full_node.mempool import MAX_BLOCK_ATOMS, MAX_BLOCK_PAIRS, MAX_SKIPPED_ITEMS, MAX_SPENDS_PER_BLOCK, Mempool
 from chia.full_node.mempool_manager import MEMPOOL_MIN_FEE_INCREASE, LineageInfoCache
 from chia.full_node.pending_tx_cache import ConflictTxCache, PendingTxCache
 from chia.protocols import full_node_protocol, wallet_protocol
@@ -3470,6 +3472,80 @@ def test_max_spends_per_block(old: bool) -> None:
     assert generator is not None
     # The 2-coin items were skipped but the final 1-coin item fits.
     assert len(generator.removals) == MAX_SPENDS_PER_BLOCK
+
+
+@pytest.mark.parametrize("old", [True, False])
+@pytest.mark.parametrize("limit", ["atoms", "pairs"])
+def test_block_atom_and_pair_limits(old: bool, limit: str) -> None:
+    max_cost = uint64(11_000_000_000)
+    fee_estimator = create_bitcoin_fee_estimator(max_cost)
+    mempool_info = MempoolInfo(
+        CLVMCost(uint64(max_cost * 10)),
+        FeeRate(uint64(1000000)),
+        CLVMCost(max_cost),
+    )
+    mempool = Mempool(mempool_info, fee_estimator)
+
+    # Each item accrues a third of the block limit, so exactly 3 items fit
+    # (the limit is inclusive), and any further item must be skipped. The other
+    # limit (cost, spends, and the counterpart of atoms/pairs) is kept small so
+    # only the limit under test is binding.
+    block_limit = MAX_BLOCK_ATOMS if limit == "atoms" else MAX_BLOCK_PAIRS
+    per_item = block_limit // 3
+    num_atoms = per_item if limit == "atoms" else 0
+    num_pairs = per_item if limit == "pairs" else 0
+
+    num_items = 6
+    for i in range(num_items):
+        item = mk_item([make_coin(i)], cost=1_000_000, fee=100, num_atoms=num_atoms, num_pairs=num_pairs)
+        info = mempool.add_to_pool(item)
+        assert info.error is None
+
+    assert mempool.size() == num_items
+
+    create_block = mempool.create_block_generator if old else mempool.create_block_generator2
+    generator = create_block(test_constants, uint32(0), 30.0)
+    assert generator is not None
+    # 3 * per_item == block_limit, so 3 items fit and the rest are skipped.
+    assert len(generator.removals) == 3
+
+
+def test_block_atom_saturation_stops_scanning(monkeypatch: pytest.MonkeyPatch) -> None:
+    max_cost = uint64(11_000_000_000)
+    fee_estimator = create_bitcoin_fee_estimator(max_cost)
+    mempool_info = MempoolInfo(
+        CLVMCost(uint64(max_cost * 10)),
+        FeeRate(uint64(1000000)),
+        CLVMCost(max_cost),
+    )
+    mempool = Mempool(mempool_info, fee_estimator)
+
+    # Each item takes a third of the atom budget, so only 3 fit; the rest are
+    # skipped. Without an early exit, every later item would still be scanned.
+    per_item = MAX_BLOCK_ATOMS // 3
+    num_items = 3 + MAX_SKIPPED_ITEMS + 5
+    for i in range(num_items):
+        item = mk_item([make_coin(i)], cost=1_000_000, fee=100, num_atoms=per_item)
+        assert mempool.add_to_pool(item).error is None
+    assert mempool.size() == num_items
+
+    dedup_calls = 0
+    original_get_deduplication_info = IdenticalSpendDedup.get_deduplication_info
+
+    def counting_get_deduplication_info(self: IdenticalSpendDedup, **kwargs: Any) -> Any:
+        nonlocal dedup_calls
+        dedup_calls += 1
+        return original_get_deduplication_info(self, **kwargs)
+
+    monkeypatch.setattr(IdenticalSpendDedup, "get_deduplication_info", counting_get_deduplication_info)
+
+    generator = mempool.create_block_generator2(test_constants, uint32(0), 30.0)
+    assert generator is not None
+    # Only 3 items fit the atom budget.
+    assert len(generator.removals) == 3
+    # Scanning stops after MAX_SKIPPED_ITEMS skips: 3 fitting + MAX_SKIPPED_ITEMS
+    # skipped items are processed, and none beyond that.
+    assert dedup_calls == 3 + MAX_SKIPPED_ITEMS
 
 
 @pytest.mark.parametrize("old", [True, False])

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -343,6 +343,8 @@ def make_test_conds(
     before_seconds_relative: int | None = None,
     before_seconds_absolute: int | None = None,
     cost: int = 0,
+    num_atoms: int = 0,
+    num_pairs: int = 0,
     spend_ids: Sequence[tuple[bytes32 | Coin, int]] = [(TEST_COIN_ID, 0)],
     created_coins: list[list[CreateCoin]] | None = None,
 ) -> SpendBundleConditions:
@@ -397,8 +399,8 @@ def make_test_conds(
         False,
         0,
         0,
-        0,
-        0,
+        num_atoms,
+        num_pairs,
         0,
     )
 
@@ -949,6 +951,8 @@ def mk_item(
     *,
     cost: int = 1,
     fee: int = 0,
+    num_atoms: int = 0,
+    num_pairs: int = 0,
     assert_height: int | None = None,
     assert_before_height: int | None = None,
     assert_before_seconds: int | None = None,
@@ -970,7 +974,7 @@ def mk_item(
         coin_spends.append(coin_spend)
         bundle_coin_spends[coin_id] = mk_bcs(coin_spend, f)
     spend_bundle = SpendBundle(coin_spends, G2Element())
-    conds = make_test_conds(cost=cost, spend_ids=spend_ids)
+    conds = make_test_conds(cost=cost, num_atoms=num_atoms, num_pairs=num_pairs, spend_ids=spend_ids)
     return MempoolItem(
         aggregated_signature=spend_bundle.aggregated_signature,
         fee=uint64(fee),

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -72,6 +72,13 @@ MEMPOOL_ITEM_FEE_LIMIT = 2**50
 # slots relative to their CLVM cost.
 MAX_SPENDS_PER_BLOCK = 6000
 
+# In addition to the CLVM cost and spend limits, blocks are limited in the
+# number of atoms and pairs their generator may allocate when executed. We track
+# these while building a block and stop before exceeding them. The atom and pair
+# counts a spend bundle uses are recorded in its SpendBundleConditions.
+MAX_BLOCK_ATOMS = 60_000_000
+MAX_BLOCK_PAIRS = 60_000_000
+
 
 @dataclass
 class MempoolRemoveInfo:
@@ -587,6 +594,8 @@ class Mempool:
         cost_sum = 0  # Checks that total cost does not exceed block maximum
         fee_sum = 0  # Checks that total fees don't exceed 64 bits
         spend_count = 0  # Checks that total spends do not exceed MAX_SPENDS_PER_BLOCK
+        atom_sum = 0  # Checks that total atoms do not exceed MAX_BLOCK_ATOMS
+        pair_sum = 0  # Checks that total pairs do not exceed MAX_BLOCK_PAIRS
         processed_spend_bundles = 0
         additions: list[Coin] = []
         # This contains a map of coin ID to a coin spend solution and its
@@ -655,13 +664,25 @@ class Mempool:
                     break  # pragma: no cover
                 new_cost_sum = cost_sum + item_cost
                 new_spend_count = spend_count + len(unique_coin_spends)
-                if new_cost_sum > self.mempool_info.max_block_clvm_cost or new_spend_count > MAX_SPENDS_PER_BLOCK:
+                new_atom_sum = atom_sum + item.conds.num_atoms
+                new_pair_sum = pair_sum + item.conds.num_pairs
+                if (
+                    new_cost_sum > self.mempool_info.max_block_clvm_cost
+                    or new_spend_count > MAX_SPENDS_PER_BLOCK
+                    or new_atom_sum > MAX_BLOCK_ATOMS
+                    or new_pair_sum > MAX_BLOCK_PAIRS
+                ):
                     log.info(
-                        "Skipping mempool item. Cumulative cost %d (max %d) spends %d (max %d)",
+                        "Skipping mempool item. Cumulative cost %d (max %d) spends %d (max %d) "
+                        "atoms %d (max %d) pairs %d (max %d)",
                         new_cost_sum,
                         self.mempool_info.max_block_clvm_cost,
                         new_spend_count,
                         MAX_SPENDS_PER_BLOCK,
+                        new_atom_sum,
+                        MAX_BLOCK_ATOMS,
+                        new_pair_sum,
+                        MAX_BLOCK_PAIRS,
                     )
                     skipped_items += 1
                     if skipped_items < MAX_SKIPPED_ITEMS:
@@ -675,6 +696,8 @@ class Mempool:
                 cost_sum = new_cost_sum
                 fee_sum = new_fee_sum
                 spend_count = new_spend_count
+                atom_sum = new_atom_sum
+                pair_sum = new_pair_sum
                 processed_spend_bundles += 1
                 # Let's stop taking more items if we don't have enough cost left
                 # for at least `MIN_COST_THRESHOLD` because that would mean we're
@@ -729,10 +752,17 @@ class Mempool:
         # the total (estimated) cost of the transactions added so far
         block_cost = 0
         added_spends = 0
+        # the number of atoms and pairs accrued from committed batches so far.
+        # We track these independently to stop before exceeding the block atom
+        # and pair limits.
+        added_atoms = 0
+        added_pairs = 0
 
         batch_transactions: list[SpendBundle] = []
         batch_additions: list[Coin] = []
         batch_spends = 0
+        batch_atoms = 0
+        batch_pairs = 0
         # this cost only includes conditions and execution cost, not byte-cost
         batch_cost = 0
 
@@ -740,6 +770,14 @@ class Mempool:
             current_time = monotonic()
             if current_time - generator_creation_start >= timeout:
                 log.info(f"exiting early, already spent {current_time - generator_creation_start:0.2f} s")
+                break
+
+            # Stop scanning once too many items don't fit, rather than burning
+            # the timeout on fast-forward and dedup work. Unlike block cost, the
+            # atom and pair budgets aren't freed by compression, so once
+            # saturated every further item keeps getting skipped here.
+            if skipped_items >= MAX_SKIPPED_ITEMS:
+                log.info("Skipped %d mempool items, stopping block creation", skipped_items)
                 break
 
             name = bytes32(row[0])
@@ -774,6 +812,12 @@ class Mempool:
                     skipped_items += 1
                     continue
 
+                new_atom_count = added_atoms + batch_atoms + item.conds.num_atoms
+                new_pair_count = added_pairs + batch_pairs + item.conds.num_pairs
+                if new_atom_count > MAX_BLOCK_ATOMS or new_pair_count > MAX_BLOCK_PAIRS:
+                    skipped_items += 1
+                    continue
+
                 # if adding item would make us exceed the block cost, commit the
                 # batch we've built up first, to see if more space may be freed
                 # up by the compression
@@ -787,6 +831,8 @@ class Mempool:
                         committed_ff = singleton_ff.copy()
                         committed_dedup = dedup_coin_spends.copy()
                         added_spends += batch_spends
+                        added_atoms += batch_atoms
+                        added_pairs += batch_pairs
                         additions.extend(batch_additions)
                         removals.extend([cs.coin for sb in batch_transactions for cs in sb.coin_spends])
                         log.info(
@@ -797,6 +843,8 @@ class Mempool:
                         batch_transactions = []
                         batch_additions = []
                         batch_spends = 0
+                        batch_atoms = 0
+                        batch_pairs = 0
                     else:
                         log.info(f"Skipping transaction batch cumulative cost: {block_cost} batch cost: {batch_cost}")
                         skipped_items += 1
@@ -808,6 +856,8 @@ class Mempool:
                         batch_transactions = []
                         batch_additions = []
                         batch_spends = 0
+                        batch_atoms = 0
+                        batch_pairs = 0
                         # Reprocess the current item against the correct fast
                         # forward and dedup state.
                         bundle_coin_spends, ff_state_update = singleton_ff.process_fast_forward_spends(
@@ -825,6 +875,8 @@ class Mempool:
                 batch_cost += cost - cost_saving
                 batch_transactions.append(SpendBundle(unique_coin_spends, item.aggregated_signature))
                 batch_spends += len(unique_coin_spends)
+                batch_atoms += item.conds.num_atoms
+                batch_pairs += item.conds.num_pairs
                 batch_additions.extend(unique_additions)
                 fee_sum = new_fee_sum
                 block_cost += item.conds.cost - cost_saving
@@ -844,6 +896,8 @@ class Mempool:
 
             if added:
                 added_spends += batch_spends
+                added_atoms += batch_atoms
+                added_pairs += batch_pairs
                 additions.extend(batch_additions)
                 removals.extend([cs.coin for sb in batch_transactions for cs in sb.coin_spends])
                 log.info(


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes full-node block creation from the mempool, which must stay aligned with consensus generator limits; scope is bounded and covered by new tests, but incorrect limits or accounting could produce invalid or suboptimal blocks.
> 
> **Overview**
> Block assembly from the mempool now respects **generator atom and pair caps** (`MAX_BLOCK_ATOMS` / `MAX_BLOCK_PAIRS`, 60M each), using `num_atoms` and `num_pairs` from each item’s `SpendBundleConditions`.
> 
> **`create_bundle_from_mempool_items`** and **`create_block_generator2`** accumulate atom/pair totals alongside cost and spend counts and skip items that would exceed the limits, with expanded skip logging.
> 
> In **`create_block_generator2`**, scanning stops once **`MAX_SKIPPED_ITEMS`** consecutive skips occur at the start of the loop, so saturated atom/pair budgets do not keep running fast-forward/dedup work on items that cannot fit (unlike CLVM cost, compression does not free atom/pair budget).
> 
> Tests add **`num_atoms` / `num_pairs`** on mempool test helpers and new coverage for atom/pair binding limits and the early-exit dedup scan behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2af2609931eab5046ef7abd85555a0b0038fed5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->