### PR TITLE
extend the log_mempool configuration option

### DIFF
--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -1719,6 +1719,23 @@ async def test_log_mempool_true_logs_spend_bundle(
         ("timeout", "timeout"),
         (None, "false"),
         ("other", "false"),
+        # Integers users may try (e.g. 0/1 as off/on); only exact bool/string forms count.
+        (0, "false"),
+        (1, "false"),
+        (2, "false"),
+        # Capitalization matters: only lowercase "true" / "timeout" are recognized.
+        ("True", "false"),
+        ("TRUE", "false"),
+        ("False", "false"),
+        ("FALSE", "false"),
+        ("Timeout", "false"),
+        ("TIMEOUT", "false"),
+        # Surrounding whitespace is not stripped.
+        (" true", "false"),
+        ("true ", "false"),
+        ("true\n", "false"),
+        (" timeout", "false"),
+        ("timeout ", "false"),
     ],
 )
 async def test_log_mempool_mode_normalization(

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -10,6 +10,7 @@ import random
 import sqlite3
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -68,6 +69,7 @@ from chia.consensus.signage_point import SignagePoint
 from chia.full_node import full_node as full_node_module
 from chia.full_node.full_node import FullNode, WalletUpdate
 from chia.full_node.full_node_api import FullNodeAPI, tx_request_and_timeout
+from chia.full_node.mempool_manager import SpendBundleAddInfo
 from chia.full_node.sync_store import Peak
 from chia.full_node.tx_processing_queue import PeerWithTx
 from chia.protocols import full_node_protocol, timelord_protocol, wallet_protocol
@@ -1663,6 +1665,72 @@ async def test_add_transaction_remove_seen_on_unexpected_exception(
 
     assert not fn.mempool_manager.in_flight(spend_name)
     assert not fn.mempool_manager.seen(spend_name)
+
+
+def _mempool_log_path(fn: FullNode, spend_name: bytes32) -> Path:
+    return path_from_root(fn.root_path, "mempool-log") / f"{fn.blockchain.get_peak_height()}" / f"{spend_name}.bundle"
+
+
+@pytest.mark.anyio
+async def test_log_mempool_true_logs_after_pre_validate(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+) -> None:
+    full_node_1, _server_1, _bt = one_node_one_block
+    fn = full_node_1.full_node
+    fn.config["log_mempool"] = True
+
+    spend_bundle = make_spend_bundle(1)
+    spend_name = spend_bundle.name()
+    log_path = _mempool_log_path(fn, spend_name)
+
+    original_pre_validate = fn.mempool_manager.pre_validate_spendbundle
+    original_add = fn.mempool_manager.add_spend_bundle
+
+    async def fake_pre_validate(*_args: Any, **_kwargs: Any) -> SpendBundleConditions:
+        return object()  # type: ignore[return-value]
+
+    async def abort_add(*_args: Any, **_kwargs: Any) -> SpendBundleAddInfo:
+        return SpendBundleAddInfo(None, MempoolInclusionStatus.FAILED, [], Err.INVALID_SPEND_BUNDLE)
+
+    fn.mempool_manager.pre_validate_spendbundle = fake_pre_validate  # type: ignore[method-assign]
+    fn.mempool_manager.add_spend_bundle = abort_add  # type: ignore[method-assign]
+    try:
+        status, err = await fn.add_transaction(spend_bundle, spend_name, test=True)
+    finally:
+        fn.mempool_manager.pre_validate_spendbundle = original_pre_validate  # type: ignore[method-assign]
+        fn.mempool_manager.add_spend_bundle = original_add  # type: ignore[method-assign]
+
+    assert status == MempoolInclusionStatus.FAILED
+    assert err == Err.INVALID_SPEND_BUNDLE
+    assert log_path.exists()
+    assert log_path.read_bytes() == bytes(spend_bundle)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, "true"),
+        ("true", "true"),
+        (False, "false"),
+        ("false", "false"),
+        ("timeout", "timeout"),
+        (None, "false"),
+        ("other", "false"),
+    ],
+)
+async def test_log_mempool_mode_normalization(
+    one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    value: object,
+    expected: str,
+) -> None:
+    full_node_1, _server_1, _bt = one_node_one_block
+    fn = full_node_1.full_node
+    if value is None:
+        fn.config.pop("log_mempool", None)
+    else:
+        fn.config["log_mempool"] = value
+    assert fn._log_mempool_mode() == expected
 
 
 @pytest.mark.anyio

--- a/chia/_tests/core/full_node/test_full_node.py
+++ b/chia/_tests/core/full_node/test_full_node.py
@@ -69,7 +69,6 @@ from chia.consensus.signage_point import SignagePoint
 from chia.full_node import full_node as full_node_module
 from chia.full_node.full_node import FullNode, WalletUpdate
 from chia.full_node.full_node_api import FullNodeAPI, tx_request_and_timeout
-from chia.full_node.mempool_manager import SpendBundleAddInfo
 from chia.full_node.sync_store import Peak
 from chia.full_node.tx_processing_queue import PeerWithTx
 from chia.protocols import full_node_protocol, timelord_protocol, wallet_protocol
@@ -1672,38 +1671,41 @@ def _mempool_log_path(fn: FullNode, spend_name: bytes32) -> Path:
 
 
 @pytest.mark.anyio
-async def test_log_mempool_true_logs_after_pre_validate(
+@pytest.mark.parametrize(
+    "log_mempool,expect_log",
+    [
+        (True, True),
+        (False, False),
+        ("timeout", False),
+    ],
+)
+async def test_log_mempool_true_logs_spend_bundle(
     one_node_one_block: tuple[FullNodeSimulator, ChiaServer, BlockTools],
+    log_mempool: bool | str,
+    expect_log: bool,
 ) -> None:
-    full_node_1, _server_1, _bt = one_node_one_block
+    full_node_1, _, bt = one_node_one_block
     fn = full_node_1.full_node
-    fn.config["log_mempool"] = True
+    fn.config["log_mempool"] = log_mempool
 
-    spend_bundle = make_spend_bundle(1)
+    blocks = bt.get_consecutive_blocks(
+        3, guarantee_transaction_block=True, farmer_reward_puzzle_hash=bt.pool_ph, pool_reward_puzzle_hash=bt.pool_ph
+    )
+    await add_blocks_in_batches(blocks, fn)
+    wt = bt.get_pool_wallet_tool()
+    spend_bundle = wt.generate_signed_transaction(
+        uint64(42), wt.get_new_puzzlehash(), blocks[-1].get_included_reward_coins()[0]
+    )
     spend_name = spend_bundle.name()
+
+    status, err = await fn.add_transaction(spend_bundle, spend_name, test=True)
+    assert status == MempoolInclusionStatus.SUCCESS
+    assert err is None
+
     log_path = _mempool_log_path(fn, spend_name)
-
-    original_pre_validate = fn.mempool_manager.pre_validate_spendbundle
-    original_add = fn.mempool_manager.add_spend_bundle
-
-    async def fake_pre_validate(*_args: Any, **_kwargs: Any) -> SpendBundleConditions:
-        return object()  # type: ignore[return-value]
-
-    async def abort_add(*_args: Any, **_kwargs: Any) -> SpendBundleAddInfo:
-        return SpendBundleAddInfo(None, MempoolInclusionStatus.FAILED, [], Err.INVALID_SPEND_BUNDLE)
-
-    fn.mempool_manager.pre_validate_spendbundle = fake_pre_validate  # type: ignore[method-assign]
-    fn.mempool_manager.add_spend_bundle = abort_add  # type: ignore[method-assign]
-    try:
-        status, err = await fn.add_transaction(spend_bundle, spend_name, test=True)
-    finally:
-        fn.mempool_manager.pre_validate_spendbundle = original_pre_validate  # type: ignore[method-assign]
-        fn.mempool_manager.add_spend_bundle = original_add  # type: ignore[method-assign]
-
-    assert status == MempoolInclusionStatus.FAILED
-    assert err == Err.INVALID_SPEND_BUNDLE
-    assert log_path.exists()
-    assert log_path.read_bytes() == bytes(spend_bundle)
+    assert log_path.exists() == expect_log
+    if expect_log:
+        assert log_path.read_bytes() == bytes(spend_bundle)
 
 
 @pytest.mark.anyio

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -5,6 +5,7 @@ import logging
 import random
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Collection, Sequence
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any, ClassVar
 
 import pytest
@@ -42,6 +43,7 @@ from chia.full_node.eligible_coin_spends import (
 from chia.full_node.mempool import MAX_SKIPPED_ITEMS, PRIORITY_TX_THRESHOLD
 from chia.full_node.mempool_manager import (
     MEMPOOL_MIN_FEE_INCREASE,
+    LogMempoolConfig,
     MempoolManager,
     TimelockConditions,
     can_replace,
@@ -264,6 +266,9 @@ async def instantiate_mempool_manager(
     block_timestamp: uint64 = TEST_TIMESTAMP,
     constants: ConsensusConstants = DEFAULT_CONSTANTS,
     max_tx_clvm_cost: uint64 | None = None,
+    validation_timeout: float = 10,
+    log_mempool: LogMempoolConfig = False,
+    root_path: Path | None = None,
 ) -> AsyncGenerator[MempoolManager, None]:
     async with MempoolManager.managed(
         get_coin_records,
@@ -271,7 +276,9 @@ async def instantiate_mempool_manager(
         constants,
         InlineExecutor(),
         max_tx_clvm_cost=max_tx_clvm_cost,
-        validation_timeout=10,
+        validation_timeout=validation_timeout,
+        log_mempool=log_mempool,
+        root_path=root_path,
     ) as mempool_manager:
         test_block_record = create_test_block_record(height=block_height, timestamp=block_timestamp)
         await mempool_manager.new_peak(test_block_record, None)
@@ -765,6 +772,81 @@ async def test_validation_timeout() -> None:
         sb = spend_bundle_from_conditions(conditions)
         with pytest.raises(ValueError, match="timeout"):
             await mempool_manager.pre_validate_spendbundle(sb)
+
+
+@pytest.mark.anyio
+async def test_validate_spend_bundle_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The wall-clock check in validate_spend_bundle rejects with INVALID_SPEND_BUNDLE."""
+    async with instantiate_mempool_manager(get_coin_records_for_test_coins) as mempool_manager:
+        conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1]]
+        sb = spend_bundle_from_conditions(conditions)
+        sbc = await mempool_manager.pre_validate_spendbundle(sb)
+        mempool_manager.validation_timeout = 0
+        clock = [1000.0]
+
+        def fake_monotonic() -> float:
+            t = clock[0]
+            clock[0] += 1.0
+            return t
+
+        # validate_spend_bundle only times Python-side work after pre_validate; on
+        # platforms with coarse monotonic() resolution duration can be 0, so force
+        # a non-zero elapsed time to test the timeout check deterministically.
+        monkeypatch.setattr("chia.full_node.mempool_manager.time.monotonic", fake_monotonic)
+        info = await mempool_manager.add_spend_bundle(sb, sbc, sb.name(), TEST_HEIGHT)
+        assert info.status == MempoolInclusionStatus.FAILED
+        assert info.error == Err.INVALID_SPEND_BUNDLE
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "log_mempool,expect_log",
+    [
+        ("timeout", True),
+        (False, False),
+        (True, False),
+    ],
+)
+async def test_log_mempool_timeout_on_pre_validate(
+    tmp_path: Path, log_mempool: LogMempoolConfig, expect_log: bool
+) -> None:
+    async with MempoolManager.managed(
+        zero_calls_get_coin_records,
+        zero_calls_get_unspent_lineage_info_for_puzzle_hash,
+        DEFAULT_CONSTANTS,
+        InlineExecutor(),
+        validation_timeout=0,
+        log_mempool=log_mempool,
+        root_path=tmp_path,
+    ) as mempool_manager:
+        await mempool_manager.new_peak(create_test_block_record(), None)
+        conditions = [[ConditionOpcode.CREATE_COIN, IDENTITY_PUZZLE_HASH, 1]]
+        sb = spend_bundle_from_conditions(conditions)
+        with pytest.raises(ValueError, match="timeout"):
+            await mempool_manager.pre_validate_spendbundle(sb)
+
+        log_path = tmp_path / "mempool-log" / f"{TEST_HEIGHT}" / f"{sb.name()}.bundle"
+        assert log_path.exists() == expect_log
+        if expect_log:
+            assert log_path.read_bytes() == bytes(sb)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, "true"),
+        ("true", "true"),
+        (False, "false"),
+        ("false", "false"),
+        ("timeout", "timeout"),
+        (None, "false"),
+        ("other", "false"),
+    ],
+)
+def test_normalize_log_mempool(value: object, expected: str) -> None:
+    from chia.full_node.mempool_manager import _normalize_log_mempool
+
+    assert _normalize_log_mempool(value) == expected
 
 
 @pytest.mark.anyio

--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -43,7 +43,7 @@ from chia.full_node.eligible_coin_spends import (
 from chia.full_node.mempool import MAX_SKIPPED_ITEMS, PRIORITY_TX_THRESHOLD
 from chia.full_node.mempool_manager import (
     MEMPOOL_MIN_FEE_INCREASE,
-    LogMempoolConfig,
+    LogMempoolMode,
     MempoolManager,
     TimelockConditions,
     can_replace,
@@ -267,7 +267,7 @@ async def instantiate_mempool_manager(
     constants: ConsensusConstants = DEFAULT_CONSTANTS,
     max_tx_clvm_cost: uint64 | None = None,
     validation_timeout: float = 10,
-    log_mempool: LogMempoolConfig = False,
+    log_mempool: LogMempoolMode = "false",
     root_path: Path | None = None,
 ) -> AsyncGenerator[MempoolManager, None]:
     async with MempoolManager.managed(
@@ -803,12 +803,12 @@ async def test_validate_spend_bundle_timeout(monkeypatch: pytest.MonkeyPatch) ->
     "log_mempool,expect_log",
     [
         ("timeout", True),
-        (False, False),
-        (True, False),
+        ("false", False),
+        ("true", False),
     ],
 )
 async def test_log_mempool_timeout_on_pre_validate(
-    tmp_path: Path, log_mempool: LogMempoolConfig, expect_log: bool
+    tmp_path: Path, log_mempool: LogMempoolMode, expect_log: bool
 ) -> None:
     async with MempoolManager.managed(
         zero_calls_get_coin_records,
@@ -829,24 +829,6 @@ async def test_log_mempool_timeout_on_pre_validate(
         assert log_path.exists() == expect_log
         if expect_log:
             assert log_path.read_bytes() == bytes(sb)
-
-
-@pytest.mark.parametrize(
-    "value,expected",
-    [
-        (True, "true"),
-        ("true", "true"),
-        (False, "false"),
-        ("false", "false"),
-        ("timeout", "timeout"),
-        (None, "false"),
-        ("other", "false"),
-    ],
-)
-def test_normalize_log_mempool(value: object, expected: str) -> None:
-    from chia.full_node.mempool_manager import _normalize_log_mempool
-
-    assert _normalize_log_mempool(value) == expected
 
 
 @pytest.mark.anyio

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -63,7 +63,7 @@ from chia.full_node.full_node_store import FullNodeStore, FullNodeStorePeakResul
 from chia.full_node.hint_management import get_hints_and_subscription_coin_ids
 from chia.full_node.hint_store import HintStore
 from chia.full_node.mempool import MempoolRemoveInfo
-from chia.full_node.mempool_manager import MempoolManager
+from chia.full_node.mempool_manager import LogMempoolMode, MempoolManager
 from chia.full_node.subscriptions import PeerSubscriptions, peers_for_spend_bundle
 from chia.full_node.sync_store import Peak, SyncStore
 from chia.full_node.tx_processing_queue import PeerWithTx, TransactionQueue, TransactionQueueEntry
@@ -349,7 +349,7 @@ class FullNode:
                 consensus_constants=self.constants,
                 pool=self.pool,
                 validation_timeout=self.config.get("block_creation_timeout", 2.0),
-                log_mempool=self.config.get("log_mempool", False),
+                log_mempool=self._log_mempool_mode(),
                 root_path=self.root_path,
             ) as self._mempool_manager:
                 # Transactions go into this queue from the server, and get sent to respond_transaction
@@ -3014,7 +3014,7 @@ class FullNode:
                 )
         return None, False
 
-    def _log_mempool_mode(self) -> str:
+    def _log_mempool_mode(self) -> LogMempoolMode:
         """Normalize log_mempool config: YAML bools or strings \"true\"/\"false\"/\"timeout\"."""
         v = self.config.get("log_mempool", False)
         if v is True or v == "true":

--- a/chia/full_node/full_node.py
+++ b/chia/full_node/full_node.py
@@ -349,6 +349,8 @@ class FullNode:
                 consensus_constants=self.constants,
                 pool=self.pool,
                 validation_timeout=self.config.get("block_creation_timeout", 2.0),
+                log_mempool=self.config.get("log_mempool", False),
+                root_path=self.root_path,
             ) as self._mempool_manager:
                 # Transactions go into this queue from the server, and get sent to respond_transaction
                 self._transaction_queue = TransactionQueue(
@@ -3012,6 +3014,15 @@ class FullNode:
                 )
         return None, False
 
+    def _log_mempool_mode(self) -> str:
+        """Normalize log_mempool config: YAML bools or strings \"true\"/\"false\"/\"timeout\"."""
+        v = self.config.get("log_mempool", False)
+        if v is True or v == "true":
+            return "true"
+        if v == "timeout":
+            return "timeout"
+        return "false"
+
     async def add_transaction(
         self,
         transaction: SpendBundle,
@@ -3043,6 +3054,8 @@ class FullNode:
             if peer_info.advertised_cost > 0:
                 fee_per_cost = max(fee_per_cost, peer_info.advertised_fee / peer_info.advertised_cost)
 
+        log_mempool_mode = self._log_mempool_mode()
+
         # Mark as in-flight before the expensive pre_validate call so
         # concurrent workers processing the same tx from different peers are
         # deduplicated without churning the bounded seen cache.
@@ -3053,7 +3066,8 @@ class FullNode:
             )
         except ValueError as e:
             # ValueError is used to indicate a soft failure. We don't want to
-            # ban the peer.
+            # ban the peer. Timeouts are logged by MempoolManager when
+            # log_mempool is "timeout".
             self.log.info(f"Rejecting transaction {spend_name}: {e}")
             return MempoolInclusionStatus.FAILED, Err.INVALID_SPEND_BUNDLE
         except ValidationError as e:
@@ -3066,7 +3080,7 @@ class FullNode:
 
         self.mempool_manager.add_and_maybe_pop_seen(spend_name)
 
-        if self.config.get("log_mempool", False):  # pragma: no cover
+        if log_mempool_mode == "true":
             try:
                 mempool_dir = path_from_root(self.root_path, "mempool-log") / f"{self.blockchain.get_peak_height()}"
                 mempool_dir.mkdir(parents=True, exist_ok=True)

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -5,8 +5,9 @@ import logging
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Collection
 from dataclasses import dataclass, field
+from pathlib import Path
 from types import TracebackType
-from typing import TypeVar
+from typing import Literal, TypeVar
 
 from chia_rs import (
     ELIGIBLE_FOR_DEDUP,
@@ -42,6 +43,7 @@ from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.types.mempool_item import BundleCoinSpend, MempoolItem, UnspentLineageInfo
 from chia.util.db_wrapper import SQLITE_INT_MAX
 from chia.util.errors import Err, ValidationError
+from chia.util.path import path_from_root
 from chia.util.priority_thread_pool_executor import Executor
 
 log = logging.getLogger(__name__)
@@ -307,6 +309,20 @@ def check_removals(
     return None, []
 
 
+LogMempoolMode = Literal["true", "false", "timeout"]
+# Values accepted from config/YAML before normalization (unknowns become "false").
+LogMempoolConfig = bool | LogMempoolMode | None
+
+
+def _normalize_log_mempool(value: object) -> LogMempoolMode:
+    """Normalize log_mempool config: YAML bools or strings "true"/"false"/"timeout"."""
+    if value is True or value == "true":
+        return "true"
+    if value == "timeout":
+        return "timeout"
+    return "false"
+
+
 class MempoolManager:
     pool: Executor
     constants: ConsensusConstants
@@ -329,6 +345,8 @@ class MempoolManager:
     max_block_clvm_cost: uint64
     max_tx_clvm_cost: uint64
     validation_timeout: float
+    log_mempool: LogMempoolMode
+    root_path: Path | None
 
     def __init__(
         self,
@@ -339,8 +357,12 @@ class MempoolManager:
         *,
         validation_timeout: float,
         max_tx_clvm_cost: uint64 | None = None,
+        log_mempool: LogMempoolConfig = False,
+        root_path: Path | None = None,
     ):
         self.constants: ConsensusConstants = consensus_constants
+        self.log_mempool = _normalize_log_mempool(log_mempool)
+        self.root_path = root_path
 
         # Keep track of seen spend_bundles
         self.seen_bundle_hashes: dict[bytes32, bytes32] = {}
@@ -396,6 +418,8 @@ class MempoolManager:
         *,
         validation_timeout: float,
         max_tx_clvm_cost: uint64 | None = None,
+        log_mempool: LogMempoolConfig = False,
+        root_path: Path | None = None,
     ) -> AsyncIterator[Self]:
         self = cls(
             get_coin_records,
@@ -404,6 +428,8 @@ class MempoolManager:
             pool,
             max_tx_clvm_cost=max_tx_clvm_cost,
             validation_timeout=validation_timeout,
+            log_mempool=log_mempool,
+            root_path=root_path,
         )
         try:
             yield self
@@ -499,6 +525,19 @@ class MempoolManager:
         if bundle_hash in self.seen_bundle_hashes:
             self.seen_bundle_hashes.pop(bundle_hash)
 
+    def _maybe_log_timeout_spend_bundle(self, spend_name: bytes32, spend_bundle: SpendBundle) -> None:
+        """Dump a spend bundle when log_mempool is "timeout" and CLVM/sig validation timed out."""
+        if self.log_mempool != "timeout" or self.root_path is None:
+            return
+        try:
+            height = self.peak.height if self.peak is not None else 0
+            mempool_dir = path_from_root(self.root_path, "mempool-log") / f"{height}"
+            mempool_dir.mkdir(parents=True, exist_ok=True)
+            with open(mempool_dir / f"{spend_name}.bundle", "wb+") as f:
+                f.write(bytes(spend_bundle))
+        except Exception:
+            log.exception(f"Failed to log mempool item: {spend_name}")
+
     async def pre_validate_spendbundle(
         self,
         spend_bundle: SpendBundle,
@@ -547,10 +586,14 @@ class MempoolManager:
             raise ValueError("too many pairs")
 
         if duration > self.validation_timeout:
+            name = spend_bundle_id if spend_bundle_id is not None else spend_bundle.name()
+            self._maybe_log_timeout_spend_bundle(name, spend_bundle)
             raise ValueError(f"timeout {duration:0.4} s")
 
         cost = sbc.execution_cost + sbc.condition_cost
         if cost == 0 or (duration > 0.1 and duration * 1e9 / cost > self.validation_timeout * 5.0):
+            name = spend_bundle_id if spend_bundle_id is not None else spend_bundle.name()
+            self._maybe_log_timeout_spend_bundle(name, spend_bundle)
             raise ValueError(f"timeout ({duration * 1e9 / cost:0.4} ns/cost)")
 
         if bls_cache is not None:

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -574,22 +574,20 @@ class MempoolManager:
         if sbc.num_pairs > sbc.cost * 60_000_000 / self.constants.MAX_BLOCK_COST_CLVM:
             raise ValueError("too many pairs")
 
+        if spend_bundle_id is None:
+            spend_bundle_id = spend_bundle.name()
+
         if duration > self.validation_timeout:
-            name = spend_bundle_id if spend_bundle_id is not None else spend_bundle.name()
-            self._maybe_log_timeout_spend_bundle(name, spend_bundle)
+            self._maybe_log_timeout_spend_bundle(spend_bundle_id, spend_bundle)
             raise ValueError(f"timeout {duration:0.4} s")
 
         cost = sbc.execution_cost + sbc.condition_cost
         if cost == 0 or (duration > 0.1 and duration * 1e9 / cost > self.validation_timeout * 5.0):
-            name = spend_bundle_id if spend_bundle_id is not None else spend_bundle.name()
-            self._maybe_log_timeout_spend_bundle(name, spend_bundle)
+            self._maybe_log_timeout_spend_bundle(spend_bundle_id, spend_bundle)
             raise ValueError(f"timeout ({duration * 1e9 / cost:0.4} ns/cost)")
 
         if bls_cache is not None:
             bls_cache.update(new_cache_entries)
-
-        if spend_bundle_id is None:
-            spend_bundle_id = spend_bundle.name()
 
         log.log(
             logging.DEBUG if duration < self.validation_timeout else logging.WARNING,

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -310,17 +310,6 @@ def check_removals(
 
 
 LogMempoolMode = Literal["true", "false", "timeout"]
-# Values accepted from config/YAML before normalization (unknowns become "false").
-LogMempoolConfig = bool | LogMempoolMode | None
-
-
-def _normalize_log_mempool(value: object) -> LogMempoolMode:
-    """Normalize log_mempool config: YAML bools or strings "true"/"false"/"timeout"."""
-    if value is True or value == "true":
-        return "true"
-    if value == "timeout":
-        return "timeout"
-    return "false"
 
 
 class MempoolManager:
@@ -357,11 +346,11 @@ class MempoolManager:
         *,
         validation_timeout: float,
         max_tx_clvm_cost: uint64 | None = None,
-        log_mempool: LogMempoolConfig = False,
+        log_mempool: LogMempoolMode = "false",
         root_path: Path | None = None,
     ):
         self.constants: ConsensusConstants = consensus_constants
-        self.log_mempool = _normalize_log_mempool(log_mempool)
+        self.log_mempool = log_mempool
         self.root_path = root_path
 
         # Keep track of seen spend_bundles
@@ -418,7 +407,7 @@ class MempoolManager:
         *,
         validation_timeout: float,
         max_tx_clvm_cost: uint64 | None = None,
-        log_mempool: LogMempoolConfig = False,
+        log_mempool: LogMempoolMode = "false",
         root_path: Path | None = None,
     ) -> AsyncIterator[Self]:
         self = cls(

--- a/chia/util/initial-config.yaml
+++ b/chia/util/initial-config.yaml
@@ -428,8 +428,11 @@ full_node:
 
   enable_memory_profiler: False
 
-  # this is a debug/auditing facility that saves all spend bundles added to the
-  # mempool, organized by peak height at the time
+  # Debug/auditing facility that saves spend bundles under mempool-log/,
+  # organized by peak height. Values: false (off), true (every tx after
+  # successful pre-validation), timeout (only txs that hit the CLVM/sig
+  # validation timeout). YAML bools true/false are accepted for backward
+  # compatibility.
   log_mempool: false
 
   # this is a debug and profiling facility that logs all SQLite commands to a


### PR DESCRIPTION
to only log transactions that time out

<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to optional debug disk logging and config parsing; core mempool acceptance rules are unchanged aside from when bundles are written to disk.
> 
> **Overview**
> Extends the **`log_mempool`** debug option from a simple on/off flag to three explicit modes: **`false`**, **`true`** (log every spend bundle after successful pre-validation), and **`timeout`** (log only bundles that fail CLVM/signature validation due to a timeout).
> 
> **`FullNode`** adds **`_log_mempool_mode()`** to normalize config values (YAML booleans map to on/off; only lowercase **`"true"`** / **`"timeout"`** strings are recognized) and passes **`log_mempool`** plus **`root_path`** into **`MempoolManager`**. Successful-transaction logging in **`add_transaction`** now runs only when the mode is **`"true"`** (preserving prior boolean-true behavior).
> 
> **`MempoolManager`** stores the mode and optional root path, and writes **`mempool-log/<height>/<spend_name>.bundle`** from **`_maybe_log_timeout_spend_bundle`** when mode is **`timeout`** and pre-validation hits either wall-clock or ns/cost timeout checks.
> 
> **`initial-config.yaml`** documents the new values. Unit/integration tests cover mode normalization, accepted vs rejected txs, and timeout dumps at both full-node and mempool-manager levels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa4b132bdbdb8169a2d5e0cf785ca3297316f84c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->