### PR TITLE
[LABS-494] Conform MIPS drivers to `Puzzle/Solution` protocols

### DIFF
--- a/chia/_tests/clvm/test_custody_architecture.py
+++ b/chia/_tests/clvm/test_custody_architecture.py
@@ -17,17 +17,27 @@ from chia.types.coin_spend import make_spend
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.wallet.conditions import CreateCoinAnnouncement
 from chia.wallet.puzzles.custody.custody_architecture import (
-    DelegatedPuzzleAndSolution,
     MemberHint,
     MemberOrDPuz,
     MIPSComponent,
+    MIPSComponentBase,
     MofN,
+    MofNSolution,
     ProvenSpend,
     PuzzleWithRestrictions,
+    PuzzleWithRestrictionsSolution,
     Restriction,
     RestrictionHint,
     UnknownMember,
     UnknownRestriction,
+)
+from chia.wallet.puzzles.puzzle_drivers import (
+    ACSPuzzle,
+    ACSSolution,
+    DelegatedPuzzleAndSolution,
+    NilSolution,
+    UnknownPuzzle,
+    UnknownSolution,
 )
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
@@ -44,13 +54,25 @@ ANY_PROGRAM = Program.to(None)
         # no restrictions
         [],
         # member validator
-        [UnknownRestriction(RestrictionHint(member_not_dpuz=True, puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM))],
+        [
+            UnknownRestriction(
+                restriction_hint=RestrictionHint(member_not_dpuz=True, puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)
+            )
+        ],
         # dpuz validator
-        [UnknownRestriction(RestrictionHint(member_not_dpuz=False, puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM))],
+        [
+            UnknownRestriction(
+                restriction_hint=RestrictionHint(member_not_dpuz=False, puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)
+            )
+        ],
         # multiple restrictions of various types
         [
-            UnknownRestriction(RestrictionHint(member_not_dpuz=True, puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)),
-            UnknownRestriction(RestrictionHint(member_not_dpuz=False, puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)),
+            UnknownRestriction(
+                restriction_hint=RestrictionHint(member_not_dpuz=True, puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)
+            ),
+            UnknownRestriction(
+                restriction_hint=RestrictionHint(member_not_dpuz=False, puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)
+            ),
         ],
     ],
 )
@@ -58,25 +80,31 @@ ANY_PROGRAM = Program.to(None)
     "puzzle",
     [
         # Custody puzzle
-        UnknownMember(MemberHint(puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)),
+        UnknownMember(puzzle_hint=MemberHint(puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)),
         # 1 of 2 (w/ & w/o restrictions)
         MofN(
             m=1,
             members=[
                 PuzzleWithRestrictions(
-                    nonce=1, restrictions=[], puzzle=UnknownMember(MemberHint(puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM))
+                    nonce=1,
+                    restrictions=[],
+                    member=UnknownMember(puzzle_hint=MemberHint(puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)),
                 ),
                 PuzzleWithRestrictions(
                     nonce=2,
                     restrictions=[
                         UnknownRestriction(
-                            RestrictionHint(member_not_dpuz=True, puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)
+                            restriction_hint=RestrictionHint(
+                                member_not_dpuz=True, puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM
+                            )
                         ),
                         UnknownRestriction(
-                            RestrictionHint(member_not_dpuz=True, puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)
+                            restriction_hint=RestrictionHint(
+                                member_not_dpuz=True, puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM
+                            )
                         ),
                     ],
-                    puzzle=UnknownMember(MemberHint(puzhash=BUNCH_OF_ONES, memo=ANY_PROGRAM)),
+                    member=UnknownMember(puzzle_hint=MemberHint(puzhash=BUNCH_OF_ONES, memo=ANY_PROGRAM)),
                 ),
             ],
         ),
@@ -87,13 +115,13 @@ ANY_PROGRAM = Program.to(None)
                 PuzzleWithRestrictions(
                     nonce=1,
                     restrictions=[],
-                    puzzle=MofN(
+                    member=MofN(
                         m=1,
                         members=[
                             PuzzleWithRestrictions(
                                 nonce=3,
                                 restrictions=[],
-                                puzzle=UnknownMember(MemberHint(puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)),
+                                member=UnknownMember(puzzle_hint=MemberHint(puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM)),
                             )
                         ],
                     ),
@@ -101,13 +129,13 @@ ANY_PROGRAM = Program.to(None)
                 PuzzleWithRestrictions(
                     nonce=4,
                     restrictions=[],
-                    puzzle=MofN(
+                    member=MofN(
                         m=1,
                         members=[
                             PuzzleWithRestrictions(
                                 nonce=5,
                                 restrictions=[],
-                                puzzle=UnknownMember(MemberHint(puzhash=BUNCH_OF_ONES, memo=ANY_PROGRAM)),
+                                member=UnknownMember(puzzle_hint=MemberHint(puzhash=BUNCH_OF_ONES, memo=ANY_PROGRAM)),
                             )
                         ],
                     ),
@@ -125,10 +153,10 @@ def test_back_and_forth_hint_parsing(restrictions: list[Restriction[MemberOrDPuz
     cwr = PuzzleWithRestrictions(
         nonce=0,
         restrictions=restrictions,
-        puzzle=puzzle,
+        member=puzzle,
     )
 
-    assert PuzzleWithRestrictions.from_memo(cwr.memo()) == cwr
+    assert PuzzleWithRestrictions.from_memo(cwr.memo) == cwr
 
 
 def test_unknown_puzzle_behavior() -> None:
@@ -140,35 +168,42 @@ def test_unknown_puzzle_behavior() -> None:
     """
 
     @dataclass(frozen=True)
-    class PlaceholderPuzzle:
+    class PlaceholderPuzzle(MIPSComponentBase):
         @property
         def member_not_dpuz(self) -> bool:
             raise NotImplementedError  # pragma: no cover
 
-        def memo(self, nonce: int) -> Program:
+        @property
+        def memo(self) -> Program:
             raise NotImplementedError  # pragma: no cover
 
-        def puzzle(self, nonce: int) -> Program:
+        @property
+        def program(self) -> Program:
             raise NotImplementedError  # pragma: no cover
 
-        def puzzle_hash(self, nonce: int) -> bytes32:
-            return bytes32([nonce] * 32)
+        @property
+        def tree_hash_optimized(self) -> bytes32:
+            assert self.nonce is not None
+            return bytes32([self.nonce] * 32)
+
+        @classmethod
+        def match(cls, *, unknown_puzzle: UnknownPuzzle) -> PlaceholderPuzzle | None: ...
 
     # First a simple PuzzleWithRestrictions that is really just a Puzzle
-    unknown_puzzle_0 = UnknownMember(MemberHint(puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM))
-    pwr = PuzzleWithRestrictions(nonce=0, restrictions=[], puzzle=unknown_puzzle_0)
+    unknown_puzzle_0 = UnknownMember(puzzle_hint=MemberHint(puzhash=BUNCH_OF_ZEROS, memo=ANY_PROGRAM))
+    pwr = PuzzleWithRestrictions(nonce=0, restrictions=[], member=unknown_puzzle_0)
     assert pwr.unknown_puzzles == {BUNCH_OF_ZEROS: unknown_puzzle_0}
     known_puzzles = {BUNCH_OF_ZEROS: PlaceholderPuzzle()}
     assert pwr.fill_in_unknown_puzzles(known_puzzles) == PuzzleWithRestrictions(
-        nonce=0, restrictions=[], puzzle=PlaceholderPuzzle()
+        nonce=0, restrictions=[], member=PlaceholderPuzzle()
     )
 
     # Now we add some restrictions
     unknown_restriction_1 = UnknownRestriction(
-        RestrictionHint(member_not_dpuz=True, puzhash=BUNCH_OF_ONES, memo=ANY_PROGRAM)
+        restriction_hint=RestrictionHint(member_not_dpuz=True, puzhash=BUNCH_OF_ONES, memo=ANY_PROGRAM)
     )
     unknown_restriction_2 = UnknownRestriction(
-        RestrictionHint(member_not_dpuz=False, puzhash=BUNCH_OF_TWOS, memo=ANY_PROGRAM)
+        restriction_hint=RestrictionHint(member_not_dpuz=False, puzhash=BUNCH_OF_TWOS, memo=ANY_PROGRAM)
     )
     pwr = replace(pwr, restrictions=[unknown_restriction_1, unknown_restriction_2])
     assert pwr.unknown_puzzles == {
@@ -182,18 +217,18 @@ def test_unknown_puzzle_behavior() -> None:
         BUNCH_OF_TWOS: PlaceholderPuzzle(),
     }
     assert pwr.fill_in_unknown_puzzles(known_puzzles) == PuzzleWithRestrictions(
-        nonce=0, restrictions=[PlaceholderPuzzle(), PlaceholderPuzzle()], puzzle=PlaceholderPuzzle()
+        nonce=0, restrictions=[PlaceholderPuzzle(), PlaceholderPuzzle()], member=PlaceholderPuzzle()
     )
 
     # Now we do test an MofN recursion
-    unknown_puzzle_3 = UnknownMember(MemberHint(puzhash=BUNCH_OF_THREES, memo=ANY_PROGRAM))
+    unknown_puzzle_3 = UnknownMember(puzzle_hint=MemberHint(puzhash=BUNCH_OF_THREES, memo=ANY_PROGRAM))
     pwr = replace(
         pwr,
-        puzzle=MofN(
+        member=MofN(
             m=1,
             members=[
-                PuzzleWithRestrictions(nonce=0, restrictions=[], puzzle=unknown_puzzle_0),
-                PuzzleWithRestrictions(nonce=1, restrictions=[], puzzle=unknown_puzzle_3),
+                PuzzleWithRestrictions(nonce=0, restrictions=[], member=unknown_puzzle_0),
+                PuzzleWithRestrictions(nonce=1, restrictions=[], member=unknown_puzzle_3),
             ],
         ),
     )
@@ -218,11 +253,11 @@ def test_unknown_puzzle_behavior() -> None:
     assert filled_in == PuzzleWithRestrictions(
         nonce=0,
         restrictions=[PlaceholderPuzzle(), PlaceholderPuzzle()],
-        puzzle=MofN(
+        member=MofN(
             m=1,
             members=[
-                PuzzleWithRestrictions(nonce=0, restrictions=[], puzzle=PlaceholderPuzzle()),
-                PuzzleWithRestrictions(nonce=1, restrictions=[], puzzle=PlaceholderPuzzle()),
+                PuzzleWithRestrictions(nonce=0, restrictions=[], member=PlaceholderPuzzle()),
+                PuzzleWithRestrictions(nonce=1, restrictions=[], member=PlaceholderPuzzle()),
             ],
         ),
     )
@@ -235,31 +270,35 @@ ACS_MEMBER_PH = ACS_MEMBER.get_tree_hash()
 
 
 @dataclass(frozen=True)
-class ACSMember:
-    def memo(self, nonce: int) -> Program:
+class ACSMember(MIPSComponentBase):
+    @property
+    def memo(self) -> Program:
         raise NotImplementedError  # pragma: no cover
 
-    def puzzle(self, nonce: int) -> Program:
+    @property
+    def program(self) -> Program:
         # (r (c (q . nonce) ACS_MEMBER_PH))
-        return Program.to([6, [4, (1, nonce), ACS_MEMBER]])
+        return Program.to([6, [4, (1, self.nonce), ACS_MEMBER]])
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
-        return self.puzzle(nonce).get_tree_hash()
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle) -> ACSMember | None: ...
 
 
 @dataclass(frozen=True)
-class ACSDPuzValidator:
+class ACSDPuzValidator(MIPSComponentBase):
     member_not_dpuz: Literal[False] = field(init=False, default=False)
 
-    def memo(self, nonce: int) -> Program:
+    @property
+    def memo(self) -> Program:
         raise NotImplementedError  # pragma: no cover
 
-    def puzzle(self, nonce: int) -> Program:
+    @property
+    def program(self) -> Program:
         # (mod (dpuz . program) (a program conditions))
         return Program.to([2, 3, 2])
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
-        return self.puzzle(nonce).get_tree_hash()
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle) -> ACSMember | None: ...
 
 
 @pytest.mark.anyio
@@ -285,19 +324,19 @@ async def test_m_of_n(cost_logger: CostLogger, with_restrictions: bool) -> None:
                 m_of_n = PuzzleWithRestrictions(
                     nonce=0,
                     restrictions=[],
-                    puzzle=MofN(
+                    member=MofN(
                         m=m,
                         members=[
-                            PuzzleWithRestrictions(nonce=n_i, restrictions=restrictions, puzzle=ACSMember())
+                            PuzzleWithRestrictions(nonce=n_i, restrictions=restrictions, member=ACSMember())
                             for n_i in range(n)
                         ],
                     ),
                 )
 
                 # Farm and find coin
-                await sim.farm_block(m_of_n.puzzle_hash())
+                await sim.farm_block(m_of_n.tree_hash)
                 m_of_n_coin = (
-                    await client.get_coin_records_by_puzzle_hashes([m_of_n.puzzle_hash()], include_spent_coins=False)
+                    await client.get_coin_records_by_puzzle_hashes([m_of_n.tree_hash], include_spent_coins=False)
                 )[0].coin
                 block_height = sim.block_height
 
@@ -308,25 +347,25 @@ async def test_m_of_n(cost_logger: CostLogger, with_restrictions: bool) -> None:
                 # Test a spend of every combination of m of n
                 for indexes in itertools.combinations(range(n), m):
                     proven_spends = {
-                        PuzzleWithRestrictions(nonce=index, restrictions=restrictions, puzzle=ACSMember()).puzzle_hash(
-                            _top_level=False
-                        ): ProvenSpend(
+                        PuzzleWithRestrictions(
+                            nonce=index, restrictions=restrictions, member=ACSMember(), _top_level=False
+                        ).tree_hash: ProvenSpend(
                             puzzle_reveal=PuzzleWithRestrictions(
-                                nonce=index, restrictions=restrictions, puzzle=ACSMember()
-                            ).puzzle_reveal(_top_level=False),
-                            solution=PuzzleWithRestrictions(
-                                nonce=index, restrictions=restrictions, puzzle=ACSMember()
-                            ).solve(
-                                [],
-                                [Program.to(None)] if with_restrictions else [],
-                                Program.to(
-                                    [announcement_1.to_program(), announcement_2.corresponding_assertion().to_program()]
+                                nonce=index, restrictions=restrictions, member=ACSMember(), _top_level=False
+                            ).program,
+                            solution=PuzzleWithRestrictionsSolution(
+                                dpuz_validator_solutions=[NilSolution()] if with_restrictions else [],
+                                member_solution=ACSSolution(
+                                    conditions=[
+                                        announcement_1,
+                                        announcement_2.corresponding_assertion(),
+                                    ]
                                 ),
                             ),
                         )
                         for index in indexes
                     }
-                    assert isinstance(m_of_n.puzzle, MofN)
+                    assert isinstance(m_of_n.member, MofN)
                     result = await client.push_tx(
                         cost_logger.add_cost(
                             f"M={m}, N={n}, indexes={indexes}{'w/ res.' if with_restrictions else ''}",
@@ -334,21 +373,21 @@ async def test_m_of_n(cost_logger: CostLogger, with_restrictions: bool) -> None:
                                 [
                                     make_spend(
                                         m_of_n_coin,
-                                        m_of_n.puzzle_reveal(),
-                                        m_of_n.solve(
-                                            [],
-                                            [],
-                                            m_of_n.puzzle.solve(proven_spends),  # pylint: disable=no-member
-                                            DelegatedPuzzleAndSolution(
-                                                puzzle=Program.to(1),
-                                                solution=Program.to(
-                                                    [
-                                                        announcement_2.to_program(),
-                                                        announcement_1.corresponding_assertion().to_program(),
+                                        m_of_n.program,
+                                        PuzzleWithRestrictionsSolution(
+                                            member_solution=MofNSolution(
+                                                puzzle=m_of_n.member, spends_to_prove=proven_spends
+                                            ),
+                                            delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
+                                                puzzle=ACSPuzzle(),
+                                                solution=ACSSolution(
+                                                    conditions=[
+                                                        announcement_2,
+                                                        announcement_1.corresponding_assertion(),
                                                     ]
                                                 ),
                                             ),
-                                        ),
+                                        ).program,
                                     )
                                 ],
                                 G2Element(),
@@ -370,25 +409,27 @@ async def test_m_of_n(cost_logger: CostLogger, with_restrictions: bool) -> None:
             MofN(
                 m=2,
                 members=[
-                    PuzzleWithRestrictions(nonce=0, restrictions=[], puzzle=ACSMember()),
-                    PuzzleWithRestrictions(nonce=0, restrictions=[], puzzle=ACSMember()),
+                    PuzzleWithRestrictions(nonce=0, restrictions=[], member=ACSMember()),
+                    PuzzleWithRestrictions(nonce=0, restrictions=[], member=ACSMember()),
                 ],
             )
 
 
 @dataclass(frozen=True)
-class ACSMemberValidator:
+class ACSMemberValidator(MIPSComponentBase):
     member_not_dpuz: Literal[True] = field(init=False, default=True)
 
-    def memo(self, nonce: int) -> Program:
+    @property
+    def memo(self) -> Program:
         raise NotImplementedError  # pragma: no cover
 
-    def puzzle(self, nonce: int) -> Program:
+    @property
+    def program(self) -> Program:
         # (mod (conditions . program) (a program conditions))
         return Program.to([2, 3, 2])
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
-        return self.puzzle(nonce).get_tree_hash()
+    @classmethod
+    def match(cls, unknown_puzzle: UnknownPuzzle) -> ACSMemberValidator | None: ...
 
 
 @pytest.mark.anyio
@@ -400,21 +441,19 @@ async def test_restriction_layer(cost_logger: CostLogger) -> None:
         pwr = PuzzleWithRestrictions(
             nonce=0,
             restrictions=[ACSMemberValidator(), ACSMemberValidator(), ACSDPuzValidator(), ACSDPuzValidator()],
-            puzzle=ACSMember(),
+            member=ACSMember(),
         )
 
         # Farm coin with puzzle inside
-        await sim.farm_block(pwr.puzzle_hash())
-        pwr_coin = (await client.get_coin_records_by_puzzle_hashes([pwr.puzzle_hash()], include_spent_coins=False))[
-            0
-        ].coin
+        await sim.farm_block(pwr.tree_hash)
+        pwr_coin = (await client.get_coin_records_by_puzzle_hashes([pwr.tree_hash], include_spent_coins=False))[0].coin
 
         # Some announcements to make a ring between the delegated puzzle and the inner puzzle
         announcement_1 = CreateCoinAnnouncement(msg=b"foo", coin_id=pwr_coin.name())
         announcement_2 = CreateCoinAnnouncement(msg=b"bar", coin_id=pwr_coin.name())
 
-        dpuz = Program.to(1)
-        dpuzhash = dpuz.get_tree_hash()
+        dpuz = ACSPuzzle()
+        dpuzhash = dpuz.tree_hash
         result = await client.push_tx(
             cost_logger.add_cost(
                 "Puzzle with 4 restrictions (2 member validators & 2 dpuz validators) all ACS",
@@ -422,36 +461,35 @@ async def test_restriction_layer(cost_logger: CostLogger) -> None:
                     [
                         make_spend(
                             pwr_coin,
-                            pwr.puzzle_reveal(),
-                            pwr.solve(
-                                [
-                                    Program.to(None),
+                            pwr.program,
+                            PuzzleWithRestrictionsSolution(
+                                member_validator_solutions=[
+                                    NilSolution(),
                                     # (mod conditions (r (r conditions)))
                                     # checks length >= 2
-                                    Program.to(7),
+                                    UnknownSolution(program=Program.to(7)),
                                 ],
-                                [
-                                    Program.to(None),
+                                dpuz_validator_solutions=[
+                                    NilSolution(),
                                     # (mod dpuzhash (if (= dpuzhash <dpuzhash>) () (x)))
                                     # (a (i (= 1 (q . <dpuzhash>)) () (q 8)) 1)
-                                    Program.to([2, [3, [9, 1, (1, dpuzhash)], None, [1, 8]], 1]),
+                                    UnknownSolution(
+                                        program=Program.to([2, [3, [9, 1, (1, dpuzhash)], None, [1, 8]], 1])
+                                    ),
                                 ],
-                                Program.to(
-                                    [
-                                        announcement_1.to_program(),
-                                        announcement_2.corresponding_assertion().to_program(),
+                                member_solution=ACSSolution(
+                                    conditions=[
+                                        announcement_1,
+                                        announcement_2.corresponding_assertion(),
                                     ]
                                 ),
-                                DelegatedPuzzleAndSolution(
+                                delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
                                     puzzle=dpuz,
-                                    solution=Program.to(
-                                        [
-                                            announcement_2.to_program(),
-                                            announcement_1.corresponding_assertion().to_program(),
-                                        ]
+                                    solution=ACSSolution(
+                                        conditions=[announcement_2, announcement_1.corresponding_assertion()]
                                     ),
                                 ),
-                            ),
+                            ).program,
                         )
                     ],
                     G2Element(),

--- a/chia/_tests/clvm/test_member_puzzles.py
+++ b/chia/_tests/clvm/test_member_puzzles.py
@@ -14,20 +14,32 @@ from chia.types.coin_spend import make_spend
 from chia.types.mempool_inclusion_status import MempoolInclusionStatus
 from chia.util.errors import Err
 from chia.util.hash import std_hash
-from chia.wallet.conditions import CreateCoinAnnouncement
+from chia.wallet.conditions import CreateCoin, CreateCoinAnnouncement
 from chia.wallet.puzzles.custody.custody_architecture import (
-    DelegatedPuzzleAndSolution,
     MemberHint,
     PuzzleWithRestrictions,
+    PuzzleWithRestrictionsSolution,
 )
 from chia.wallet.puzzles.custody.member_puzzles import (
     BLSWithTaprootMember,
+    BLSWithTaprootMemberSolution,
     FixedPuzzleMember,
     SingletonMember,
+    SingletonMemberSolution,
 )
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
     calculate_synthetic_public_key,
     puzzle_for_synthetic_public_key,
+)
+from chia.wallet.puzzles.puzzle_drivers import (
+    ACS_PH,
+    ACSPuzzle,
+    ACSSolution,
+    DelegatedPuzzleAndSolution,
+    NilPuzzle,
+    NilSolution,
+    P2Conditions,
+    UnknownSolution,
 )
 from chia.wallet.singleton import SINGLETON_LAUNCHER_PUZZLE, SINGLETON_LAUNCHER_PUZZLE_HASH, SINGLETON_TOP_LAYER_MOD
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
@@ -36,18 +48,18 @@ from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 @pytest.mark.anyio
 async def test_bls_with_taproot_member(cost_logger: CostLogger) -> None:
     async with sim_and_client() as (sim, client):
-        delegated_puzzle = Program.to(1)
-        delegated_puzzle_hash = delegated_puzzle.get_tree_hash()
+        delegated_puzzle = ACSPuzzle()
+        delegated_puzzle_hash = delegated_puzzle.tree_hash
         sk = AugSchemeMPL.key_gen(bytes.fromhex(str(0) * 64))
 
         bls_with_taproot_member = BLSWithTaprootMember(public_key=sk.public_key(), hidden_puzzle=delegated_puzzle)
-        bls_puzzle = PuzzleWithRestrictions(nonce=0, restrictions=[], puzzle=bls_with_taproot_member)
+        bls_puzzle = PuzzleWithRestrictions(nonce=0, restrictions=[], member=bls_with_taproot_member)
         memo = MemberHint(
-            puzhash=bls_puzzle.puzzle.puzzle_hash(0),
-            memo=bls_puzzle.puzzle.memo(0),
+            puzhash=bls_puzzle.member.tree_hash,
+            memo=bls_puzzle.member.memo,
         )
 
-        assert bls_puzzle.memo() == Program.to(
+        assert bls_puzzle.memo == Program.to(
             (
                 bls_puzzle.spec_namespace,
                 [
@@ -60,8 +72,8 @@ async def test_bls_with_taproot_member(cost_logger: CostLogger) -> None:
         )
 
         # Farm and find coin
-        await sim.farm_block(bls_puzzle.puzzle_hash())
-        coin = (await client.get_coin_records_by_puzzle_hashes([bls_puzzle.puzzle_hash()], include_spent_coins=False))[
+        await sim.farm_block(bls_puzzle.tree_hash)
+        coin = (await client.get_coin_records_by_puzzle_hashes([bls_puzzle.tree_hash], include_spent_coins=False))[
             0
         ].coin
         block_height = sim.block_height
@@ -74,21 +86,14 @@ async def test_bls_with_taproot_member(cost_logger: CostLogger) -> None:
             [
                 make_spend(
                     coin,
-                    bls_puzzle.puzzle_reveal(),
-                    bls_puzzle.solve(
-                        [],
-                        [],
-                        bls_with_taproot_member.solve(),
-                        DelegatedPuzzleAndSolution(
+                    bls_puzzle.program,
+                    PuzzleWithRestrictionsSolution(
+                        member_solution=BLSWithTaprootMemberSolution(),
+                        delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
                             puzzle=delegated_puzzle,
-                            solution=Program.to(
-                                [
-                                    announcement.to_program(),
-                                    announcement.corresponding_assertion().to_program(),
-                                ]
-                            ),
+                            solution=ACSSolution(conditions=[announcement, announcement.corresponding_assertion()]),
                         ),
-                    ),
+                    ).program,
                 )
             ],
             bls_with_taproot_member.sign_with_synthetic_secret_key(
@@ -110,21 +115,17 @@ async def test_bls_with_taproot_member(cost_logger: CostLogger) -> None:
             [
                 make_spend(
                     coin,
-                    bls_puzzle.puzzle_reveal(),
-                    bls_puzzle.solve(
-                        [],
-                        [],
-                        bls_with_taproot_member.solve(True),
-                        DelegatedPuzzleAndSolution(
-                            puzzle=delegated_puzzle,
-                            solution=Program.to(
-                                [
-                                    announcement.to_program(),
-                                    announcement.corresponding_assertion().to_program(),
-                                ]
-                            ),
+                    bls_puzzle.program,
+                    PuzzleWithRestrictionsSolution(
+                        member_solution=BLSWithTaprootMemberSolution(
+                            original_public_key=bls_with_taproot_member.public_key,
+                            hidden_puzzle=bls_with_taproot_member.hidden_puzzle,
                         ),
-                    ),
+                        delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
+                            puzzle=delegated_puzzle,
+                            solution=ACSSolution(conditions=[announcement, announcement.corresponding_assertion()]),
+                        ),
+                    ).program,
                 )
             ],
             G2Element(),  # no signature required in our test hidden_puzzle
@@ -138,16 +139,18 @@ async def test_bls_with_taproot_member(cost_logger: CostLogger) -> None:
         assert result == (MempoolInclusionStatus.SUCCESS, None)
 
         # test invalid taproot spend
-        illegal_taproot_puzzle = Program.to([1, [51, Program.to(1).get_tree_hash(), 1]])
-        assert illegal_taproot_puzzle.run([]) == Program.to([[51, Program.to(1).get_tree_hash(), 1]])
-        bls_with_taproot_member = BLSWithTaprootMember(public_key=sk.public_key(), hidden_puzzle=illegal_taproot_puzzle)
-        bls_puzzle = PuzzleWithRestrictions(nonce=0, restrictions=[], puzzle=bls_with_taproot_member)
+        illegal_taproot_puzzle = P2Conditions(conditions=[CreateCoin(ACS_PH, uint64(1))])
+        assert illegal_taproot_puzzle.program.run([]) == ACSSolution(conditions=[CreateCoin(ACS_PH, uint64(1))]).program
+        bls_with_taproot_member_illegal = BLSWithTaprootMember(
+            public_key=sk.public_key(), hidden_puzzle=illegal_taproot_puzzle
+        )
+        bls_puzzle = PuzzleWithRestrictions(nonce=0, restrictions=[], member=bls_with_taproot_member_illegal)
         memo = MemberHint(
-            puzhash=bls_puzzle.puzzle.puzzle_hash(0),
-            memo=bls_puzzle.puzzle.memo(0),
+            puzhash=bls_puzzle.member.tree_hash,
+            memo=bls_puzzle.member.memo,
         )
 
-        assert bls_puzzle.memo() == Program.to(
+        assert bls_puzzle.memo == Program.to(
             (
                 bls_puzzle.spec_namespace,
                 [
@@ -160,8 +163,8 @@ async def test_bls_with_taproot_member(cost_logger: CostLogger) -> None:
         )
 
         # Farm and find coin
-        await sim.farm_block(bls_puzzle.puzzle_hash())
-        coin = (await client.get_coin_records_by_puzzle_hashes([bls_puzzle.puzzle_hash()], include_spent_coins=False))[
+        await sim.farm_block(bls_puzzle.tree_hash)
+        coin = (await client.get_coin_records_by_puzzle_hashes([bls_puzzle.tree_hash], include_spent_coins=False))[
             0
         ].coin
         block_height = sim.block_height
@@ -170,21 +173,22 @@ async def test_bls_with_taproot_member(cost_logger: CostLogger) -> None:
             [
                 make_spend(
                     coin,
-                    bls_puzzle.puzzle_reveal(),
-                    bls_puzzle.solve(
-                        [],
-                        [],
-                        bls_with_taproot_member.solve(True),
-                        DelegatedPuzzleAndSolution(
+                    bls_puzzle.program,
+                    PuzzleWithRestrictionsSolution(
+                        member_solution=BLSWithTaprootMemberSolution(
+                            original_public_key=bls_with_taproot_member_illegal.public_key,
+                            hidden_puzzle=bls_with_taproot_member_illegal.hidden_puzzle,
+                        ),
+                        delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
                             puzzle=delegated_puzzle,
-                            solution=Program.to(
-                                [
-                                    announcement.to_program(),
-                                    announcement.corresponding_assertion().to_program(),
-                                ]
+                            # Intentionally invalid ACS solution shape to force a taproot spend failure
+                            solution=UnknownSolution(
+                                program=P2Conditions(
+                                    conditions=[announcement, announcement.corresponding_assertion()]
+                                ).program
                             ),
                         ),
-                    ),
+                    ).program,
                 )
             ],
             G2Element(),  # no signature required in our test hidden_puzzle
@@ -196,13 +200,13 @@ async def test_bls_with_taproot_member(cost_logger: CostLogger) -> None:
             )
         )
         assert result == (MempoolInclusionStatus.FAILED, Err.GENERATOR_RUNTIME_ERROR)
-        assert bls_with_taproot_member.hidden_puzzle is not None
-        assert bls_with_taproot_member.public_key is not None
+        assert bls_with_taproot_member_illegal.hidden_puzzle is not None
+        assert bls_with_taproot_member_illegal.public_key is not None
         synthetic_public_key = calculate_synthetic_public_key(
-            bls_with_taproot_member.public_key, bls_with_taproot_member.hidden_puzzle.get_tree_hash()
+            bls_with_taproot_member_illegal.public_key, bls_with_taproot_member_illegal.hidden_puzzle.tree_hash
         )
         bls_with_taproot_member_synthetic = BLSWithTaprootMember(synthetic_key=synthetic_public_key)
-        assert bls_with_taproot_member.puzzle(0) == bls_with_taproot_member_synthetic.puzzle(0)
+        assert bls_with_taproot_member_illegal.program == bls_with_taproot_member_synthetic.program
 
         # test some errors
         with pytest.raises(
@@ -217,14 +221,22 @@ async def test_bls_with_taproot_member(cost_logger: CostLogger) -> None:
                 original_secret_key=sk, message=b""
             )
 
-        with pytest.raises(ValueError, match=re.escape("Hidden puzzle or original key are unknown")):
-            BLSWithTaprootMember(synthetic_key=sk.public_key()).solve(use_hidden_puzzle=True)
+        with pytest.raises(
+            ValueError, match=re.escape("Must specify both or neither of original_public_key and hidden_puzzle")
+        ):
+            BLSWithTaprootMemberSolution(
+                original_public_key=sk.public_key(),
+                hidden_puzzle=None,
+            )
+        synthetic_only = BLSWithTaprootMember(synthetic_key=sk.public_key())
+        assert synthetic_only.public_key is None
+        assert synthetic_only.hidden_puzzle is None
 
 
 @pytest.mark.anyio
 async def test_singleton_member(cost_logger: CostLogger) -> None:
     async with sim_and_client() as (sim, client):
-        delegated_puzzle = Program.to(1)
+        delegated_puzzle = ACSPuzzle()
 
         sk = AugSchemeMPL.key_gen(bytes.fromhex(str(0) * 64))
         pk = sk.public_key()
@@ -237,7 +249,7 @@ async def test_singleton_member(cost_logger: CostLogger) -> None:
 
         launcher_coin = Coin(coin.name(), SINGLETON_LAUNCHER_PUZZLE_HASH, uint64(1))
         singleton_member = SingletonMember(singleton_id=launcher_coin.name())
-        singleton_member_puzzle = PuzzleWithRestrictions(nonce=0, restrictions=[], puzzle=singleton_member)
+        singleton_member_puzzle = PuzzleWithRestrictions(nonce=0, restrictions=[], member=singleton_member)
 
         singleton_struct = (
             SINGLETON_TOP_LAYER_MOD.get_tree_hash(),
@@ -281,11 +293,11 @@ async def test_singleton_member(cost_logger: CostLogger) -> None:
         )[0].coin
 
         memo = MemberHint(
-            puzhash=singleton_member_puzzle.puzzle.puzzle_hash(0),
-            memo=singleton_member_puzzle.puzzle.memo(0),
+            puzhash=singleton_member_puzzle.member.tree_hash,
+            memo=singleton_member_puzzle.member.memo,
         )
 
-        assert singleton_member_puzzle.memo() == Program.to(
+        assert singleton_member_puzzle.memo == Program.to(
             (
                 singleton_member_puzzle.spec_namespace,
                 [
@@ -298,10 +310,10 @@ async def test_singleton_member(cost_logger: CostLogger) -> None:
         )
 
         # Farm and find coin
-        await sim.farm_block(singleton_member_puzzle.puzzle_hash())
+        await sim.farm_block(singleton_member_puzzle.tree_hash)
         coin = (
             await client.get_coin_records_by_puzzle_hashes(
-                [singleton_member_puzzle.puzzle_hash()], include_spent_coins=False
+                [singleton_member_puzzle.tree_hash], include_spent_coins=False
             )
         )[0].coin
         block_height = sim.block_height
@@ -319,7 +331,7 @@ async def test_singleton_member(cost_logger: CostLogger) -> None:
                     [
                         66,
                         0x17,
-                        delegated_puzzle.get_tree_hash(),
+                        delegated_puzzle.tree_hash,
                         coin.name(),
                     ],  # 00010111  - puzzle sender, coin receiver
                 ],  # create approval message to singleton member puzzle
@@ -330,21 +342,16 @@ async def test_singleton_member(cost_logger: CostLogger) -> None:
             [
                 make_spend(
                     coin,
-                    singleton_member_puzzle.puzzle_reveal(),
-                    singleton_member_puzzle.solve(
-                        [],
-                        [],
-                        singleton_member.solve(singleton_inner_puzzle_hash=singleton_innerpuz.get_tree_hash()),
-                        DelegatedPuzzleAndSolution(
-                            puzzle=delegated_puzzle,
-                            solution=Program.to(
-                                [
-                                    announcement.to_program(),
-                                    announcement.corresponding_assertion().to_program(),
-                                ]
-                            ),
+                    singleton_member_puzzle.program,
+                    PuzzleWithRestrictionsSolution(
+                        member_solution=SingletonMemberSolution(
+                            singleton_inner_puzzle_hash=singleton_innerpuz.get_tree_hash()
                         ),
-                    ),
+                        delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
+                            puzzle=delegated_puzzle,
+                            solution=ACSSolution(conditions=[announcement, announcement.corresponding_assertion()]),
+                        ),
+                    ).program,
                 ),
                 make_spend(
                     singleton_coin,
@@ -368,17 +375,17 @@ async def test_singleton_member(cost_logger: CostLogger) -> None:
 @pytest.mark.anyio
 async def test_fixed_puzzle_member(cost_logger: CostLogger) -> None:
     async with sim_and_client() as (sim, client):
-        delegated_puzzle = Program.to(1)
-        delegated_puzzle_hash = delegated_puzzle.get_tree_hash()
+        delegated_puzzle = ACSPuzzle()
+        delegated_puzzle_hash = delegated_puzzle.tree_hash
 
         fixed_puzzle_member = FixedPuzzleMember(fixed_puzzle_hash=delegated_puzzle_hash)
-        bls_puzzle = PuzzleWithRestrictions(nonce=0, restrictions=[], puzzle=fixed_puzzle_member)
+        bls_puzzle = PuzzleWithRestrictions(nonce=0, restrictions=[], member=fixed_puzzle_member)
         memo = MemberHint(
-            puzhash=bls_puzzle.puzzle.puzzle_hash(0),
-            memo=bls_puzzle.puzzle.memo(0),
+            puzhash=bls_puzzle.member.tree_hash,
+            memo=bls_puzzle.member.memo,
         )
 
-        assert bls_puzzle.memo() == Program.to(
+        assert bls_puzzle.memo == Program.to(
             (
                 bls_puzzle.spec_namespace,
                 [
@@ -391,8 +398,8 @@ async def test_fixed_puzzle_member(cost_logger: CostLogger) -> None:
         )
 
         # Farm and find coin
-        await sim.farm_block(bls_puzzle.puzzle_hash())
-        coin = (await client.get_coin_records_by_puzzle_hashes([bls_puzzle.puzzle_hash()], include_spent_coins=False))[
+        await sim.farm_block(bls_puzzle.tree_hash)
+        coin = (await client.get_coin_records_by_puzzle_hashes([bls_puzzle.tree_hash], include_spent_coins=False))[
             0
         ].coin
         block_height = sim.block_height
@@ -404,21 +411,14 @@ async def test_fixed_puzzle_member(cost_logger: CostLogger) -> None:
             [
                 make_spend(
                     coin,
-                    bls_puzzle.puzzle_reveal(),
-                    bls_puzzle.solve(
-                        [],
-                        [],
-                        Program.to(0),
-                        DelegatedPuzzleAndSolution(
-                            puzzle=Program.to(0),  # not the fixed puzzle
-                            solution=Program.to(
-                                [
-                                    announcement.to_program(),
-                                    announcement.corresponding_assertion().to_program(),
-                                ]
-                            ),
+                    bls_puzzle.program,
+                    PuzzleWithRestrictionsSolution(
+                        member_solution=UnknownSolution(program=Program.to(0)),
+                        delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
+                            puzzle=NilPuzzle(),  # not the fixed puzzle
+                            solution=ACSSolution(conditions=[announcement, announcement.corresponding_assertion()]),
                         ),
-                    ),
+                    ).program,
                 )
             ],
             G2Element(),
@@ -437,21 +437,14 @@ async def test_fixed_puzzle_member(cost_logger: CostLogger) -> None:
             [
                 make_spend(
                     coin,
-                    bls_puzzle.puzzle_reveal(),
-                    bls_puzzle.solve(
-                        [],
-                        [],
-                        fixed_puzzle_member.solve(),
-                        DelegatedPuzzleAndSolution(
+                    bls_puzzle.program,
+                    PuzzleWithRestrictionsSolution(
+                        member_solution=NilSolution(),
+                        delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
                             puzzle=delegated_puzzle,  # the fixed puzzle
-                            solution=Program.to(
-                                [
-                                    announcement.to_program(),
-                                    announcement.corresponding_assertion().to_program(),
-                                ]
-                            ),
+                            solution=ACSSolution(conditions=[announcement, announcement.corresponding_assertion()]),
                         ),
-                    ),
+                    ).program,
                 )
             ],
             G2Element(),

--- a/chia/_tests/clvm/test_restrictions.py
+++ b/chia/_tests/clvm/test_restrictions.py
@@ -22,47 +22,64 @@ from chia.wallet.conditions import (
     parse_conditions_non_consensus,
 )
 from chia.wallet.puzzles.custody.custody_architecture import (
-    DelegatedPuzzleAndSolution,
+    MIPSComponentBase,
     PuzzleWithRestrictions,
+    PuzzleWithRestrictionsSolution,
 )
-from chia.wallet.puzzles.custody.restriction_utilities import ValidatorStackRestriction
+from chia.wallet.puzzles.custody.restriction_utilities import (
+    ValidatorStackRestriction,
+    ValidatorStackRestrictionSolution,
+)
 from chia.wallet.puzzles.custody.restrictions import FixedCreateCoinDestinations, Heightlock, SendMessageBanned
-from chia.wallet.puzzles.puzzle_drivers import ACSSolution, NilSolution, P2Conditions
+from chia.wallet.puzzles.puzzle_drivers import (
+    ACSSolution,
+    DelegatedPuzzleAndSolution,
+    NilPuzzle,
+    NilSolution,
+    P2Conditions,
+    UnknownPuzzle,
+    UnknownSolution,
+)
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
 
-class EasyDPuzWrapper:
-    def memo(self, nonce: int) -> Program:
+class EasyDPuzWrapper(MIPSComponentBase):
+    @property
+    def memo(self) -> Program:
         return Program.to(None)
 
-    def puzzle(self, nonce: int) -> Program:
+    @property
+    def program(self) -> Program:
         # (mod (conditions remark) (c (list REMARK remark) conditions)) -> (c (c (q . 1) (c 5 ())) 2)
         return Program.to([4, [4, (1, 1), [4, 5, None]], 2])
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
-        return self.puzzle(nonce).get_tree_hash()
+    @classmethod
+    def match(cls, unknown_puzzle: UnknownPuzzle) -> EasyDPuzWrapper | None: ...
 
 
 @pytest.mark.anyio
 async def test_dpuz_validator_stack_restriction(cost_logger: CostLogger) -> None:
     async with sim_and_client() as (sim, client):
         restriction = ValidatorStackRestriction(required_wrappers=[EasyDPuzWrapper(), EasyDPuzWrapper()])
-        pwr = PuzzleWithRestrictions(nonce=0, restrictions=[restriction], puzzle=ACSMember())
+        pwr = PuzzleWithRestrictions(nonce=0, restrictions=[restriction], member=ACSMember())
 
         # Farm and find coin
-        await sim.farm_block(pwr.puzzle_hash())
-        coin = (await client.get_coin_records_by_puzzle_hashes([pwr.puzzle_hash()], include_spent_coins=False))[0].coin
+        await sim.farm_block(pwr.tree_hash)
+        coin = (await client.get_coin_records_by_puzzle_hashes([pwr.tree_hash], include_spent_coins=False))[0].coin
 
         # Attempt to just use any old dpuz
         any_old_dpuz = DelegatedPuzzleAndSolution(
-            puzzle=P2Conditions(conditions=[Remark(rest=Program.to(["foo"]))]).program, solution=NilSolution().program
+            puzzle=P2Conditions(conditions=[Remark(rest=Program.to(["foo"]))]), solution=NilSolution()
         )
         not_wrapped_attempt = WalletSpendBundle(
             [
                 make_spend(
                     coin,
-                    pwr.puzzle_reveal(),
-                    pwr.solve([], [], ACSSolution(conditions=[Remark(rest=Program.to(["bar"]))]).program, any_old_dpuz),
+                    pwr.program,
+                    PuzzleWithRestrictionsSolution(
+                        member_solution=ACSSolution(conditions=[Remark(rest=Program.to(["bar"]))]),
+                        delegated_puzzle_and_solution=any_old_dpuz,
+                    ).program,
                 )
             ],
             G2Element(),
@@ -72,7 +89,8 @@ async def test_dpuz_validator_stack_restriction(cost_logger: CostLogger) -> None
 
         # Now actually put the dpuz in the wrapper
         wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(
-            any_old_dpuz, [Program.to(["bat"]), Program.to(["baz"])]
+            any_old_dpuz,
+            [UnknownSolution(program=Program.to(["bat"])), UnknownSolution(program=Program.to(["baz"]))],
         )
         wrapped_spend = cost_logger.add_cost(
             "Minimal dpuz wrapper w/ wrapper stack enforcement",
@@ -80,13 +98,12 @@ async def test_dpuz_validator_stack_restriction(cost_logger: CostLogger) -> None
                 [
                     make_spend(
                         coin,
-                        pwr.puzzle_reveal(),
-                        pwr.solve(
-                            [],
-                            [restriction.solve(original_dpuz=any_old_dpuz.puzzle)],
-                            ACSSolution(conditions=[Remark(rest=Program.to(["bar"]))]).program,
-                            wrapped_dpuz,
-                        ),
+                        pwr.program,
+                        PuzzleWithRestrictionsSolution(
+                            dpuz_validator_solutions=[ValidatorStackRestrictionSolution.from_dpuz(any_old_dpuz.puzzle)],
+                            member_solution=ACSSolution(conditions=[Remark(rest=Program.to(["bar"]))]),
+                            delegated_puzzle_and_solution=wrapped_dpuz,
+                        ).program,
                     )
                 ],
                 G2Element(),
@@ -96,41 +113,42 @@ async def test_dpuz_validator_stack_restriction(cost_logger: CostLogger) -> None
         assert result == (MempoolInclusionStatus.SUCCESS, None)
 
         # memo format assertion for coverage sake
-        assert restriction.memo(0) == Program.to([None, None])
+        assert restriction.memo == Program.to([None, None])
 
         # error check
         with pytest.raises(
             ValueError, match=re.escape("Number of wrapper solutions does not match number of required wrappers")
         ):
-            restriction.modify_delegated_puzzle_and_solution(any_old_dpuz, [Program.to(["only one"])])
+            restriction.modify_delegated_puzzle_and_solution(
+                any_old_dpuz, [UnknownSolution(program=Program.to(["only one"]))]
+            )
 
 
 @pytest.mark.anyio
 async def test_heightlock_wrapper(cost_logger: CostLogger) -> None:
     async with sim_and_client() as (sim, client):
         restriction = ValidatorStackRestriction(required_wrappers=[Heightlock(heightlock=uint32(10))])
-        pwr = PuzzleWithRestrictions(nonce=0, restrictions=[restriction], puzzle=ACSMember())
+        pwr = PuzzleWithRestrictions(nonce=0, restrictions=[restriction], member=ACSMember())
 
         # Farm and find coin
-        await sim.farm_block(pwr.puzzle_hash())
-        coin = (await client.get_coin_records_by_puzzle_hashes([pwr.puzzle_hash()], include_spent_coins=False))[0].coin
+        await sim.farm_block(pwr.tree_hash)
+        coin = (await client.get_coin_records_by_puzzle_hashes([pwr.tree_hash], include_spent_coins=False))[0].coin
 
         # Attempt to just use any old dpuz
         any_old_dpuz = DelegatedPuzzleAndSolution(
-            puzzle=P2Conditions(conditions=[Remark(rest=Program.to(["foo"]))]).program, solution=NilSolution().program
+            puzzle=P2Conditions(conditions=[Remark(rest=Program.to(["foo"]))]), solution=NilSolution()
         )
-        wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(any_old_dpuz, [Program.to(None)])
+        wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(any_old_dpuz, [NilSolution()])
         not_timelocked_attempt = WalletSpendBundle(
             [
                 make_spend(
                     coin,
-                    pwr.puzzle_reveal(),
-                    pwr.solve(
-                        [],
-                        [Program.to([any_old_dpuz.puzzle.get_tree_hash()])],
-                        ACSSolution(conditions=[Remark(rest=Program.to(["bar"]))]).program,
-                        any_old_dpuz,
-                    ),
+                    pwr.program,
+                    PuzzleWithRestrictionsSolution(
+                        dpuz_validator_solutions=[ValidatorStackRestrictionSolution.from_dpuz(any_old_dpuz.puzzle)],
+                        member_solution=ACSSolution(conditions=[Remark(rest=Program.to(["bar"]))]),
+                        delegated_puzzle_and_solution=any_old_dpuz,
+                    ).program,
                 )
             ],
             G2Element(),
@@ -146,23 +164,24 @@ async def test_heightlock_wrapper(cost_logger: CostLogger) -> None:
                     Remark(rest=Program.to(["foo"])),
                     Remark(rest=Program.to(["bat"])),
                 ],
-            ).program,
-            solution=NilSolution().program,
+            ),
+            solution=NilSolution(),
         )
-        wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(timelocked_dpuz, [Program.to(None)])
+        wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(timelocked_dpuz, [NilSolution()])
         sb = cost_logger.add_cost(
             "Minimal puzzle with restrictions w/ heightlock wrapper",
             WalletSpendBundle(
                 [
                     make_spend(
                         coin,
-                        pwr.puzzle_reveal(),
-                        pwr.solve(
-                            [],
-                            [Program.to([timelocked_dpuz.puzzle.get_tree_hash()])],
-                            ACSSolution(conditions=[Remark(rest=Program.to(["bar"]))]).program,
-                            wrapped_dpuz,
-                        ),
+                        pwr.program,
+                        PuzzleWithRestrictionsSolution(
+                            dpuz_validator_solutions=[
+                                ValidatorStackRestrictionSolution.from_dpuz(timelocked_dpuz.puzzle)
+                            ],
+                            member_solution=ACSSolution(conditions=[Remark(rest=Program.to(["bar"]))]),
+                            delegated_puzzle_and_solution=wrapped_dpuz,
+                        ).program,
                     )
                 ],
                 G2Element(),
@@ -184,7 +203,7 @@ async def test_heightlock_wrapper(cost_logger: CostLogger) -> None:
         assert Remark(Program.to(["bat"])) in conditions
 
         # memo format assertion for coverage sake
-        assert restriction.memo(0) == Program.to([None])
+        assert restriction.memo == Program.to([None])
 
 
 @pytest.mark.anyio
@@ -193,29 +212,28 @@ async def test_fixed_create_coin_wrapper(cost_logger: CostLogger) -> None:
         restriction = ValidatorStackRestriction(
             required_wrappers=[FixedCreateCoinDestinations(allowed_ph=bytes32.zeros)]
         )
-        pwr = PuzzleWithRestrictions(nonce=0, restrictions=[restriction], puzzle=ACSMember())
+        pwr = PuzzleWithRestrictions(nonce=0, restrictions=[restriction], member=ACSMember())
 
         # Farm and find coin
-        await sim.farm_block(pwr.puzzle_hash())
-        coin = (await client.get_coin_records_by_puzzle_hashes([pwr.puzzle_hash()], include_spent_coins=False))[0].coin
+        await sim.farm_block(pwr.tree_hash)
+        coin = (await client.get_coin_records_by_puzzle_hashes([pwr.tree_hash], include_spent_coins=False))[0].coin
 
         # Attempt to create a coin somewhere else
         any_old_dpuz = DelegatedPuzzleAndSolution(
-            puzzle=P2Conditions(conditions=[CreateCoin(bytes32([1] * 32), uint64(1))]).program,
-            solution=NilSolution().program,
+            puzzle=P2Conditions(conditions=[CreateCoin(bytes32([1] * 32), uint64(1))]),
+            solution=NilSolution(),
         )
-        wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(any_old_dpuz, [Program.to(None)])
+        wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(any_old_dpuz, [NilSolution()])
         escape_attempt = WalletSpendBundle(
             [
                 make_spend(
                     coin,
-                    pwr.puzzle_reveal(),
-                    pwr.solve(
-                        [],
-                        [Program.to([any_old_dpuz.puzzle.get_tree_hash()])],
-                        ACSSolution(conditions=[Remark(rest=Program.to(["bar"]))]).program,
-                        any_old_dpuz,
-                    ),
+                    pwr.program,
+                    PuzzleWithRestrictionsSolution(
+                        dpuz_validator_solutions=[ValidatorStackRestrictionSolution.from_dpuz(any_old_dpuz.puzzle)],
+                        member_solution=ACSSolution(conditions=[Remark(rest=Program.to(["bar"]))]),
+                        delegated_puzzle_and_solution=any_old_dpuz,
+                    ).program,
                 )
             ],
             G2Element(),
@@ -225,23 +243,22 @@ async def test_fixed_create_coin_wrapper(cost_logger: CostLogger) -> None:
 
         # Now send it to the correct place
         correct_dpuz = DelegatedPuzzleAndSolution(
-            puzzle=P2Conditions(conditions=[CreateCoin(bytes32.zeros, uint64(1)), Remark(Program.to("foo"))]).program,
-            solution=NilSolution().program,
+            puzzle=P2Conditions(conditions=[CreateCoin(bytes32.zeros, uint64(1)), Remark(Program.to("foo"))]),
+            solution=NilSolution(),
         )
-        wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(correct_dpuz, [Program.to(None)])
+        wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(correct_dpuz, [NilSolution()])
         sb = cost_logger.add_cost(
             "Minimal puzzle with restrictions w/ fixed create coin wrapper",
             WalletSpendBundle(
                 [
                     make_spend(
                         coin,
-                        pwr.puzzle_reveal(),
-                        pwr.solve(
-                            [],
-                            [Program.to([correct_dpuz.puzzle.get_tree_hash()])],
-                            Program.to([Remark(Program.to("bar")).to_program()]),
-                            wrapped_dpuz,
-                        ),
+                        pwr.program,
+                        PuzzleWithRestrictionsSolution(
+                            dpuz_validator_solutions=[ValidatorStackRestrictionSolution.from_dpuz(correct_dpuz.puzzle)],
+                            member_solution=ACSSolution(conditions=[Remark(Program.to("bar"))]),
+                            delegated_puzzle_and_solution=wrapped_dpuz,
+                        ).program,
                     )
                 ],
                 G2Element(),
@@ -257,18 +274,18 @@ async def test_fixed_create_coin_wrapper(cost_logger: CostLogger) -> None:
         assert Remark(Program.to("bar")) in conditions
 
         # memo format assertion for coverage sake
-        assert restriction.memo(0) == Program.to([None])
+        assert restriction.memo == Program.to([None])
 
 
 @pytest.mark.anyio
 async def test_send_message_banned(cost_logger: CostLogger) -> None:
     async with sim_and_client() as (sim, client):
         restriction = ValidatorStackRestriction(required_wrappers=[SendMessageBanned()])
-        pwr = PuzzleWithRestrictions(nonce=0, restrictions=[restriction], puzzle=ACSMember())
+        pwr = PuzzleWithRestrictions(nonce=0, restrictions=[restriction], member=ACSMember())
 
         # Farm and find coin
-        await sim.farm_block(pwr.puzzle_hash())
-        coin = (await client.get_coin_records_by_puzzle_hashes([pwr.puzzle_hash()], include_spent_coins=False))[0].coin
+        await sim.farm_block(pwr.tree_hash)
+        coin = (await client.get_coin_records_by_puzzle_hashes([pwr.tree_hash], include_spent_coins=False))[0].coin
 
         # Attempt to send a message
         send_message_dpuz = DelegatedPuzzleAndSolution(
@@ -280,21 +297,22 @@ async def test_send_message_banned(cost_logger: CostLogger) -> None:
                         receiver=MessageParticipant(parent_id_committed=bytes32.zeros),
                     )
                 ]
-            ).program,
-            solution=NilSolution().program,
+            ),
+            solution=NilSolution(),
         )
-        wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(send_message_dpuz, [Program.to(None)])
+        wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(send_message_dpuz, [NilSolution()])
         escape_attempt = WalletSpendBundle(
             [
                 make_spend(
                     coin,
-                    pwr.puzzle_reveal(),
-                    pwr.solve(
-                        [],
-                        [Program.to([send_message_dpuz.puzzle.get_tree_hash()])],
-                        Program.to(None),
-                        wrapped_dpuz,
-                    ),
+                    pwr.program,
+                    PuzzleWithRestrictionsSolution(
+                        dpuz_validator_solutions=[
+                            ValidatorStackRestrictionSolution.from_dpuz(send_message_dpuz.puzzle)
+                        ],
+                        member_solution=NilSolution(),
+                        delegated_puzzle_and_solution=wrapped_dpuz,
+                    ).program,
                 )
             ],
             G2Element(),
@@ -303,24 +321,22 @@ async def test_send_message_banned(cost_logger: CostLogger) -> None:
         assert result == (MempoolInclusionStatus.FAILED, Err.GENERATOR_RUNTIME_ERROR)
 
         # Now send it to the correct place
-        self_destruct_dpuz = DelegatedPuzzleAndSolution(
-            puzzle=Program.to(None),
-            solution=NilSolution().program,
-        )
-        wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(self_destruct_dpuz, [Program.to(None)])
+        self_destruct_dpuz = DelegatedPuzzleAndSolution(puzzle=NilPuzzle(), solution=NilSolution())
+        wrapped_dpuz = restriction.modify_delegated_puzzle_and_solution(self_destruct_dpuz, [NilSolution()])
         sb = cost_logger.add_cost(
             "Minimal puzzle with restrictions w/ send message banned wrapper",
             WalletSpendBundle(
                 [
                     make_spend(
                         coin,
-                        pwr.puzzle_reveal(),
-                        pwr.solve(
-                            [],
-                            [Program.to([self_destruct_dpuz.puzzle.get_tree_hash()])],
-                            Program.to(None),
-                            wrapped_dpuz,
-                        ),
+                        pwr.program,
+                        PuzzleWithRestrictionsSolution(
+                            dpuz_validator_solutions=[
+                                ValidatorStackRestrictionSolution.from_dpuz(self_destruct_dpuz.puzzle)
+                            ],
+                            member_solution=NilSolution(),
+                            delegated_puzzle_and_solution=wrapped_dpuz,
+                        ).program,
                     )
                 ],
                 G2Element(),
@@ -330,4 +346,4 @@ async def test_send_message_banned(cost_logger: CostLogger) -> None:
         assert result == (MempoolInclusionStatus.SUCCESS, None)
 
         # memo format assertion for coverage sake
-        assert restriction.memo(0) == Program.to([None])
+        assert restriction.memo == Program.to([None])

--- a/chia/_tests/pools/test_plotnft_v2_drivers.py
+++ b/chia/_tests/pools/test_plotnft_v2_drivers.py
@@ -35,12 +35,20 @@ from chia.wallet.conditions import (
     parse_conditions_non_consensus,
 )
 from chia.wallet.lineage_proof import LineageProof
-from chia.wallet.puzzles.custody.custody_architecture import DelegatedPuzzleAndSolution, PuzzleWithRestrictions
+from chia.wallet.puzzles.custody.custody_architecture import PuzzleWithRestrictions
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
     DEFAULT_HIDDEN_PUZZLE_HASH,
     calculate_synthetic_secret_key,
 )
-from chia.wallet.puzzles.puzzle_drivers import NilSolution, P2Conditions, UnknownPuzzle
+from chia.wallet.puzzles.puzzle_drivers import (
+    ACSPuzzle,
+    ACSSolution,
+    DelegatedPuzzleAndSolution,
+    NilPuzzle,
+    NilSolution,
+    P2Conditions,
+    UnknownPuzzle,
+)
 from chia.wallet.uncurried_puzzle import UncurriedPuzzle
 from chia.wallet.wallet_spend_bundle import WalletSpendBundle
 
@@ -124,16 +132,12 @@ async def test_plotnft_transitions(cost_logger: CostLogger) -> None:
 
         with pytest.raises(ValueError, match=re.escape("Cannot exit to waiting room while self pooling.")):
             plotnft.exit_to_waiting_room(
-                delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
-                    puzzle=Program.to(None), solution=NilSolution().program
-                )
+                delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(puzzle=NilPuzzle(), solution=NilSolution())
             )
 
         with pytest.raises(ValueError, match=re.escape("Cannot exit waiting room while self pooling.")):
             plotnft.exit_waiting_room(
-                delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
-                    puzzle=Program.to(None), solution=NilSolution().program
-                )
+                delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(puzzle=NilPuzzle(), solution=NilSolution())
             )
 
         # Join a pool
@@ -168,14 +172,12 @@ async def test_plotnft_transitions(cost_logger: CostLogger) -> None:
 
         with pytest.raises(ValueError, match=re.escape("Cannot exit waiting room while not in it")):
             plotnft.exit_waiting_room(
-                delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
-                    puzzle=Program.to(None), solution=NilSolution().program
-                )
+                delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(puzzle=NilPuzzle(), solution=NilSolution())
             )
 
         # Attempt to leave without waiting room
         quick_exit_dpuz_and_solution = DelegatedPuzzleAndSolution(
-            puzzle=ACS, solution=Program.to([CreateCoin(bytes32.zeros, uint64(1)).to_program()])
+            puzzle=ACSPuzzle(), solution=ACSSolution(conditions=[CreateCoin(bytes32.zeros, uint64(1))])
         )
         singing_info = plotnft.modify_delegated_puzzle_and_solution(quick_exit_dpuz_and_solution)
         coin_spends = plotnft.exit_to_waiting_room(quick_exit_dpuz_and_solution)
@@ -183,7 +185,7 @@ async def test_plotnft_transitions(cost_logger: CostLogger) -> None:
             WalletSpendBundle(
                 coin_spends,
                 user_sk.sign(
-                    singing_info.puzzle.get_tree_hash() + plotnft.coin.name() + sim.defaults.AGG_SIG_ME_ADDITIONAL_DATA
+                    singing_info.puzzle.tree_hash + plotnft.coin.name() + sim.defaults.AGG_SIG_ME_ADDITIONAL_DATA
                 ),
             )
         )
@@ -191,15 +193,15 @@ async def test_plotnft_transitions(cost_logger: CostLogger) -> None:
 
         # # Attempt to make a message while leaving
         message_dpuz_and_solution = DelegatedPuzzleAndSolution(
-            puzzle=ACS,
-            solution=Program.to(
-                [
-                    plotnft.exit_to_waiting_room_condition().to_program(),
+            puzzle=ACSPuzzle(),
+            solution=ACSSolution(
+                conditions=[
+                    plotnft.exit_to_waiting_room_condition(),
                     SendMessage(
                         bytes32.zeros,
                         sender=MessageParticipant(parent_id_committed=bytes32.zeros),
                         receiver=MessageParticipant(parent_id_committed=bytes32.zeros),
-                    ).to_program(),
+                    ),
                 ]
             ),
         )
@@ -209,7 +211,7 @@ async def test_plotnft_transitions(cost_logger: CostLogger) -> None:
             WalletSpendBundle(
                 coin_spends,
                 user_sk.sign(
-                    singing_info.puzzle.get_tree_hash() + plotnft.coin.name() + sim.defaults.AGG_SIG_ME_ADDITIONAL_DATA
+                    singing_info.puzzle.tree_hash + plotnft.coin.name() + sim.defaults.AGG_SIG_ME_ADDITIONAL_DATA
                 ),
             )
         )
@@ -217,8 +219,8 @@ async def test_plotnft_transitions(cost_logger: CostLogger) -> None:
 
         # Leave honestly
         honest_exit_dpuz_and_solution = DelegatedPuzzleAndSolution(
-            puzzle=ACS,
-            solution=Program.to([plotnft.exit_to_waiting_room_condition().to_program()]),
+            puzzle=ACSPuzzle(),
+            solution=ACSSolution(conditions=[plotnft.exit_to_waiting_room_condition()]),
         )
         singing_info = plotnft.modify_delegated_puzzle_and_solution(honest_exit_dpuz_and_solution)
         coin_spends = plotnft.exit_to_waiting_room(honest_exit_dpuz_and_solution)
@@ -228,9 +230,7 @@ async def test_plotnft_transitions(cost_logger: CostLogger) -> None:
                 WalletSpendBundle(
                     coin_spends,
                     user_sk.sign(
-                        singing_info.puzzle.get_tree_hash()
-                        + plotnft.coin.name()
-                        + sim.defaults.AGG_SIG_ME_ADDITIONAL_DATA
+                        singing_info.puzzle.tree_hash + plotnft.coin.name() + sim.defaults.AGG_SIG_ME_ADDITIONAL_DATA
                     ),
                 ),
             )
@@ -241,23 +241,19 @@ async def test_plotnft_transitions(cost_logger: CostLogger) -> None:
 
         with pytest.raises(ValueError, match=re.escape("Already exiting to waiting room, cannot exit again")):
             plotnft.exit_to_waiting_room(
-                delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
-                    puzzle=Program.to(None), solution=NilSolution().program
-                )
+                delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(puzzle=NilPuzzle(), solution=NilSolution())
             )
 
         # Return to self-pooling
         exit_dpuz_and_solution = DelegatedPuzzleAndSolution(
-            puzzle=ACS,
-            solution=Program.to([cond.to_program() for cond in plotnft.exit_from_waiting_room_conditions()]),
+            puzzle=ACSPuzzle(),
+            solution=ACSSolution(conditions=plotnft.exit_from_waiting_room_conditions()),
         )
         singing_info = plotnft.modify_delegated_puzzle_and_solution(exit_dpuz_and_solution)
         coin_spends = plotnft.exit_waiting_room(exit_dpuz_and_solution)
         timelocked_spend = WalletSpendBundle(
             coin_spends,
-            user_sk.sign(
-                singing_info.puzzle.get_tree_hash() + plotnft.coin.name() + sim.defaults.AGG_SIG_ME_ADDITIONAL_DATA
-            ),
+            user_sk.sign(singing_info.puzzle.tree_hash + plotnft.coin.name() + sim.defaults.AGG_SIG_ME_ADDITIONAL_DATA),
         )
         result = await sim_client.push_tx(timelocked_spend)
         assert result == (MempoolInclusionStatus.PENDING, Err.ASSERT_HEIGHT_RELATIVE_FAILED)
@@ -301,7 +297,7 @@ async def test_plotnft_self_custody_claim(cost_logger: CostLogger) -> None:
             plotnft.claim_pool_rewards(rewards_to_claim=[reward], reward_delegated_puzzles_and_solutions=[])
 
         reward_dpuz_and_sol = DelegatedPuzzleAndSolution(
-            puzzle=ACS, solution=Program.to([CreateCoin(bytes32.zeros, uint64(1)).to_program()])
+            puzzle=ACSPuzzle(), solution=ACSSolution(conditions=[CreateCoin(bytes32.zeros, uint64(1))])
         )
         coin_spends = plotnft.claim_pool_rewards(
             rewards_to_claim=[reward], reward_delegated_puzzles_and_solutions=[reward_dpuz_and_sol]
@@ -342,7 +338,7 @@ async def test_plotnft_pooling_claim(
             plotnft.claim_pool_rewards(
                 rewards_to_claim=[reward],
                 reward_delegated_puzzles_and_solutions=[
-                    DelegatedPuzzleAndSolution(puzzle=Program.to(None), solution=NilSolution().program)
+                    DelegatedPuzzleAndSolution(puzzle=NilPuzzle(), solution=NilSolution())
                 ],
             )
 

--- a/chia/pools/plotnft_drivers.py
+++ b/chia/pools/plotnft_drivers.py
@@ -27,16 +27,32 @@ from chia.wallet.conditions import (
 )
 from chia.wallet.lineage_proof import LineageProof
 from chia.wallet.puzzles.custody.custody_architecture import (
-    DelegatedPuzzleAndSolution,
     MofN,
+    MofNSolution,
     ProvenSpend,
     PuzzleWithRestrictions,
+    PuzzleWithRestrictionsSolution,
 )
-from chia.wallet.puzzles.custody.member_puzzles import BLSWithTaprootMember, FixedPuzzleMember, SingletonMember
-from chia.wallet.puzzles.custody.restriction_utilities import ValidatorStackRestriction
+from chia.wallet.puzzles.custody.member_puzzles import (
+    BLSWithTaprootMember,
+    BLSWithTaprootMemberSolution,
+    FixedPuzzleMember,
+    SingletonMember,
+    SingletonMemberSolution,
+)
+from chia.wallet.puzzles.custody.restriction_utilities import (
+    ValidatorStackRestriction,
+    ValidatorStackRestrictionSolution,
+)
 from chia.wallet.puzzles.custody.restrictions import FixedCreateCoinDestinations, Heightlock, SendMessageBanned
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
-from chia.wallet.puzzles.puzzle_drivers import P2Conditions, UnknownPuzzle
+from chia.wallet.puzzles.puzzle_drivers import (
+    DelegatedPuzzleAndSolution,
+    NilSolution,
+    P2Conditions,
+    UnknownPuzzle,
+    UnknownSolution,
+)
 from chia.wallet.puzzles.singleton_top_layer_v1_1 import (
     SINGLETON_LAUNCHER,
     SINGLETON_LAUNCHER_HASH,
@@ -137,7 +153,7 @@ class PlotNFTPuzzle:
         return self.pool_config
 
     @property
-    def bls_member(self) -> BLSWithTaprootMember:
+    def bls_member(self) -> BLSWithTaprootMember[None]:
         return BLSWithTaprootMember(synthetic_key=self.user_config.synthetic_pubkey)
 
     def reward_puzhash(self) -> bytes32:
@@ -162,8 +178,8 @@ class PlotNFTPuzzle:
 
     def claim_pool_reward_dpuz_and_solution(self, reward: PoolReward) -> DelegatedPuzzleAndSolution:
         return DelegatedPuzzleAndSolution(
-            puzzle=self.claim_pool_reward_dpuz(),
-            solution=Program.to([self.inner_puzzle_hash(), reward.height, reward.coin.amount]),
+            puzzle=UnknownPuzzle(known_program=self.claim_pool_reward_dpuz()),
+            solution=UnknownSolution(Program.to([self.inner_puzzle_hash(), reward.height, reward.coin.amount])),
         )
 
     def user_restriction(self) -> ValidatorStackRestriction:
@@ -173,31 +189,33 @@ class PlotNFTPuzzle:
                 SendMessageBanned(),
             ]
             if not self.exiting
-            else [Heightlock(self.guaranteed_pool_config.heightlock), SendMessageBanned()]
+            else [Heightlock(heightlock=self.guaranteed_pool_config.heightlock), SendMessageBanned()]
         )
 
     def modify_delegated_puzzle_and_solution(
         self, delegated_puzzle_and_solution: DelegatedPuzzleAndSolution
     ) -> DelegatedPuzzleAndSolution:
         return self.user_restriction().modify_delegated_puzzle_and_solution(
-            delegated_puzzle_and_solution, [Program.to(None), Program.to(None)]
+            delegated_puzzle_and_solution, [NilSolution(), NilSolution()]
         )
 
     def user_puzzle_with_restrictions(self) -> PuzzleWithRestrictions:
         return PuzzleWithRestrictions(
             nonce=0,
             restrictions=[self.user_restriction()],
-            puzzle=self.bls_member,
+            member=self.bls_member,
+            _top_level=False,
         )
 
     def user_proven_spend(self, premodified_dpuz: Program) -> dict[bytes32, ProvenSpend]:
+        user_pwr = self.user_puzzle_with_restrictions()
         return {
-            self.user_puzzle_with_restrictions().puzzle_hash(_top_level=False): ProvenSpend(
-                puzzle_reveal=self.user_puzzle_with_restrictions().puzzle_reveal(_top_level=False),
-                solution=self.user_puzzle_with_restrictions().solve(
+            user_pwr.tree_hash: ProvenSpend(
+                puzzle_reveal=user_pwr.program,
+                solution=PuzzleWithRestrictionsSolution(
                     member_validator_solutions=[],
-                    dpuz_validator_solutions=[self.user_restriction().solve(premodified_dpuz)],
-                    member_solution=self.bls_member.solve(),
+                    dpuz_validator_solutions=[ValidatorStackRestrictionSolution.from_dpuz(premodified_dpuz)],
+                    member_solution=BLSWithTaprootMemberSolution(),
                 ),
             )
         }
@@ -209,17 +227,17 @@ class PlotNFTPuzzle:
         return PuzzleWithRestrictions(
             nonce=0,
             restrictions=[],
-            puzzle=self.fixed_puzzle_member(),
+            member=self.fixed_puzzle_member(),
+            _top_level=False,
         )
 
     def pool_proven_spend(self) -> dict[bytes32, ProvenSpend]:
+        pool_pwr = self.pool_puzzle_with_restrictions()
         return {
-            self.pool_puzzle_with_restrictions().puzzle_hash(_top_level=False): ProvenSpend(
-                puzzle_reveal=self.pool_puzzle_with_restrictions().puzzle_reveal(_top_level=False),
-                solution=self.pool_puzzle_with_restrictions().solve(
-                    member_validator_solutions=[],
-                    dpuz_validator_solutions=[],
-                    member_solution=self.fixed_puzzle_member().solve(),
+            pool_pwr.tree_hash: ProvenSpend(
+                puzzle_reveal=pool_pwr.program,
+                solution=PuzzleWithRestrictionsSolution(
+                    member_solution=NilSolution(),
                 ),
             )
         }
@@ -228,7 +246,7 @@ class PlotNFTPuzzle:
         return PuzzleWithRestrictions(
             nonce=0,
             restrictions=[],
-            puzzle=MofN(
+            member=MofN(
                 m=1,
                 members=[
                     self.user_puzzle_with_restrictions(),
@@ -241,7 +259,7 @@ class PlotNFTPuzzle:
         )
 
     def memo(self) -> Program:
-        return self.puzzle_with_restrictions().memo()
+        return self.puzzle_with_restrictions().memo
 
     def additional_memos(self) -> Program:
         if self.pooling:
@@ -257,7 +275,7 @@ class PlotNFTPuzzle:
             return Program.to([self.bls_member.synthetic_key])
 
     def inner_puzzle(self) -> Program:
-        return self.puzzle_with_restrictions().puzzle_reveal()
+        return self.puzzle_with_restrictions().program
 
     def inner_puzzle_hash(self) -> bytes32:
         return self.inner_puzzle().get_tree_hash()
@@ -268,7 +286,7 @@ class PlotNFTPuzzle:
             launcher_hash=self.singleton_struct.singleton_puzzles.singleton_launcher_hash,
             singleton_mod=self.singleton_struct.singleton_puzzles.singleton_mod,
             singleton_mod_hash=self.singleton_struct.singleton_puzzles.singleton_mod_hash,
-            inner_puz=self.puzzle_with_restrictions().puzzle_reveal(),
+            inner_puz=self.puzzle_with_restrictions().program,
         )
 
     def puzzle_hash(self, nonce: int) -> bytes32:
@@ -276,27 +294,26 @@ class PlotNFTPuzzle:
 
     def forward_pool_reward_inner_solution(self, reward: PoolReward) -> Program:
         custody_pwr = self.puzzle_with_restrictions()
-        assert isinstance(custody_pwr.puzzle, MofN)
-        return custody_pwr.solve(
-            member_validator_solutions=[],
-            dpuz_validator_solutions=[],
-            member_solution=custody_pwr.puzzle.solve(self.pool_proven_spend()),
+        assert isinstance(custody_pwr.member, MofN)
+        return PuzzleWithRestrictionsSolution(
+            member_solution=MofNSolution(puzzle=custody_pwr.member, spends_to_prove=self.pool_proven_spend()),
             delegated_puzzle_and_solution=self.claim_pool_reward_dpuz_and_solution(reward),
-        )
+        ).program
 
     def exit_to_from_waiting_room_inner_solution(
         self, delegated_puzzle_and_solution: DelegatedPuzzleAndSolution
     ) -> Program:
         custody_pwr = self.puzzle_with_restrictions()
-        assert isinstance(custody_pwr.puzzle, MofN)
-        return custody_pwr.solve(
-            member_validator_solutions=[],
-            dpuz_validator_solutions=[],
-            member_solution=custody_pwr.puzzle.solve(self.user_proven_spend(delegated_puzzle_and_solution.puzzle)),
-            delegated_puzzle_and_solution=self.user_restriction().modify_delegated_puzzle_and_solution(
-                delegated_puzzle_and_solution, [Program.to([]), Program.to([])]
+        assert isinstance(custody_pwr.member, MofN)
+        return PuzzleWithRestrictionsSolution(
+            member_solution=MofNSolution(
+                puzzle=custody_pwr.member,
+                spends_to_prove=self.user_proven_spend(delegated_puzzle_and_solution.puzzle.program),
             ),
-        )
+            delegated_puzzle_and_solution=self.user_restriction().modify_delegated_puzzle_and_solution(
+                delegated_puzzle_and_solution, [NilSolution(), NilSolution()]
+            ),
+        ).program
 
     def exit_to_waiting_room_condition(self) -> CreateCoin:
         return CreateCoin(
@@ -356,7 +373,7 @@ class PlotNFT(PlotNFTPuzzle):
                 CreateCoin(
                     plotnft_puzzle.inner_puzzle_hash(),
                     uint64(1),
-                    memo_blob=Program.to((hint, plotnft_puzzle.puzzle_with_restrictions().memo())),
+                    memo_blob=Program.to((hint, plotnft_puzzle.puzzle_with_restrictions().memo)),
                 ),
                 CreateCoinAnnouncement(msg=b""),
                 *([] if remark is None else [remark]),
@@ -481,7 +498,7 @@ class PlotNFT(PlotNFTPuzzle):
             if unknown_inner_puzzle.additional_memos is None:
                 raise GetNextPlotNFTError("Invalid memoization of PlotNFT")
             pubkey = G1Element.from_bytes(unknown_inner_puzzle.additional_memos.at("f").as_atom())
-            if isinstance(unknown_inner_puzzle.puzzle, MofN):
+            if isinstance(unknown_inner_puzzle.member, MofN):
                 pool_puzzle_hash = bytes32(unknown_inner_puzzle.additional_memos.at("rf").as_atom())
                 timelock = uint32(unknown_inner_puzzle.additional_memos.at("rrf").as_int())
                 pool_memoization = unknown_inner_puzzle.additional_memos.at("rrrf")
@@ -490,8 +507,8 @@ class PlotNFT(PlotNFTPuzzle):
                 )
                 exiting = (
                     ValidatorStackRestriction(
-                        required_wrappers=[Heightlock(timelock), SendMessageBanned()]
-                    ).puzzle_hash(nonce=0)
+                        required_wrappers=[Heightlock(heightlock=timelock), SendMessageBanned()]
+                    ).tree_hash
                     in unknown_inner_puzzle.unknown_puzzles
                 )
             else:
@@ -552,13 +569,13 @@ class PlotNFT(PlotNFTPuzzle):
             make_spend(
                 coin=reward.coin,
                 puzzle_reveal=reward.puzzle(),
-                solution=reward.solve(
-                    self.inner_puzzle_hash(),
+                solution=PuzzleWithRestrictionsSolution(
+                    member_solution=SingletonMemberSolution(singleton_inner_puzzle_hash=self.inner_puzzle_hash()),
                     delegated_puzzle_and_solution=DelegatedPuzzleAndSolution(
-                        puzzle=self.forward_pool_reward_dpuz(),
-                        solution=Program.to([reward.coin.amount]),
+                        puzzle=UnknownPuzzle(known_program=self.forward_pool_reward_dpuz()),
+                        solution=UnknownSolution(program=Program.to([reward.coin.amount])),
                     ),
-                ),
+                ).program,
             ),
         ]
 
@@ -603,33 +620,31 @@ class PlotNFT(PlotNFTPuzzle):
                     ),
                     *(
                         SendMessage(
-                            msg=dpuz_and_sol.puzzle.get_tree_hash(),
+                            msg=dpuz_and_sol.puzzle.tree_hash,
                             sender=MessageParticipant(puzzle_hash_committed=self.puzzle_hash(nonce=0)),
                             receiver=MessageParticipant(coin_id_committed=reward.coin.name()),
                         )
                         for reward, dpuz_and_sol in zip(rewards_to_claim, reward_delegated_puzzles_and_solutions)
                     ),
                 ]
-            ).program,
-            solution=Program.to([]),
+            ),
+            solution=NilSolution(),
         )
         return [
             self.singleton_action_spend(
-                inner_solution=self.puzzle_with_restrictions().solve(
-                    member_validator_solutions=[],
-                    dpuz_validator_solutions=[],
-                    member_solution=self.bls_member.solve(),
+                inner_solution=PuzzleWithRestrictionsSolution(
+                    member_solution=BLSWithTaprootMemberSolution(),
                     delegated_puzzle_and_solution=dpuz_and_solution,
-                )
+                ).program
             ),
             *(
                 make_spend(
                     coin=reward.coin,
                     puzzle_reveal=reward.puzzle(),
-                    solution=reward.solve(
-                        self.inner_puzzle_hash(),
+                    solution=PuzzleWithRestrictionsSolution(
+                        member_solution=SingletonMemberSolution(singleton_inner_puzzle_hash=self.inner_puzzle_hash()),
                         delegated_puzzle_and_solution=dpuz_and_sol,
-                    ),
+                    ).program,
                 )
                 for reward, dpuz_and_sol in zip(rewards_to_claim, reward_delegated_puzzles_and_solutions)
             ),
@@ -656,17 +671,15 @@ class PlotNFT(PlotNFTPuzzle):
                     ),
                     *(cond for cond in extra_conditions),
                 ]
-            ).program,
-            solution=Program.to([]),
+            ),
+            solution=NilSolution(),
         )
         return [
             self.singleton_action_spend(
-                inner_solution=self.puzzle_with_restrictions().solve(
-                    member_validator_solutions=[],
-                    dpuz_validator_solutions=[],
-                    member_solution=self.bls_member.solve(),
+                inner_solution=PuzzleWithRestrictionsSolution(
+                    member_solution=BLSWithTaprootMemberSolution(),
                     delegated_puzzle_and_solution=dpuz_and_solution,
-                )
+                ).program
             )
         ]
 
@@ -685,29 +698,24 @@ class PlotNFT(PlotNFTPuzzle):
         )
 
         dpuz_and_solution = DelegatedPuzzleAndSolution(
-            puzzle=Program.to(
-                (
-                    1,
-                    [
-                        CreateCoin(
-                            plotnft_puzzle.inner_puzzle_hash(),
-                            amount=self.coin.amount,
-                            memo_blob=Program.to((hint, plotnft_puzzle.memo())),
-                        ).to_program(),
-                        *(cond.to_program() for cond in extra_conditions),
-                    ],
-                )
+            puzzle=P2Conditions(
+                conditions=[
+                    CreateCoin(
+                        plotnft_puzzle.inner_puzzle_hash(),
+                        amount=self.coin.amount,
+                        memo_blob=Program.to((hint, plotnft_puzzle.memo())),
+                    ),
+                    *extra_conditions,
+                ],
             ),
-            solution=Program.to([]),
+            solution=NilSolution(),
         )
         return [
             self.singleton_action_spend(
-                inner_solution=self.puzzle_with_restrictions().solve(
-                    member_validator_solutions=[],
-                    dpuz_validator_solutions=[],
-                    member_solution=self.bls_member.solve(),
+                inner_solution=PuzzleWithRestrictionsSolution(
+                    member_solution=BLSWithTaprootMemberSolution(),
                     delegated_puzzle_and_solution=dpuz_and_solution,
-                )
+                ).program
             )
         ]
 
@@ -716,25 +724,20 @@ class PlotNFT(PlotNFTPuzzle):
             raise ValueError("Cannot melt a pooling PlotNFT")
 
         dpuz_and_solution = DelegatedPuzzleAndSolution(
-            puzzle=Program.to(
-                (
-                    1,
-                    [
-                        UnknownCondition(opcode=Program.to(51), args=[Program.to(None), Program.to(-113)]).to_program(),
-                        *(cond.to_program() for cond in extra_conditions),
-                    ],
-                )
+            puzzle=P2Conditions(
+                conditions=[
+                    UnknownCondition(opcode=Program.to(51), args=[Program.to(None), Program.to(-113)]),
+                    *extra_conditions,
+                ],
             ),
-            solution=Program.to([]),
+            solution=NilSolution(),
         )
         return [
             self.singleton_action_spend(
-                inner_solution=self.puzzle_with_restrictions().solve(
-                    member_validator_solutions=[],
-                    dpuz_validator_solutions=[],
-                    member_solution=self.bls_member.solve(),
+                inner_solution=PuzzleWithRestrictionsSolution(
+                    member_solution=BLSWithTaprootMemberSolution(),
                     delegated_puzzle_and_solution=dpuz_and_solution,
-                )
+                ).program
             )
         ]
 
@@ -748,23 +751,13 @@ class RewardPuzzle:
         return SingletonMember(singleton_id=self.singleton_id)
 
     def puzzle_with_restrictions(self) -> PuzzleWithRestrictions:
-        return PuzzleWithRestrictions(nonce=0, restrictions=[], puzzle=self.singleton_member)
+        return PuzzleWithRestrictions(nonce=0, restrictions=[], member=self.singleton_member)
 
     def puzzle(self) -> Program:
-        return self.puzzle_with_restrictions().puzzle_reveal()
+        return self.puzzle_with_restrictions().program
 
     def puzzle_hash(self) -> bytes32:
         return self.puzzle().get_tree_hash()
-
-    def solve(
-        self, singleton_inner_puzzle_hash: bytes32, delegated_puzzle_and_solution: DelegatedPuzzleAndSolution
-    ) -> Program:
-        return self.puzzle_with_restrictions().solve(
-            [],
-            [],
-            self.singleton_member.solve(singleton_inner_puzzle_hash),
-            delegated_puzzle_and_solution,
-        )
 
 
 @dataclass(kw_only=True, frozen=True)

--- a/chia/wallet/plotnft_wallet/plotnft_wallet.py
+++ b/chia/wallet/plotnft_wallet/plotnft_wallet.py
@@ -25,9 +25,8 @@ from chia.server.ws_connection import WSChiaConnection
 from chia.types.blockchain_format.program import Program
 from chia.wallet.conditions import AssertCoinAnnouncement, Condition, CreateCoin, CreateCoinAnnouncement, Remark
 from chia.wallet.derive_keys import master_pk_to_wallet_pk_unhardened
-from chia.wallet.puzzles.custody.custody_architecture import DelegatedPuzzleAndSolution
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import puzzle_hash_for_synthetic_public_key
-from chia.wallet.puzzles.puzzle_drivers import NilSolution, P2Conditions, UnknownPuzzle
+from chia.wallet.puzzles.puzzle_drivers import DelegatedPuzzleAndSolution, NilSolution, P2Conditions, UnknownPuzzle
 from chia.wallet.util.wallet_types import WalletIdentifier, WalletType
 from chia.wallet.wallet import Wallet
 from chia.wallet.wallet_action_scope import PlotNFTTargetStateInfo, WalletActionScope
@@ -165,19 +164,21 @@ class PlotNFT2Wallet:
             rewards_to_claim=rewards_to_claim,
             reward_delegated_puzzles_and_solutions=[
                 DelegatedPuzzleAndSolution(
-                    puzzle=self.xch_wallet.make_solution(
-                        primaries=[
-                            CreateCoin(
-                                puzzle_hash=self.rewards_claim_puzhash,
-                                amount=uint64(total_reward_amount - fee),
-                            ),
-                        ],
-                        fee=fee,
-                        conditions=(*extra_conditions, CreateCoinAnnouncement(b""))
-                        if len(rewards_to_claim) > 1
-                        else extra_conditions,
-                    ).at("rf"),  # strips away to just the delegated puzzle (bit of a hack)
-                    solution=NilSolution().program,
+                    puzzle=UnknownPuzzle(
+                        known_program=self.xch_wallet.make_solution(
+                            primaries=[
+                                CreateCoin(
+                                    puzzle_hash=self.rewards_claim_puzhash,
+                                    amount=uint64(total_reward_amount - fee),
+                                ),
+                            ],
+                            fee=fee,
+                            conditions=(*extra_conditions, CreateCoinAnnouncement(b""))
+                            if len(rewards_to_claim) > 1
+                            else extra_conditions,
+                        ).at("rf")  # strips away to just the delegated puzzle (bit of a hack)
+                    ),
+                    solution=NilSolution(),
                 )
                 if i == 0
                 else DelegatedPuzzleAndSolution(
@@ -185,8 +186,8 @@ class PlotNFT2Wallet:
                         conditions=[
                             AssertCoinAnnouncement(asserted_id=rewards_to_claim[0].coin.name(), asserted_msg=b"")
                         ],
-                    ).program,
-                    solution=NilSolution().program,
+                    ),
+                    solution=NilSolution(),
                 )
                 for i, reward in enumerate(rewards_to_claim)
             ],
@@ -305,11 +306,13 @@ class PlotNFT2Wallet:
         fee_hook = CreateCoinAnnouncement(msg=b"", coin_id=plotnft.coin.name())
         exit_create_coin = plotnft.exit_to_waiting_room_condition()
         exit_to_waiting_room_dpuz_and_sol = DelegatedPuzzleAndSolution(
-            puzzle=self.xch_wallet.make_solution(
-                primaries=[exit_create_coin],
-                conditions=(*extra_conditions, fee_hook),
-            ).at("rf"),  # strips away to just the delegated puzzle (bit of a hack)
-            solution=NilSolution().program,
+            puzzle=UnknownPuzzle(
+                known_program=self.xch_wallet.make_solution(
+                    primaries=[exit_create_coin],
+                    conditions=(*extra_conditions, fee_hook),
+                ).at("rf")  # strips away to just the delegated puzzle (bit of a hack)
+            ),
+            solution=NilSolution(),
         )
         coin_spends = plotnft.exit_to_waiting_room(exit_to_waiting_room_dpuz_and_sol)
         if fee > 0:
@@ -361,11 +364,13 @@ class PlotNFT2Wallet:
         fee_hook = CreateCoinAnnouncement(msg=b"", coin_id=plotnft.coin.name())
         heightlock, exit_create_coin = plotnft.exit_from_waiting_room_conditions()
         exit_to_waiting_room_dpuz_and_sol = DelegatedPuzzleAndSolution(
-            puzzle=self.xch_wallet.make_solution(
-                primaries=[exit_create_coin],
-                conditions=(fee_hook, heightlock, *extra_conditions),
-            ).at("rf"),  # strips away to just the delegated puzzle (bit of a hack)
-            solution=NilSolution().program,
+            puzzle=UnknownPuzzle(
+                known_program=self.xch_wallet.make_solution(
+                    primaries=[exit_create_coin],
+                    conditions=(fee_hook, heightlock, *extra_conditions),
+                ).at("rf")  # strips away to just the delegated puzzle (bit of a hack)
+            ),
+            solution=NilSolution(),
         )
         coin_spends = plotnft.exit_waiting_room(exit_to_waiting_room_dpuz_and_sol)
         next_plotnft = PlotNFT.get_next_from_coin_spend(

--- a/chia/wallet/puzzles/custody/custody_architecture.py
+++ b/chia/wallet/puzzles/custody/custody_architecture.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
+from functools import cached_property
 from typing import ClassVar, Protocol, TypeVar
 
 from chia_puzzles_py import programs as puzzle_mods
 from chia_rs.sized_bytes import bytes32
-from typing_extensions import runtime_checkable
+from typing_extensions import Self, runtime_checkable
 
 from chia.types.blockchain_format.program import Program
+from chia.wallet.puzzles.puzzle_drivers import (
+    DelegatedPuzzleAndSolution,
+    Puzzle,
+    PuzzleBase,
+    Solution,
+    UnknownPuzzle,
+    UnknownSolution,
+)
 from chia.wallet.util.merkle_tree import MerkleTree, hash_a_pair, hash_an_atom
 
 MofN_MOD = Program.from_bytes(puzzle_mods.M_OF_N)
@@ -25,12 +34,22 @@ INDEX_WRAPPER_HASH = INDEX_WRAPPER.get_tree_hash()
 
 
 # General (inner) puzzle driver spec
-class MIPSComponent(Protocol):
-    def memo(self, nonce: int) -> Program: ...
+class MIPSComponent(Puzzle, Protocol):
+    @property
+    def nonce(self) -> int | None: ...
 
-    def puzzle(self, nonce: int) -> Program: ...
+    @property
+    def memo(self) -> Program: ...
 
-    def puzzle_hash(self, nonce: int) -> bytes32: ...
+    def with_nonce(self, nonce: int | None) -> Self: ...
+
+
+@dataclass(frozen=True)
+class MIPSComponentBase(PuzzleBase):
+    nonce: int | None = None
+
+    def with_nonce(self, nonce: int | None) -> Self:
+        return replace(self, nonce=nonce)
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -50,18 +69,24 @@ class MemberHint:
         )
 
 
-@dataclass(frozen=True)
-class UnknownMember:
+@dataclass(kw_only=True, frozen=True)
+class UnknownMember(MIPSComponentBase):
     puzzle_hint: MemberHint
 
-    def memo(self, nonce: int) -> Program:
+    @property
+    def memo(self) -> Program:
         return self.puzzle_hint.memo
 
-    def puzzle(self, nonce: int) -> Program:
+    @property
+    def program(self) -> Program:
         raise NotImplementedError("An unknown puzzle type cannot generate a puzzle reveal")  # pragma: no cover
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
+    @property
+    def tree_hash_optimized(self) -> bytes32:
         return self.puzzle_hint.puzhash
+
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle) -> Puzzle | None: ...
 
 
 # A spec for "restrictions" on specific inner puzzles
@@ -95,29 +120,36 @@ class RestrictionHint:
         )
 
 
-@dataclass(frozen=True)
-class UnknownRestriction:
+@dataclass(kw_only=True, frozen=True)
+class UnknownRestriction(MIPSComponentBase):
     restriction_hint: RestrictionHint
 
     @property
     def member_not_dpuz(self) -> bool:
         return self.restriction_hint.member_not_dpuz
 
-    def memo(self, nonce: int) -> Program:
+    @property
+    def memo(self) -> Program:
         return self.restriction_hint.memo
 
-    def puzzle(self, nonce: int) -> Program:
+    @property
+    def program(self) -> Program:
         raise NotImplementedError("An unknown restriction type cannot generate a puzzle reveal")  # pragma: no cover
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
+    @property
+    def tree_hash_optimized(self) -> bytes32:
         return self.restriction_hint.puzhash
+
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle) -> Puzzle | None:
+        raise NotImplementedError("An unknown restriction type cannot match anything")  # pragma: no cover
 
 
 # MofN puzzle drivers which are a fundamental component of the architecture
 @dataclass(kw_only=True, frozen=True)
 class ProvenSpend:
     puzzle_reveal: Program
-    solution: Program
+    solution: Solution
 
 
 class MofNMerkleTree(MerkleTree):  # Special subclass that can generate proofs for m of n puzzles in the tree
@@ -126,7 +158,7 @@ class MofNMerkleTree(MerkleTree):  # Special subclass that can generate proofs f
             if puzzle_hashes[0] in spends_to_prove:
                 spend_to_prove = spends_to_prove[puzzle_hashes[0]]
                 # If it's one that we've been requested to prove, the format is (() puzzle_reveal . solution)
-                return Program.to((None, (spend_to_prove.puzzle_reveal, spend_to_prove.solution)))
+                return Program.to((None, (spend_to_prove.puzzle_reveal, spend_to_prove.solution.program)))
             else:
                 return Program.to(hash_an_atom(puzzle_hashes[0]))
         else:
@@ -162,7 +194,7 @@ class MofNHint:
 
 
 @dataclass(kw_only=True, frozen=True)
-class MofN:  # Technically matches Puzzle protocol but is a bespoke part of the architecture
+class MofN(MIPSComponentBase):
     m: int
     members: list[PuzzleWithRestrictions]
 
@@ -175,84 +207,138 @@ class MofN:  # Technically matches Puzzle protocol but is a bespoke part of the 
             raise ValueError("Duplicate nodes not currently supported by MofN drivers")
 
     @property
+    def members_non_top_level(self) -> list[PuzzleWithRestrictions]:
+        return [replace(member, _top_level=False) for member in self.members]
+
+    @property
     def n(self) -> int:
         return len(self.members)
 
     @property
     def _merkle_tree(self) -> MerkleTree:
-        nodes = [member.puzzle_hash(_top_level=False) for member in self.members]
+        nodes = [member.tree_hash for member in self.members_non_top_level]
         if self.m > 1:
             return MofNMerkleTree(nodes)
         else:
             return MerkleTree(nodes)
 
-    def solve(self, spends_to_prove: dict[bytes32, ProvenSpend]) -> Program:
-        assert len(spends_to_prove) == self.m, "Must prove as many spends as the M value"
-        if self.m == self.n:
-            return Program.to([[spends_to_prove[node].solution for node in self._merkle_tree.nodes]])
-        elif self.m > 1:
-            return Program.to([self._merkle_tree.generate_m_of_n_proof(spends_to_prove)])  # type: ignore[attr-defined]
-        else:
-            only_key = next(iter(spends_to_prove.keys()))
-            proven_spend = spends_to_prove[only_key]
-            proof = self._merkle_tree.generate_proof(only_key)
-            return Program.to([(proof[0], proof[1][0]), proven_spend.puzzle_reveal, proven_spend.solution])
-
-    def memo(self, nonce: int) -> Program:  # pragma: no cover
+    @property
+    def memo(self) -> Program:  # pragma: no cover
         raise NotImplementedError("PuzzleWithRestrictions handles MofN memos, this method should not be called")
 
-    def puzzle(self, nonce: int) -> Program:
+    @property
+    def program(self) -> Program:
         if self.m == self.n:
-            return NofN_MOD.curry([member.puzzle_reveal(_top_level=False) for member in self.members])
+            return NofN_MOD.curry([member.program for member in self.members_non_top_level])
         elif self.m > 1:
             return MofN_MOD.curry(self.m, self._merkle_tree.calculate_root())
         else:
             return OneOfN_MOD.curry(self._merkle_tree.calculate_root())
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
+    @property
+    def tree_hash_optimized(self) -> bytes32:
         if self.m == self.n:
-            member_hashes = [member.puzzle_hash(_top_level=False) for member in self.members]
+            member_hashes = [member.tree_hash for member in self.members_non_top_level]
             return NofN_MOD.curry(member_hashes).get_tree_hash_precalc(*member_hashes)
         else:
-            return self.puzzle(nonce).get_tree_hash()
+            return self.program.get_tree_hash()
+
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle) -> MofN | None:
+        if unknown_puzzle.mod not in [MofN_MOD, NofN_MOD, OneOfN_MOD] or unknown_puzzle.curried_args is None:  # ruff: ignore[literal-membership]
+            return None
+
+        if unknown_puzzle.mod == NofN_MOD:
+            list_of_members = [_ for _ in unknown_puzzle.curried_args]
+            pwr_matches = [
+                PuzzleWithRestrictions.match(unknown_puzzle=UnknownPuzzle(known_program=member))
+                for member in list_of_members
+            ]
+            if None in pwr_matches:
+                return None
+            # come on mypy, be better
+            return MofN(m=len(list_of_members), members=pwr_matches)  # type: ignore[arg-type]
+        elif unknown_puzzle.mod == MofN_MOD:
+            # TODO: We need to figure out a way to implement arbitrary context as part of the matching protocol
+            (m, _) = unknown_puzzle.curried_args
+            return MofN(m=m.as_int(), members=[])
+        else:
+            # TODO: We need to figure out a way to implement arbitrary context as part of the matching protocol
+            return MofN(m=1, members=[])
 
 
-# A convenience object for hinting the two solution values that must always exist
 @dataclass(kw_only=True, frozen=True)
-class DelegatedPuzzleAndSolution:
-    puzzle: Program
-    solution: Program
+class MofNSolution:
+    puzzle: MofN
+    spends_to_prove: Mapping[bytes32, ProvenSpend]
+
+    def __post_init__(self) -> None:
+        if len(self.spends_to_prove) != self.puzzle.m:
+            raise ValueError("Must prove as many spends as the M value")
+
+    @property
+    def program(self) -> Program:
+        if self.puzzle.m == self.puzzle.n:
+            return Program.to(
+                [[self.spends_to_prove[node].solution.program for node in self.puzzle._merkle_tree.nodes]]
+            )
+        elif self.puzzle.m > 1:
+            return Program.to(
+                [self.puzzle._merkle_tree.generate_m_of_n_proof(self.spends_to_prove)]  # type: ignore[attr-defined]
+            )
+        else:
+            only_key = next(iter(self.spends_to_prove.keys()))
+            proven_spend = self.spends_to_prove[only_key]
+            proof = self.puzzle._merkle_tree.generate_proof(only_key)
+            return Program.to([(proof[0], proof[1][0]), proven_spend.puzzle_reveal, proven_spend.solution.program])
+
+    @classmethod
+    def match(cls, *, unknown_solution: UnknownSolution) -> MofNSolution | None: ...
 
 
 # The top-level object inside every "outer" puzzle
 @dataclass(kw_only=True, frozen=True)
-class PuzzleWithRestrictions:
+class PuzzleWithRestrictions(PuzzleBase):
     nonce: int  # Arbitrary nonce to make otherwise identical custody arrangements have different puzzle hashes
     restrictions: list[Restriction[MemberOrDPuz]]
-    puzzle: MIPSComponent
+    member: MIPSComponent
     additional_memos: Program | None = None
     spec_namespace: ClassVar[str] = "CHIP-0043"
+    _top_level: bool = True
 
+    def __post_init__(self) -> None:
+        if self.member.nonce is not None or not all(restriction.nonce is None for restriction in self.restrictions):
+            raise ValueError("Do not set nonces on members or restrictions, only on PuzzleWithRestrictions")
+
+    @cached_property
+    def restrictions_with_nonces(self) -> list[Restriction[MemberOrDPuz]]:
+        return [restriction.with_nonce(self.nonce) for restriction in self.restrictions]
+
+    @cached_property
+    def member_with_nonce(self) -> MIPSComponent:
+        return self.member.with_nonce(self.nonce)
+
+    @property
     def memo(self) -> Program:
         restriction_hints: list[RestrictionHint] = [
             RestrictionHint(
                 member_not_dpuz=restriction.member_not_dpuz,
-                puzhash=restriction.puzzle_hash(self.nonce),
-                memo=restriction.memo(self.nonce),
+                puzhash=restriction.tree_hash,
+                memo=restriction.memo,
             )
-            for restriction in self.restrictions
+            for restriction in self.restrictions_with_nonces
         ]
 
         puzzle_hint: MofNHint | MemberHint
-        if isinstance(self.puzzle, MofN):
+        if isinstance(self.member_with_nonce, MofN):
             puzzle_hint = MofNHint(
-                m=self.puzzle.m,
-                member_memos=[member.memo() for member in self.puzzle.members],
+                m=self.member_with_nonce.m,
+                member_memos=[member.memo for member in self.member_with_nonce.members],
             )
         else:
             puzzle_hint = MemberHint(
-                puzhash=self.puzzle.puzzle_hash(self.nonce),
-                memo=self.puzzle.memo(self.nonce),
+                puzhash=self.member_with_nonce.tree_hash,
+                memo=self.member_with_nonce.memo,
             )
 
         return Program.to(
@@ -261,7 +347,7 @@ class PuzzleWithRestrictions:
                 [
                     self.nonce,
                     [hint.to_program() for hint in restriction_hints],
-                    1 if isinstance(self.puzzle, MofN) else 0,
+                    1 if isinstance(self.member_with_nonce, MofN) else 0,
                     puzzle_hint.to_program(),
                 ]
                 + ([self.additional_memos] if self.additional_memos is not None else []),
@@ -286,12 +372,12 @@ class PuzzleWithRestrictions:
             )
         else:
             puzzle_hint = MemberHint.from_program(puzzle_hint_prog)
-            puzzle = UnknownMember(puzzle_hint)
+            puzzle = UnknownMember(puzzle_hint=puzzle_hint)
 
         return PuzzleWithRestrictions(
             nonce=nonce.as_int(),
-            restrictions=[UnknownRestriction(hint) for hint in restriction_hints],
-            puzzle=puzzle,
+            restrictions=[UnknownRestriction(restriction_hint=hint) for hint in restriction_hints],
+            member=puzzle,
             additional_memos=additional_memos,
         )
 
@@ -302,12 +388,12 @@ class PuzzleWithRestrictions:
         }
 
         unknown_puzzles: Mapping[bytes32, UnknownMember | UnknownRestriction]
-        if isinstance(self.puzzle, UnknownMember):
-            unknown_puzzles = {self.puzzle.puzzle_hint.puzhash: self.puzzle}
-        elif isinstance(self.puzzle, MofN):
+        if isinstance(self.member, UnknownMember):
+            unknown_puzzles = {self.member.puzzle_hint.puzhash: self.member}
+        elif isinstance(self.member, MofN):
             unknown_puzzles = {
                 uph: up
-                for puz_w_restriction in self.puzzle.members
+                for puz_w_restriction in self.member.members
                 for uph, up in puz_w_restriction.unknown_puzzles.items()
             }
         else:
@@ -329,62 +415,53 @@ class PuzzleWithRestrictions:
                 new_restrictions.append(restriction)
 
         new_puzzle: MIPSComponent
-        if (
-            isinstance(self.puzzle, UnknownMember) and self.puzzle.puzzle_hint.puzhash in puzzle_dict  # pylint: disable=no-member
-        ):
-            new_puzzle = puzzle_dict[self.puzzle.puzzle_hint.puzhash]  # pylint: disable=no-member
-        elif isinstance(self.puzzle, MofN):
+        if isinstance(self.member, UnknownMember) and self.member.puzzle_hint.puzhash in puzzle_dict:
+            new_puzzle = puzzle_dict[self.member.puzzle_hint.puzhash]
+        elif isinstance(self.member, MofN):
             new_puzzle = replace(
-                self.puzzle,
-                members=[
-                    puz.fill_in_unknown_puzzles(puzzle_dict)
-                    for puz in self.puzzle.members  # pylint: disable=no-member
-                ],
+                self.member,
+                members=[puz.fill_in_unknown_puzzles(puzzle_dict) for puz in self.member.members],
             )
         else:
-            new_puzzle = self.puzzle
+            new_puzzle = self.member
 
         return PuzzleWithRestrictions(
             nonce=self.nonce,
             restrictions=new_restrictions,
-            puzzle=new_puzzle,
+            member=new_puzzle,
             additional_memos=self.additional_memos,
         )
 
-    def puzzle_reveal(self, _top_level: bool = True) -> Program:
-        inner_puzzle = self.puzzle.puzzle(self.nonce)  # pylint: disable=assignment-from-no-return
+    @property
+    def program(self) -> Program:
+        inner_puzzle = self.member_with_nonce.program
 
         if len(self.restrictions) > 0:  # We optimize away the restriction layer when no restrictions are present
             restricted_inner_puzzle = RESTRICTION_MOD.curry(
-                [restriction.puzzle(self.nonce) for restriction in self.restrictions if restriction.member_not_dpuz],
-                [
-                    restriction.puzzle(self.nonce)
-                    for restriction in self.restrictions
-                    if not restriction.member_not_dpuz
-                ],
+                [restriction.program for restriction in self.restrictions if restriction.member_not_dpuz],
+                [restriction.program for restriction in self.restrictions if not restriction.member_not_dpuz],
                 inner_puzzle,
             )
         else:
             restricted_inner_puzzle = inner_puzzle
 
-        if _top_level:
+        if self._top_level:
             fed_inner_puzzle = DELEGATED_PUZZLE_FEEDER.curry(restricted_inner_puzzle)
         else:
             fed_inner_puzzle = restricted_inner_puzzle
 
         return INDEX_WRAPPER.curry(self.nonce, fed_inner_puzzle)
 
-    def puzzle_hash(self, _top_level: bool = True) -> bytes32:
-        inner_puzzle_hash = self.puzzle.puzzle_hash(self.nonce)  # pylint: disable=assignment-from-no-return
+    @property
+    def tree_hash_optimized(self) -> bytes32:
+        inner_puzzle_hash = self.member_with_nonce.tree_hash
 
         if len(self.restrictions) > 0:  # We optimize away the restriction layer when no restrictions are present
             member_validator_hashes = [
-                restriction.puzzle_hash(self.nonce) for restriction in self.restrictions if restriction.member_not_dpuz
+                restriction.tree_hash for restriction in self.restrictions if restriction.member_not_dpuz
             ]
             dpuz_validator_hashes = [
-                restriction.puzzle_hash(self.nonce)
-                for restriction in self.restrictions
-                if not restriction.member_not_dpuz
+                restriction.tree_hash for restriction in self.restrictions if not restriction.member_not_dpuz
             ]
             restricted_inner_puzzle_hash = (
                 Program.to(RESTRICTION_MOD_HASH)
@@ -400,7 +477,7 @@ class PuzzleWithRestrictions:
         else:
             restricted_inner_puzzle_hash = inner_puzzle_hash
 
-        if _top_level:
+        if self._top_level:
             fed_inner_puzzle_hash = (
                 Program.to(DELEGATED_PUZZLE_FEEDER_HASH)
                 .curry(restricted_inner_puzzle_hash)
@@ -411,21 +488,77 @@ class PuzzleWithRestrictions:
 
         return INDEX_WRAPPER.curry(self.nonce, fed_inner_puzzle_hash).get_tree_hash_precalc(fed_inner_puzzle_hash)
 
-    def solve(
-        self,
-        member_validator_solutions: list[Program],  # solution for the restriction puzzle
-        dpuz_validator_solutions: list[Program],
-        member_solution: Program,
-        delegated_puzzle_and_solution: DelegatedPuzzleAndSolution | None = None,
-    ) -> Program:
-        if len(self.restrictions) > 0:  # We optimize away the restriction layer when no restrictions are present
-            solution = Program.to([member_validator_solutions, dpuz_validator_solutions, member_solution])
-        else:
-            solution = member_solution
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle, solution: object | None = None) -> PuzzleWithRestrictions | None:
+        if unknown_puzzle.mod != INDEX_WRAPPER or unknown_puzzle.curried_args is None:
+            return None
 
-        if delegated_puzzle_and_solution is not None:
+        nonce, fed_inner_puzzle_prog = unknown_puzzle.curried_args
+        fed_inner_puzzle = UnknownPuzzle(known_program=fed_inner_puzzle_prog)
+        if fed_inner_puzzle != DELEGATED_PUZZLE_FEEDER or fed_inner_puzzle.curried_args is None:
+            return None
+
+        (potentially_restricted_puzzle_prog,) = fed_inner_puzzle.curried_args
+        potentially_restricted_puzzle = UnknownPuzzle(known_program=potentially_restricted_puzzle_prog)
+        if potentially_restricted_puzzle == RESTRICTION_MOD:
+            if potentially_restricted_puzzle.curried_args is None:
+                return None
+            member_restrictions, dpuz_restrictions, inner_puzzle_prog = potentially_restricted_puzzle.curried_args
+            restrictions = [
+                *(
+                    UnknownRestriction(
+                        restriction_hint=RestrictionHint(
+                            member_not_dpuz=member_not_dpuz,
+                            puzhash=restriction_prog.get_tree_hash(),
+                            memo=Program.to(None),
+                        )
+                    )
+                    for restriction_set, member_not_dpuz in zip((member_restrictions, dpuz_restrictions), (True, False))
+                    for restriction_prog in restriction_set.as_iter()
+                ),
+            ]
+            inner_puzzle = UnknownPuzzle(known_program=inner_puzzle_prog)
+        else:
+            restrictions = []
+            inner_puzzle = potentially_restricted_puzzle
+
+        return cls(nonce=nonce, restrictions=restrictions, member=inner_puzzle)  # type: ignore[arg-type]
+
+
+@dataclass(kw_only=True, frozen=True)
+class PuzzleWithRestrictionsSolution:
+    member_solution: Solution
+    member_validator_solutions: list[Solution] = field(default_factory=list)
+    dpuz_validator_solutions: list[Solution] = field(default_factory=list)
+    delegated_puzzle_and_solution: DelegatedPuzzleAndSolution | None = None
+
+    @property
+    def program(self) -> Program:
+        if self.member_validator_solutions != [] or self.dpuz_validator_solutions != []:
             solution = Program.to(
-                [delegated_puzzle_and_solution.puzzle, delegated_puzzle_and_solution.solution, *solution.as_iter()]
+                [
+                    [validator_solution.program for validator_solution in self.member_validator_solutions],
+                    [validator_solution.program for validator_solution in self.dpuz_validator_solutions],
+                    self.member_solution.program,
+                ]
+            )
+        else:
+            solution = self.member_solution.program
+
+        if self.delegated_puzzle_and_solution is not None:
+            solution = Program.to(
+                [
+                    self.delegated_puzzle_and_solution.puzzle.program,
+                    self.delegated_puzzle_and_solution.solution.program,
+                    *solution.as_iter(),
+                ]
             )
 
         return solution
+
+    @classmethod
+    def match(cls, *, unknown_solution: UnknownSolution) -> PuzzleWithRestrictionsSolution | None:
+        if unknown_solution.program.atom is not None:
+            return None
+        # TODO: We need to figure out a way to implement arbitrary context as part of the matching protocol
+        return cls(member_solution=UnknownSolution(program=unknown_solution.program))

--- a/chia/wallet/puzzles/custody/member_puzzles.py
+++ b/chia/wallet/puzzles/custody/member_puzzles.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Generic, TypeVar
 
 from chia_puzzles_py import programs as puzzle_mods
 from chia_rs import AugSchemeMPL, G1Element, G2Element, PrivateKey
 from chia_rs.sized_bytes import bytes32
 
 from chia.types.blockchain_format.program import Program
+from chia.wallet.puzzles.custody.custody_architecture import MIPSComponentBase
 from chia.wallet.puzzles.p2_delegated_puzzle_or_hidden_puzzle import (
     calculate_synthetic_public_key,
     calculate_synthetic_secret_key,
 )
+from chia.wallet.puzzles.puzzle_drivers import Puzzle, UnknownPuzzle, UnknownSolution
 from chia.wallet.singleton import SINGLETON_LAUNCHER_PUZZLE_HASH, SINGLETON_TOP_LAYER_MOD_HASH
 
 BLS_WITH_TAPROOT_MEMBER_MOD = Program.from_bytes(puzzle_mods.BLS_WITH_TAPROOT_MEMBER)
@@ -19,77 +22,145 @@ SINGLETON_MEMBER_MOD = Program.from_bytes(puzzle_mods.SINGLETON_MEMBER)
 
 FIXED_PUZZLE_MEMBER_MOD = Program.from_bytes(puzzle_mods.FIXED_PUZZLE_MEMBER)
 
+_T_Puzzle = TypeVar("_T_Puzzle", bound=Puzzle | None, default=None)
+
 
 @dataclass(kw_only=True, frozen=True)
-class BLSWithTaprootMember:
+class BLSWithTaprootMember(MIPSComponentBase, Generic[_T_Puzzle]):
     synthetic_key: G1Element | None = None
     public_key: G1Element | None = None
-    hidden_puzzle: Program | None = None  # must be specified manually due to frozen class
+    # must be specified manually due to frozen class
+    hidden_puzzle: _T_Puzzle = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
         if self.synthetic_key is None and (self.public_key is None or self.hidden_puzzle is None):
             raise ValueError("Must specify either the synthetic key or public key and hidden puzzle")
 
-    def memo(self, nonce: int) -> Program:
+    @property
+    def memo(self) -> Program:
         return Program.to(0)
 
-    def puzzle(self, nonce: int) -> Program:
-        if self.synthetic_key is None:
-            assert self.public_key is not None and self.hidden_puzzle is not None
-            synthetic_public_key = calculate_synthetic_public_key(self.public_key, self.hidden_puzzle.get_tree_hash())
-            return BLS_WITH_TAPROOT_MEMBER_MOD.curry(bytes(synthetic_public_key))
+    @property
+    def guaranteed_synthetic_key(self) -> G1Element:
+        if self.synthetic_key is not None:
+            return self.synthetic_key
         else:
-            return BLS_WITH_TAPROOT_MEMBER_MOD.curry(bytes(self.synthetic_key))
+            assert self.hidden_puzzle is not None  # guarded by __post_init__
+            return calculate_synthetic_public_key(self.public_key, self.hidden_puzzle.tree_hash)
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
-        return self.puzzle(nonce).get_tree_hash()
+    @property
+    def program(self) -> Program:
+        return BLS_WITH_TAPROOT_MEMBER_MOD.curry(bytes(self.guaranteed_synthetic_key))
 
     def sign_with_synthetic_secret_key(self, original_secret_key: PrivateKey, message: bytes) -> G2Element:
         if self.hidden_puzzle is None:
             raise ValueError("Hidden puzzle must be specified to sign with synthetic secret key")
-        synthetic_sk = calculate_synthetic_secret_key(original_secret_key, self.hidden_puzzle.get_tree_hash())
+        synthetic_sk = calculate_synthetic_secret_key(original_secret_key, self.hidden_puzzle.tree_hash)
         return AugSchemeMPL.sign(synthetic_sk, message)
 
-    def solve(self, use_hidden_puzzle: bool = False) -> Program:
-        if use_hidden_puzzle:
-            if self.hidden_puzzle is None or self.public_key is None:
-                raise ValueError("Hidden puzzle or original key are unknown")
-            return Program.to([self.public_key, self.hidden_puzzle])
-        return Program.to([0])
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle) -> BLSWithTaprootMember[None] | None:
+        if unknown_puzzle.mod != BLS_WITH_TAPROOT_MEMBER_MOD or unknown_puzzle.curried_args is None:
+            return None
+        (synthetic_key_prog,) = unknown_puzzle.curried_args
+        synthetic_key = G1Element.from_bytes(synthetic_key_prog.as_atom())
+        original_key = None
+        # hidden_puzzle = None
+        # TODO: We need to figure out a way to implement arbitrary context as part of the matching protocol
+        # if solution is not None:
+        #     solution_match = BLSWithTaprootMemberSolution.match(unknown_solution=solution)
+        #     if solution_match is not None:
+        #         original_key = solution_match.original_public_key
+        #         hidden_puzzle = solution_match.hidden_puzzle
+        return BLSWithTaprootMember(synthetic_key=synthetic_key, public_key=original_key)
 
 
 @dataclass(kw_only=True, frozen=True)
-class SingletonMember:
+class BLSWithTaprootMemberSolution:
+    original_public_key: G1Element | None = None
+    hidden_puzzle: Puzzle | None = None
+
+    def __post_init__(self) -> None:
+        if (self.original_public_key is not None and self.hidden_puzzle is None) or (
+            self.original_public_key is None and self.hidden_puzzle is not None
+        ):
+            raise ValueError("Must specify both or neither of original_public_key and hidden_puzzle")
+
+    @property
+    def program(self) -> Program:
+        if self.hidden_puzzle is not None:
+            if self.original_public_key is None:
+                raise ValueError("Need original_public_key for hidden_puzzle spend")
+            return Program.to([self.original_public_key, self.hidden_puzzle.program])
+        return Program.to([0])
+
+    @classmethod
+    def match(cls, *, unknown_solution: UnknownSolution) -> BLSWithTaprootMemberSolution | None:
+        if unknown_solution.program.atom is not None:
+            return None
+        list_of_values = list(unknown_solution.program.as_iter())
+        if len(list_of_values) == 2:
+            return BLSWithTaprootMemberSolution(
+                original_public_key=G1Element.from_bytes(list_of_values[0].as_atom()),
+                hidden_puzzle=UnknownPuzzle(known_program=list_of_values[1]),
+            )
+        elif len(list_of_values) == 1:
+            return BLSWithTaprootMemberSolution()
+        else:
+            return None
+
+
+@dataclass(kw_only=True, frozen=True)
+class SingletonMember(MIPSComponentBase):
     singleton_id: bytes32
     singleton_mod_hash: bytes32 = SINGLETON_TOP_LAYER_MOD_HASH
     singleton_launcher_hash: bytes32 = SINGLETON_LAUNCHER_PUZZLE_HASH
 
-    def memo(self, nonce: int) -> Program:
+    @property
+    def memo(self) -> Program:
         return Program.to(0)
 
-    def puzzle(self, nonce: int) -> Program:
+    @property
+    def program(self) -> Program:
         singleton_struct = (self.singleton_mod_hash, (self.singleton_id, self.singleton_launcher_hash))
         return SINGLETON_MEMBER_MOD.curry(singleton_struct)
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
-        return self.puzzle(nonce).get_tree_hash()
-
-    def solve(self, singleton_inner_puzzle_hash: bytes32) -> Program:
-        return Program.to([singleton_inner_puzzle_hash])
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle) -> SingletonMember | None: ...
 
 
 @dataclass(kw_only=True, frozen=True)
-class FixedPuzzleMember:
+class SingletonMemberSolution:
+    singleton_inner_puzzle_hash: bytes32
+
+    @property
+    def program(self) -> Program:
+        return Program.to([self.singleton_inner_puzzle_hash])
+
+    @classmethod
+    def match(cls, *, unknown_solution: UnknownSolution) -> SingletonMemberSolution | None:
+        if unknown_solution.program.atom is not None:
+            return None
+        list_of_values = list(unknown_solution.program.as_iter())
+        if len(list_of_values) != 1:
+            return None
+        try:
+            return SingletonMemberSolution(singleton_inner_puzzle_hash=bytes32(list_of_values[0].as_atom()))
+        except ValueError:
+            return None
+
+
+@dataclass(kw_only=True, frozen=True)
+class FixedPuzzleMember(MIPSComponentBase):
     fixed_puzzle_hash: bytes32
 
-    def memo(self, nonce: int) -> Program:
+    @property
+    def memo(self) -> Program:
         return Program.to(0)
 
-    def puzzle(self, nonce: int) -> Program:
+    @property
+    def program(self) -> Program:
         return FIXED_PUZZLE_MEMBER_MOD.curry(self.fixed_puzzle_hash)
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
-        return self.puzzle(nonce).get_tree_hash()
-
-    def solve(self) -> Program:
-        return Program.to([])
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle) -> FixedPuzzleMember | None: ...

--- a/chia/wallet/puzzles/custody/restriction_utilities.py
+++ b/chia/wallet/puzzles/custody/restriction_utilities.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from chia_puzzles_py import programs as puzzle_mods
 from chia_rs.sized_bytes import bytes32
 
 from chia.types.blockchain_format.program import Program
-from chia.wallet.puzzles.custody.custody_architecture import DelegatedPuzzleAndSolution, MIPSComponent
+from chia.wallet.puzzles.custody.custody_architecture import MIPSComponent, MIPSComponentBase
+from chia.wallet.puzzles.puzzle_drivers import (
+    DelegatedPuzzleAndSolution,
+    Puzzle,
+    Solution,
+    UnknownPuzzle,
+    UnknownSolution,
+)
 
 UNUSED_NONCE = 0
 
@@ -17,47 +25,86 @@ QUOTED_ADD_DPUZ_WRAPPER_HASH = Program.to((1, ADD_DPUZ_WRAPPER)).get_tree_hash()
 
 
 @dataclass(kw_only=True, frozen=True)
-class ValidatorStackRestriction:
-    required_wrappers: list[MIPSComponent]
+class ValidatorStackRestriction(MIPSComponentBase):
+    required_wrappers: Sequence[MIPSComponent]
+
+    @property
+    def wrappers(self) -> Sequence[MIPSComponent]:
+        return [wrapper.with_nonce(self.nonce) for wrapper in self.required_wrappers]
 
     @property
     def member_not_dpuz(self) -> bool:
         return False
 
-    def memo(self, nonce: int) -> Program:
-        return Program.to([wrapper.memo(nonce) for wrapper in self.required_wrappers])
+    @property
+    def memo(self) -> Program:
+        return Program.to([wrapper.memo for wrapper in self.wrappers])
 
-    def required_quoted_wrappers_hashes(self, nonce: int) -> list[bytes32]:
+    @property
+    def required_quoted_wrappers_hashes(self) -> list[bytes32]:
         required_quoted_wrappers_hashes = []
-        for wrapper in self.required_wrappers:
-            puzhash = wrapper.puzzle_hash(nonce)
+        for wrapper in self.wrappers:
+            puzhash = wrapper.tree_hash
             required_quoted_wrappers_hashes.append(Program.to((1, puzhash)).get_tree_hash_precalc(puzhash))
 
         return required_quoted_wrappers_hashes
 
-    def puzzle(self, nonce: int) -> Program:
-        return ENFORCE_DPUZ_WRAPPERS.curry(QUOTED_ADD_DPUZ_WRAPPER_HASH, self.required_quoted_wrappers_hashes(nonce))
+    @property
+    def program(self) -> Program:
+        return ENFORCE_DPUZ_WRAPPERS.curry(QUOTED_ADD_DPUZ_WRAPPER_HASH, self.required_quoted_wrappers_hashes)
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
+    @property
+    def tree_hash_optimized(self) -> bytes32:
         return (
             Program.to(ENFORCE_DPUZ_WRAPPERS_HASH)
-            .curry(QUOTED_ADD_DPUZ_WRAPPER_HASH, self.required_quoted_wrappers_hashes(nonce))
+            .curry(QUOTED_ADD_DPUZ_WRAPPER_HASH, self.required_quoted_wrappers_hashes)
             .get_tree_hash_precalc(ENFORCE_DPUZ_WRAPPERS_HASH)
         )
 
-    def solve(self, original_dpuz: Program) -> Program:
-        return Program.to([original_dpuz.get_tree_hash()])
-
     def modify_delegated_puzzle_and_solution(
-        self, delegated_puzzle_and_solution: DelegatedPuzzleAndSolution, wrapper_solutions: list[Program]
+        self, delegated_puzzle_and_solution: DelegatedPuzzleAndSolution, wrapper_solutions: Sequence[Solution]
     ) -> DelegatedPuzzleAndSolution:
-        if len(wrapper_solutions) != len(self.required_wrappers):
+        if len(wrapper_solutions) != len(self.wrappers):
             raise ValueError("Number of wrapper solutions does not match number of required wrappers")
 
-        for wrapper, wrapper_solution in zip(reversed(self.required_wrappers), reversed(wrapper_solutions)):
+        for wrapper, wrapper_solution in zip(reversed(self.wrappers), reversed(wrapper_solutions)):
             delegated_puzzle_and_solution = DelegatedPuzzleAndSolution(
-                puzzle=ADD_DPUZ_WRAPPER.curry(wrapper.puzzle(UNUSED_NONCE), delegated_puzzle_and_solution.puzzle),
-                solution=Program.to([wrapper_solution, delegated_puzzle_and_solution.solution]),
+                puzzle=UnknownPuzzle(
+                    known_program=ADD_DPUZ_WRAPPER.curry(wrapper.program, delegated_puzzle_and_solution.puzzle.program)
+                ),
+                solution=UnknownSolution(
+                    program=Program.to([wrapper_solution.program, delegated_puzzle_and_solution.solution.program])
+                ),
             )
 
         return delegated_puzzle_and_solution
+
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle) -> ValidatorStackRestriction | None: ...
+
+
+@dataclass(kw_only=True, frozen=True)
+class ValidatorStackRestrictionSolution:
+    original_dpuz_hash: bytes32
+
+    @classmethod
+    def from_dpuz(cls, original_dpuz: Puzzle | Program) -> ValidatorStackRestrictionSolution:
+        if isinstance(original_dpuz, Program):
+            return cls(original_dpuz_hash=original_dpuz.get_tree_hash())
+        return cls(original_dpuz_hash=original_dpuz.tree_hash)
+
+    @property
+    def program(self) -> Program:
+        return Program.to([self.original_dpuz_hash])
+
+    @classmethod
+    def match(cls, *, unknown_solution: UnknownSolution) -> ValidatorStackRestrictionSolution | None:
+        if unknown_solution.program.atom is not None:
+            return None
+        list_of_values = list(unknown_solution.program.as_iter())
+        if len(list_of_values) != 1:
+            return None
+        try:
+            return cls(original_dpuz_hash=bytes32(list_of_values[0].as_atom()))
+        except ValueError:
+            return None

--- a/chia/wallet/puzzles/custody/restrictions.py
+++ b/chia/wallet/puzzles/custody/restrictions.py
@@ -6,7 +6,9 @@ from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import uint32
 
 from chia.types.blockchain_format.program import Program
+from chia.wallet.puzzles.custody.custody_architecture import MIPSComponentBase
 from chia.wallet.puzzles.load_clvm import load_clvm_maybe_recompile
+from chia.wallet.puzzles.puzzle_drivers import UnknownPuzzle
 
 FIXED_CREATE_COIN_DESTINATIONS = load_clvm_maybe_recompile(
     "fixed_create_coin_destinations.clsp", package_or_requirement="chia.wallet.puzzles.custody"
@@ -17,41 +19,47 @@ SEND_MESSAGE_BANNED = load_clvm_maybe_recompile(
 HEIGHTLOCK_WRAPPER = load_clvm_maybe_recompile("heightlock.clsp", package_or_requirement="chia.wallet.puzzles.custody")
 
 
-@dataclass(frozen=True)
-class Heightlock:
+@dataclass(kw_only=True, frozen=True)
+class Heightlock(MIPSComponentBase):
     heightlock: uint32
 
-    def memo(self, nonce: int) -> Program:
+    @property
+    def memo(self) -> Program:
         return Program.to(None)
 
-    def puzzle(self, nonce: int) -> Program:
+    @property
+    def program(self) -> Program:
         return HEIGHTLOCK_WRAPPER.curry(self.heightlock)
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
-        return self.puzzle(nonce).get_tree_hash()
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle) -> Heightlock | None: ...
 
 
 @dataclass(kw_only=True, frozen=True)
-class FixedCreateCoinDestinations:
+class FixedCreateCoinDestinations(MIPSComponentBase):
     allowed_ph: bytes32
 
-    def memo(self, nonce: int) -> Program:
+    @property
+    def memo(self) -> Program:
         return Program.to(None)
 
-    def puzzle(self, nonce: int) -> Program:
+    @property
+    def program(self) -> Program:
         return FIXED_CREATE_COIN_DESTINATIONS.curry(self.allowed_ph)
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
-        return self.puzzle(nonce).get_tree_hash()
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle) -> FixedCreateCoinDestinations | None: ...
 
 
 @dataclass(kw_only=True, frozen=True)
-class SendMessageBanned:
-    def memo(self, nonce: int) -> Program:
+class SendMessageBanned(MIPSComponentBase):
+    @property
+    def memo(self) -> Program:
         return Program.to(None)
 
-    def puzzle(self, nonce: int) -> Program:
+    @property
+    def program(self) -> Program:
         return SEND_MESSAGE_BANNED
 
-    def puzzle_hash(self, nonce: int) -> bytes32:
-        return self.puzzle(nonce).get_tree_hash()  # TODO: optimize
+    @classmethod
+    def match(cls, *, unknown_puzzle: UnknownPuzzle) -> SendMessageBanned | None: ...

--- a/chia/wallet/puzzles/puzzle_driver_registry.py
+++ b/chia/wallet/puzzles/puzzle_driver_registry.py
@@ -3,6 +3,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from chia.wallet.puzzles import puzzle_drivers
+from chia.wallet.puzzles.custody import custody_architecture, member_puzzles, restriction_utilities, restrictions
+
+"""
+This file may have more utility in the future but for right now it acts as a substitute for putting:
+```
+if TYPE_CHECKING:
+    _protocol_check: ClassVar[Puzzle/Solution] = cast("Something", None)
+```
+into every driver class
+"""
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -17,4 +27,59 @@ DRIVER_REGISTRY = [
     PuzzleDriverSet(name="acs", puzzle=puzzle_drivers.ACSPuzzle, solution=puzzle_drivers.ACSSolution),
     PuzzleDriverSet(name="nil", puzzle=puzzle_drivers.NilPuzzle, solution=puzzle_drivers.NilSolution),
     PuzzleDriverSet(name="p2_conditions", puzzle=puzzle_drivers.P2Conditions, solution=puzzle_drivers.NilSolution),
+    PuzzleDriverSet(
+        name="unknown_member",
+        puzzle=custody_architecture.UnknownMember,
+        solution=puzzle_drivers.UnknownSolution,
+    ),
+    PuzzleDriverSet(
+        name="unknown_restriction",
+        puzzle=custody_architecture.UnknownRestriction,
+        solution=puzzle_drivers.UnknownSolution,
+    ),
+    PuzzleDriverSet(
+        name="m_of_n",
+        puzzle=custody_architecture.MofN,
+        solution=custody_architecture.MofNSolution,
+    ),
+    PuzzleDriverSet(
+        name="puzzle_with_restrictions",
+        puzzle=custody_architecture.PuzzleWithRestrictions,
+        solution=custody_architecture.PuzzleWithRestrictionsSolution,
+    ),
+    PuzzleDriverSet(
+        name="bls_with_taproot_member",
+        puzzle=member_puzzles.BLSWithTaprootMember,
+        solution=member_puzzles.BLSWithTaprootMemberSolution,
+    ),
+    PuzzleDriverSet(
+        name="singleton_member",
+        puzzle=member_puzzles.SingletonMember,
+        solution=member_puzzles.SingletonMemberSolution,
+    ),
+    PuzzleDriverSet(
+        name="fixed_puzzle_member",
+        puzzle=member_puzzles.FixedPuzzleMember,
+        solution=puzzle_drivers.NilSolution,
+    ),
+    PuzzleDriverSet(
+        name="heightlock",
+        puzzle=restrictions.Heightlock,
+        solution=puzzle_drivers.NilSolution,
+    ),
+    PuzzleDriverSet(
+        name="fixed_create_coin_destinations",
+        puzzle=restrictions.FixedCreateCoinDestinations,
+        solution=puzzle_drivers.NilSolution,
+    ),
+    PuzzleDriverSet(
+        name="send_message_banned",
+        puzzle=restrictions.SendMessageBanned,
+        solution=puzzle_drivers.NilSolution,
+    ),
+    PuzzleDriverSet(
+        name="validator_stack_restriction",
+        puzzle=restriction_utilities.ValidatorStackRestriction,
+        solution=restriction_utilities.ValidatorStackRestrictionSolution,
+    ),
 ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large API churn across custody, PlotNFT, and wallet spend construction; incorrect solution encoding could break spends or memo sync even if CLVM puzzles are unchanged.
> 
> **Overview**
> Refactors **CHIP-0043 MIPS custody drivers** so puzzles and spends use the shared **`Puzzle` / `Solution`** model (`program`, `tree_hash`, typed solutions) instead of nonce-parameterized `puzzle()` / `solve()` and raw `Program` blobs.
> 
> **`PuzzleWithRestrictions`** now holds a **`member`** (not `puzzle`), exposes **`memo`** as a property, and spends go through **`PuzzleWithRestrictionsSolution`**. **`MofN`** is built on **`MofNMerkleTree`** with **`MofNSolution`** for proofs; member nodes use **`_top_level=False`**. **`MIPSComponentBase`** centralizes nonce handling via **`with_nonce`**, and drivers gain **`match()`** hooks for **`UnknownPuzzle`** parsing.
> 
> Member and restriction drivers (**BLS taproot**, singleton, fixed puzzle, heightlock, validator stack, etc.) get dedicated **solution types**; **`ValidatorStackRestriction`** wrapper spends use **`Solution`** instead of bare programs. **`DelegatedPuzzleAndSolution`** lives in **`puzzle_drivers`** with **`ACSPuzzle` / `P2Conditions` / `NilPuzzle`** used in PlotNFT and wallet paths. **`puzzle_driver_registry`** registers the custody driver set. Tests and **`plotnft_drivers`** / **`plotnft_wallet`** are updated to the new spend shape; on-chain puzzle semantics are intended to stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3bae29b6d09ff4738e2b0e5a4a3a1849efe907b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->