### PR TITLE
Remove obsolete bladebit cache filter and 2021 harvester config shim

### DIFF
--- a/chia/_tests/plotting/test_plot_manager.py
+++ b/chia/_tests/plotting/test_plot_manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 import time
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, replace
@@ -12,14 +11,13 @@ from typing import cast
 
 import pytest
 from chia_rs import G1Element
-from chia_rs.sized_ints import uint16, uint32
+from chia_rs.sized_ints import uint32
 from chiapos import DiskProver
 
 from chia._tests.plotting.util import get_test_plots
 from chia._tests.util.misc import boolean_datacases
 from chia._tests.util.time_out_assert import time_out_assert
 from chia.consensus.default_constants import DEFAULT_CONSTANTS
-from chia.plotting.cache import CURRENT_VERSION, CacheDataV1
 from chia.plotting.manager import Cache, PlotManager
 from chia.plotting.prover import V1Prover
 from chia.plotting.util import (
@@ -31,7 +29,6 @@ from chia.plotting.util import (
 from chia.simulator.block_tools import get_plot_dir
 from chia.util.config import create_default_chia_config, lock_and_load_config, save_config
 from chia.util.harvester_config import add_plot_directory, get_plot_directories, remove_plot_directory
-from chia.util.streamable import VersionedBlob
 
 log = logging.getLogger(__name__)
 
@@ -531,91 +528,6 @@ async def test_plot_info_caching(environment, bt):
     await refresh_tester.run(expected_result)
     assert len(plot_manager.plots) == len(plot_manager.plots)
     plot_manager.stop_refreshing()
-
-
-@pytest.mark.anyio
-async def test_drop_too_large_cache_entries(environment, bt):
-    env: Environment = environment
-    expected_result = PlotRefreshResult(loaded=env.dir_1.plot_info_list(), processed=len(env.dir_1))
-    add_plot_directory(env.root_path, str(env.dir_1.path))
-    await env.refresh_tester.run(expected_result)
-    assert env.refresh_tester.plot_manager.cache.path().exists()
-    assert len(env.dir_1) >= 6, "This test requires at least 6 cache entries"
-    # Load the cache entries
-    cache_path = env.refresh_tester.plot_manager.cache.path()
-    serialized = cache_path.read_bytes()
-    stored_cache: VersionedBlob = VersionedBlob.from_bytes(serialized)
-    cache_data: CacheDataV1 = CacheDataV1.from_bytes(stored_cache.blob)
-
-    def modify_cache_entry(index: int, additional_data: int, modify_memo: bool) -> str:
-        path, cache_entry = cache_data.entries[index]
-        prover_data = cache_entry.prover_data
-        # Size of length hints in chiapos serialization currently depends on the platform
-        size_length = 8 if sys.maxsize > 2**32 else 4
-        # Version
-        version_size = 2
-        version = prover_data[0:version_size]
-        # Filename
-        filename_offset = version_size + size_length
-        filename_length = int.from_bytes(prover_data[version_size:filename_offset], byteorder=sys.byteorder)
-        filename = prover_data[filename_offset : filename_offset + filename_length]
-        # Memo
-        memo_length_offset = filename_offset + filename_length
-        memo_length = int.from_bytes(
-            prover_data[memo_length_offset : memo_length_offset + size_length], byteorder=sys.byteorder
-        )
-        memo_offset = memo_length_offset + size_length
-        memo = prover_data[memo_offset : memo_offset + memo_length]
-        # id, k, table pointers, C2
-        remainder = prover_data[memo_offset + memo_length :]
-
-        # Add the additional data to the filename
-        filename_length += additional_data
-        filename += bytes(b"\a" * additional_data)
-
-        # Add the additional data to the memo if requested
-        if modify_memo:
-            memo_length += additional_data
-            memo += bytes(b"\b" * additional_data)
-
-        filename_length_bytes = filename_length.to_bytes(size_length, byteorder=sys.byteorder)
-        memo_length_bytes = memo_length.to_bytes(size_length, byteorder=sys.byteorder)
-
-        cache_data.entries[index] = (
-            path,
-            replace(
-                cache_entry,
-                prover_data=bytes(version + filename_length_bytes + filename + memo_length_bytes + memo + remainder),
-            ),
-        )
-        return path
-
-    def assert_cache(expected: list[MockPlotInfo]) -> None:
-        test_cache = Cache(cache_path)
-        assert len(test_cache) == 0
-        test_cache.load()
-        assert len(test_cache) == len(expected)
-        for plot_info in expected:
-            assert test_cache.get(Path(plot_info.prover.get_filename())) is not None
-
-    # Modify two entries, with and without memo modification, they both should remain in the cache after load
-    modify_cache_entry(0, 1500, modify_memo=False)
-    modify_cache_entry(1, 1500, modify_memo=True)
-
-    invalid_entries = [
-        modify_cache_entry(2, 2000, modify_memo=False),
-        modify_cache_entry(3, 2000, modify_memo=True),
-        modify_cache_entry(4, 50000, modify_memo=False),
-        modify_cache_entry(5, 50000, modify_memo=True),
-    ]
-
-    plot_infos = env.dir_1.plot_info_list()
-    # Make sure the cache currently contains all plots from dir1
-    assert_cache(plot_infos)
-    # Write the modified cache entries to the file
-    cache_path.write_bytes(bytes(VersionedBlob(uint16(CURRENT_VERSION), bytes(cache_data))))
-    # And now test that plots in invalid_entries are not longer loaded
-    assert_cache([plot_info for plot_info in plot_infos if plot_info.prover.get_filename() not in invalid_entries])
 
 
 @pytest.mark.anyio

--- a/chia/harvester/harvester.py
+++ b/chia/harvester/harvester.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import concurrent
 import contextlib
-import dataclasses
 import logging
 from collections.abc import AsyncIterator
 from concurrent.futures.thread import ThreadPoolExecutor
@@ -72,16 +71,7 @@ class Harvester:
     def __init__(self, root_path: Path, config: dict[str, Any], constants: ConsensusConstants):
         self.log = log
         self.root_path = root_path
-        # TODO, remove checks below later after some versions / time
         refresh_parameter: PlotsRefreshParameter = PlotsRefreshParameter()
-        if "plot_loading_frequency_seconds" in config:
-            self.log.info(
-                "`harvester.plot_loading_frequency_seconds` is deprecated. Consider replacing it with the new section "
-                "`harvester.plots_refresh_parameter`. See `initial-config.yaml`."
-            )
-            refresh_parameter = dataclasses.replace(
-                refresh_parameter, interval_seconds=config["plot_loading_frequency_seconds"]
-            )
         if "plots_refresh_parameter" in config:
             refresh_parameter = PlotsRefreshParameter.from_json_dict(config["plots_refresh_parameter"])
 

--- a/chia/plotting/cache.py
+++ b/chia/plotting/cache.py
@@ -6,7 +6,6 @@ import traceback
 from collections.abc import ItemsView, KeysView, ValuesView
 from dataclasses import dataclass, field
 from functools import lru_cache
-from math import ceil
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -146,17 +145,6 @@ class Cache:
                 start = time.time()
                 cache_data: CacheDataV1 = CacheDataV1.from_bytes(stored_cache.blob)
                 self._data = {}
-                estimated_c2_sizes: dict[int, int] = {}
-                measured_sizes: dict[int, int] = {
-                    32: 738,
-                    33: 1083,
-                    34: 1771,
-                    35: 3147,
-                    36: 5899,
-                    37: 11395,
-                    38: 22395,
-                    39: 44367,
-                }
                 for path, cache_entry in cache_data.entries:
                     prover: ProverProtocol = get_prover_from_bytes(path, cache_entry.prover_data)
                     new_entry = CacheEntry(
@@ -167,37 +155,7 @@ class Cache:
                         cache_entry.plot_public_key,
                         float(cache_entry.last_use),
                     )
-                    # TODO, drop the below entry dropping after few versions or whenever we force a cache recreation.
-                    #       it's here to filter invalid cache entries coming from bladebit RAM plotting.
-                    #       Related: - https://github.com/Chia-Network/chia-blockchain/issues/13084
-                    #                - https://github.com/Chia-Network/chiapos/pull/337
-                    param = new_entry.prover.get_param()
-                    if param.size_v1 is not None:
-                        k = param.size_v1
-                        if k not in estimated_c2_sizes:
-                            estimated_c2_sizes[k] = ceil(2**k / 100_000_000) * ceil(k / 8)
-                        memo_size = len(new_entry.prover.get_memo())
-                        prover_size = len(cache_entry.prover_data)
-                        # Estimated C2 size + memo size + 2000 (static data + path)
-                        # static data: version(2) + table pointers (<=96) + id(32) + k(1) => ~130
-                        # path: up to ~1870, all above will lead to false positive.
-                        # See https://github.com/Chia-Network/chiapos/blob/3ee062b86315823dd775453ad320b8be892c7df3/src/prover_disk.hpp#L282-L287
-
-                        # Use experimental measurements if more than estimates
-                        # https://github.com/Chia-Network/chia-blockchain/issues/16063
-                        check_size = estimated_c2_sizes[k] + memo_size + 2000
-                        if k in measured_sizes:
-                            check_size = max(check_size, measured_sizes[k])
-
-                        if prover_size > check_size:
-                            log.warning(
-                                "Suspicious cache entry dropped. Recommended: stop the harvester, remove "
-                                f"{self._path}, restart. Entry: size {prover_size}, path {path}"
-                            )
-                        else:
-                            self._data[Path(path)] = new_entry
-                    elif param.strength_v2 is not None:
-                        self._data[Path(path)] = new_entry
+                    self._data[Path(path)] = new_entry
 
                 log.info(f"Parsed {len(self._data)} cache entries in {time.time() - start:.2f}s")
 


### PR DESCRIPTION
Two removals whose expiry conditions have long since fired:

**1. Plot-cache "suspicious entry" filter** (`chia/plotting/cache.py`, -30 lines)
Added Sep 2022 (`0df4d8cb`) to drop corrupt cache entries produced by bladebit RAM plotting (#13084; root cause fixed in chiapos#337). Its own TODO says drop it "after few versions or whenever we force a cache recreation". The removal condition was met in Jul 2023: #15776 bumped `CURRENT_VERSION` 1→2, and `Cache.load()` discards any cache with a version mismatch — every v1 cache (including any corrupted entries) was already thrown away. The v1/v2 `param` split inside the loop existed only to scope this heuristic (added with the chia_rs 0.34 bump, Nov 2025) and goes with it; entries are now added unconditionally, as before 2022. The dedicated test `test_drop_too_large_cache_entries` tested only this heuristic and is removed with it (its orphaned imports too).

**2. Harvester `plot_loading_frequency_seconds` fallback** (`chia/harvester/harvester.py`, -10 lines)
Deprecated Aug 2021 (#7848, per `git blame`) with "TODO, remove checks below later after some versions / time". Five years and many releases later: removed. Configs untouched since 2021 that still carry the old key fall back to the default 120s refresh interval; `plots_refresh_parameter` has been the documented replacement the whole time.

Diff: -142/+2 across 3 files. Risk: harvester plot-cache load and config parsing only; no consensus surface.

Gates run locally: `ruff check` + `ruff format --check` clean; `mypy` clean; `chia/_tests/plotting/test_plot_manager.py` 13/13 passed.

Made with [Cursor](https://cursor.com)