### PR TITLE
Update 2.7.4 changelog date to 2026-09-10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project does not yet adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for setuptools_scm/PEP 440 reasons.
 
-## 2.7.4 Chia blockchain 2026-XX-XX
+## 2.7.4 Chia blockchain 2026-09-10
 
 ## What's Changed
 


### PR DESCRIPTION
Updates the placeholder date `2026-XX-XX` in the 2.7.4 changelog header to today's date `2026-09-10`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only date fix with no runtime or behavioral impact.
> 
> **Overview**
> Replaces the placeholder **`2026-XX-XX`** in the **2.7.4 Chia blockchain** section header of `CHANGELOG.md` with **`2026-09-10`**. No release notes or feature bullets are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit defe0d45b3282639b8d4b5416103c93444e4fcf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->