### PR TITLE
Remove actions reviewers requirement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 *	@Chia-Network/required-reviewers
-/.github/**/* @Chia-Network/actions-reviewers
 /PRETTY_GOOD_PRACTICES.md	@Chia-Network/required-reviewers
 /tests/ether.py @Chia-Network/required-reviewers
 /pyproject.toml @Chia-Network/required-reviewers


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Governance-only change to review routing; no runtime or application code is affected.
> 
> **Overview**
> Removes the **CODEOWNERS** entry that required `@Chia-Network/actions-reviewers` on all paths under `.github/**/*`.
> 
> Workflow and GitHub config changes in `.github` will now follow only the repo-wide `*` rule (`@Chia-Network/required-reviewers`), without an extra mandatory actions team review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbeb9da95ad5be6286af6766728b0cf50138c1ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->