### PR TITLE
CHIA-4406 Adjust the block fill rate to 60%

### DIFF
--- a/chia/_tests/core/mempool/test_mempool_manager.py
+++ b/chia/_tests/core/mempool/test_mempool_manager.py
@@ -1427,7 +1427,7 @@ async def test_create_bundle_from_mempool_on_max_cost(num_skipped_items: int, ca
             TEST_AGGSIG_CONDITION_COST = (
                 ConditionCost.AGG_SIG.value + TEST_AGG_SIG_SPEND_BYTESIZE * DEFAULT_CONSTANTS.COST_PER_BYTE
             )
-            while spend_bundle_cost + TEST_AGGSIG_CONDITION_COST < MAX_BLOCK_CLVM_COST:
+            while spend_bundle_cost + TEST_AGGSIG_CONDITION_COST < mempool_manager.max_block_clvm_cost:
                 conditions.append([ConditionOpcode.AGG_SIG_UNSAFE, g1, IDENTITY_PUZZLE_HASH])
                 aggsig += sig
                 spend_bundle_cost += TEST_AGGSIG_CONDITION_COST
@@ -2965,7 +2965,7 @@ def transactions_1000_fixture(test_wallet: WalletTool, seeded_random: random.Ran
     return bundles
 
 
-# if we try to fill the mempool with more than 550, all spends won't
+# if we try to fill the mempool with more than 300, all spends won't
 # necessarily fit in the block, which the test assumes
 @pytest.mark.anyio
 @pytest.mark.parametrize("mempool_size", [1, 2, 100, 300, 400, 550, 630])
@@ -2974,9 +2974,9 @@ def transactions_1000_fixture(test_wallet: WalletTool, seeded_random: random.Ran
 async def test_create_block_generator(
     mempool_size: int, seed: int, old: bool, transactions_1000: list[SpendBundle]
 ) -> None:
-    # the old way of creating bloks doesn't fit this many transactions, so we
-    # expect it to fail
-    expect_failure = mempool_size == 630 and old
+    # Both the old and new ways of creating blocks don't fit this many
+    # transactions with the 60% fill rate, so we expect it to fail.
+    expect_failure = mempool_size >= 400
 
     bundles = transactions_1000
     all_coins = [s.coin for b in bundles for s in b.coin_spends]

--- a/chia/full_node/mempool.py
+++ b/chia/full_node/mempool.py
@@ -871,7 +871,7 @@ class Mempool:
                 # if adding item would make us exceed the block cost, commit the
                 # batch we've built up first, to see if more space may be freed
                 # up by the compression
-                if block_cost + item.conds.cost - cost_saving > constants.MAX_BLOCK_COST_CLVM:
+                if block_cost + item.conds.cost - cost_saving > self.mempool_info.max_block_clvm_cost:
                     added, done = builder.add_spend_bundles(batch_transactions, uint64(batch_cost), constants)
 
                     block_cost = builder.cost()
@@ -927,7 +927,9 @@ class Mempool:
 
                     if done:
                         break
-
+                    if block_cost + item.conds.cost - cost_saving > self.mempool_info.max_block_clvm_cost:
+                        skipped_items += 1
+                        continue
                 # Skip this item if any of its spends conflict with a coin
                 # already committed to this block, whether in an accepted batch
                 # or in the batch we're currently assembling.

--- a/chia/full_node/mempool_manager.py
+++ b/chia/full_node/mempool_manager.py
@@ -360,8 +360,8 @@ class MempoolManager:
         # We need to deduct the block overhead, which consists of the wrapping
         # quote opcode's bytes cost as well as its execution cost.
         BLOCK_OVERHEAD = QUOTE_BYTES * self.constants.COST_PER_BYTE + QUOTE_EXECUTION_COST
-
-        self.max_block_clvm_cost = uint64(self.constants.MAX_BLOCK_COST_CLVM - BLOCK_OVERHEAD)
+        BLOCK_SIZE_LIMIT_FACTOR = 0.6
+        self.max_block_clvm_cost = uint64(self.constants.MAX_BLOCK_COST_CLVM * BLOCK_SIZE_LIMIT_FACTOR - BLOCK_OVERHEAD)
         self.max_tx_clvm_cost = (
             max_tx_clvm_cost if max_tx_clvm_cost is not None else uint64(self.constants.MAX_BLOCK_COST_CLVM // 2)
         )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes full-node block assembly and mempool sizing behavior (fewer txs per block), though consensus max block cost is unchanged. Touches core farming/mempool logic.
> 
> **Overview**
> **Caps how full blocks are when built from the mempool** by setting `max_block_clvm_cost` to **60%** of `MAX_BLOCK_COST_CLVM` (minus block overhead), instead of using nearly the full protocol limit. Mempool admission and block assembly both honor this lower target via `mempool_info.max_block_clvm_cost`.
> 
> **Block generator path** (`create_block_generator2`) now compares cumulative cost against that mempool limit (not `constants.MAX_BLOCK_COST_CLVM`) and **skips an item after a rejected batch** if it would still exceed the limit after compression.
> 
> **Tests** updated to use the manager’s `max_block_clvm_cost` and to expect block-generator mismatch when the simulated mempool has **≥400** transactions under the 60% fill assumption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5efef2d3ea440e8e797e009caaa510b9c773afc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->