### PR TITLE
sync change

### DIFF
--- a/chia/_tests/core/full_node/stores/test_sync_store.py
+++ b/chia/_tests/core/full_node/stores/test_sync_store.py
@@ -192,6 +192,29 @@ async def test_peer_peak_change_removes_old_peak_membership() -> None:
 
 
 @pytest.mark.anyio
+async def test_peer_peak_change_preserves_target_peak_membership() -> None:
+    """A peer that advances past the sync target must still be treated as holding that peak.
+
+    NewPeak during weight-proof validation used to discard the peer from
+    peak_to_peer[target], so long sync logged "no peers with header_hash" and
+    aborted the first batch even though the peer still had the target block.
+    """
+    store = SyncStore()
+    peer_id = std_hash(b"peer")
+    hash_a = std_hash(b"block_a")
+    hash_b = std_hash(b"block_b")
+
+    store.peer_has_block(hash_a, peer_id, uint128(100), uint32(10), True)
+    store.target_peak = Peak(hash_a, uint32(10), uint128(100))
+
+    store.peer_has_block(hash_b, peer_id, uint128(200), uint32(20), True)
+
+    assert peer_id in store.get_peers_that_have_peak([hash_a])
+    assert peer_id in store.get_peers_that_have_peak([hash_b])
+    assert store.peer_to_peak[peer_id].header_hash == hash_b
+
+
+@pytest.mark.anyio
 async def test_peer_peak_change_same_hash_preserves_membership() -> None:
     """Re-advertising the same peak hash does not remove the peer from its membership set."""
     store = SyncStore()

--- a/chia/full_node/sync_store.py
+++ b/chia/full_node/sync_store.py
@@ -78,8 +78,14 @@ class SyncStore:
         if new_peak:
             old_peak = self.peer_to_peak.get(peer_id)
             if old_peak is not None and old_peak.header_hash != header_hash:
-                if old_peak.header_hash in self.peak_to_peer:
-                    self.peak_to_peer[old_peak.header_hash].discard(peer_id)
+                # A peer that has moved to a newer peak still holds the blocks
+                # behind the current sync target. Dropping them from that
+                # mapping during weight-proof validation leaves long sync with
+                # "no peers with header_hash" even though they can still serve
+                # the target. Keep membership for the active target peak.
+                if self.target_peak is None or old_peak.header_hash != self.target_peak.header_hash:
+                    if old_peak.header_hash in self.peak_to_peer:
+                        self.peak_to_peer[old_peak.header_hash].discard(peer_id)
             self.peer_to_peak[peer_id] = Peak(header_hash, height, weight)
 
     def get_peers_that_have_peak(self, header_hashes: list[bytes32]) -> set[bytes32]:


### PR DESCRIPTION
DO NOT MERGE
<!-- Merging Requirements:
- Please give your PR a title that is release-note friendly
- In order to be merged, you must add the most appropriate category Label (Added, Changed, Fixed) to your PR
-->
<!-- Explain why this is an improvement (Does this add missing functionality, improve performance, or reduce complexity?) -->

### Purpose:

<!-- Does this PR introduce a breaking change? -->

### Current Behavior:

### New Behavior:

<!-- As we aim for complete code coverage, please include details regarding unit, and regression tests -->

### Testing Notes:

<!-- Attach any visual examples, or supporting evidence (attach any .gif/video/console output below) -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes peer-to-peak bookkeeping used during long sync; wrong logic could mis-route batch sync or retain stale peer sets, but scope is narrow and covered by new unit tests.
> 
> **Overview**
> Fixes long sync failing with **"no peers with header_hash"** when a peer sends `NewPeak` for a block ahead of the active sync target during weight-proof validation.
> 
> **`SyncStore.peer_has_block`** no longer removes a peer from `peak_to_peer` for their *previous* peak when that hash is the current **`target_peak`**. The peer’s advertised peak still updates in `peer_to_peak`, but they remain eligible via **`get_peers_that_have_peak`** for the target they can still serve.
> 
> Adds **`test_peer_peak_change_preserves_target_peak_membership`** to lock in this behavior alongside the existing test that still drops membership when there is no active target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde9afcbf188e4ef1cedd6c9dfeefabec235a6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->