### PR TITLE
Answer requests for services that are not connected to the daemon instead of dropping them

### DIFF
--- a/chia/_tests/core/daemon/test_daemon.py
+++ b/chia/_tests/core/daemon/test_daemon.py
@@ -480,6 +480,47 @@ async def test_daemon_passthru(get_daemon, bt):
                 assert message["data"]["blockchain_state"]["genesis_challenge_initialized"] is True
 
 
+@pytest.mark.anyio
+async def test_daemon_replies_when_destination_is_not_connected(get_daemon, bt):
+    config = bt.config
+    daemon_port = config["daemon_port"]
+
+    async with aiohttp.ClientSession() as client:
+        async with client.ws_connect(
+            f"wss://127.0.0.1:{daemon_port}",
+            autoclose=True,
+            autoping=True,
+            ssl=bt.get_daemon_ssl_context(),
+            max_msg_size=100 * 1024 * 1024,
+        ) as ws:
+            service_name = "test_service_name"
+            data = {"service": service_name}
+            payload = create_payload("register_service", data, service_name, "daemon")
+            await ws.send_str(payload)
+            assert_response_success_only(await ws.receive())
+
+            # a request for a service without a registered connection is answered with an error,
+            # instead of being dropped and leaving the sender to wait for its own timeout
+            request = create_payload_dict("get_blockchain_state", {}, service_name, "chia_full_node")
+            await ws.send_str(dict_to_json_str(request))
+            assert_response(
+                await ws.receive(),
+                {"success": False, "error": "chia_full_node is not connected to the daemon"},
+                request_id=request["request_id"],
+                command="get_blockchain_state",
+            )
+
+            # a state change broadcast to the UI while no UI is connected, and a reply routed to a client
+            # that has gone, are still dropped silently: the next message received answers the ping below
+            await ws.send_str(create_payload("state_changed", {"state": "peak"}, service_name, "wallet_ui"))
+            stale_reply = create_payload_dict("get_blockchain_state", {"success": True}, service_name, "gone_ui")
+            stale_reply["ack"] = True
+            await ws.send_str(dict_to_json_str(stale_reply))
+            ping = create_payload_dict("running_services", {}, service_name, "daemon")
+            await ws.send_str(dict_to_json_str(ping))
+            assert_response_success_only(await ws.receive(), request_id=ping["request_id"])
+
+
 @pytest.mark.parametrize(
     "service, expected_result",
     [

--- a/chia/_tests/core/daemon/test_daemon.py
+++ b/chia/_tests/core/daemon/test_daemon.py
@@ -16,7 +16,7 @@ from pytest_mock import MockerFixture
 
 from chia._tests.conftest import ConsensusMode
 from chia._tests.util.misc import Marks, datacases
-from chia._tests.util.time_out_assert import time_out_assert_not_none
+from chia._tests.util.time_out_assert import time_out_assert, time_out_assert_not_none
 from chia.daemon.client import DaemonProxy, connect_to_daemon
 from chia.daemon.keychain_server import (
     DeleteLabelRequest,
@@ -482,6 +482,7 @@ async def test_daemon_passthru(get_daemon, bt):
 
 @pytest.mark.anyio
 async def test_daemon_replies_when_destination_is_not_connected(get_daemon, bt):
+    ws_server = get_daemon
     config = bt.config
     daemon_port = config["daemon_port"]
 
@@ -510,9 +511,33 @@ async def test_daemon_replies_when_destination_is_not_connected(get_daemon, bt):
                 command="get_blockchain_state",
             )
 
-            # a state change broadcast to the UI while no UI is connected, and a reply routed to a client
+            # the same for a service that registered and whose session was closed afterwards, which leaves
+            # an empty connection set behind under its name
+            async with client.ws_connect(
+                f"wss://127.0.0.1:{daemon_port}",
+                autoclose=True,
+                autoping=True,
+                ssl=bt.get_daemon_ssl_context(),
+                max_msg_size=100 * 1024 * 1024,
+            ) as flaky_ws:
+                await flaky_ws.send_str(create_payload("register_service", {"service": "flaky"}, "flaky", "daemon"))
+                assert_response_success_only(await flaky_ws.receive())
+                assert len(ws_server.connections["flaky"]) == 1
+            await time_out_assert(30, lambda: len(ws_server.connections["flaky"]), 0)
+            request = create_payload_dict("healthz", {}, service_name, "flaky")
+            await ws.send_str(dict_to_json_str(request))
+            assert_response(
+                await ws.receive(),
+                {"success": False, "error": "flaky is not connected to the daemon"},
+                request_id=request["request_id"],
+                command="healthz",
+            )
+
+            # state change broadcasts to subscribers that are not connected, and a reply routed to a client
             # that has gone, are still dropped silently: the next message received answers the ping below
             await ws.send_str(create_payload("state_changed", {"state": "peak"}, service_name, "wallet_ui"))
+            await ws.send_str(create_payload("farming_info", {}, service_name, "metrics"))
+            await ws.send_str(create_payload("unfinished_block", {}, service_name, "unfinished_block_info"))
             stale_reply = create_payload_dict("get_blockchain_state", {"success": True}, service_name, "gone_ui")
             stale_reply["ack"] = True
             await ws.send_str(dict_to_json_str(stale_reply))

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -419,7 +419,17 @@ class WebSocketServer:
                 sockets = self.connections[destination]
                 return dict_to_json_str(message), sockets
 
-            return None
+            if message["ack"] or destination == "wallet_ui":
+                # A reply routed to a client that has gone, or a state change broadcast to the UI while no UI is
+                # connected: nothing is waiting for these, so there is nothing to say.
+                return None
+
+            # A request for a service that has no registered connection, for example one that is still starting
+            # or one whose session this daemon closed after missed heartbeats.  Answer the sender so it can retry
+            # or report the failure instead of waiting for a reply that will never come.
+            self.log.debug(f"Request '{command}' from {message['origin']} for {destination}, which is not connected")
+            response = {"success": False, "error": f"{destination} is not connected to the daemon"}
+            return format_response(message, response), {websocket}
 
         data = message["data"]
         commands_with_data = [

--- a/chia/daemon/server.py
+++ b/chia/daemon/server.py
@@ -83,6 +83,10 @@ log = logging.getLogger(__name__)
 
 service_plotter = "chia_plotter"
 
+# Destinations the services broadcast state changes to (see the _state_changed methods of the rpc apis).  Nobody
+# waits for an answer to those, so a broadcast to a subscriber that is not connected is dropped silently.
+broadcast_destinations = frozenset({"wallet_ui", "metrics", "unfinished_block_info"})
+
 
 class PlotState(str, Enum):
     SUBMITTED = "SUBMITTED"
@@ -415,18 +419,19 @@ class WebSocketServer:
         command = message["command"]
         destination = message["destination"]
         if destination != "daemon":
-            if destination in self.connections:
-                sockets = self.connections[destination]
+            # remove_connection() leaves an empty set behind for a service whose session was closed
+            sockets = self.connections.get(destination)
+            if sockets:
                 return dict_to_json_str(message), sockets
 
-            if message["ack"] or destination == "wallet_ui":
-                # A reply routed to a client that has gone, or a state change broadcast to the UI while no UI is
-                # connected: nothing is waiting for these, so there is nothing to say.
+            if message["ack"] or destination in broadcast_destinations:
+                # A reply routed to a client that has gone, or a state change broadcast to a subscriber that is
+                # not connected: nothing is waiting for these, so there is nothing to say.
                 return None
 
-            # A request for a service that has no registered connection, for example one that is still starting
-            # or one whose session this daemon closed after missed heartbeats.  Answer the sender so it can retry
-            # or report the failure instead of waiting for a reply that will never come.
+            # A request for a service that has no connection, for example one that is still starting or one
+            # whose session this daemon closed after missed heartbeats.  Answer the sender so it can retry or
+            # report the failure instead of waiting for a reply that will never come.
             self.log.debug(f"Request '{command}' from {message['origin']} for {destination}, which is not connected")
             response = {"success": False, "error": f"{destination} is not connected to the daemon"}
             return format_response(message, response), {websocket}


### PR DESCRIPTION
### Purpose:

Make a request for a service that is not connected to the daemon fail visibly instead of silently. `WebSocketServer.handle_message` returned `None` when a message's destination had no registered connection, so the sender got nothing at all. In the GUI that means a spinner until its own ten-minute client timeout, with no hint of what went wrong.

This surfaced while diagnosing a GUI that was unusable after every restart on a large wallet (see #21392 for the root cause and the fix on the service side): once the daemon had closed the wallet's session after missed heartbeats, every command the GUI sent to `chia_wallet` was discarded here without a reply, and the key-selection screen just spun.

### Current Behavior:

A message addressed to a service with no registered daemon connection is dropped. The sender never learns that, and waits for its own timeout.

### New Behavior:

A request addressed to a service with no live connection (never registered, or registered and since closed by the daemon, which leaves an empty set behind under its name) is answered, to the sender only, with `{"success": false, "error": "<service> is not connected to the daemon"}` in the usual response shape (same `request_id`, `ack: true`), so the client can retry or report it right away.

Two kinds of messages are deliberately still dropped without a reply, because nothing waits for them: replies routed to a client that has gone (`ack: true` messages), and state change broadcasts to a subscriber that is not connected. The services broadcast to `wallet_ui`, `metrics` and `unfinished_block_info` (see the `_state_changed` methods of the rpc apis); those three are named once in `broadcast_destinations`. Answering them would generate a useless error back to the producing service on every event on headless nodes.

The GUI copes with the new answer as it is: its service start-up wait (`Daemon.waitForService` in `@chia-network/api`) pings the service through the daemon and retries after one second on any failure, so start-up behaves as before, and an ordinary request now fails immediately with a message instead of hanging.

### Testing Notes:

New `test_daemon_replies_when_destination_is_not_connected` in `chia/_tests/core/daemon/test_daemon.py`, against a real daemon: a request for `chia_full_node` with no full node registered gets the error reply with the matching `request_id`; so does a request for a service that registered on a second websocket and then disconnected (after the daemon has processed the close); broadcasts to `wallet_ui`, `metrics` and `unfinished_block_info` and a stale `ack` reply to a vanished client get no reply, verified by the next received message being the answer to a following `running_services` call. Without the change the test hangs on the first receive, which is the old behaviour.

`chia/_tests/core/daemon/test_daemon.py`, `test_daemon_register.py`, `chia/_tests/core/test_daemon_rpc.py` and `chia/_tests/rpc/test_rpc_server.py` pass locally (147 tests in the three daemon modules, plus `chia/_tests/rpc/test_rpc_server.py`); ruff and mypy are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon message routing for all clients (including the GUI) when services are offline or disconnected; behavior is intentional fail-fast but alters long-standing silent-drop semantics for requests.
> 
> **Overview**
> When a websocket message targets a Chia service that has **no live daemon connection** (never registered or left as an empty set after disconnect), the daemon now **responds to the sender** with `success: false` and `"<service> is not connected to the daemon"` instead of dropping the message and letting clients hang until their own timeout.
> 
> **Unchanged silent drops:** **`ack`** replies to clients that are gone, and broadcasts to **`wallet_ui`**, **`metrics`**, and **`unfinished_block_info`** (listed in new **`broadcast_destinations`**) still return no reply, since nothing waits on those.
> 
> Routing now treats an empty connection set like missing connections via **`connections.get(destination)`** and a truthy check on the socket set.
> 
> Adds integration test **`test_daemon_replies_when_destination_is_not_connected`** covering error replies, post-disconnect behavior, and that broadcasts/stale acks stay silent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efe2e71306a91c0fb9a152777d4219d4cffe55f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->