### PR TITLE
CHIA-4405 Handle ConnectionError from send_bytes in test_large_message_disconnect_and_ban

### DIFF
--- a/chia/_tests/core/server/test_dos.py
+++ b/chia/_tests/core/server/test_dos.py
@@ -145,16 +145,19 @@ class TestDos:
             large_msg: bytes = bytes([0] * (60 * 1024 * 1024))
             with monkeypatch.context() as monkey_patch_context:
                 monkey_patch_context.setattr(chia.server.server, "is_localhost", not_localhost)
-                await ws.send_bytes(large_msg)
-
-                response = await ws.receive()
+                # aiohttp rejects the oversized frame from its header before
+                # reading the payload, so the server tears down the socket
+                # while the ~60MB message is still in flight. The resulting TCP
+                # reset can raise ConnectionError on send and/or discard the
+                # server's close frame, leaving the client with an abrupt
+                # CLOSED instead of a clean CLOSE carrying MESSAGE_TOO_BIG.
+                try:
+                    await ws.send_bytes(large_msg)
+                    response = await ws.receive()
+                except ConnectionError:  # pragma: no cover
+                    await time_out_assert(10, lambda: self_hostname in server_1.banned_peers)
+                    return
                 await time_out_assert(10, lambda: self_hostname in server_1.banned_peers)
-
-            print(response)
-            # aiohttp rejects the oversized frame from its header before reading the payload, so the
-            # server tears down the socket while the ~60MB message is still in flight. The resulting
-            # TCP reset can discard the server's close frame, leaving the client with an abrupt CLOSED
-            # instead of a clean CLOSE carrying the MESSAGE_TOO_BIG code.
             assert response.type in {WSMsgType.CLOSE, WSMsgType.CLOSED}
             if response.type == WSMsgType.CLOSE:
                 assert response.data == WSCloseCode.MESSAGE_TOO_BIG


### PR DESCRIPTION
aiohttp can reset the socket from the frame header before the too large payload finishes writing, so treat a lost connection like a missing close frame and still assert the peer is banned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to tolerate flaky TCP/WebSocket teardown; no production server or ban logic is modified.
> 
> **Overview**
> Hardens **`test_large_message_disconnect_and_ban`** against aiohttp tearing down the socket while a ~60MB frame is still sending, which can surface as **`ConnectionError`** on `send_bytes` instead of a clean WebSocket close with **`MESSAGE_TOO_BIG`**.
> 
> The send/receive path is wrapped in **`try/except ConnectionError`**: on that path the test still waits for the peer to appear in **`banned_peers`** and exits without asserting close message type/code. The existing ban check and **`CLOSE`/`CLOSED`** assertions remain for the non-error path. Inline comments document the race; a debug **`print(response)`** is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f2755b02731ae553b7ff3b99b50afff6f8922d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->