### PR TITLE
seeder

### DIFF
--- a/chia/_tests/core/test_crawler.py
+++ b/chia/_tests/core/test_crawler.py
@@ -130,6 +130,44 @@ async def test_crawler_to_db(crawler_service_no_loop: CrawlerService, one_node: 
 
 
 @pytest.mark.anyio
+async def test_crawler_unbindable_timestamp(
+    crawler_service_no_loop: CrawlerService, caplog: pytest.LogCaptureFixture
+) -> None:
+    """
+    A record whose best_timestamp is too large for sqlite to bind must be skipped instead of
+    abandoning the batch and leaving good_peers stale.
+    """
+    crawler = crawler_service_no_loop._node
+    crawl_store = crawler.crawl_store
+    assert crawl_store is not None
+    good_address = "10.0.0.1"
+    bad_address = "10.0.0.2"
+
+    for peer_address, best_timestamp in [(good_address, uint64(time.time())), (bad_address, uint64(2**64 - 1))]:
+        peer_record = PeerRecord(
+            peer_address,
+            peer_address,
+            uint32(8444),
+            False,
+            uint64(0),
+            uint32(0),
+            uint64(0),
+            uint64(time.time()),
+            best_timestamp,
+            "undefined",
+            uint64(0),
+            tls_version="unknown",
+        )
+        await crawl_store.add_peer(peer_record, PeerReliability(peer_address, tries=1, successes=1))
+
+    with caplog.at_level(logging.ERROR):
+        await crawler.save_to_db()
+
+    assert f"Skipping peer {bad_address}" in caplog.text
+    assert good_address in await crawl_store.get_good_peers()
+
+
+@pytest.mark.anyio
 async def test_crawler_peer_cleanup(
     crawler_service_no_loop: CrawlerService, one_node: SimulatorsAndWalletsServices
 ) -> None:

--- a/chia/seeder/crawl_store.py
+++ b/chia/seeder/crawl_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ipaddress
 import logging
 import random
+import sqlite3
 import time
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
@@ -262,7 +263,11 @@ class CrawlStore:
             if peer_id in self.host_to_reliability and peer_id in self.host_to_records:
                 reliability = self.host_to_reliability[peer_id]
                 record = self.host_to_records[peer_id]
-                await self.add_peer(record, reliability, True)
+                try:
+                    await self.add_peer(record, reliability, True)
+                except (OverflowError, ValueError, sqlite3.InterfaceError) as e:
+                    # A single record that sqlite cannot bind must not abandon the whole batch.
+                    log.error(f"Skipping peer {peer_id} that could not be saved to DB: {e}")
         await self.crawl_db.commit()
         log.warning(" - Done saving peers to DB")
 

--- a/chia/seeder/crawler.py
+++ b/chia/seeder/crawler.py
@@ -230,15 +230,18 @@ class Crawler:
 
                 for response in self.peers_retrieved:
                     for response_peer in response.peer_list:
+                        # Gossiped timestamps are unvalidated, and values outside this range cannot be
+                        # bound by SQLite. Treat them as stale, the same way node_discovery does.
+                        if response_peer.timestamp < 100000000 or response_peer.timestamp > time.time() + 10 * 60:
+                            peer_timestamp = uint64(time.time() - 5 * 24 * 60 * 60)
+                        else:
+                            peer_timestamp = response_peer.timestamp
                         if response_peer.host not in self.best_timestamp_per_peer:
-                            self.best_timestamp_per_peer[response_peer.host] = response_peer.timestamp
+                            self.best_timestamp_per_peer[response_peer.host] = peer_timestamp
                         self.best_timestamp_per_peer[response_peer.host] = max(
-                            self.best_timestamp_per_peer[response_peer.host], response_peer.timestamp
+                            self.best_timestamp_per_peer[response_peer.host], peer_timestamp
                         )
-                        if (
-                            response_peer.host not in self.seen_nodes
-                            and response_peer.timestamp > time.time() - 5 * 24 * 3600
-                        ):
+                        if response_peer.host not in self.seen_nodes and peer_timestamp > time.time() - 5 * 24 * 3600:
                             self.seen_nodes.add(response_peer.host)
                             new_peer = PeerRecord(
                                 response_peer.host,
@@ -249,7 +252,7 @@ class Crawler:
                                 uint32(0),
                                 uint64(0),
                                 uint64(time.time()),
-                                uint64(response_peer.timestamp),
+                                peer_timestamp,
                                 "undefined",
                                 uint64(0),
                                 tls_version="unknown",
@@ -308,16 +311,18 @@ class Crawler:
         # Try up to 5 times to write to the DB in case there is a lock that causes a timeout
         if self.crawl_store is None:
             raise ValueError("Not Connected to DB")
-        for i in range(1, 5):
-            try:
-                await self.crawl_store.load_to_db()
-                await self.crawl_store.load_reliable_peers_to_db()
-                return
-            except Exception as e:
-                self.log.error(f"Exception while saving to DB: {e}.")
-                self.log.error("Waiting 5 seconds before retry...")
-                await asyncio.sleep(5)
-                continue
+        # good_peers is rewritten by load_reliable_peers_to_db, so it must not be skipped when the
+        # peer_records write fails, otherwise the DNS server keeps serving a stale snapshot.
+        for save in (self.crawl_store.load_to_db, self.crawl_store.load_reliable_peers_to_db):
+            for i in range(1, 5):
+                try:
+                    await save()
+                    break
+                except Exception as e:
+                    self.log.error(f"Exception while saving to DB: {e}.")
+                    self.log.error("Waiting 5 seconds before retry...")
+                    await asyncio.sleep(5)
+                    continue
 
     def set_server(self, server: ChiaServer) -> None:
         self._server = server


### PR DESCRIPTION
### Purpose:

Keep the seeder DNS `good_peers` snapshot current when a crawled peer has a timestamp that SQLite cannot bind. 

### Current Behavior:

- `respond_peers` timestamps are stored and compared as-is. Values far in the past/future, or too large for SQLite integer binding, flow into `best_timestamp`.
- `CrawlStore.load_to_db` writes every peer in one pass. One unbindable record raises and the rest of the batch is not committed.
- `Crawler.save_to_db` runs `load_to_db` and `load_reliable_peers_to_db` in the same retry loop. If the peer-records write fails, the reliable-peers rewrite is skipped, so `good_peers` is not refreshed.

### New Behavior:

- Gossiped timestamps outside the same window node discovery uses (before ~2001, or more than ~10 minutes in the future) are treated as stale (`now - 5 days`) before they are stored or used for freshness.
- `load_to_db` catches `OverflowError`, `ValueError`, and `sqlite3.InterfaceError` per peer, logs and skips that record, and still commits the rest of the batch.
- `save_to_db` retries `load_to_db` and `load_reliable_peers_to_db` independently, so a failed peer-records write no longer skips rewriting `good_peers`.

### Testing Notes:

- `test_crawler_unbindable_timestamp` adds a valid peer and a peer with `best_timestamp = 2**64 - 1`, runs `save_to_db`, asserts the bad peer is logged as skipped, and asserts the valid peer is still in `good_peers`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bootstrap DNS peer selection and persistence; mistakes could skew seed lists, but changes are defensive (filter/skip/per-peer isolation).
> 
> **Overview**
> Hardens the crawler so bad peer gossip and unbindable SQLite values cannot block DNS **`good_peers`** updates or artificially refresh stale peers.
> 
> **RespondPeers** handling moves into **`ingest_retrieved_peers`**, which **drops** timestamps outside the discovery window (before `100000000` or more than ~10 minutes ahead of now) instead of storing them—so invalid gossip cannot bump **`best_timestamp`**, create new candidates, or survive pruning/RPC “recent peer” counts.
> 
> **`CrawlStore.load_to_db`** now skips individual peers that raise **`OverflowError`**, **`ValueError`**, or **`sqlite3.InterfaceError`** while still committing the rest of the batch. **`Crawler.save_to_db`** retries **`load_to_db`** and **`load_reliable_peers_to_db`** separately so a failed peer-record write no longer skips rewriting **`good_peers`**.
> 
> Tests cover unbindable **`best_timestamp`**, ignored invalid gossip, and valid gossip refresh paths; seeder docs match the skip-not-rewrite behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa52107d145d3eaa8b06475d3f8a6e8c51fd401c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->