### PR TITLE
checkpoint: into main from release/2.7.3  @ ab5512dccffca4775aac7c8447f3e6a230812db7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
+## 2.7.3 Chia blockchain 2026-07-16
+
+## What's Changed
+
+### Changed
+
+- Allow `chia_getHeightInfo` and `chia_getCoinRecordsByNames` WalletConnect commands to bypass confirmation prompts for read-only queries
+
+### Fixed
+
+- Fix confirmation dialogs not appearing on Linux (especially Wayland) when the `ready-to-show` event never fires
+- Fix Plot NFTs appearing assigned to the wrong key due to `launcherId` hex normalization
+- Fix log viewing in the reference wallet GUI by restoring missing Electron main-process imports
+- Fix "Asset type is not valid" error when confirming offers to sell NFTs
+
 ## 2.7.2 Chia blockchain 2026-07-09
 
 ## What's Changed


### PR DESCRIPTION
Source hash: ab5512dccffca4775aac7c8447f3e6a230812db7
Remaining commits: 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The visible diff only updates the changelog; documented fixes touch wallet GUI and offers but are typical release-integration scope for a checkpoint merge.
> 
> **Overview**
> **Release checkpoint** merging `release/2.7.3` into `main` and adding the **2.7.3** (2026-07-16) section to `CHANGELOG.md`.
> 
> **Changed:** Read-only WalletConnect calls `chia_getHeightInfo` and `chia_getCoinRecordsByNames` no longer require confirmation prompts.
> 
> **Fixed:** Linux/Wayland wallet GUI confirmation dialogs when `ready-to-show` never fires; Plot NFT key assignment via `launcherId` hex normalization; reference wallet log viewer (Electron main-process imports); NFT sell offer confirmation (“Asset type is not valid”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8d74ff50049447b717f1ce037059670fa39c7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->