### PR TITLE
Don't fail coverage when there's a diff anymore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -334,9 +334,6 @@ jobs:
           diff-cover --config-file=.diffcover.toml --compare-branch=${{ env.compare-branch }} --fail-under=100 --format html:coverage-reports/diff-cover.html,markdown:coverage-reports/diff-cover.md coverage-reports/coverage.xml | tee coverage-reports/diff-cover-stdout
           COV_STATUS="${PIPESTATUS[0]}"
           echo "COV_STATUS=$COV_STATUS" >> "$GITHUB_ENV"
-          if [[ $COV_STATUS != '0' && "$GITHUB_BASE_REF" != '' ]]; then
-            exit 1
-          fi
 
       - name: Remove previous coverage report comment and label from PR
         if: github.base_ref != '' && always() && steps.alls-green.outputs.success == 'true'

--- a/chia/uncovered.py
+++ b/chia/uncovered.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+def some_func() -> None:
+    some_variable = "foo"
+    print(some_variable)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> This only relaxes CI gating; coverage reporting and PR labeling behavior stay the same.
> 
> **Overview**
> **Diff coverage no longer blocks CI.** The test workflow still runs `diff-cover` with `--fail-under=100` and records the exit code in `COV_STATUS`, but the coverage step always ends with **`exit 0`** instead of failing the job when coverage is short on PRs.
> 
> The step adds **`set +e`** so a non-zero `diff-cover` result is captured via `PIPESTATUS` before the step succeeds. **PR comments and the `coverage-diff` label** (when `COV_STATUS != 0`) are unchanged—only the hard merge gate is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 562cb6e41f590f993a7c374c7160d1f2b79cbc42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->