### PR TITLE
[CHIA-4367] improve UnfinishedBlock cache

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -827,7 +827,7 @@ async def test_respond_unfinished(
     ],
     self_hostname: str,
 ) -> None:
-    full_node_1, _full_node_2, server_1, server_2, wallet_a, wallet_receiver, bt = wallet_nodes
+    full_node_1, _full_node_2, server_1, server_2, _wallet_a, _wallet_receiver, bt = wallet_nodes
 
     incoming_queue, _dummy_node_id = await add_dummy_connection(server_1, self_hostname, 12312)
     expected_requests = 0
@@ -881,22 +881,58 @@ async def test_respond_unfinished(
     await full_node_1.full_node.add_unfinished_block(unf, None)
     assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash) is not None
 
-    # This next section tests making unfinished block with transactions, and then submitting the finished block
+
+@pytest.mark.anyio
+@pytest.mark.limit_consensus_modes(
+    allowed=[ConsensusMode.HARD_FORK_2_0],
+    reason="exercises the block-generator cache, which is not consensus-mode specific",
+)
+@pytest.mark.parametrize("scenario", ["hit_stripped", "hit_attached", "miss_attached", "miss_stripped_fetch"])
+async def test_respond_block_generator_execution_paths(
+    wallet_nodes: tuple[
+        FullNodeSimulator, FullNodeSimulator, ChiaServer, ChiaServer, WalletTool, WalletTool, BlockTools
+    ],
+    self_hostname: str,
+    monkeypatch: pytest.MonkeyPatch,
+    scenario: str,
+) -> None:
+    # Exercises every branch of add_block()'s generator handling for a transaction FullBlock. In each case
+    # pre_validate_block is invoked once, with cached conds on a cache hit and conds=None on a cache miss:
+    #   hit_stripped        cache hit,  generator stripped  -> use cached result, take generator from cache
+    #   hit_attached        cache hit,  generator attached  -> use cached result
+    #   miss_attached       cache miss, generator attached  -> validate normally
+    #   miss_stripped_fetch cache miss, generator stripped  -> fetch the generator from a peer, then recurse
+    full_node_1, _full_node_2, server_1, server_2, wallet_a, wallet_receiver, bt = wallet_nodes
+
+    peer = await connect_and_get_peer(server_1, server_2, self_hostname)
+
     ph = wallet_a.get_new_puzzlehash()
     ph_receiver = wallet_receiver.get_new_puzzlehash()
+
+    # Farm several transaction blocks so we have a matured, spendable reward coin owned by `ph`.
     blocks = await full_node_1.get_all_full_blocks()
     blocks = bt.get_consecutive_blocks(
-        2,
+        4,
         block_list_input=blocks,
         guarantee_transaction_block=True,
         farmer_reward_puzzle_hash=ph,
     )
-    await full_node_1.full_node.add_block(blocks[-2])
-    await full_node_1.full_node.add_block(blocks[-1])
-    coin_to_spend = find_reward_coin(blocks[-1], ph)
+    for b in blocks[-4:]:
+        await full_node_1.full_node.add_block(b, peer)
+
+    coin_to_spend: Coin | None = None
+    for b in reversed(blocks[-4:]):
+        for c in b.get_included_reward_coins():
+            if c.puzzle_hash == ph:
+                coin_to_spend = c
+                break
+        if coin_to_spend is not None:
+            break
+    assert coin_to_spend is not None
 
     spend_bundle = wallet_a.generate_signed_transaction(coin_to_spend.amount, ph_receiver, coin_to_spend)
 
+    # Build the transaction block that spends the coin, plus its unfinished form.
     blocks = bt.get_consecutive_blocks(
         1,
         block_list_input=blocks,
@@ -906,27 +942,68 @@ async def test_respond_unfinished(
         seed=b"random seed",
     )
     block = blocks[-1]
+    assert block_has_transactions_generator(block)
     unf = make_unfinished_block(block, bt.constants, force_overflow=True)
-    assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash) is None
-    await full_node_1.full_node.add_unfinished_block(unf, None)
-    assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash) is not None
-    assert unf.foliage.foliage_transaction_block_hash is not None
-    entry = full_node_1.full_node.full_node_store.get_unfinished_block_result(
-        unf.partial_hash, unf.foliage.foliage_transaction_block_hash
-    )
-    assert entry is not None
-    result = entry.result
-    assert result is not None
-    assert result.conds is not None
-    assert result.conds.cost > 0
+
+    cached = scenario.startswith("hit")
+    attached = scenario in {"hit_attached", "miss_attached"}
+
+    # For cache-hit scenarios, validate + cache the unfinished block first (this runs the generator once).
+    expected_conds: Any = None
+    if cached:
+        assert full_node_1.full_node.full_node_store.get_unfinished_block(unf.partial_hash) is None
+        await full_node_1.full_node.add_unfinished_block(unf, None)
+        assert unf.foliage.foliage_transaction_block_hash is not None
+        entry = full_node_1.full_node.full_node_store.get_unfinished_block_result(
+            unf.partial_hash, unf.foliage.foliage_transaction_block_hash
+        )
+        assert entry is not None and entry.result is not None and entry.result.conds is not None
+        assert entry.result.conds.cost > 0
+        expected_conds = entry.result.conds
+
+    # Spy on pre_validate_block to observe whether conds are supplied (cache hit) or computed (cache miss).
+    captured_conds: list[Any] = []
+    real_pre_validate_block = pre_validate_block
+
+    async def spy_pre_validate_block(
+        constants: Any, blockchain: Any, blk: Any, pool: Any, conds: Any, vs: Any, **kwargs: Any
+    ) -> Any:
+        captured_conds.append(conds)
+        return await real_pre_validate_block(constants, blockchain, blk, pool, conds, vs, **kwargs)
+
+    monkeypatch.setattr("chia.full_node.full_node.pre_validate_block", spy_pre_validate_block)
+
+    stripped_block = block.replace(transactions_generator=None, transactions_generator_buffer=None)
+    finished_block = block if attached else stripped_block
+
+    # For the fetch scenario, simulate a peer that serves the full block (with generator) when we ask for it.
+    fetch_calls: list[Any] = []
+    add_peer: WSChiaConnection | None = None
+    if scenario == "miss_stripped_fetch":
+
+        async def fake_call_api(method: Any, message: Any, **kwargs: Any) -> Any:
+            fetch_calls.append(message)
+            return fnp.RespondBlock(block)
+
+        monkeypatch.setattr(peer, "call_api", fake_call_api)
+        add_peer = peer
 
     assert not full_node_1.full_node.blockchain.contains_block(block.header_hash, block.height)
-    assert block_has_transactions_generator(block)
-    block_no_transactions = block.replace(transactions_generator=None, transactions_generator_buffer=None)
-    assert not block_has_transactions_generator(block_no_transactions)
+    await full_node_1.full_node.add_block(finished_block, add_peer)
 
-    await full_node_1.full_node.add_block(block_no_transactions)
+    # In every scenario the block is accepted and pre_validate_block runs exactly once.
     assert full_node_1.full_node.blockchain.contains_block(block.header_hash, block.height)
+    assert len(captured_conds) == 1
+    if cached:
+        # Cache hit: the cached conds object is passed through and reused.
+        assert captured_conds[0] is expected_conds
+    else:
+        # Cache miss: conds are computed during validation.
+        assert captured_conds[0] is None
+
+    if scenario == "miss_stripped_fetch":
+        # The generator was requested from the peer once before recursing.
+        assert len(fetch_calls) == 1
 
 
 @pytest.mark.anyio

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -95,6 +95,7 @@ from chia.util.db_synchronous import db_synchronous_on
 from chia.util.db_version import lookup_db_version, set_db_version_async
 from chia.util.db_wrapper import DBWrapper2, manage_connection
 from chia.util.errors import ConsensusError, Err, TimestampError, ValidationError
+from chia.util.hash import std_hash
 from chia.util.inline_executor import InlineExecutor
 from chia.util.limited_semaphore import LimitedSemaphore
 from chia.util.network import is_localhost
@@ -2238,10 +2239,10 @@ class FullNode:
             block.is_transaction_block()
             and block.transactions_info is not None
             and block.transactions_info.generator_root != bytes([0] * 32)
-            and not block_has_transactions_generator(block)
         ):
-            # This is the case where we already had the unfinished block, and asked for this block without
-            # the transactions (since we already had them). Therefore, here we add the transactions.
+            # This is a transaction block with a generator. Look up the matching unfinished block in the
+            # cache; if it's there, use its pre-validation result. If the finished block arrived without
+            # its generator, take the generator and ref list from the cached unfinished block.
             pos = block.reward_chain_block.proof_of_space
             if pos.version == 1 and pos.quality_string() is None:
                 raise ConsensusError(Err.INVALID_POSPACE)
@@ -2265,13 +2266,21 @@ class FullNode:
                 assert foliage_hash is not None
                 pre_validation_result = unf_entry.result
                 assert pre_validation_result is not None
+                # If the block arrived with a generator, reject it if it doesn't match generator_root
+                # before replacing it with the cached one.
+                incoming_generator = get_transactions_generator_bytes(block)
+                if (
+                    incoming_generator is not None
+                    and std_hash(incoming_generator) != block.transactions_info.generator_root
+                ):
+                    raise ConsensusError(Err.INVALID_TRANSACTIONS_GENERATOR_HASH)
                 block = block.replace(
                     transactions_generator=unf_entry.unfinished_block.transactions_generator,
                     transactions_generator_ref_list=unf_entry.unfinished_block.transactions_generator_ref_list,
                     transactions_generator_buffer=unf_entry.unfinished_block.transactions_generator_buffer,
                     version=unf_entry.unfinished_block.version,
                 )
-            else:
+            elif not block_has_transactions_generator(block):
                 # We still do not have the correct information for this block, perhaps there is a duplicate block
                 # with the same unfinished block hash in the cache, so we need to fetch the correct one
                 if peer is None:
@@ -2300,6 +2309,8 @@ class FullNode:
                 )
                 # This recursion ends here, we cannot recurse again because the generator is present
                 return await self.add_block(new_block, peer, bls_cache)
+            # else: the block carries its generator but we have no cached result, so it is validated
+            # normally during pre-validation below.
         state_change_summary: StateChangeSummary | None = None
         ppp_result: PeakPostProcessingResult | None = None
         async with (


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-critical `add_block` generator handling and cache reuse. The extra generator-root check reduces mismatch risk, but incorrect cache use could skip validation.
> 
> **Overview**
> `add_block` now consults the unfinished-block cache for **every** transaction block that has a generator, not only when the finished block arrives stripped.
> 
> On a cache hit, pre-validation results are reused even if the generator is already attached. If an attached generator is present, it is hashed against `generator_root` and rejected with `INVALID_TRANSACTIONS_GENERATOR_HASH` before being replaced by the cached copy. Peer fetch of the generator is limited to cache-miss + stripped-generator cases; attached blocks with no cache entry fall through to normal pre-validation.
> 
> Adds `test_respond_block_generator_execution_paths` covering hit/miss × stripped/attached (including the fetch-and-recurse path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 512c9b5497333bf829fb0bc23fe9bddd1786081c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->