### PR TITLE
Bad merge - sync scope for PlotNFT deletion

### DIFF
--- a/chia/wallet/plotnft_wallet/plotnft_wallet.py
+++ b/chia/wallet/plotnft_wallet/plotnft_wallet.py
@@ -35,7 +35,7 @@ from chia.wallet.wallet_coin_record import WalletCoinRecord
 from chia.wallet.wallet_info import WalletInfo
 from chia.wallet.wallet_protocol import GSTOptionalArgs
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
-from chia.wallet.wallet_sync_scope import WalletSyncScope
+from chia.wallet.wallet_sync_scope import WalletSyncScope, WebSocketEvent
 
 if TYPE_CHECKING:
     from chia.wallet.wallet_state_manager import WalletStateManager
@@ -521,6 +521,7 @@ class PlotNFT2Wallet:
         uncurried: UncurriedPuzzle,
         coin_spend: CoinSpend,
         created_height: uint32 | None,
+        sync_scope: WalletSyncScope,
     ) -> tuple[WalletIdentifier, PlotNFT] | None:
         try:
             try:
@@ -580,7 +581,7 @@ class PlotNFT2Wallet:
                         )
                     )
                     if created_height is not None and current_plotnft_created_height < created_height:
-                        await plotnft_wallet.delete_self(deleted_at_height=created_height)
+                        await plotnft_wallet.delete_self(deleted_at_height=created_height, sync_scope=sync_scope)
             else:
                 return (
                     WalletIdentifier(id=matched_plotnft_wallet_id, type=WalletType.PLOTNFT_2),
@@ -666,14 +667,17 @@ class PlotNFT2Wallet:
             ) as action_scope:
                 await self._finish_leaving_pool(action_scope=action_scope, exiting_info=finish_info)
 
-    async def delete_self(self, deleted_at_height: uint32) -> None:
+    async def delete_self(self, deleted_at_height: uint32, sync_scope: WalletSyncScope) -> None:
         await self.wallet_state_manager.plotnft2_store.add_deleted_wallet(
             launcher_id=self.plotnft_id, name=self.wallet_info.name, height=deleted_at_height
         )
         await self.wallet_state_manager.delete_wallet(self.id())
         self.wallet_state_manager.wallets.pop(self.id())
         self.log.info("Removed PlotNFT2 wallet with ID: %s", self.plotnft_id.hex())
-        self.wallet_state_manager.state_changed("wallet_removed", wallet_id=self.id())
+        async with sync_scope.use() as interface:
+            interface.side_effects.websocket_events.append(
+                WebSocketEvent(name="wallet_removed", data={"wallet_id": self.id()})
+            )
         with PoolingShareState.acquire(
             root_path=self.wallet_state_manager.root_path, p2_singleton_puzzle_hash=self.p2_singleton_puzzle_hash
         ) as pool_config:
@@ -681,7 +685,7 @@ class PlotNFT2Wallet:
 
     @classmethod
     async def potentially_reinitialize_deleted_wallets(
-        cls, *, wallet_state_manager: WalletStateManager, height: int
+        cls, *, wallet_state_manager: WalletStateManager, height: int, sync_scope: WalletSyncScope
     ) -> None:
         try:
             async for launcher_id, name in wallet_state_manager.plotnft2_store.pop_deleted_wallets(height=height):
@@ -707,6 +711,7 @@ class PlotNFT2Wallet:
                     # this function happens to not use the peer so we can get away with this for now
                     peer=object(),  # type: ignore[arg-type]
                     coin_data=plotnft,
+                    sync_scope=sync_scope,
                 )
         except Exception as e:
             wallet_state_manager.log.error(f"Error reintializing PlotNFT wallet with launcher id {launcher_id}: {e}")

--- a/chia/wallet/plotnft_wallet/plotnft_wallet.py
+++ b/chia/wallet/plotnft_wallet/plotnft_wallet.py
@@ -675,9 +675,7 @@ class PlotNFT2Wallet:
         self.wallet_state_manager.wallets.pop(self.id())
         self.log.info("Removed PlotNFT2 wallet with ID: %s", self.plotnft_id.hex())
         async with sync_scope.use() as interface:
-            interface.side_effects.websocket_events.append(
-                WebSocketEvent(name="wallet_removed", data={"wallet_id": self.id()})
-            )
+            interface.side_effects.websocket_events.append(WebSocketEvent(name="wallet_removed", wallet_id=self.id()))
         with PoolingShareState.acquire(
             root_path=self.wallet_state_manager.root_path, p2_singleton_puzzle_hash=self.p2_singleton_puzzle_hash
         ) as pool_config:

--- a/chia/wallet/wallet_state_manager.py
+++ b/chia/wallet/wallet_state_manager.py
@@ -1004,7 +1004,9 @@ class WalletStateManager:
 
         # Check if the coin is a PlotNFT
         if uncurried.mod == PlotNFT.singleton_puzzles.singleton_mod:
-            plotnft_result = await PlotNFT2Wallet.identify(self, uncurried, coin_spend, coin_state.created_height)
+            plotnft_result = await PlotNFT2Wallet.identify(
+                self, uncurried, coin_spend, coin_state.created_height, sync_scope
+            )
             if plotnft_result is not None:
                 # Streamable hint is in error
                 return plotnft_result  # type: ignore[return-value]
@@ -1440,7 +1442,7 @@ class WalletStateManager:
                     if children == []:
                         plotnft_wallet = self.wallets[wallet_identifier.id]
                         assert isinstance(plotnft_wallet, PlotNFT2Wallet)
-                        await plotnft_wallet.delete_self(coin_state.spent_height)
+                        await plotnft_wallet.delete_self(coin_state.spent_height, sync_scope)
                 except ValueError:
                     pass
                 if isinstance(coin_data, PlotNFT):
@@ -1990,7 +1992,9 @@ class WalletStateManager:
                 )
 
         # Reinitialize deleted wallets
-        await PlotNFT2Wallet.potentially_reinitialize_deleted_wallets(wallet_state_manager=self, height=height)
+        await PlotNFT2Wallet.potentially_reinitialize_deleted_wallets(
+            wallet_state_manager=self, height=height, sync_scope=sync_scope
+        )
 
         return remove_ids
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Behavior change is limited to how wallet_removed notifications are emitted during sync; aligns PlotNFT paths with existing sync-scope websocket batching and should fix inconsistent client updates after a bad merge.
> 
> **Overview**
> **Threads `WalletSyncScope` through PlotNFT2 wallet removal and re-init** so PlotNFT deletion matches the sync-scope side-effect pattern used elsewhere (e.g. bulk wallet cleanup and DID removal).
> 
> `PlotNFT2Wallet.identify`, `delete_self`, and `potentially_reinitialize_deleted_wallets` now take `sync_scope`. **`delete_self` no longer calls `state_changed("wallet_removed")`**; it appends a `WebSocketEvent` via `sync_scope.use()` instead. `WalletStateManager` passes `sync_scope` into PlotNFT identify, spent-coin `delete_self`, and post-sync `potentially_reinitialize_deleted_wallets` (including `coin_added` on reinit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3567ecad23e325353fe6596ea511b20b9460bca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->