### PR TITLE
[CHIA-4394] improve mempool robustness

### DIFF
--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -609,6 +609,9 @@ class Mempool:
         # singleton spends.
         singleton_ff = SingletonFastForward()
         coin_spends: list[CoinSpend] = []
+        # Track coins already committed to spend so we never add a conflicting
+        # spend to the same block.
+        spent_coin_ids: set[bytes32] = set()
         sigs: list[G2Element] = []
         log.info(f"Starting to make block, max cost: {self.mempool_info.max_block_clvm_cost}")
         bundle_creation_start = monotonic()
@@ -688,9 +691,16 @@ class Mempool:
                     if skipped_items < MAX_SKIPPED_ITEMS:
                         continue
                     break
+                # Skip this item if any of its spends conflict with a coin
+                # already added to this block.
+                item_removal_ids = [cs.coin.name() for cs in unique_coin_spends]
+                if any(removal_id in spent_coin_ids for removal_id in item_removal_ids):
+                    log.warning(f"Skipping mempool item {name} that conflicts with an already added spend")
+                    continue
                 singleton_ff.update_fast_forward_spends(ff_state_update)
                 dedup_coin_spends.update_deduplication_spends(dedup_state_update)
                 coin_spends.extend(unique_coin_spends)
+                spent_coin_ids.update(item_removal_ids)
                 additions.extend(unique_additions)
                 sigs.append(item.aggregated_signature)
                 cost_sum = new_cost_sum
@@ -757,6 +767,12 @@ class Mempool:
         # and pair limits.
         added_atoms = 0
         added_pairs = 0
+        # Track coins already committed to spend so we never add a conflicting
+        # spend to the same block. `spent_coin_ids` holds coins from accepted
+        # batches, `batch_spent_coin_ids` holds coins from the batch currently
+        # being assembled (dropped if that batch is rejected).
+        spent_coin_ids: set[bytes32] = set()
+        batch_spent_coin_ids: set[bytes32] = set()
 
         batch_transactions: list[SpendBundle] = []
         batch_additions: list[Coin] = []
@@ -855,6 +871,7 @@ class Mempool:
                         added_pairs += batch_pairs
                         additions.extend(batch_additions)
                         removals.extend([cs.coin for sb in batch_transactions for cs in sb.coin_spends])
+                        spent_coin_ids.update(batch_spent_coin_ids)
                         log.info(
                             f"adding TX batch, additions: {len(batch_additions)} removals: {batch_spends} "
                             f"cost: {batch_cost} total cost: {block_cost}"
@@ -865,6 +882,7 @@ class Mempool:
                         batch_spends = 0
                         batch_atoms = 0
                         batch_pairs = 0
+                        batch_spent_coin_ids = set()
                     else:
                         log.info(f"Skipping transaction batch cumulative cost: {block_cost} batch cost: {batch_cost}")
                         skipped_items += 1
@@ -878,6 +896,7 @@ class Mempool:
                         batch_spends = 0
                         batch_atoms = 0
                         batch_pairs = 0
+                        batch_spent_coin_ids = set()
                         # Reprocess the current item against the correct fast
                         # forward and dedup state.
                         bundle_coin_spends, ff_state_update = singleton_ff.process_fast_forward_spends(
@@ -890,6 +909,17 @@ class Mempool:
                     if done:
                         break
 
+                # Skip this item if any of its spends conflict with a coin
+                # already committed to this block, whether in an accepted batch
+                # or in the batch we're currently assembling.
+                item_removal_ids = [cs.coin.name() for cs in unique_coin_spends]
+                if any(
+                    removal_id in spent_coin_ids or removal_id in batch_spent_coin_ids
+                    for removal_id in item_removal_ids
+                ):
+                    log.warning(f"Skipping mempool item {name} that conflicts with an already added spend")
+                    continue
+
                 singleton_ff.update_fast_forward_spends(ff_state_update)
                 dedup_coin_spends.update_deduplication_spends(dedup_state_update)
                 batch_cost += cost - cost_saving
@@ -898,6 +928,7 @@ class Mempool:
                 batch_atoms += item.conds.num_atoms
                 batch_pairs += item.conds.num_pairs
                 batch_additions.extend(unique_additions)
+                batch_spent_coin_ids.update(item_removal_ids)
                 fee_sum = new_fee_sum
                 block_cost += item.conds.cost - cost_saving
                 if added_spends + batch_spends >= MAX_SPENDS_PER_BLOCK:
@@ -920,6 +951,7 @@ class Mempool:
                 added_pairs += batch_pairs
                 additions.extend(batch_additions)
                 removals.extend([cs.coin for sb in batch_transactions for cs in sb.coin_spends])
+                spent_coin_ids.update(batch_spent_coin_ids)
                 log.info(
                     f"adding TX batch, additions: {len(batch_additions)} removals: {batch_spends} "
                     f"cost: {batch_cost} total cost: {block_cost}"


### PR DESCRIPTION
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-critical block construction from the mempool; the change only skips items that would make the block invalid, but incorrect conflict tracking could drop valid transactions or still miss edge cases.
> 
> **Overview**
> Block assembly from the mempool now tracks **which coin IDs are already slated to be spent** in the block being built, and **drops lower-priority items** that would spend any of those coins again.
> 
> In **`create_bundle_from_mempool_items`**, a `spent_coin_ids` set is updated as items are accepted; conflicting items are skipped with a warning instead of being merged into the bundle.
> 
> In **`create_block_generator2`**, the same guard uses **`spent_coin_ids`** for committed batches and **`batch_spent_coin_ids`** for the in-flight batch. Accepted batches merge into `spent_coin_ids`; rejected or reset batches clear the batch set so a failed compression pass does not leave stale conflict state.
> 
> Together this keeps a single block from containing two spends of the same coin when fast-forward/dedup reshaping or priority ordering would otherwise let both through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae645f9d99b52b36e103aa0abd46ffae9fa55c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->