### PR TITLE
CHIA-4387 Demote None challenge_root log line in make_sub_epoch_summary

### DIFF
--- a/chia/consensus/make_sub_epoch_summary.py
+++ b/chia/consensus/make_sub_epoch_summary.py
@@ -74,7 +74,7 @@ def make_sub_epoch_summary(
         )
     else:
         challenge_root = None
-        log.info(
+        log.debug(
             f"make_sub_epoch_summary: height={blocks_included_height} < fork_height={constants.HARD_FORK2_HEIGHT}, "
             f"using None for challenge_root"
         )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Logging-only change with no consensus, security, or data-handling impact.
> 
> **Overview**
> Reduces log noise from **sub-epoch summary** construction on chains below the hard-fork height by changing one message in `make_sub_epoch_summary` from `log.info` to `log.debug` when `make_challenge_root` is false and `challenge_root` stays `None`.
> 
> The **info**-level line that logs a computed `challenge_root` at or above `HARD_FORK2_HEIGHT` is unchanged, so operators still see the higher-signal fork-era case without flooding logs on every pre-fork SES.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e5e3d8b237e9719a5fa9d8a6c10c95840b93e8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->