### PR TITLE
CHIA-4369 Perform CLVM serialization check on spends with the FF flag too

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -674,7 +674,9 @@ class MempoolManager:
             # SpendBundleConditions.
             spend_conds = spend_conditions.pop(coin_id)
 
-            if bool(spend_conds.flags & ELIGIBLE_FOR_DEDUP) and not is_clvm_canonical(bytes(coin_spend.solution)):
+            if bool(spend_conds.flags & (ELIGIBLE_FOR_DEDUP | ELIGIBLE_FOR_FF)) and not is_clvm_canonical(
+                bytes(coin_spend.solution)
+            ):
                 return Err.INVALID_COIN_SOLUTION, None, []
 
             lineage_info = None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Tightens mempool validation for fast-forward spends, which can change which transactions are accepted. Scope is a one-line condition change with no new attack surface.
> 
> **Overview**
> Rejects mempool spends marked **fast-forward eligible** if their coin solution is not in canonical CLVM form, matching the existing check for DEDUP-eligible spends.
> 
> In `validate_spend_bundle`, `is_clvm_canonical` now runs when either `ELIGIBLE_FOR_DEDUP` or `ELIGIBLE_FOR_FF` is set, returning `INVALID_COIN_SOLUTION` for non-canonical encodings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa7b35c2b8267b462802c318f0c20c48b1de4fd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->