### PR TITLE
Remove config keys that nothing reads from initial-config.yaml

### DIFF
--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -231,8 +231,6 @@ farmer:
   # analyze with python -m chia.util.profiler <path>
   enable_profiler: False
 
-  # To send a share to a pool, a proof of space must have required_iters less than this number
-  pool_share_threshold: 1000
   logging: *logging
   network_overrides: *network_overrides
   selected_network: *selected_network
@@ -260,13 +258,9 @@ timelord:
       - *self_hostname
       - localhost
       - 127.0.0.1
-    ips_estimate:
-      - 150000
   full_node_peers:
     - host: *self_hostname
       port: 8444
-  # Maximum number of seconds allowed for a client to reconnect to the server.
-  max_connection_time: 60
   # The ip and port where the TCP clients will connect.
   vdf_server:
     host: *self_hostname
@@ -338,8 +332,6 @@ full_node:
 
   # Run multiple nodes with different databases by changing the database_path
   database_path: db/blockchain_v2_CHALLENGE.sqlite
-  # peer_db_path is deprecated and has been replaced by peers_file_path
-  peer_db_path: db/peer_table_node.sqlite
   peers_file_path: db/peers.dat
 
   multiprocessing_start_method: default
@@ -482,8 +474,6 @@ ui:
   # Which port to use to communicate with the full node
   rpc_port: 8555
 
-  # This SSH key is for the ui SSH server
-  ssh_filename: config/ssh_host_key
   logging: *logging
   network_overrides: *network_overrides
   selected_network: *selected_network
@@ -544,17 +534,11 @@ wallet:
   full_node_peers:
     - host: *self_hostname
       port: 8444
-  # The path of NFT off-chain metadata cache
-  nft_metadata_cache_path: "nft_cache"
-  # The length of NFT ID prefix will be used as hash index
-  nft_metadata_cache_hash_length: 3
   multiprocessing_start_method: default
 
   testing: False
   # v2 used by the light wallet sync protocol
   database_path: wallet/db/blockchain_wallet_v2_CHALLENGE_KEY.sqlite
-  # wallet_peers_path is deprecated and has been replaced by wallet_peers_file_path
-  wallet_peers_path: wallet/db/wallet_peers.sqlite
   wallet_peers_file_path: wallet/db/wallet_peers.dat
 
   # this is a debug and profiling facility that logs all SQLite commands to a

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -251,8 +251,7 @@ timelord_launcher:
   logging: *logging
 
 timelord:
-  # Provides a list of VDF clients expected to connect to this timelord.
-  # For each client, an IP is provided, together with the estimated iterations per second.
+  # Provides a list of VDF client IPs allowed to connect to this timelord.
   vdf_clients:
     ip:
       - *self_hostname


### PR DESCRIPTION
Eight keys in the default config template are read by no code anywhere (`chia/`, `tools/`, `benchmarks/`, tests — checked by grepping every template key against the codebase). Dated with `git log -S` over full history including the pre-2021 `src/` era:

| Key | Section | Reader removed |
|-----|---------|----------------|
| `ssh_filename` | `ui` | Mar 2020 (`e83aa36b` "remove SSH ui and dependencies") — outlived its feature by 6 years |
| `pool_share_threshold` | `farmer` | Jan 2021 |
| `ips_estimate` | `timelord` | Jan 2021 |
| `max_connection_time` | `timelord` | Jan 2021 |
| `nft_metadata_cache_path`, `nft_metadata_cache_hash_length` | `wallet` | reader landed #13018, reverted #13660 (Oct 2022); keys stayed |
| `peer_db_path` | `full_node` | migration removed #17517 (Feb 2024); was comment-marked deprecated |
| `wallet_peers_path` | `wallet` | same (#17517); was comment-marked deprecated |

Also searched Chia-Network/chia-blockchain-gui via GitHub code search for all eight keys: zero references.

Template-only change (-16 lines, one file): existing user configs keep whatever keys they have (ignored today, ignored after); new installs stop inheriting dead keys. `daemon_host` and everything else in the `ui` section is untouched.

Gates run locally: YAML parses; `chia/_tests/core/util/test_config.py` 10/10 passed.

Made with [Cursor](https://cursor.com)