### PR TITLE
CHIA-4386 Respect the threshold after which we stop including mempool items with fast forward or dedup spends in create_block_generator2

### DIFF
--- a/chia/_tests/core/mempool/test_mempool.py
+++ b/chia/_tests/core/mempool/test_mempool.py
@@ -48,7 +48,14 @@ from chia.full_node.bitcoin_fee_estimator import create_bitcoin_fee_estimator
 from chia.full_node.eligible_coin_spends import DedupCoinSpend, IdenticalSpendDedup
 from chia.full_node.fee_estimation import EmptyMempoolInfo, MempoolInfo
 from chia.full_node.full_node_api import FullNodeAPI
-from chia.full_node.mempool import MAX_BLOCK_ATOMS, MAX_BLOCK_PAIRS, MAX_SKIPPED_ITEMS, MAX_SPENDS_PER_BLOCK, Mempool
+from chia.full_node.mempool import (
+    MAX_BLOCK_ATOMS,
+    MAX_BLOCK_PAIRS,
+    MAX_SKIPPED_ITEMS,
+    MAX_SPENDS_PER_BLOCK,
+    PRIORITY_TX_THRESHOLD,
+    Mempool,
+)
 from chia.full_node.mempool_manager import MEMPOOL_MIN_FEE_INCREASE, LineageInfoCache
 from chia.full_node.pending_tx_cache import ConflictTxCache, PendingTxCache
 from chia.protocols import full_node_protocol, wallet_protocol
@@ -3544,9 +3551,9 @@ def test_block_atom_saturation_stops_scanning(monkeypatch: pytest.MonkeyPatch) -
     assert generator is not None
     # Only 3 items fit the atom budget.
     assert len(generator.removals) == 3
-    # Scanning stops after MAX_SKIPPED_ITEMS skips: 3 fitting + MAX_SKIPPED_ITEMS
+    # Scanning stops after PRIORITY_TX_THRESHOLD skips: 3 fitting + PRIORITY_TX_THRESHOLD
     # skipped items are processed, and none beyond that.
-    assert dedup_calls == 3 + MAX_SKIPPED_ITEMS
+    assert dedup_calls == 3 + PRIORITY_TX_THRESHOLD
 
 
 @pytest.mark.parametrize("old", [True, False])

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -786,16 +786,36 @@ class Mempool:
             try:
                 assert item.conds is not None
                 cost = item.conds.condition_cost + item.conds.execution_cost
-                # This `ff_state_update` is only committed later on via
-                # `update_fast_forward_spends` if the item gets batched.
-                bundle_coin_spends, ff_state_update = singleton_ff.process_fast_forward_spends(
-                    mempool_item=item, prev_tx_height=prev_tx_height, constants=constants
-                )
-                # This `dedup_state_update` is only committed later on via
-                # `update_deduplication_spends` if the item gets batched.
-                unique_coin_spends, cost_saving, unique_additions, dedup_state_update = (
-                    dedup_coin_spends.get_deduplication_info(bundle_coin_spends=bundle_coin_spends)
-                )
+                if skipped_items >= PRIORITY_TX_THRESHOLD:
+                    # If we've encountered `PRIORITY_TX_THRESHOLD` number of
+                    # transactions that don't fit in the remaining block size,
+                    # we want to keep looking for smaller transactions that
+                    # might fit, but we also want to avoid spending too much
+                    # time on potentially expensive ones, hence this shortcut.
+                    if any(
+                        sd.eligible_for_dedup or sd.supports_fast_forward for sd in item.bundle_coin_spends.values()
+                    ):
+                        log.info(f"Skipping transaction with dedup or FF spends {name}")
+                        continue
+                    unique_coin_spends = []
+                    unique_additions = []
+                    for spend_data in item.bundle_coin_spends.values():
+                        unique_coin_spends.append(spend_data.coin_spend)
+                        unique_additions.extend(spend_data.additions)
+                    ff_state_update: dict[bytes32, UnspentLineageInfo] = {}
+                    dedup_state_update: dict[bytes32, DedupCoinSpend] = {}
+                    cost_saving = 0
+                else:
+                    # This `ff_state_update` is only committed later on via
+                    # `update_fast_forward_spends` if the item gets batched.
+                    bundle_coin_spends, ff_state_update = singleton_ff.process_fast_forward_spends(
+                        mempool_item=item, prev_tx_height=prev_tx_height, constants=constants
+                    )
+                    # This `dedup_state_update` is only committed later on via
+                    # `update_deduplication_spends` if the item gets batched.
+                    unique_coin_spends, cost_saving, unique_additions, dedup_state_update = (
+                        dedup_coin_spends.get_deduplication_info(bundle_coin_spends=bundle_coin_spends)
+                    )
                 new_fee_sum = fee_sum + fee
                 if new_fee_sum > DEFAULT_CONSTANTS.MAX_COIN_AMOUNT:
                     # Such a fee is very unlikely to happen but we're defensively


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes block-building selection and performance for dedup/FF transactions near full blocks; behavior is intentional but could alter which txs get included when the mempool is near capacity.
> 
> **Overview**
> **`create_block_generator2`** now mirrors the **`create_bundle_from_mempool_items`** behavior: once **`skipped_items`** reaches **`PRIORITY_TX_THRESHOLD`** (3), the scanner still looks for smaller txs that might fit, but **skips fast-forward and dedup processing** for items that have dedup- or FF-eligible spends (logs and **`continue`**). Those expensive paths are only used while fewer than 3 items have been skipped for size limits.
> 
> For later items without dedup/FF, spends are taken directly from **`bundle_coin_spends`** with no FF/dedup state updates. A mempool test now asserts dedup work stops after **3 fitting items + `PRIORITY_TX_THRESHOLD`** skipped scans, instead of **`MAX_SKIPPED_ITEMS`** (10).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5afb4ee98851b9d391dd588bcc312fdd52781da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->