### PR TITLE
Load config.yaml once per service start

### DIFF
--- a/chia/data_layer/start_data_layer.py
+++ b/chia/data_layer/start_data_layer.py
@@ -20,7 +20,7 @@ from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_service import RpcInfo, Service, async_run
 from chia.ssl.create_ssl import create_all_ssl
 from chia.util.chia_logging import initialize_logging
-from chia.util.config import load_config, load_config_cli
+from chia.util.config import apply_config_cli_overrides, load_config
 from chia.util.default_root import resolve_root_path
 from chia.util.task_timing import maybe_manage_task_instrumentation
 from chia.wallet.wallet_rpc_client import WalletRpcClient
@@ -94,9 +94,8 @@ def create_data_layer_service(
 
 
 async def async_main(root_path: pathlib.Path) -> int:
-    # TODO: refactor to avoid the double load
     config = load_config(root_path, "config.yaml", fill_missing_services=True)
-    service_config = load_config_cli(root_path, "config.yaml", SERVICE_NAME, fill_missing_services=True)
+    service_config = apply_config_cli_overrides(config[SERVICE_NAME])
     config[SERVICE_NAME] = service_config
     initialize_logging(
         service_name=SERVICE_NAME,

--- a/chia/farmer/start_farmer.py
+++ b/chia/farmer/start_farmer.py
@@ -20,7 +20,7 @@ from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_service import RpcInfo, Service, async_run
 from chia.types.peer_info import UnresolvedPeerInfo
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import load_config, load_config_cli
+from chia.util.config import apply_config_cli_overrides, load_config
 from chia.util.default_root import resolve_root_path
 from chia.util.keychain import Keychain
 from chia.util.task_timing import maybe_manage_task_instrumentation
@@ -78,11 +78,10 @@ def create_farmer_service(
 
 
 async def async_main(root_path: pathlib.Path) -> int:
-    # TODO: refactor to avoid the double load
     config = load_config(root_path, "config.yaml", fill_missing_services=True)
-    service_config = load_config_cli(root_path, "config.yaml", SERVICE_NAME)
+    service_config = apply_config_cli_overrides(config[SERVICE_NAME])
     config[SERVICE_NAME] = service_config
-    config_pool = load_config_cli(root_path, "config.yaml", "pool")
+    config_pool = apply_config_cli_overrides(config["pool"])
     config["pool"] = config_pool
     initialize_service_logging(service_name=SERVICE_NAME, config=config, root_path=root_path)
 

--- a/chia/full_node/start_full_node.py
+++ b/chia/full_node/start_full_node.py
@@ -21,7 +21,7 @@ from chia.server.resolve_peer_info import get_unresolved_peer_infos
 from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_service import RpcInfo, Service, async_run
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import load_config, load_config_cli
+from chia.util.config import apply_config_cli_overrides, load_config
 from chia.util.default_root import resolve_root_path
 from chia.util.task_timing import maybe_manage_task_instrumentation
 
@@ -75,10 +75,7 @@ async def create_full_node_service(
     )
 
 
-async def async_main(service_config: dict[str, Any], root_path: pathlib.Path) -> int:
-    # TODO: refactor to avoid the double load
-    config = load_config(root_path, "config.yaml")
-    config[SERVICE_NAME] = service_config
+async def async_main(config: dict[str, Any], service_config: dict[str, Any], root_path: pathlib.Path) -> int:
     network_id = service_config["selected_network"]
     overrides = service_config["network_overrides"]["constants"][network_id]
     update_testnet_overrides(network_id, overrides)
@@ -100,7 +97,9 @@ def main() -> int:
     with maybe_manage_task_instrumentation(
         enable=os.environ.get(f"CHIA_INSTRUMENT_{SERVICE_NAME.upper()}") is not None
     ):
-        service_config = load_config_cli(root_path, "config.yaml", SERVICE_NAME)
+        config = load_config(root_path, "config.yaml")
+        service_config = apply_config_cli_overrides(config[SERVICE_NAME])
+        config[SERVICE_NAME] = service_config
         target_peer_count = service_config.get("target_peer_count", 40) - service_config.get(
             "target_outbound_peer_count", 8
         )
@@ -108,7 +107,9 @@ def main() -> int:
             target_peer_count = None
         if not service_config.get("use_chia_loop_policy", True):
             target_peer_count = None
-        return async_run(coro=async_main(service_config, root_path=root_path), connection_limit=target_peer_count)
+        return async_run(
+            coro=async_main(config, service_config, root_path=root_path), connection_limit=target_peer_count
+        )
 
 
 if __name__ == "__main__":

--- a/chia/harvester/start_harvester.py
+++ b/chia/harvester/start_harvester.py
@@ -20,7 +20,7 @@ from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_service import RpcInfo, Service, async_run
 from chia.types.peer_info import UnresolvedPeerInfo
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import load_config, load_config_cli
+from chia.util.config import apply_config_cli_overrides, load_config
 from chia.util.default_root import resolve_root_path
 from chia.util.task_timing import maybe_manage_task_instrumentation
 
@@ -69,9 +69,8 @@ def create_harvester_service(
 
 
 async def async_main(root_path: pathlib.Path) -> int:
-    # TODO: refactor to avoid the double load
     config = load_config(root_path, "config.yaml")
-    service_config = load_config_cli(root_path, "config.yaml", SERVICE_NAME)
+    service_config = apply_config_cli_overrides(config[SERVICE_NAME])
     config[SERVICE_NAME] = service_config
     initialize_service_logging(service_name=SERVICE_NAME, config=config, root_path=root_path)
     farmer_peers = get_unresolved_peer_infos(service_config, NodeType.FARMER)

--- a/chia/introducer/start_introducer.py
+++ b/chia/introducer/start_introducer.py
@@ -13,7 +13,7 @@ from chia.protocols.outbound_message import NodeType
 from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_service import Service, async_run
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import load_config, load_config_cli
+from chia.util.config import apply_config_cli_overrides, load_config
 from chia.util.default_root import resolve_root_path
 from chia.util.task_timing import maybe_manage_task_instrumentation
 
@@ -65,9 +65,8 @@ def create_introducer_service(
 
 
 async def async_main(root_path: pathlib.Path) -> int:
-    # TODO: refactor to avoid the double load
     config = load_config(root_path, "config.yaml")
-    service_config = load_config_cli(root_path, "config.yaml", SERVICE_NAME)
+    service_config = apply_config_cli_overrides(config[SERVICE_NAME])
     config[SERVICE_NAME] = service_config
     initialize_service_logging(service_name=SERVICE_NAME, config=config, root_path=root_path)
 

--- a/chia/seeder/dns_server.py
+++ b/chia/seeder/dns_server.py
@@ -21,7 +21,7 @@ from dnslib import AAAA, EDNS0, NS, QTYPE, RCODE, RD, RR, SOA, A, DNSError, DNSH
 from chia.seeder.crawl_store import CrawlStore
 from chia.server.signal_handlers import SignalHandlers
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import load_config, load_config_cli
+from chia.util.config import apply_config_cli_overrides, load_config
 from chia.util.default_root import resolve_root_path
 from chia.util.path import path_from_root
 from chia.util.task_referencer import create_referenced_task
@@ -583,9 +583,8 @@ def main() -> None:  # pragma: no cover
     freeze_support()
     root_path = resolve_root_path(override=None)
 
-    # TODO: refactor to avoid the double load
     config = load_config(root_path, "config.yaml")
-    service_config = load_config_cli(root_path, "config.yaml", SERVICE_NAME)
+    service_config = apply_config_cli_overrides(config[SERVICE_NAME])
     config[SERVICE_NAME] = service_config
     initialize_service_logging(service_name=SERVICE_NAME, config=config, root_path=root_path)
 

--- a/chia/seeder/start_crawler.py
+++ b/chia/seeder/start_crawler.py
@@ -19,7 +19,7 @@ from chia.seeder.crawler_service import CrawlerService
 from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_service import RpcInfo, Service, async_run
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import load_config, load_config_cli
+from chia.util.config import apply_config_cli_overrides, load_config
 from chia.util.default_root import resolve_root_path
 
 # See: https://bugs.python.org/issue29288
@@ -68,9 +68,8 @@ def create_full_node_crawler_service(
 
 
 async def async_main(root_path: pathlib.Path) -> int:
-    # TODO: refactor to avoid the double load
     config = load_config(root_path, "config.yaml")
-    service_config = load_config_cli(root_path, "config.yaml", SERVICE_NAME)
+    service_config = apply_config_cli_overrides(config[SERVICE_NAME])
     config[SERVICE_NAME] = service_config
     overrides = service_config["network_overrides"]["constants"][service_config["selected_network"]]
     updated_constants = replace_str_to_bytes(DEFAULT_CONSTANTS, **overrides)

--- a/chia/solver/start_solver.py
+++ b/chia/solver/start_solver.py
@@ -20,7 +20,7 @@ from chia.solver.solver_api import SolverAPI
 from chia.solver.solver_rpc_api import SolverRpcApi
 from chia.solver.solver_service import SolverService
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import load_config, load_config_cli
+from chia.util.config import apply_config_cli_overrides, load_config
 from chia.util.default_root import resolve_root_path
 from chia.util.task_timing import maybe_manage_task_instrumentation
 
@@ -70,9 +70,7 @@ def create_solver_service(
     )
 
 
-async def async_main(service_config: dict[str, Any], root_path: pathlib.Path) -> int:
-    config = load_config(root_path, "config.yaml", fill_missing_services=True)
-    config[SERVICE_NAME] = service_config
+async def async_main(config: dict[str, Any], service_config: dict[str, Any], root_path: pathlib.Path) -> int:
     network_id = service_config["selected_network"]
     overrides = service_config["network_overrides"]["constants"][network_id]
     update_testnet_overrides(network_id, overrides)
@@ -94,8 +92,10 @@ def main() -> int:
     with maybe_manage_task_instrumentation(
         enable=os.environ.get(f"CHIA_INSTRUMENT_{SERVICE_NAME.upper()}") is not None
     ):
-        service_config = load_config_cli(root_path, "config.yaml", SERVICE_NAME)
-        return async_run(coro=async_main(service_config, root_path=root_path))
+        config = load_config(root_path, "config.yaml", fill_missing_services=True)
+        service_config = apply_config_cli_overrides(config[SERVICE_NAME])
+        config[SERVICE_NAME] = service_config
+        return async_run(coro=async_main(config, service_config, root_path=root_path))
 
 
 if __name__ == "__main__":

--- a/chia/timelord/start_timelord.py
+++ b/chia/timelord/start_timelord.py
@@ -19,7 +19,7 @@ from chia.timelord.timelord_api import TimelordAPI
 from chia.timelord.timelord_rpc_api import TimelordRpcApi
 from chia.timelord.timelord_service import TimelordService
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import load_config, load_config_cli
+from chia.util.config import apply_config_cli_overrides, load_config
 from chia.util.default_root import resolve_root_path
 from chia.util.task_timing import maybe_manage_task_instrumentation
 
@@ -66,9 +66,8 @@ def create_timelord_service(
 
 
 async def async_main(root_path: pathlib.Path) -> int:
-    # TODO: refactor to avoid the double load
     config = load_config(root_path, "config.yaml")
-    service_config = load_config_cli(root_path, "config.yaml", SERVICE_NAME)
+    service_config = apply_config_cli_overrides(config[SERVICE_NAME])
     config[SERVICE_NAME] = service_config
     initialize_service_logging(service_name=SERVICE_NAME, config=config, root_path=root_path)
 

--- a/chia/util/config.py
+++ b/chia/util/config.py
@@ -149,20 +149,13 @@ def _load_config_maybe_locked(
     raise RuntimeError("Was not able to read config file successfully")
 
 
-def load_config_cli(
-    root_path: Path,
-    filename: str,
-    sub_config: str | None = None,
-    fill_missing_services: bool = False,
-) -> dict[str, Any]:
+def apply_config_cli_overrides(config: dict[str, Any]) -> dict[str, Any]:
     """
-    Loads configuration from the specified filename, in the config directory,
-    and then overrides any properties using the passed in command line arguments.
-    Nested properties in the config file can be used in the command line with ".",
-    for example --farmer_peer.host. Does not support lists.
+    Overrides any properties of the given (already loaded) config section
+    using command line arguments. Nested properties can be used on the
+    command line with ".", for example --farmer_peer.host. Does not
+    support lists.
     """
-    config = load_config(root_path, filename, sub_config, fill_missing_services=fill_missing_services)
-
     flattened_props = flatten_properties(config)
     parser = argparse.ArgumentParser()
 
@@ -177,6 +170,20 @@ def load_config_cli(
             flattened_props[key] = value
 
     return unflatten_properties(flattened_props)
+
+
+def load_config_cli(
+    root_path: Path,
+    filename: str,
+    sub_config: str | None = None,
+    fill_missing_services: bool = False,
+) -> dict[str, Any]:
+    """
+    Loads configuration from the specified filename, in the config directory,
+    and then overrides any properties using the passed in command line arguments.
+    """
+    config = load_config(root_path, filename, sub_config, fill_missing_services=fill_missing_services)
+    return apply_config_cli_overrides(config)
 
 
 def flatten_properties(config: dict[str, Any]) -> dict[str, Any]:

--- a/chia/wallet/start_wallet.py
+++ b/chia/wallet/start_wallet.py
@@ -17,7 +17,7 @@ from chia.server.resolve_peer_info import get_unresolved_peer_infos
 from chia.server.signal_handlers import SignalHandlers
 from chia.server.start_service import RpcInfo, Service, async_run
 from chia.util.chia_logging import initialize_service_logging
-from chia.util.config import load_config, load_config_cli
+from chia.util.config import apply_config_cli_overrides, load_config
 from chia.util.default_root import resolve_root_path
 from chia.util.keychain import Keychain
 from chia.util.task_timing import maybe_manage_task_instrumentation
@@ -80,9 +80,8 @@ def create_wallet_service(
 
 
 async def async_main(root_path: pathlib.Path) -> int:
-    # TODO: refactor to avoid the double load
     config = load_config(root_path, "config.yaml")
-    service_config = load_config_cli(root_path, "config.yaml", SERVICE_NAME)
+    service_config = apply_config_cli_overrides(config[SERVICE_NAME])
     config[SERVICE_NAME] = service_config
 
     # This is simulator


### PR DESCRIPTION
Nine service entry points carried the same `# TODO: refactor to avoid the double load`: each start loaded the full `config.yaml`, then called `load_config_cli`, which **re-read the same file** (taking the config lock again) just to apply CLI overrides to the service section. The farmer read the file three times (full + service + pool).

The fix is one extraction: the argparse step of `load_config_cli` moves verbatim into a new `apply_config_cli_overrides(section)` in `chia/util/config.py`, which operates on the already-loaded dict. Each entry point becomes:

```python
config = load_config(root_path, "config.yaml")
service_config = apply_config_cli_overrides(config[SERVICE_NAME])
config[SERVICE_NAME] = service_config
```

Behavior is otherwise identical — same argparse parser built from the same section dict, same override semantics, same graft-back. The only observable change is one file read + one config-lock acquisition instead of two (three for farmer).

Notes for review:

- `full_node` and `solver` had the split variant (`load_config_cli` in `main()`, full `load_config` again in `async_main`); their `async_main` now takes the config dict `main()` already had. Neither `async_main` has callers outside its own file. Solver had no TODO comment but the identical pattern, so it's included.
- `load_config_cli` itself is kept as a thin wrapper (`load_config` + `apply_config_cli_overrides`) because `chia/simulator/start_simulator.py` still uses it; the simulator is left untouched to keep this PR services-only (its `async_main` is imported by `simulator_test_tools`).
- `data_layer` keeps its `fill_missing_services=True` on the single remaining load; farmer keeps both argparse passes (service + pool).

Diff: +50/-50 across 11 files.

Gates run locally: `ruff check` + `ruff format --check` clean on all 11 files; `mypy` (template config) clean except one pre-existing strict-bytes error in `dns_server.py:181` that reproduces on `main` and is covered by `mypy-strict-bytes-exclusions.txt` in CI; all 12 touched/related service modules import cleanly; `chia/_tests/core/util/test_config.py` 10/10 passed.

Made with [Cursor](https://cursor.com)