### PR TITLE
[CHIA-4369] transition to canonical CLVM serialization

### DIFF
--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -3118,13 +3118,26 @@ async def test_check_removals_with_block_creation(flags: int, old: bool) -> None
 
 
 @pytest.mark.anyio
-async def test_dedup_not_canonical() -> None:
-    # this is ((1)), but with a non-canonical encoding
-    coin_spend = mk_coin_spend(TEST_COIN, solution="ffffc001018080")
+@pytest.mark.parametrize("flags", [0, ELIGIBLE_FOR_DEDUP, ELIGIBLE_FOR_FF, ELIGIBLE_FOR_FF | ELIGIBLE_FOR_DEDUP])
+@pytest.mark.parametrize(
+    "puzzle_hex,solution_hex",
+    [
+        # ((1)) with a non-canonical atom length prefix in the solution
+        (None, "ffffc001018080"),
+        # atom 1 with a non-canonical length prefix in the puzzle
+        ("c00101", "80"),
+    ],
+)
+async def test_mempool_requires_canonical_clvm(flags: int, puzzle_hex: str | None, solution_hex: str) -> None:
+    coin_spend = make_spend(
+        TEST_COIN,
+        SerializedProgram.fromhex(puzzle_hex) if puzzle_hex is not None else IDENTITY_PUZZLE,
+        SerializedProgram.fromhex(solution_hex),
+    )
     coins = TestCoins([TEST_COIN], lineage={})
     async with setup_mempool(coins) as mempool_manager:
         sb = SpendBundle([coin_spend], G2Element())
-        sb_conds = make_test_conds(spend_ids=[(TEST_COIN, ELIGIBLE_FOR_DEDUP)])
+        sb_conds = make_test_conds(spend_ids=[(TEST_COIN, flags)])
         bundle_add_info = await mempool_manager.add_spend_bundle(sb, sb_conds, sb.name(), uint32(1))
         assert bundle_add_info.status == MempoolInclusionStatus.FAILED
         assert bundle_add_info.error == Err.INVALID_COIN_SOLUTION

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -674,7 +674,9 @@ class MempoolManager:
             # SpendBundleConditions.
             spend_conds = spend_conditions.pop(coin_id)
 
-            if bool(spend_conds.flags & ELIGIBLE_FOR_DEDUP) and not is_clvm_canonical(bytes(coin_spend.solution)):
+            if not is_clvm_canonical(bytes(coin_spend.puzzle_reveal)) or not is_clvm_canonical(
+                bytes(coin_spend.solution)
+            ):
                 return Err.INVALID_COIN_SOLUTION, None, []
 
             lineage_info = None


### PR DESCRIPTION
### Purpose:

Requiring canonical serialization was activated in soft fork 9. Move the mempool over.

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mempool acceptance rules for all transactions at admission; incorrect canonical checks could reject valid spends or admit invalid ones, but scope is limited to serialization validation aligned with an activated soft fork.
> 
> **Overview**
> Aligns mempool admission with **soft fork 9** by requiring **canonical CLVM serialization** for every coin spend, not only dedup-eligible solutions.
> 
> **Mempool validation** now rejects any spend whose `puzzle_reveal` or `solution` fails `is_clvm_canonical`, returning `Err.INVALID_COIN_SOLUTION`. The previous rule only checked the solution when `ELIGIBLE_FOR_DEDUP` was set.
> 
> **Tests** replace the single dedup-only case with `test_mempool_requires_canonical_clvm`, covering non-canonical encodings in the solution and puzzle across several spend flags (plain, dedup, FF, combined).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit befc3ac696f3f1195e8e6e9d0127ae543d93f95e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->