### PR TITLE
Bring-in CHIA-4405 Handle ConnectionError from send_bytes in test_large_message_disconnect_and_ban

### DIFF
--- a/chia/_tests/core/server/test_dos.py
+++ b/chia/_tests/core/server/test_dos.py
@@ -145,16 +145,19 @@ class TestDos:
             large_msg: bytes = bytes([0] * (60 * 1024 * 1024))
             with monkeypatch.context() as monkey_patch_context:
                 monkey_patch_context.setattr(chia.server.server, "is_localhost", not_localhost)
-                await ws.send_bytes(large_msg)
-
-                response = await ws.receive()
+                # aiohttp rejects the oversized frame from its header before
+                # reading the payload, so the server tears down the socket
+                # while the ~60MB message is still in flight. The resulting TCP
+                # reset can raise ConnectionError on send and/or discard the
+                # server's close frame, leaving the client with an abrupt
+                # CLOSED instead of a clean CLOSE carrying MESSAGE_TOO_BIG.
+                try:
+                    await ws.send_bytes(large_msg)
+                    response = await ws.receive()
+                except ConnectionError:  # pragma: no cover
+                    await time_out_assert(10, lambda: self_hostname in server_1.banned_peers)
+                    return
                 await time_out_assert(10, lambda: self_hostname in server_1.banned_peers)
-
-            print(response)
-            # aiohttp rejects the oversized frame from its header before reading the payload, so the
-            # server tears down the socket while the ~60MB message is still in flight. The resulting
-            # TCP reset can discard the server's close frame, leaving the client with an abrupt CLOSED
-            # instead of a clean CLOSE carrying the MESSAGE_TOO_BIG code.
             assert response.type in {WSMsgType.CLOSE, WSMsgType.CLOSED}
             if response.type == WSMsgType.CLOSE:
                 assert response.data == WSCloseCode.MESSAGE_TOO_BIG


### PR DESCRIPTION
This brings-in PR #21333.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production server or protocol logic is modified.
> 
> **Overview**
> Hardens **`test_large_message_disconnect_and_ban`** against a race when sending a ~60MB WebSocket frame: if the server drops the connection early, **`send_bytes`** can raise **`ConnectionError`** instead of yielding a clean **`MESSAGE_TOO_BIG`** close.
> 
> The test now wraps send/receive in **`try/except ConnectionError`**, still waits for the peer to appear in **`banned_peers`**, and returns early on that path. Comments document the aiohttp/TCP-reset behavior, and a stray **`print(response)`** is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a929f6c0cb1f146bffd90653faa6562dc533bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->