### PR TITLE
Prototype for Adding configurable minimum fee per cost

### DIFF
--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -49,6 +49,7 @@ from chia.full_node.mempool_manager import (
     compute_assert_height,
     is_atom_canonical,
     is_clvm_canonical,
+    minimum_fee_for_cost,
     optional_max,
     optional_min,
 )
@@ -264,6 +265,7 @@ async def instantiate_mempool_manager(
     block_timestamp: uint64 = TEST_TIMESTAMP,
     constants: ConsensusConstants = DEFAULT_CONSTANTS,
     max_tx_clvm_cost: uint64 | None = None,
+    minimum_fee_per_cost: uint64 = uint64(0),
 ) -> AsyncGenerator[MempoolManager, None]:
     async with MempoolManager.managed(
         get_coin_records,
@@ -271,6 +273,7 @@ async def instantiate_mempool_manager(
         constants,
         InlineExecutor(),
         max_tx_clvm_cost=max_tx_clvm_cost,
+        minimum_fee_per_cost=minimum_fee_per_cost,
         validation_timeout=10,
     ) as mempool_manager:
         test_block_record = create_test_block_record(height=block_height, timestamp=block_timestamp)
@@ -1599,6 +1602,38 @@ def assert_sb_in_pool(mempool_manager: MempoolManager, sb: SpendBundle) -> None:
 
 def assert_sb_not_in_pool(mempool_manager: MempoolManager, sb: SpendBundle) -> None:
     assert mempool_manager.get_spendbundle(sb.name()) is None
+
+
+@pytest.mark.parametrize(
+    "cost, fee_per_million_cost, expected_fee",
+    [
+        (0, uint64(1_818_182), 0),
+        (1, uint64(1), 1),
+        (1_000_000, uint64(1), 1),
+        (1_000_001, uint64(1), 2),
+        (5_500_000, uint64(1_818_182), 10_000_001),
+        (11_000_000_000, uint64(0), 0),
+    ],
+)
+def test_minimum_fee_for_cost(cost: int, fee_per_million_cost: uint64, expected_fee: int) -> None:
+    assert minimum_fee_for_cost(cost, fee_per_million_cost) == expected_fee
+
+
+@pytest.mark.anyio
+async def test_configured_minimum_fee_per_cost() -> None:
+    async with instantiate_mempool_manager(
+        get_coin_records_for_test_coins, minimum_fee_per_cost=uint64(1_000_000)
+    ) as mempool_manager:
+        await make_and_send_spendbundle(
+            mempool_manager,
+            TEST_COIN,
+            expected_result=(MempoolInclusionStatus.FAILED, Err.INVALID_FEE_TOO_CLOSE_TO_ZERO),
+        )
+
+    async with instantiate_mempool_manager(
+        get_coin_records_for_test_coins, minimum_fee_per_cost=uint64(1_000_000)
+    ) as mempool_manager:
+        await make_and_send_spendbundle(mempool_manager, TEST_COIN, fee=100_000_000)
 
 
 @pytest.mark.anyio

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -349,6 +349,7 @@ class FullNode:
                 consensus_constants=self.constants,
                 pool=self.pool,
                 validation_timeout=self.config.get("block_creation_timeout", 2.0),
+                minimum_fee_per_cost=uint64(self.config.get("min_fee", 1_818_182)),
             ) as self._mempool_manager:
                 # Transactions go into this queue from the server, and get sent to respond_transaction
                 self._transaction_queue = TransactionQueue(

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -51,6 +51,10 @@ log = logging.getLogger(__name__)
 MEMPOOL_MIN_FEE_INCREASE = uint64(10000000)
 
 
+def minimum_fee_for_cost(cost: int, fee_per_million_cost: uint64) -> int:
+    return (cost * fee_per_million_cost + 999_999) // 1_000_000
+
+
 @dataclass
 class TimelockConditions:
     assert_height: uint32 = uint32(0)
@@ -312,6 +316,7 @@ class MempoolManager:
     _worker_queue_size: int
     max_block_clvm_cost: uint64
     max_tx_clvm_cost: uint64
+    minimum_fee_per_cost: uint64
     validation_timeout: float
 
     def __init__(
@@ -323,6 +328,7 @@ class MempoolManager:
         *,
         validation_timeout: float,
         max_tx_clvm_cost: uint64 | None = None,
+        minimum_fee_per_cost: uint64 = uint64(0),
     ):
         self.constants: ConsensusConstants = consensus_constants
 
@@ -340,6 +346,7 @@ class MempoolManager:
         # transactions. This prevents spam. This is equivalent to 0.055 XCH per block, or about 0.00005 XCH for two
         # spends.
         self.nonzero_fee_minimum_fpc = 5
+        self.minimum_fee_per_cost = minimum_fee_per_cost
 
         # We need to deduct the block overhead, which consists of the wrapping
         # quote opcode's bytes cost as well as its execution cost.
@@ -380,6 +387,7 @@ class MempoolManager:
         *,
         validation_timeout: float,
         max_tx_clvm_cost: uint64 | None = None,
+        minimum_fee_per_cost: uint64 = uint64(0),
     ) -> AsyncIterator[Self]:
         self = cls(
             get_coin_records,
@@ -387,6 +395,7 @@ class MempoolManager:
             consensus_constants,
             pool,
             max_tx_clvm_cost=max_tx_clvm_cost,
+            minimum_fee_per_cost=minimum_fee_per_cost,
             validation_timeout=validation_timeout,
         )
         try:
@@ -781,6 +790,10 @@ class MempoolManager:
             return Err.INVALID_BLOCK_FEE_AMOUNT, None, []
 
         fees_per_cost: float = fees / cost
+        required_fee = minimum_fee_for_cost(cost, self.minimum_fee_per_cost)
+        if fees < required_fee:
+            return Err.INVALID_FEE_TOO_CLOSE_TO_ZERO, None, []
+
         # If pool is at capacity check the fee, if not then accept even without the fee
         if self.mempool.at_full_capacity(cost):
             if fees_per_cost < self.nonzero_fee_minimum_fpc:

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -331,6 +331,9 @@ full_node:
   # measure to not spend too much time building the block generator.
   # block_creation_timeout: 2.0
 
+  # Minimum transaction fee in mojos per million CLVM cost. A value of 0 disables the floor.
+  min_fee: 1818182
+
   # the number of threads used to read from the blockchain database
   # concurrently. There's always only 1 writer, but the number of readers is
   # configurable


### PR DESCRIPTION
### Purpose:

Provide a prototype/reference implementation of CHIP-0003:
https://github.com/Chia-Network/chips/pull/13

### Current Behavior:

Full nodes accept zero-fee transactions while the mempool has capacity.
The existing fee-per-cost threshold applies only when capacity pressure
requires transaction eviction.

### New Behavior:

Adds the `full_node.min_fee` configuration in mojos per million CLVM
cost. The default is `1818182`, as specified by CHIP-0003.

The full node calculates the required fee using ceiling division and
rejects transactions below that floor before mempool admission.

This is a prototype submitted for technical review, not a production-ready
implementation.

### Testing Notes:

- 19 focused fee and configuration tests passed
- Ruff lint and formatting checks passed
- No node or testnet was started
- The broader mempool suite produced 429 passes
- Five zero-fee wallet integration cases require wallet-side follow-up
- 43 external-vector cases could not run because
  `~/.chia/test-bundles` was unavailable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes default mempool admission for all transactions on nodes using the new default `min_fee`, which can reject previously accepted low- or zero-fee spends before they reach capacity-based rules.
> 
> **Overview**
> Adds a **configurable minimum transaction fee** tied to CLVM cost, aligned with CHIP-0003. Full nodes read **`full_node.min_fee`** (mojos per million cost; default **`1818182`**) and pass it into **`MempoolManager`** as **`minimum_fee_per_cost`**.
> 
> Before mempool capacity eviction rules run, admission now computes **`required_fee`** via **`minimum_fee_for_cost`** (ceiling division) and rejects spends with **`Err.INVALID_FEE_TOO_CLOSE_TO_ZERO`** when the fee is below that floor. Setting the config to **`0`** disables the floor.
> 
> Tests cover the fee formula and mempool rejection/acceptance when **`minimum_fee_per_cost`** is **`1_000_000`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b72ab2c4b06dafbaf5a05dd28c72068c44e61b7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->