### PR TITLE
Bring-in CHIA-4395 Improve singleton fast forward removals handling

### DIFF
--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -244,19 +244,32 @@ def check_removals(
             return Err.DOUBLE_SPEND, []
 
         # 2. Checks if there's a mempool conflict
-        conflicting_items = get_items_by_coin_ids([coin_id])
+        # Fast forward spends rebase onto the latest singleton coin, so look
+        # that up as well.
+        latest_ff_id = None if coin_bcs.latest_singleton_lineage is None else coin_bcs.latest_singleton_lineage.coin_id
+        coin_ids = [coin_id]
+        if latest_ff_id is not None and latest_ff_id != coin_id:
+            coin_ids.append(latest_ff_id)
+        conflicting_items = get_items_by_coin_ids(coin_ids)
         for item in conflicting_items:
             if item in conflicts:
                 continue
             conflict_bcs = item.bundle_coin_spends.get(coin_id)
+            if conflict_bcs is None and latest_ff_id is not None:
+                conflict_bcs = item.bundle_coin_spends.get(latest_ff_id)
             if conflict_bcs is None:
                 # Check if this is an item that spends an older ff singleton
-                # version with a latest version that matches our coin ID.
+                # version with a latest version that matches our coin ID or the
+                # same latest version we rebase onto.
                 conflict_bcs = next(
                     (
                         bcs
                         for bcs in item.bundle_coin_spends.values()
-                        if bcs.latest_singleton_lineage is not None and bcs.latest_singleton_lineage.coin_id == coin_id
+                        if bcs.latest_singleton_lineage is not None
+                        and (
+                            bcs.latest_singleton_lineage.coin_id == coin_id
+                            or (latest_ff_id is not None and bcs.latest_singleton_lineage.coin_id == latest_ff_id)
+                        )
                     ),
                     None,
                 )
@@ -264,25 +277,28 @@ def check_removals(
                 if conflict_bcs is None:
                     log.warning(f"Coin ID {coin_id} expected but not found in mempool item {item.name}")
                     return Err.INVALID_SPEND_BUNDLE, []
+            same_coin = coin_id == conflict_bcs.coin_spend.coin.name()
             # if the spend we're adding to the mempool is not DEDUP nor FF, it's
             # just a regular conflict
             if not coin_bcs.supports_fast_forward and not coin_bcs.eligible_for_dedup:
                 conflicts.add(item)
 
-            # if the spend we're adding is FF, but there's a conflicting spend
-            # that isn't FF, they can't be chained, so that's a conflict
-            elif coin_bcs.supports_fast_forward and not conflict_bcs.supports_fast_forward:
+            # If one spend is FF and the other isn't FF, they can't be chained
+            # so that's a conflict.
+            elif coin_bcs.supports_fast_forward != conflict_bcs.supports_fast_forward:
                 conflicts.add(item)
 
             # if the spend we're adding is DEDUP, but there's a conflicting spend
             # that isn't DEDUP, we cannot merge them, so that's a conflict
-            elif coin_bcs.eligible_for_dedup and not conflict_bcs.eligible_for_dedup:
+            elif same_coin and coin_bcs.eligible_for_dedup and not conflict_bcs.eligible_for_dedup:
                 conflicts.add(item)
 
             # if the spend we're adding is DEDUP but the existing spend has a
             # different solution, we cannot merge them, so that's a conflict
-            elif coin_bcs.eligible_for_dedup and bytes(coin_bcs.coin_spend.solution) != bytes(
-                conflict_bcs.coin_spend.solution
+            elif (
+                same_coin
+                and coin_bcs.eligible_for_dedup
+                and bytes(coin_bcs.coin_spend.solution) != bytes(conflict_bcs.coin_spend.solution)
             ):
                 conflicts.add(item)
 


### PR DESCRIPTION
This brings-in PR #21326.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mempool conflict detection for FF singletons and dedup eligibility, which can affect which transactions are accepted, rejected, or replaceable.
> 
> **Overview**
> **Improves mempool conflict checks for singleton fast-forward (FF) spends** in `check_removals`, so FF transactions are compared against the right mempool entries and dedup rules do not misfire across different coins.
> 
> When validating removals, the node now also looks up mempool items by the **latest singleton coin ID** from `latest_singleton_lineage`, not only the coin ID in the bundle. Matching logic for conflicting items is extended to resolve spends via that latest ID and to treat lineage matches when either the removal or the rebase target aligns with an existing FF spend.
> 
> **DEDUP** merge vs conflict rules are gated on **`same_coin`** (the conflicting spend must be for the same physical removal). **FF vs non-FF** conflicts are treated symmetrically: any pairing where only one side supports fast-forward is a conflict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a853380efb7363759f1bf2d6bc5a03628a58c9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->